### PR TITLE
docs: build-only DocC CI for private repo (no Pages deploy)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,30 +1,27 @@
 name: Docs
 
-# Build the DocC documentation and publish it to GitHub Pages on every push to
-# main. Set Settings ▸ Pages ▸ Source = "GitHub Actions" once for this to serve.
+# Build the DocC documentation on every push to main and upload it as a
+# downloadable artifact. The repo is PRIVATE, so GitHub Pages isn't available on
+# the current plan — docs are not published; build them locally with:
+#   swift package --disable-sandbox preview-documentation --target GlobalUIComponents
+# This job's value is catching broken doc comments / DocC links in CI, and
+# producing a browsable archive reviewers can download.
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-# Required for the Pages deployment.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
-# Only one Pages deploy at a time; let an in-flight one finish.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
-    name: Build DocC & deploy to Pages
+  build:
+    name: Build DocC
     runs-on: macos-15
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -34,25 +31,19 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-
-      # Project site → assets are served under /<repo>/, so the base path MUST be
-      # the repo name or every CSS/JS asset 404s.
+      # Static-hosting transform (no base path) → a self-contained, browsable
+      # site. Download the artifact and serve it, e.g. `python3 -m http.server`.
       - name: Build DocC (static hosting)
         run: |
           swift package --disable-sandbox \
             generate-documentation \
             --target GlobalUIComponents \
             --transform-for-static-hosting \
-            --hosting-base-path GlobalUIComponents \
             --output-path ./docs-out
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload DocC artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: GlobalUIComponents-docc
           path: ./docs-out
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          retention-days: 14

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -45,5 +45,5 @@ back/next arrows) are flipped via the library's RTL helper.
 
 iOS 17+ and macOS 14+.
 
-📖 Full API reference:
-https://isamercan.github.io/GlobalUIComponents/documentation/globaluicomponents/
+📖 Full API reference — build the DocC docs locally (the repo is private):
+`swift package --disable-sandbox preview-documentation --target GlobalUIComponents`

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -6,7 +6,12 @@ A themable palette, 100+ token-bound SwiftUI components, a validation layer, and
 accessibility (Dynamic Type, VoiceOver, RTL) — all with no third-party
 dependencies in the core.
 
-📖 **Full documentation:** https://isamercan.github.io/GlobalUIComponents/documentation/globaluicomponents/
+📖 **Full DocC documentation** is built locally (the repo is private, so it isn't
+published to Pages):
+
+```bash
+swift package --disable-sandbox preview-documentation --target GlobalUIComponents
+```
 
 ## Quick install
 
@@ -25,7 +30,7 @@ ContentView().globalUITheme()
 - **[[Kurulum|Installation]]** — add the package to your project.
 - **[[SSS|FAQ]]** — common questions.
 - **[[Sorun Giderme|Troubleshooting]]** — fixes for typical issues.
-- **API reference** → https://isamercan.github.io/GlobalUIComponents/documentation/globaluicomponents/
+- **API reference** → build the DocC docs locally (command above)
 
-The detailed, styled docs live on GitHub Pages (DocC). This wiki holds the
-light, fast-changing helper pages.
+The detailed, styled DocC docs are built locally / downloaded from the **Docs**
+CI artifact. This wiki holds the light, fast-changing helper pages.

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -31,5 +31,6 @@ Swift Package Manager, in Xcode or `Package.swift`.
 The core is **zero-dependency**; Lottie is pulled in only via the
 `GlobalUIComponentsLottie` product.
 
-📖 Detailed version with screenshots: see the
-[Installation article in the full docs](https://isamercan.github.io/GlobalUIComponents/documentation/globaluicomponents/installation).
+📖 Detailed version: the **Installation** article in the DocC docs
+(`Sources/GlobalUIComponents/Documentation.docc/Installation.md`), viewable with
+`swift package --disable-sandbox preview-documentation --target GlobalUIComponents`.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,3 +1,3 @@
 [Repo](https://github.com/isamercan/GlobalUIComponents) ·
-[Documentation](https://isamercan.github.io/GlobalUIComponents/documentation/globaluicomponents/) ·
+DocC docs: build locally (`preview-documentation`) ·
 MIT License

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -8,4 +8,5 @@
 
 ---
 
-📖 [Full docs](https://isamercan.github.io/GlobalUIComponents/documentation/globaluicomponents/)
+📖 DocC docs: build locally
+(`preview-documentation`)


### PR DESCRIPTION
The repo is private → GitHub Pages isn't available on the current plan, so the Pages-deploy workflow failed on every `main` push.

- **docs.yml** now *builds* DocC and uploads a downloadable artifact (still catches broken doc comments / links in CI), instead of deploying to Pages.
- Wiki "full docs" links now point to local preview (`swift package --disable-sandbox preview-documentation`) instead of the unreachable Pages URL.

The DocC catalog, articles, and `.spi.yml` stay in place — publishing becomes a one-step change if the repo ever goes public.

Verified: `generate-documentation` runs with 0 errors / 0 warnings; YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)