### PR TITLE
ci(docs): tar DocC site before artifact upload

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,9 +41,15 @@ jobs:
             --transform-for-static-hosting \
             --output-path ./docs-out
 
+      # DocC emits operator pages whose filenames contain ':' (e.g.
+      # `!=(_:_:).json`), which actions/upload-artifact rejects. Tar the site into
+      # a single file first so those names live inside the archive.
+      - name: Archive DocC site
+        run: tar -czf GlobalUIComponents-docc.tgz -C docs-out .
+
       - name: Upload DocC artifact
         uses: actions/upload-artifact@v4
         with:
           name: GlobalUIComponents-docc
-          path: ./docs-out
+          path: GlobalUIComponents-docc.tgz
           retention-days: 14


### PR DESCRIPTION
DocC emits operator pages with `:` in the filename (e.g. `!=(_:_:).json`), which `actions/upload-artifact` rejects — the build passed but upload failed. Tar `docs-out` into a single `.tgz` first. Verified locally: build + tar exit 0 (73M archive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)