### PR TITLE
feat(toast): stacking, action button, swipe-to-dismiss & async task

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -132,7 +132,7 @@ enum ComponentRegistry {
         .knob("Timeline", .organisms, demo: TimelineDemo(), usage: #"Timeline([.init(title: "Placed", state: .done, color: .success)], pending: "Awaiting…")"#),
         .knob("Coupon", .organisms, demo: CouponDemo(), usage: #"Coupon(code: "UXMUQ", style: .outlined, onCopy: { })"#),
         .knob("EmptyState", .organisms, demo: EmptyStateDemo(), usage: #"EmptyState(systemImage: "tray", title: "Empty", message: "…", buttonTitle: "Retry", action: { })"#),
-        .knob("Feedback", .organisms, demo: FeedbackDemo(), usage: #"@EnvironmentObject var feedback: FeedbackPresenter\nfeedback.toast("Saved", kind: .success)\nfeedback.confirm(title: "Delete?", primaryTitle: "Delete", primaryKind: .error) { }"#),
+        .knob("Feedback", .organisms, demo: FeedbackDemo(), usage: #"@EnvironmentObject var feedback: FeedbackPresenter\nfeedback.toast("Saved", kind: .success)              // stacks\nfeedback.toast("Deleted", action: ToastAction("Undo") { }, duration: nil)\nawait feedback.toastTask(loading: "Saving…", success: "Saved") { try await save() }\n// install once: .feedbackHost(maxVisibleToasts: 3, toastPosition: .bottom)"#),
         .knob("Gallery", .organisms, demo: GalleryDemo(), usage: #"Gallery(items, columns: 2, aspect: .square) { item in mediaView }"#),
         .knob("ImageCollage", .organisms, demo: ImageCollageDemo(), usage: #"ImageCollage(urls, height: 220) { index in open(index) }   // 1·2·3·4+ layouts + "+N""#),
         .knob("InfoBanner", .organisms, demo: InfoBannerDemo(), usage: #"InfoBanner("Message", type: .info, links: [("link", action)])"#),

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -1043,6 +1043,24 @@ struct FeedbackDemo: View {
                                    message: "Bu bir \(kind.rawValue) bildirimi.", kind: kind)
                     last = "toast: \(kind.rawValue)"
                 }
+                ThemeButton("Stack (3 toast)", color: kind.semanticColor, variant: .soft, block: true) {
+                    for i in 1 ... 3 { feedback.toast("Toast #\(i)", kind: kind) }
+                    last = "stack: 3"
+                }
+                ThemeButton("Undo (action + sticky)", variant: .outline, block: true) {
+                    feedback.toast("Mesaj silindi", kind: .info,
+                                   action: ToastAction("Geri al") { feedback.toast("Geri alındı", kind: .success) },
+                                   duration: nil)
+                    last = "undo toast"
+                }
+                ThemeButton("Async görev (task)", variant: .outline, block: true) {
+                    Task {
+                        await feedback.toastTask(loading: "Kaydediliyor…", success: "Kaydedildi") {
+                            try await Task.sleep(nanoseconds: 1_500_000_000)
+                        }
+                    }
+                    last = "async task"
+                }
                 ThemeButton("Bildirim göster (notification)", color: kind.semanticColor, variant: .soft, block: true) {
                     feedback.notify("\(kind.rawValue.capitalized)", message: "Üstten gelen bir bildirim.", kind: kind)
                     last = "notify: \(kind.rawValue)"

--- a/Sources/ThemeKit/Components/Organisms/AlertToast.swift
+++ b/Sources/ThemeKit/Components/Organisms/AlertToast.swift
@@ -39,27 +39,54 @@ public enum AlertToastType {
     }
 }
 
+/// An optional tappable action rendered inline in a toast (e.g. "Undo"). Its
+/// label inherits the toast's foreground color so it reads on the solid fill.
+public struct ToastAction {
+    public let title: String
+    public let handler: () -> Void
+
+    public init(_ title: String, handler: @escaping () -> Void) {
+        self.title = title
+        self.handler = handler
+    }
+}
+
 public struct AlertToast: View {
     private let title: String
     private let message: String?
     private let type: AlertToastType
+    private let systemImage: String?
+    private let isLoading: Bool
+    private let action: ToastAction?
     private let onClose: (() -> Void)?
 
     public init(
         _ title: String,
         message: String? = nil,
         type: AlertToastType = .info,
+        systemImage: String? = nil,
+        isLoading: Bool = false,
+        action: ToastAction? = nil,
         onClose: (() -> Void)? = nil
     ) {
         self.title = title
         self.message = message
         self.type = type
+        self.systemImage = systemImage
+        self.isLoading = isLoading
+        self.action = action
         self.onClose = onClose
     }
 
     public var body: some View {
         HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
-            Icon(systemName: type.systemImage, size: .sm, color: type.foreground)
+            // Leading accessory: an activity spinner while loading, otherwise the
+            // status icon (a caller override falls back to the type's default).
+            if isLoading {
+                Spinner(size: IconSize.sm.value, lineWidth: 2, color: type.foreground)
+            } else {
+                Icon(systemName: systemImage ?? type.systemImage, size: .sm, color: type.foreground)
+            }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title).textStyle(.labelBase600)
@@ -68,6 +95,13 @@ public struct AlertToast: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let action {
+                Button(action: action.handler) {
+                    Text(action.title).textStyle(.labelBase700).underline()
+                }
+                .buttonStyle(.plain)
+            }
 
             if let onClose {
                 Button(action: onClose) {
@@ -89,6 +123,8 @@ public struct AlertToast: View {
         AlertToast("Check your input", message: "One field needs attention.", type: .warning)
         AlertToast("Something went wrong", type: .danger, onClose: {})
         AlertToast("New update available", type: .info)
+        AlertToast("Message deleted", type: .info, action: ToastAction("Undo") {}, onClose: {})
+        AlertToast("Uploading…", type: .info, isLoading: true)
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -50,16 +50,22 @@ public enum FeedbackKind: String, CaseIterable {
     }
 }
 
+/// Which edge the toast stack is anchored to.
+public enum ToastPosition { case top, bottom }
+
 /// Imperative presenter for app-global feedback. A single shared instance is
 /// injected via `.feedbackHost()`; call it from any descendant view.
 public final class FeedbackPresenter: ObservableObject {
 
-    public struct ToastItem: Identifiable, Equatable {
+    public struct ToastItem: Identifiable {
         public let id = UUID()
         let title: String
         let message: String?
         let kind: FeedbackKind
-        let duration: Double
+        let systemImage: String?
+        let isLoading: Bool
+        let action: ToastAction?
+        let duration: Double?
     }
 
     public struct ConfirmRequest: Identifiable {
@@ -81,16 +87,66 @@ public final class FeedbackPresenter: ObservableObject {
         let duration: Double
     }
 
-    @Published var activeToast: ToastItem?
+    /// Stacked toasts (newest last), capped at `maxVisibleToasts`.
+    @Published var toasts: [ToastItem] = []
     @Published var activeConfirm: ConfirmRequest?
     @Published var activeNotification: NotificationItem?
     @Published var activeLoading: String?
 
-    public init() {}
+    private let maxVisibleToasts: Int
 
-    /// Show a transient toast (auto-dismisses). Replaces any visible toast.
-    public func toast(_ title: String, message: String? = nil, kind: FeedbackKind = .success, duration: Double = 2.5) {
-        activeToast = ToastItem(title: title, message: message, kind: kind, duration: duration)
+    public init(maxVisibleToasts: Int = 3) {
+        self.maxVisibleToasts = max(1, maxVisibleToasts)
+    }
+
+    /// Show a transient toast. Multiple toasts stack (the oldest drops past the
+    /// visible cap). Pass `duration: nil` for a sticky toast — e.g. one with an
+    /// `action` the user must reach (Undo). Returns the id for manual dismissal.
+    @discardableResult
+    public func toast(
+        _ title: String,
+        message: String? = nil,
+        kind: FeedbackKind = .success,
+        systemImage: String? = nil,
+        action: ToastAction? = nil,
+        duration: Double? = 2.5
+    ) -> UUID {
+        enqueue(ToastItem(title: title, message: message, kind: kind,
+                          systemImage: systemImage, isLoading: false, action: action, duration: duration))
+    }
+
+    /// Present a loading toast (spinner), run async work, then morph the *same*
+    /// toast into a success or failure result. Mirrors imperative toast task APIs.
+    @MainActor
+    public func toastTask(
+        loading loadingTitle: String,
+        success successTitle: String,
+        failure: @escaping (Error) -> String = { _ in String(themeKit: "Something went wrong") },
+        duration: Double? = 2.5,
+        perform operation: @escaping () async throws -> Void
+    ) async {
+        let id = enqueue(ToastItem(title: loadingTitle, message: nil, kind: .info,
+                                   systemImage: nil, isLoading: true, action: nil, duration: nil))
+        do {
+            try await operation()
+            replaceToast(id, with: ToastItem(title: successTitle, message: nil, kind: .success,
+                                             systemImage: nil, isLoading: false, action: nil, duration: duration))
+        } catch {
+            replaceToast(id, with: ToastItem(title: failure(error), message: nil, kind: .error,
+                                             systemImage: nil, isLoading: false, action: nil, duration: duration))
+        }
+    }
+
+    @discardableResult
+    private func enqueue(_ item: ToastItem) -> UUID {
+        toasts.append(item)
+        if toasts.count > maxVisibleToasts { toasts.removeFirst(toasts.count - maxVisibleToasts) }
+        return item.id
+    }
+
+    private func replaceToast(_ id: UUID, with item: ToastItem) {
+        if let i = toasts.firstIndex(where: { $0.id == id }) { toasts[i] = item }
+        else { _ = enqueue(item) }
     }
 
     /// Present a modal confirmation dialog with a primary (and optional secondary) action.
@@ -118,7 +174,8 @@ public final class FeedbackPresenter: ObservableObject {
     /// call `dismissLoading()` when the work completes (Ant `message.loading`).
     public func loading(_ title: String = String(themeKit: "Loading…")) { activeLoading = title }
 
-    public func dismissToast() { activeToast = nil }
+    public func dismissToast(_ id: UUID) { toasts.removeAll { $0.id == id } }
+    public func dismissAllToasts() { toasts.removeAll() }
     public func dismissConfirm() { activeConfirm = nil }
     public func dismissNotification() { activeNotification = nil }
     public func dismissLoading() { activeLoading = nil }
@@ -127,16 +184,22 @@ public final class FeedbackPresenter: ObservableObject {
 // MARK: - Host
 
 private struct FeedbackHostModifier: ViewModifier {
-    @StateObject private var presenter = FeedbackPresenter()
+    @StateObject private var presenter: FeedbackPresenter
+    private let toastEdge: Edge
+
+    init(maxVisibleToasts: Int, toastPosition: ToastPosition) {
+        _presenter = StateObject(wrappedValue: FeedbackPresenter(maxVisibleToasts: maxVisibleToasts))
+        toastEdge = toastPosition == .top ? .top : .bottom
+    }
 
     func body(content: Content) -> some View {
         content
             .environmentObject(presenter)
             .overlay(alignment: .top) { notificationLayer }
-            .overlay(alignment: .bottom) { toastLayer }
+            .overlay(alignment: toastEdge == .top ? .top : .bottom) { toastLayer }
             .overlay { confirmLayer }
             .overlay { loadingLayer }
-            .animation(Motion.base.animation, value: presenter.activeToast)
+            .animation(Motion.base.spring, value: presenter.toasts.map(\.id))
             .animation(Motion.base.animation, value: presenter.activeConfirm?.id)
             .animation(Motion.base.animation, value: presenter.activeNotification?.id)
             .animation(Motion.fast.animation, value: presenter.activeLoading)
@@ -188,18 +251,16 @@ private struct FeedbackHostModifier: ViewModifier {
         }
     }
 
-    @ViewBuilder
     private var toastLayer: some View {
-        if let toast = presenter.activeToast {
-            AlertToast(toast.title, message: toast.message, type: toast.kind.toastType,
-                       onClose: { presenter.dismissToast() })
-                .padding(Theme.SpacingKey.md.value)
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-                .task(id: toast.id) {
-                    try? await Task.sleep(nanoseconds: UInt64(toast.duration * 1_000_000_000))
-                    if presenter.activeToast?.id == toast.id { presenter.dismissToast() }
-                }
+        // Newest nearest the anchored edge: bottom keeps array order, top reverses.
+        let ordered = toastEdge == .top ? Array(presenter.toasts.reversed()) : presenter.toasts
+        return VStack(spacing: Theme.SpacingKey.sm.value) {
+            ForEach(ordered) { item in
+                FeedbackToastRow(item: item, edge: toastEdge) { presenter.dismissToast(item.id) }
+            }
         }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(Theme.SpacingKey.md.value)
     }
 
     @ViewBuilder
@@ -225,10 +286,88 @@ private struct FeedbackHostModifier: ViewModifier {
     }
 }
 
+/// One stacked toast row: a solid AlertToast with elevation, auto-dismiss, and a
+/// drag-toward-the-edge swipe-to-dismiss gesture.
+private struct FeedbackToastRow: View {
+    let item: FeedbackPresenter.ToastItem
+    let edge: Edge
+    let onDismiss: () -> Void
+
+    @State private var offset: CGFloat = 0
+
+    var body: some View {
+        AlertToast(item.title, message: item.message, type: item.kind.toastType,
+                   systemImage: item.systemImage, isLoading: item.isLoading,
+                   action: item.action, onClose: onDismiss)
+            .themeShadow(.elevated)
+            .offset(y: offset)
+            .opacity(dragOpacity)
+            .gesture(swipe)
+            .transition(.move(edge: edge).combined(with: .opacity))
+            .task(id: item.id) {
+                guard let duration = item.duration else { return }   // nil = sticky
+                try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+                onDismiss()
+            }
+    }
+
+    /// Fade the row out as it is dragged toward its anchored edge.
+    private var dragOpacity: Double {
+        let towardEdge = (edge == .bottom && offset > 0) || (edge == .top && offset < 0)
+        guard towardEdge else { return 1 }
+        return max(0, 1 - Double(abs(offset)) / 120)
+    }
+
+    private var swipe: some Gesture {
+        DragGesture(minimumDistance: 8)
+            .onChanged { value in
+                let dy = value.translation.height
+                if (edge == .bottom && dy > 0) || (edge == .top && dy < 0) { offset = dy }
+            }
+            .onEnded { _ in
+                if abs(offset) > 60 {
+                    onDismiss()
+                } else {
+                    withAnimation(Motion.fast.animation) { offset = 0 }
+                }
+            }
+    }
+}
+
 public extension View {
     /// Installs the shared `FeedbackPresenter` and its toast/confirm overlays.
     /// Apply once near the app root, above any view that calls `feedback`.
-    func feedbackHost() -> some View {
-        modifier(FeedbackHostModifier())
+    ///
+    /// - Parameters:
+    ///   - maxVisibleToasts: how many stacked toasts stay on screen (oldest drops).
+    ///   - toastPosition: which edge the toast stack anchors to (default `.bottom`).
+    func feedbackHost(maxVisibleToasts: Int = 3, toastPosition: ToastPosition = .bottom) -> some View {
+        modifier(FeedbackHostModifier(maxVisibleToasts: maxVisibleToasts, toastPosition: toastPosition))
     }
+}
+
+#Preview("Toasts: stack / action / task") {
+    struct Demo: View {
+        @EnvironmentObject private var feedback: FeedbackPresenter
+        var body: some View {
+            VStack(spacing: 12) {
+                ThemeButton("Stack ×3") {
+                    for i in 1 ... 3 { feedback.toast("Toast #\(i)", kind: .success) }
+                }
+                ThemeButton("Undo (sticky + action)", variant: .outline) {
+                    feedback.toast("Message deleted", kind: .info,
+                                   action: ToastAction("Undo") {}, duration: nil)
+                }
+                ThemeButton("Async task", variant: .outline) {
+                    Task {
+                        await feedback.toastTask(loading: "Saving…", success: "Saved") {
+                            try await Task.sleep(nanoseconds: 600_000_000)
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+    }
+    return Demo().feedbackHost(toastPosition: .bottom)
 }

--- a/Tests/ThemeKitTests/FeedbackPresenterTests.swift
+++ b/Tests/ThemeKitTests/FeedbackPresenterTests.swift
@@ -1,0 +1,72 @@
+//
+//  FeedbackPresenterTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Pure-logic coverage for the stacked toast model on FeedbackPresenter
+//  (stacking, visible cap, dismissal, sticky toasts, and the async task morph).
+//
+
+import XCTest
+@testable import ThemeKit
+
+@MainActor
+final class FeedbackPresenterTests: XCTestCase {
+
+    func testToastsStackInOrder() {
+        let p = FeedbackPresenter()
+        p.toast("a")
+        p.toast("b")
+        XCTAssertEqual(p.toasts.map(\.title), ["a", "b"])
+    }
+
+    func testStackCapDropsOldest() {
+        let p = FeedbackPresenter(maxVisibleToasts: 2)
+        p.toast("a")
+        p.toast("b")
+        p.toast("c")
+        XCTAssertEqual(p.toasts.map(\.title), ["b", "c"])
+    }
+
+    func testDismissByID() {
+        let p = FeedbackPresenter()
+        let id = p.toast("a")
+        p.toast("b")
+        p.dismissToast(id)
+        XCTAssertEqual(p.toasts.map(\.title), ["b"])
+    }
+
+    func testDismissAllToasts() {
+        let p = FeedbackPresenter()
+        p.toast("a")
+        p.toast("b")
+        p.dismissAllToasts()
+        XCTAssertTrue(p.toasts.isEmpty)
+    }
+
+    func testStickyToastWithActionHasNoDuration() {
+        let p = FeedbackPresenter()
+        p.toast("Deleted", kind: .info, action: ToastAction("Undo") {}, duration: nil)
+        XCTAssertNil(p.toasts.first?.duration)
+        XCTAssertNotNil(p.toasts.first?.action)
+    }
+
+    func testToastTaskSuccessMorphsInPlace() async {
+        let p = FeedbackPresenter()
+        await p.toastTask(loading: "Saving…", success: "Saved") { /* immediate success */ }
+        XCTAssertEqual(p.toasts.count, 1)
+        XCTAssertEqual(p.toasts.first?.title, "Saved")
+        XCTAssertEqual(p.toasts.first?.kind, .success)
+        XCTAssertEqual(p.toasts.first?.isLoading, false)
+    }
+
+    func testToastTaskFailureMorphsToError() async {
+        struct Boom: Error {}
+        let p = FeedbackPresenter()
+        await p.toastTask(loading: "Saving…", success: "Saved", failure: { _ in "Failed" }) {
+            throw Boom()
+        }
+        XCTAssertEqual(p.toasts.first?.title, "Failed")
+        XCTAssertEqual(p.toasts.first?.kind, .error)
+    }
+}


### PR DESCRIPTION
Extends the toast system, drawing inspiration from [sunghyun-k/swiftui-toasts](https://github.com/sunghyun-k/swiftui-toasts) — **without** introducing a parallel API. The existing `.feedbackHost()` / `feedback.toast()` stays the single entry point, and every current call site keeps compiling.

## Inspiration → what landed

| Reference feature | ThemeKit addition |
|---|---|
| Multiple toasts | **Stacking** with a visible cap (`maxVisibleToasts`, oldest drops) |
| `ToastButton` (Undo) | Inline **`ToastAction`** in `AlertToast` + `feedback.toast` |
| Slide-to-dismiss | **Swipe-to-dismiss** (drag toward the anchored edge, opacity fade) |
| `presentToast(task:onSuccess:onFailure:)` | **`toastTask(loading:success:failure:perform:)`** — loading toast morphs in-place into success/failure |
| `.installToast(position:)` | `.feedbackHost(toastPosition: .top/.bottom)` |
| Custom `Image` icon | `systemImage` override + `Spinner` while loading |

## API

```swift
.feedbackHost(maxVisibleToasts: 3, toastPosition: .bottom)   // install once at root

feedback.toast("Saved", kind: .success)                       // stacks
let id = feedback.toast("Deleted", kind: .info,
                        action: ToastAction("Undo") { restore() },
                        duration: nil)                         // sticky (no auto-dismiss)
feedback.dismissToast(id)

await feedback.toastTask(loading: "Saving…", success: "Saved") {
    try await save()                                           // -> auto success/failure
}
```

## Changes
- **AlertToast** (additive, backward-compatible): optional `action`, `isLoading` (Spinner), `systemImage` override.
- **FeedbackPresenter**: `activeToast?` → `toasts: [ToastItem]` stack; `toast(...)` returns an id and gains `action:` / `systemImage:` / `duration: nil`; new `toastTask(...)`; `dismissToast(id)` / `dismissAllToasts()`.
- **Host**: `.feedbackHost(maxVisibleToasts:toastPosition:)`; per-row elevation, spring stack animation, drag-to-dismiss, per-toast auto-dismiss (sticky when `duration == nil`).
- **Demo** gallery: Stack / Undo / Async-task buttons + updated usage hint.

## Verification
- `swift build` green (core + Lottie)
- **65 tests pass** (58 existing + 7 new covering stacking, cap, dismissal, sticky, task-morph)
- Xcode Demo not built here, but the exact API the Demo uses is compile-checked via a library `#Preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)