### PR TITLE
docs: overhaul README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,152 @@
 # GlobalUIComponents
 
-A theme-driven SwiftUI component library whose colors, typography, spacing,
-radii and shadows are **design tokens** sourced from the Figma design system and
-loaded from JSON at runtime — so components render under any theme without code
-changes.
+A theme-driven, **brand-neutral** SwiftUI component library. Every color,
+typography, spacing, radius and shadow is a **design token** resolved at runtime
+from the active `Theme`, so the whole UI re-skins from a single accent color —
+without touching component code.
 
-> Per **ADR-0001**, components never hardcode colors — every color resolves from
-> the active `Theme`.
+![Swift](https://img.shields.io/badge/Swift-6.2-orange.svg)
+![Platforms](https://img.shields.io/badge/Platforms-iOS%2017%20%7C%20macOS%2014-blue.svg)
+![Dependencies](https://img.shields.io/badge/Core%20dependencies-0-success.svg)
+
+> **Principle:** components never hardcode a color — every value resolves from the
+> active `Theme`. Swap the theme and everything follows.
 
 ```swift
 import GlobalUIComponents
 ```
 
+## Features
+
+- **Token system** — colors / radius / spacing from JSON, typography / shadows in
+  code; one semantic name (`fg-hero`, `rd-sm`), different values per theme.
+- **Runtime theming** — a Swift token generator + a live configurator turn any
+  accent color into a full Ant-style palette on device (no Python, no baked files).
+- **130+ components** — Atoms / Molecules / Organisms, all token-bound.
+- **Validation** — pure, testable predicates + a SwiftUI presentation layer.
+- **Accessibility** — Dynamic Type and Reduce Motion honored throughout.
+- **Localization** — English-default strings via a bundled String Catalog (with
+  Turkish), every default still overridable.
+- **Zero-dependency core** — Lottie is an opt-in, separate product.
+- **DocC catalog**, a demo app, and a test suite.
+
+## Requirements
+
+| | |
+|---|---|
+| Platforms | iOS 17+ · macOS 14+ |
+| Swift tools | 6.2 |
+| Dependencies | none (core) · `lottie-ios` 4.4.0+ (only the Lottie add-on) |
+
+## Installation
+
+Swift Package Manager. In **Xcode**: *File ▸ Add Package Dependencies…* and enter
+the repository URL, or add it to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/isamercan/GlobalUIComponents.git", from: "0.1.0"),
+],
+targets: [
+    .target(
+        name: "MyApp",
+        dependencies: [
+            .product(name: "GlobalUIComponents", package: "GlobalUIComponents"),
+            // Optional — only if you need Lottie-backed animations:
+            // .product(name: "GlobalUIComponentsLottie", package: "GlobalUIComponents"),
+        ]
+    ),
+]
+```
+
+> This is a **private** repository — resolving it requires GitHub access
+> (an authenticated SSH key or token).
+
+### Products
+
+| Product | Dependencies | Use |
+|---|---|---|
+| `GlobalUIComponents` | none | the full design system (core) |
+| `GlobalUIComponentsLottie` | `lottie-ios` | adds Lottie (After Effects / JSON) animation views; pulls Lottie **only** if imported |
+
+## Quick start
+
+Install the theme once at the root, then build with token-bound views:
+
+```swift
+@main
+struct MyApp: App {
+    init() { Theme.shared.applyPersistedConfig() }   // restore last-used theme (optional)
+    var body: some Scene {
+        WindowGroup {
+            ContentView().globalUITheme()            // inject + repaint on theme change
+        }
+    }
+}
+
+struct ContentView: View {
+    @ThemeContext private var theme
+    var body: some View {
+        VStack(spacing: theme.spacing(.md)) {
+            Text("Welcome").textStyle(.headingBase)
+            PrimaryButton(title: "Get started") { await signIn() }
+        }
+        .padding(theme.spacing(.base))
+        .background(theme.background(.bgElevatorPrimary))
+        .cornerRadius(.base)
+        .themeShadow(.elevated)
+    }
+}
+
+Theme.shared.loadTheme(named: "oceanTheme")          // runtime switch
+```
+
+## Components
+
+~130 token-bound components, grouped by complexity:
+
+- **Atoms** (26) — `Badge`, `Chip`, `Avatar`, `Icon`, `Rating`, `Spinner`,
+  `StatusDot`, `Skeleton`, `ProgressBar`, `BorderBeam`, `RollingNumber`…
+- **Molecules** (35) — `TextInput`, `OTPInput`, `Select`, `Checkbox`,
+  `RadioGroup`, `Slider`, `RangeSlider`, `SearchBar`, `Tooltip`, buttons…
+- **Organisms** (44) — `Card`, `Carousel`, `DataTable`, `Accordion`, `Steps`,
+  `Timeline`, `ResultView`, `Upload`, `Tour`, `NavigationBar`…
+
+Every component is curated by category in the [DocC catalog](#documentation).
+
 ## Token system
 
 ```
 Sources/GlobalUIComponents/
-├─ Theme/
-│  ├─ Theme.swift                    # ObservableObject singleton (Theme.shared)
-│  ├─ ThemeModel.swift               # RadiusKey / SpacingKey
-│  ├─ ColorTokens.generated.swift    # Foreground/Background/Border/Text color keys (generated)
-│  ├─ Typography.swift               # TextStyle ramp (Montserrat)
-│  ├─ Shadows.swift                  # ShadowStyle + .themeShadow()
-│  ├─ ThemeContext.swift             # @ThemeContext property wrapper
-│  └─ ThemedHostingController.swift  # UIKit bridge
-├─ Extensions/Color+Extensions.swift # Color(hex:) — supports RRGGBB + RRGGBBAA
-│  ├─ AspectRatio.swift             # AspectRatioToken + .aspectRatioToken()
-│  ├─ Motion.swift                  # Motion durations / animations
-│  └─ Grid.swift                    # GridLayout column helpers
-├─ Views/
-│  ├─ CornerRadiusModifier.swift     # .cornerRadius(.rdBase)
-│  ├─ DividerView.swift
-│  ├─ Icon.swift                     # Icon + IconSize (SF Symbols; FA Pro drop-in)
-│  ├─ Badge.swift                    # Badge (semantic + brand styles)
-│  ├─ Chip.swift                     # Chip (tonal / solid selection)
-│  ├─ Accordion.swift                # Accordion (expandable)
-│  ├─ InfoBanner.swift               # light-surface status banner
-│  ├─ AlertToast.swift               # solid-fill status banner
-│  ├─ Buttons/                       # PrimaryButton / SecondaryButton / OutlineButton
-│  └─ Controls/                      # Checkbox / RadioButton / ThemeToggle / TextInput / Select
+├─ Theme/              # Theme.shared, tokens, generator, configurator API
+│  ├─ Theme.swift                 # ObservableObject singleton (Theme.shared)
+│  ├─ ColorTokens.generated.swift # Foreground/Background/Border/Text color keys
+│  ├─ ThemeModel.swift            # RadiusKey / SpacingKey
+│  ├─ Typography.swift            # TextStyle ramp (Montserrat, Dynamic Type)
+│  ├─ Shadows.swift               # ShadowStyle + .themeShadow()
+│  ├─ SemanticColor.swift         # named palette colors
+│  ├─ ThemeGenerator.swift        # runtime palette generator (Swift port)
+│  ├─ ThemeConfig.swift           # Codable theme recipe
+│  ├─ GlobalUITheme.swift         # .globalUITheme() root modifier
+│  ├─ ThemeContext.swift          # @ThemeContext property wrapper
+│  └─ ThemedHostingController.swift
+├─ Components/         # Atoms / Molecules / Organisms (all token-bound)
+├─ Validation/         # Validators / ValidationRule / Validator / InfoMessage
+├─ Accessibility/      # Reduce Motion + Dynamic Type helpers
+├─ Extensions/         # Color(hex:), AspectRatio, Motion, Grid
+├─ Utils/              # Haptics, Impression, Localization bridge
+├─ Documentation.docc/ # DocC catalog
 └─ Resources/
-   ├─ *.json                         # defaultTheme / oceanTheme / sunsetTheme
-   └─ Fonts/Montserrat.ttf           # bundled, registered at runtime
+   ├─ *.json                  # defaultTheme / oceanTheme / sunsetTheme (+ Dark)
+   ├─ Localizable.xcstrings    # String Catalog (en source + tr)
+   └─ Fonts/Montserrat.ttf     # bundled, registered at runtime
 ```
 
 ### Token groups
 
 | Group | Source of truth | Keys |
 |---|---|---|
-| Colors | `Resources/*.json` | `Theme.ForegroundColorKey` · `BackgroundColorKey` · `BorderColorKey` · `TextColorKey` (128 semantic tokens) |
+| Colors | `Resources/*.json` | `Theme.ForegroundColorKey` · `BackgroundColorKey` · `BorderColorKey` · `TextColorKey` |
 | Radius | `Resources/*.json` | `Theme.RadiusKey` (`rd-xs`…`rd-4xl`) |
 | Spacing | `Resources/*.json` | `Theme.SpacingKey` (`sp-xs`…`sp-4xl`) |
 | Typography | code (`Typography.swift`) | `TextStyle` — Display / Heading / Label / Body / Overline / Link |
@@ -57,70 +155,21 @@ Sources/GlobalUIComponents/
 Colors / radius / spacing vary per theme (JSON). Typography & shadows are
 structural and constant across themes.
 
-### Usage
-
-```swift
-// Inject once
-WindowGroup { ContentView().environmentObject(Theme.shared) }
-
-struct Example: View {
-    @ThemeContext private var theme
-    var body: some View {
-        Text("Hi")
-            .textStyle(.headingBase)
-            .foregroundStyle(theme.text(.textPrimary))
-            .padding(theme.spacing(.md))
-            .background(theme.background(.bgElevatorPrimary))
-            .cornerRadius(.base)
-            .themeShadow(.elevated)
-    }
-}
-
-Theme.shared.loadTheme(named: "oceanTheme")   // runtime switch
-```
-
-## Adding / updating tokens
-
-Colors are generated to keep JSON ↔ Swift in sync. Edit the single source and
-re-run the generator (the token maps live in the generator script):
-
-1. Update the token maps in `tools/gen_tokens.py`.
-2. Re-run: `python3 tools/gen_tokens.py .` (regenerates `Resources/*.json` +
-   `ColorTokens.generated.swift`).
-
-Radius / spacing live in `Resources/*.json` + the `RadiusKey` / `SpacingKey`
-enums. Typography / shadows are in `Typography.swift` / `Shadows.swift`.
-
 ## Themes
 
-`default` (blue) · `ocean` (turquoise accent) · `sunset` (orange accent).
-Token **names** are semantic (`fg-hero`, `bg-primary`, `rd-sm`); only the values
-differ per theme. Add a theme by dropping a `<name>Theme.json` into `Resources/`.
+`default` (blue) · `ocean` (turquoise) · `sunset` (orange) — each with a Dark
+variant. Token **names** are semantic; only the values differ per theme. Add a
+theme by dropping a `<name>Theme.json` into `Resources/`.
 
 ## Theming your app (Configurator export)
 
-The library ships a **runtime token generator** (`ThemeGenerator`, a Swift port
-of `tools/gen_tokens.py`): from a handful of inputs it regenerates the whole
-Ant-style palette, neutral ramp, surfaces, borders, text, radius/spacing/font/
-shadow ramps — on device, no Python and no baked palette files.
+The library ships a **runtime token generator** (`ThemeGenerator`, a Swift port of
+`tools/gen_tokens.py`): from a handful of inputs it regenerates the whole palette,
+neutral ramp, surfaces, borders, text, and radius / spacing / font / shadow ramps
+— on device, no Python and no baked palette files.
 
 The Demo's **Theme Configurator** (Colors tab) lets you dial in an accent color +
-tint + scale knobs + font + dark and exports a `ThemeConfig` recipe. To use it in
-your own app:
-
-**1. Install the root modifier — once.** It injects the theme and repaints the UI
-on a theme swap (see "How live theming works" below):
-
-```swift
-@main struct MyApp: App {
-    init() { Theme.shared.applyPersistedConfig() }     // restore last-used theme (if any)
-    var body: some Scene {
-        WindowGroup { ContentView().globalUITheme() }
-    }
-}
-```
-
-**2. Apply a theme** — pick the level of portability you want:
+tint + scale knobs + font + dark and exports a `ThemeConfig` recipe. To apply one:
 
 ```swift
 // a) one-liner (paste the configurator's "Apply (Swift)" export)
@@ -131,8 +180,7 @@ let cfg = try ThemeConfig(jsonData: Data(contentsOf: themeJSONURL))
 Theme.shared.apply(cfg)
 Theme.shared.persistConfig()                            // remember across launches
 
-// c) fully Python-free + generator-free: bundle the pre-baked token JSON
-//    (configurator → "Copy full token JSON") and load it directly
+// c) generator-free: bundle the pre-baked token JSON ("Copy full token JSON")
 Theme.shared.setTheme(jsonData: Data(contentsOf: tokensURL))
 ```
 
@@ -141,54 +189,111 @@ Theme.shared.setTheme(jsonData: Data(contentsOf: tokensURL))
 ### How live theming works
 
 Components resolve tokens from the `Theme.shared` singleton (no per-call
-environment lookups), so SwiftUI can't infer that an arbitrary view depends on
-the theme. `.globalUITheme()` closes that gap: it injects `Theme` into the
-environment **and** (by default) rebuilds the subtree keyed on `Theme.revision`
-when the theme changes, so every view re-reads the regenerated tokens.
+environment lookups), so SwiftUI can't infer that an arbitrary view depends on the
+theme. `.globalUITheme()` closes that gap: it injects `Theme` into the environment
+**and** (by default) rebuilds the subtree keyed on `Theme.revision` when the theme
+changes, so every view re-reads the regenerated tokens.
 
 - Switching theme from a **settings screen** → keep the default
-  (`reactToRuntimeChanges: true`), the whole UI repaints.
-- Editing the theme **in-session** (a sheet/inspector that mutates it live) → use
+  (`reactToRuntimeChanges: true`); the whole UI repaints.
+- Editing the theme **in-session** (a live editor/inspector) → use
   `.globalUITheme(reactToRuntimeChanges: false)` so the editor isn't torn down,
-  and scope a `.id(Theme.shared.revision)` onto just the live-preview subtree.
+  and scope `.id(Theme.shared.revision)` onto just the live-preview subtree.
 
 ### Fonts
 
 `Montserrat` is bundled. `System` / `SystemRounded` / `SystemSerif` / `SystemMono`
-need nothing. Any other family must be registered by the host app (add the
-`.ttf` + `UIAppFonts`), then pass its PostScript family name as `font:`.
+need nothing. Any other family must be registered by the host app (add the `.ttf` +
+`UIAppFonts`), then pass its PostScript family name as `font:`.
+
+## Accessibility
+
+- **Dynamic Type** — the type ramp scales with the user's preferred text size:
+  each `TextStyle` anchors to a semantic `Font.TextStyle` via `relativeTo:`. At the
+  default size nothing changes; it only grows/shrinks when the user opts in. Clamp
+  per-screen if needed: `MyScreen().dynamicTypeSize(...DynamicTypeSize.accessibility2)`.
+- **Reduce Motion** — decorative/continuous animation is suppressed while
+  functional motion is kept: `BorderBeam`, `Skeleton`, `RollingNumber`, `StatusDot`,
+  `Carousel` autoplay, the OTP caret all calm down; `Spinner` keeps spinning.
+
+No caller configuration is required — components read the environment directly.
+
+## Validation
+
+A pure logic layer (no SwiftUI, no theme) plus a separate presentation layer:
+
+```swift
+let messages = Validator.validate(email, [.required(), .email()])   // [InfoMessage]
+InfoMessageList(messages)                                            // SwiftUI rendering
+```
+
+Feed your own logic — a custom predicate, a regex, a typed `Regex`, or an async
+(server-side) check:
+
+```swift
+.regex("^[a-z]+$", caseInsensitive: true, "letters only")
+ValidationRule("only AAA") { $0 == "AAA" }
+let unique = AsyncValidationRule("Username taken") { await api.isAvailable($0) }
+```
+
+`FormValidator` ties fields, rules, focus and messages together for a whole form.
 
 ## Localization
 
 User-facing default strings (validation messages, placeholders, accessibility
-labels, etc.) come from a bundled **String Catalog**
-(`Resources/Localizable.xcstrings`). The source language is **English**; a
-**Turkish** translation ships too, and consumers can add their own.
+labels…) come from a bundled **String Catalog** (`Resources/Localizable.xcstrings`).
+The source language is **English**; a **Turkish** translation ships too, and
+consumers can add their own.
 
-Every such string also stays **overridable** via API parameters — e.g.
+Every such string is also **overridable** via API parameters — e.g.
 `ValidationRule.required("Custom message")` — so the catalog only supplies the
-default. The bridge `String(globalUIComponents:)` resolves a key from the
-package bundle if you need it directly.
+default.
 
-> Note: a plain `swift build` copies `.xcstrings` verbatim (CLI doesn't run the
-> catalog compiler), so only English resolves there. Xcode / `xcodebuild`
-> compile it, so all bundled localizations resolve in real apps.
+> Note: a plain `swift build` copies `.xcstrings` verbatim (the SwiftPM CLI
+> doesn't run the catalog compiler), so only English resolves there. Xcode /
+> `xcodebuild` compile it, so all bundled localizations resolve in real apps.
 
 ## Documentation
 
-A DocC catalog ships with the package (`Sources/GlobalUIComponents/Documentation.docc`).
-Build it in Xcode via **Product ▸ Build Documentation** (⌃⌘D), or from the
-command line:
+A DocC catalog ships with the package
+(`Sources/GlobalUIComponents/Documentation.docc`). Build it in Xcode via
+**Product ▸ Build Documentation** (⌃⌘D), or from the command line:
 
 ```sh
 xcodebuild docbuild -scheme GlobalUIComponents -destination 'generic/platform=iOS'
 ```
 
 It curates every component by category and includes guide articles for
-**Theming**, **Accessibility** (Dynamic Type + Reduce Motion), and
-**Validation**. No extra dependency is required — the catalog builds natively.
+**Theming**, **Accessibility**, and **Validation**. No extra dependency required.
 
 ## Demo
 
-`Demo/` — a SwiftUI app (local package reference) with three tabs: **Colors**
-(token gallery), **Typography**, **Components**, plus a runtime theme switcher.
+`Demo/` — a SwiftUI app (local package reference) with five tabs: **Components**
+(gallery), **Colors** (token gallery + live Theme Configurator), **Type**,
+**Layout** (spacing / radius / shadow tokens), and **Example** (a full flow built
+from the real components), plus a light/dark switcher.
+
+## Adding / updating tokens
+
+Colors are generated to keep JSON ↔ Swift in sync:
+
+1. Update the token maps in `tools/gen_tokens.py`.
+2. Re-run: `python3 tools/gen_tokens.py .` (regenerates `Resources/*.json` +
+   `ColorTokens.generated.swift`).
+
+Radius / spacing live in `Resources/*.json` (+ the `RadiusKey` / `SpacingKey`
+enums); typography / shadows in `Typography.swift` / `Shadows.swift`.
+
+## Testing
+
+```sh
+swift test
+```
+
+The suite covers the token generator, theme integrity across every bundled theme,
+validation, localization, accessibility mapping, and component render smoke tests.
+
+## License
+
+Proprietary — all rights reserved. (Replace with your chosen license before any
+public distribution.)


### PR DESCRIPTION
Rewrites the README to be a complete project front page.

**Added**
- Features overview, Requirements, Installation (SPM + Xcode, both products incl. the `GlobalUIComponentsLottie` add-on), Quick start
- Accessibility (Dynamic Type + Reduce Motion), Validation, Testing, License sections

**Fixed (was stale)**
- File tree now reflects `Components/{Atoms,Molecules,Organisms}` + `Validation/` `Accessibility/` `Utils/` `Documentation.docc/`
- Demo description corrected to the 5 actual tabs
- Removed the dangling `ADR-0001` reference

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)