### PR TITLE
feat: extend BottomSheet, DataTable, Autocomplete & Upload

### DIFF
--- a/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
+++ b/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
@@ -3,16 +3,26 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A typeahead text field with a filtered suggestion list. State owned
-//  by the caller (the bound text); suggestions are filtered as the user types.
+//  Molecule. A typeahead text field with a suggestion list. Two sources:
+//    • a static `[String]` filtered locally as the user types, or
+//    • an async `suggest` provider (remote search) with debounce, a loading
+//      spinner, an empty "no results" state, and in-flight cancellation.
+//  State (the bound text) is owned by the caller.
 //
 
 import SwiftUI
 
 public struct Autocomplete: View {
+
+    /// Where suggestions come from.
+    private enum Source {
+        case staticList([String])
+        case asyncProvider((String) async -> [String])
+    }
+
     private let label: String?
     @Binding private var text: String
-    private let suggestions: [String]
+    private let source: Source
     private let placeholder: String
     private let maxResults: Int
     private let debounce: TimeInterval
@@ -22,7 +32,11 @@ public struct Autocomplete: View {
     private let onSearch: ((String) -> Void)?
 
     @FocusState private var isFocused: Bool
+    @State private var results: [String] = []
+    @State private var isLoading = false
+    @State private var searchTask: Task<Void, Never>?
 
+    /// Local filtering over a static list.
     public init(
         label: String? = nil,
         text: Binding<String>,
@@ -37,7 +51,7 @@ public struct Autocomplete: View {
     ) {
         self.label = label
         self._text = text
-        self.suggestions = suggestions
+        self.source = .staticList(suggestions)
         self.placeholder = placeholder
         self.maxResults = maxResults
         self.debounce = debounce
@@ -47,10 +61,43 @@ public struct Autocomplete: View {
         self.onSearch = onSearch
     }
 
-    private var filtered: [String] {
-        guard !text.isEmpty else { return [] }
-        return suggestions.filter { $0.localizedCaseInsensitiveContains(text) }.prefix(maxResults).map { $0 }
+    /// Async suggestions from a provider (e.g. a remote search). Debounced, with a
+    /// loading spinner and an empty state; the previous request is cancelled when
+    /// the query changes.
+    public init(
+        label: String? = nil,
+        text: Binding<String>,
+        suggest: @escaping (String) async -> [String],
+        placeholder: String = "Ara",
+        maxResults: Int = 5,
+        debounce: TimeInterval = 0.3,
+        accessibilityID: String? = nil,
+        isEnabled: Bool = true,
+        onSelect: @escaping (String) -> Void = { _ in }
+    ) {
+        self.label = label
+        self._text = text
+        self.source = .asyncProvider(suggest)
+        self.placeholder = placeholder
+        self.maxResults = maxResults
+        self.debounce = debounce
+        self.accessibilityID = accessibilityID
+        self.isEnabled = isEnabled
+        self.onSelect = onSelect
+        self.onSearch = nil
     }
+
+    /// Pure matcher for the static source (extracted for testing).
+    static func staticMatches(_ query: String, in all: [String], max: Int) -> [String] {
+        guard !query.isEmpty else { return [] }
+        return all.filter { $0.localizedCaseInsensitiveContains(query) }.prefix(max).map { $0 }
+    }
+
+    private var showsDropdown: Bool {
+        isFocused && !text.isEmpty && (isLoading || !results.isEmpty || isEmptyResult)
+    }
+
+    private var isEmptyResult: Bool { !isLoading && results.isEmpty }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
@@ -66,7 +113,9 @@ public struct Autocomplete: View {
                     .disabled(!isEnabled)
                     .a11y(A11yElement.Field.field, in: accessibilityID)
                     .accessibilityLabel(label ?? placeholder)
-                if !text.isEmpty {
+                if isLoading {
+                    Spinner(size: IconSize.sm.value, lineWidth: 2)
+                } else if !text.isEmpty {
                     Button { text = "" } label: {
                         Icon(systemName: "xmark.circle.fill", size: .sm, color: Theme.shared.text(.textTertiary))
                     }
@@ -81,47 +130,105 @@ public struct Autocomplete: View {
                     .strokeBorder(isFocused ? Theme.shared.border(.borderHero) : Theme.shared.border(.borderPrimary), lineWidth: isFocused ? 1.5 : 1)
             )
 
-            if isFocused && !filtered.isEmpty {
-                VStack(spacing: 0) {
-                    ForEach(filtered, id: \.self) { suggestion in
-                        Button {
-                            text = suggestion
-                            onSelect(suggestion)
-                            isFocused = false
-                        } label: {
-                            HStack {
-                                Text(suggestion).textStyle(.bodyBase400).foregroundStyle(Theme.shared.text(.textPrimary))
-                                Spacer()
-                            }
-                            .padding(.horizontal, Theme.SpacingKey.md.value)
-                            .padding(.vertical, Theme.SpacingKey.sm.value)
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        if suggestion != filtered.last { DividerView(size: .small).padding(.leading, Theme.SpacingKey.md.value) }
+            if showsDropdown { dropdown }
+        }
+        .onAppear { update(for: text) }
+        .onDebouncedChange(of: text, for: debounce) { value in
+            update(for: value)
+            onSearch?(value)
+        }
+    }
+
+    @ViewBuilder
+    private var dropdown: some View {
+        VStack(spacing: 0) {
+            if isLoading {
+                row { HStack(spacing: Theme.SpacingKey.sm.value) {
+                    Spinner(size: IconSize.sm.value, lineWidth: 2)
+                    Text(String(themeKit: "Searching…")).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary))
+                    Spacer()
+                } }
+            } else if results.isEmpty {
+                row { Text(String(themeKit: "No results")).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary)) }
+            } else {
+                ForEach(results, id: \.self) { suggestion in
+                    Button {
+                        text = suggestion
+                        results = []
+                        onSelect(suggestion)
+                        isFocused = false
+                    } label: {
+                        row { HStack {
+                            Text(suggestion).textStyle(.bodyBase400).foregroundStyle(Theme.shared.text(.textPrimary))
+                            Spacer()
+                        } }
                     }
+                    .buttonStyle(.plain)
+                    if suggestion != results.last { DividerView(size: .small).padding(.leading, Theme.SpacingKey.md.value) }
                 }
-                .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                        .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1)
-                )
-                .themeShadow(.soft)
             }
         }
-        .onDebouncedChange(of: text, for: onSearch == nil ? 0 : debounce) { value in
-            onSearch?(value)
+        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
+                .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1)
+        )
+        .themeShadow(.soft)
+    }
+
+    private func row<V: View>(@ViewBuilder _ content: () -> V) -> some View {
+        content()
+            .padding(.horizontal, Theme.SpacingKey.md.value)
+            .padding(.vertical, Theme.SpacingKey.sm.value)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+    }
+
+    private func update(for query: String) {
+        searchTask?.cancel()
+        guard !query.isEmpty else {
+            results = []
+            isLoading = false
+            return
+        }
+        switch source {
+        case .staticList(let all):
+            results = Self.staticMatches(query, in: all, max: maxResults)
+            isLoading = false
+        case .asyncProvider(let provider):
+            isLoading = true
+            searchTask = Task { @MainActor in
+                let found = await provider(query)
+                if Task.isCancelled { return }
+                results = Array(found.prefix(maxResults))
+                isLoading = false
+            }
         }
     }
 }
 
-#Preview {
+#Preview("Static") {
     struct Demo: View {
         @State var text = ""
         var body: some View {
             Autocomplete(label: "Destination", text: $text,
                          suggestions: ["İstanbul", "İzmir", "İzmit", "Ankara", "Antalya", "Bursa"])
                 .padding()
+        }
+    }
+    return Demo()
+}
+
+#Preview("Async") {
+    struct Demo: View {
+        @State var text = ""
+        let cities = ["İstanbul", "İzmir", "İzmit", "Ankara", "Antalya", "Bursa"]
+        var body: some View {
+            Autocomplete(label: "Destination", text: $text, suggest: { query in
+                try? await Task.sleep(nanoseconds: 400_000_000)   // simulate network
+                return cities.filter { $0.localizedCaseInsensitiveContains(query) }
+            })
+            .padding()
         }
     }
     return Demo()

--- a/Sources/ThemeKit/Components/Organisms/BottomSheet.swift
+++ b/Sources/ThemeKit/Components/Organisms/BottomSheet.swift
@@ -4,45 +4,129 @@
 //  Created by İsa Mercan on 23.06.2026.
 //
 //  Organism. Presents content in a bottom sheet with detents + drag indicator
-//  (native sheet under the hood). Detent modifiers are iOS-only.
+//  (native sheet under the hood). Two entry points:
+//    • `.bottomSheet(isPresented:detents:)` — declarative, binding-driven.
+//    • `.sheetHost()` + `@EnvironmentObject SheetPresenter` — imperative; present
+//      a sheet from anywhere without owning a binding.
+//  Detent modifiers are iOS-only; the content still presents on macOS.
 //
 
 import SwiftUI
 
+/// A sheet snap point. Maps to the native `PresentationDetent`, plus absolute
+/// `height` and screen-`fraction` detents for fully custom sheets.
+public enum BottomSheetDetent: Hashable {
+    case medium
+    case large
+    case height(CGFloat)
+    case fraction(Double)
+
+    var presentationDetent: PresentationDetent {
+        switch self {
+        case .medium: return .medium
+        case .large: return .large
+        case .height(let h): return .height(h)
+        case .fraction(let f): return .fraction(f)
+        }
+    }
+}
+
 public extension View {
+    /// Declarative bottom sheet. Pass custom `detents` (default medium + large)
+    /// and toggle the drag indicator.
     func bottomSheet<SheetContent: View>(
         isPresented: Binding<Bool>,
+        detents: [BottomSheetDetent] = [.medium, .large],
+        showsDragIndicator: Bool = true,
         @ViewBuilder content: @escaping () -> SheetContent
     ) -> some View {
         sheet(isPresented: isPresented) {
             content()
                 .padding(Theme.SpacingKey.md.value)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .sheetDetents()
+                .sheetDetents(detents, dragIndicator: showsDragIndicator)
         }
+    }
+}
+
+// MARK: - Imperative presenter
+
+/// Imperative bottom-sheet presenter. Install once with `.sheetHost()`, then from
+/// any descendant view:
+///
+///     @EnvironmentObject var sheet: SheetPresenter
+///     sheet.present(detents: [.height(280), .large]) { FilterView() }
+///     sheet.dismiss()
+public final class SheetPresenter: ObservableObject {
+
+    struct Request: Identifiable {
+        let id = UUID()
+        let detents: [BottomSheetDetent]
+        let showsDragIndicator: Bool
+        let content: AnyView
+    }
+
+    @Published var current: Request?
+
+    public init() {}
+
+    /// Present a sheet. Replaces any visible sheet.
+    public func present<C: View>(
+        detents: [BottomSheetDetent] = [.medium, .large],
+        showsDragIndicator: Bool = true,
+        @ViewBuilder _ content: () -> C
+    ) {
+        current = Request(detents: detents, showsDragIndicator: showsDragIndicator, content: AnyView(content()))
+    }
+
+    public func dismiss() { current = nil }
+
+    public var isPresented: Bool { current != nil }
+}
+
+private struct SheetHostModifier: ViewModifier {
+    @StateObject private var presenter = SheetPresenter()
+
+    func body(content: Content) -> some View {
+        content
+            .environmentObject(presenter)
+            .sheet(item: $presenter.current) { request in
+                request.content
+                    .padding(Theme.SpacingKey.md.value)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .sheetDetents(request.detents, dragIndicator: request.showsDragIndicator)
+            }
+    }
+}
+
+public extension View {
+    /// Installs the shared `SheetPresenter`. Apply once near the app root, above
+    /// any view that calls `sheet.present(…)`.
+    func sheetHost() -> some View {
+        modifier(SheetHostModifier())
     }
 }
 
 private extension View {
     @ViewBuilder
-    func sheetDetents() -> some View {
+    func sheetDetents(_ detents: [BottomSheetDetent], dragIndicator: Bool) -> some View {
         #if os(iOS)
         self
-            .presentationDetents([.medium, .large])
-            .presentationDragIndicator(.visible)
+            .presentationDetents(Set(detents.map(\.presentationDetent)))
+            .presentationDragIndicator(dragIndicator ? .visible : .hidden)
         #else
         self
         #endif
     }
 }
 
-#Preview {
+#Preview("Declarative") {
     struct Demo: View {
         @State var show = false
         var body: some View {
             PrimaryButton("Open sheet") { show = true }
                 .padding()
-                .bottomSheet(isPresented: $show) {
+                .bottomSheet(isPresented: $show, detents: [.height(260), .large]) {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("Filters").textStyle(.headingSm)
                         Text("Sheet content goes here.").textStyle(.bodyBase400)
@@ -51,4 +135,19 @@ private extension View {
         }
     }
     return Demo()
+}
+
+#Preview("Imperative host") {
+    struct Demo: View {
+        @EnvironmentObject var sheet: SheetPresenter
+        var body: some View {
+            PrimaryButton("Present") {
+                sheet.present(detents: [.medium, .large]) {
+                    Text("Imperative sheet").textStyle(.headingSm)
+                }
+            }
+            .padding()
+        }
+    }
+    return Demo().sheetHost()
 }

--- a/Sources/ThemeKit/Components/Organisms/DataTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/DataTable.swift
@@ -4,6 +4,7 @@
 //  Created by İsa Mercan on 23.06.2026.
 //
 //  Organism. A multi-column data table with a header and optional zebra striping.
+//  Supports tap-to-sort columns, row selection, and fully custom cell views.
 //  (daisyUI "Table"; complements the label/value KeyValueTable.)
 //
 
@@ -16,46 +17,110 @@ public enum ColumnAlign {
     }
 }
 
+/// Type-erased, comparable sort value for a sortable column. `string` uses a
+/// natural (numeric-aware) ordering so "item2" sorts before "item10".
+public enum TableSortKey: Comparable {
+    case number(Double)
+    case string(String)
+    case date(Date)
+
+    public static func < (lhs: TableSortKey, rhs: TableSortKey) -> Bool {
+        switch (lhs, rhs) {
+        case let (.number(a), .number(b)): return a < b
+        case let (.string(a), .string(b)): return a.localizedStandardCompare(b) == .orderedAscending
+        case let (.date(a), .date(b)): return a < b
+        default: return false   // mixed kinds: undefined ordering, keep stable
+        }
+    }
+}
+
 public struct DataTable<Row: Identifiable>: View {
     public struct Column {
         let title: String
         let align: ColumnAlign
-        let value: (Row) -> String
-        public init(_ title: String, align: ColumnAlign = .leading, value: @escaping (Row) -> String) {
+        let sortKey: ((Row) -> TableSortKey)?
+        let content: (Row) -> AnyView
+
+        /// Custom-view cell. Pass `sortKey` to make the column tap-to-sort.
+        public init<V: View>(
+            _ title: String,
+            align: ColumnAlign = .leading,
+            sortKey: ((Row) -> TableSortKey)? = nil,
+            @ViewBuilder content: @escaping (Row) -> V
+        ) {
             self.title = title
             self.align = align
-            self.value = value
+            self.sortKey = sortKey
+            self.content = { AnyView(content($0)) }
+        }
+
+        /// Plain-text cell convenience.
+        public init(
+            _ title: String,
+            align: ColumnAlign = .leading,
+            sortKey: ((Row) -> TableSortKey)? = nil,
+            value: @escaping (Row) -> String
+        ) {
+            self.init(title, align: align, sortKey: sortKey) { row in
+                Text(value(row))
+                    .textStyle(.bodyBase400)
+                    .foregroundStyle(Theme.shared.text(.textPrimary))
+            }
         }
     }
 
     private let columns: [Column]
     private let rows: [Row]
     private let striped: Bool
+    private let selection: Binding<Set<Row.ID>>?
+    private let onRowTap: ((Row) -> Void)?
 
-    public init(columns: [Column], rows: [Row], striped: Bool = true) {
+    @State private var sortColumn: Int?
+    @State private var sortAscending = true
+
+    public init(
+        columns: [Column],
+        rows: [Row],
+        striped: Bool = true,
+        selection: Binding<Set<Row.ID>>? = nil,
+        onRowTap: ((Row) -> Void)? = nil
+    ) {
         self.columns = columns
         self.rows = rows
         self.striped = striped
+        self.selection = selection
+        self.onRowTap = onRowTap
     }
+
+    private var displayRows: [Row] {
+        guard let c = sortColumn, columns.indices.contains(c), let key = columns[c].sortKey else { return rows }
+        let sorted = rows.sorted { key($0) < key($1) }
+        return sortAscending ? sorted : sorted.reversed()
+    }
+
+    private var isInteractive: Bool { selection != nil || onRowTap != nil }
 
     public var body: some View {
         VStack(spacing: 0) {
             headerRow
-            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
-                dataRow(row, index: index)
+            if displayRows.isEmpty {
+                emptyRow
+            } else {
+                ForEach(Array(displayRows.enumerated()), id: \.element.id) { index, row in
+                    dataRow(row, index: index)
+                }
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).stroke(Theme.shared.border(.borderPrimary), lineWidth: 1))
     }
 
+    // MARK: - Header
+
     private var headerRow: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
-            ForEach(Array(columns.enumerated()), id: \.offset) { _, column in
-                Text(column.title)
-                    .textStyle(.labelSm700)
-                    .foregroundStyle(Theme.shared.text(.textSecondary))
-                    .frame(maxWidth: .infinity, alignment: column.align.alignment)
+            ForEach(Array(columns.enumerated()), id: \.offset) { index, column in
+                headerCell(column, index: index)
             }
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
@@ -63,32 +128,98 @@ public struct DataTable<Row: Identifiable>: View {
         .background(Theme.shared.background(.bgElevatorPrimary))
     }
 
+    @ViewBuilder
+    private func headerCell(_ column: Column, index: Int) -> some View {
+        let title = HStack(spacing: 4) {
+            Text(column.title)
+                .textStyle(.labelSm700)
+                .foregroundStyle(Theme.shared.text(.textSecondary))
+            if column.sortKey != nil {
+                Icon(systemName: sortColumn == index ? (sortAscending ? "chevron.up" : "chevron.down") : "chevron.up.chevron.down",
+                     size: .xs,
+                     color: sortColumn == index ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textTertiary))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: column.align.alignment)
+
+        if column.sortKey != nil {
+            Button { toggleSort(index) } label: { title }
+                .buttonStyle(.plain)
+        } else {
+            title
+        }
+    }
+
+    private func toggleSort(_ index: Int) {
+        if sortColumn == index { sortAscending.toggle() }
+        else { sortColumn = index; sortAscending = true }
+    }
+
+    // MARK: - Rows
+
+    @ViewBuilder
     private func dataRow(_ row: Row, index: Int) -> some View {
-        HStack(spacing: Theme.SpacingKey.sm.value) {
+        let isSelected = selection?.wrappedValue.contains(row.id) ?? false
+        let base = HStack(spacing: Theme.SpacingKey.sm.value) {
             ForEach(Array(columns.enumerated()), id: \.offset) { _, column in
-                Text(column.value(row))
-                    .textStyle(.bodyBase400)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                column.content(row)
                     .frame(maxWidth: .infinity, alignment: column.align.alignment)
             }
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
         .padding(.vertical, Theme.SpacingKey.sm.value)
-        .background(striped && index % 2 == 1 ? Theme.shared.background(.bgElevatorPrimary).opacity(0.5) : Theme.shared.background(.bgWhite))
+        .background(rowBackground(index: index, isSelected: isSelected))
+
+        if isInteractive {
+            base.contentShape(Rectangle()).onTapGesture { handleTap(row) }
+        } else {
+            base
+        }
+    }
+
+    private func rowBackground(index: Int, isSelected: Bool) -> Color {
+        if isSelected { return Theme.shared.background(.systemcolorsBgInfoLight) }
+        if striped && index % 2 == 1 { return Theme.shared.background(.bgElevatorPrimary).opacity(0.5) }
+        return Theme.shared.background(.bgWhite)
+    }
+
+    private func handleTap(_ row: Row) {
+        if let selection {
+            if selection.wrappedValue.contains(row.id) { selection.wrappedValue.remove(row.id) }
+            else { selection.wrappedValue.insert(row.id) }
+        }
+        onRowTap?(row)
+    }
+
+    private var emptyRow: some View {
+        Text(String(themeKit: "No data"))
+            .textStyle(.bodyBase400)
+            .foregroundStyle(Theme.shared.text(.textTertiary))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Theme.SpacingKey.lg.value)
+            .background(Theme.shared.background(.bgWhite))
     }
 }
 
 #Preview {
-    struct Booking: Identifiable { let id = UUID(); let hotel: String; let nights: Int; let price: String }
-    let rows = [
-        Booking(hotel: "Grand Hotel", nights: 3, price: "₺4.250"),
-        Booking(hotel: "Sea Resort", nights: 5, price: "₺7.800"),
-        Booking(hotel: "City Inn", nights: 2, price: "₺1.900"),
-    ]
-    return DataTable(columns: [
-        .init("Hotel") { $0.hotel },
-        .init("Nights", align: .center) { "\($0.nights)" },
-        .init("Price", align: .trailing) { $0.price },
-    ], rows: rows)
-    .padding()
+    struct Booking: Identifiable { let id = UUID(); let hotel: String; let nights: Int; let price: Double }
+    struct Demo: View {
+        @State private var selected: Set<UUID> = []
+        let rows = [
+            Booking(hotel: "Grand Hotel", nights: 3, price: 4250),
+            Booking(hotel: "Sea Resort", nights: 5, price: 7800),
+            Booking(hotel: "City Inn", nights: 2, price: 1900),
+        ]
+        var body: some View {
+            DataTable(columns: [
+                .init("Hotel", sortKey: { .string($0.hotel) }) { $0.hotel },
+                .init("Nights", align: .center, sortKey: { .number(Double($0.nights)) }) { "\($0.nights)" },
+                .init("Price", align: .trailing, sortKey: { .number($0.price) }) { row in
+                    Text("₺\(Int(row.price))").textStyle(.labelSm700)
+                },
+            ], rows: rows, selection: $selected)
+            .padding()
+        }
+    }
+    return Demo()
 }

--- a/Sources/ThemeKit/Components/Organisms/Upload.swift
+++ b/Sources/ThemeKit/Components/Organisms/Upload.swift
@@ -32,19 +32,22 @@ public struct Upload: View {
     private let files: [UploadFile]
     private let onPick: () -> Void
     private let onRemove: (UploadFile) -> Void
+    private let onRetry: ((UploadFile) -> Void)?
 
     public init(
         prompt: String = String(themeKit: "Add a photo from your device or take one with the camera."),
         buttonTitle: String = String(themeKit: "Upload Photo"),
         files: [UploadFile] = [],
         onPick: @escaping () -> Void = {},
-        onRemove: @escaping (UploadFile) -> Void = { _ in }
+        onRemove: @escaping (UploadFile) -> Void = { _ in },
+        onRetry: ((UploadFile) -> Void)? = nil
     ) {
         self.prompt = prompt
         self.buttonTitle = buttonTitle
         self.files = files
         self.onPick = onPick
         self.onRemove = onRemove
+        self.onRetry = onRetry
     }
 
     public var body: some View {
@@ -81,6 +84,14 @@ public struct Upload: View {
 
             Spacer(minLength: 0)
 
+            if let onRetry, case .failed = file.status {
+                Button { onRetry(file) } label: {
+                    Icon(systemName: "arrow.clockwise", size: .sm, color: Theme.shared.foreground(.fgHero))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(themeKit: "Retry"))
+            }
+
             Button { onRemove(file) } label: {
                 Icon(systemName: "trash", size: .sm, color: Theme.shared.text(.textTertiary))
             }
@@ -107,11 +118,124 @@ public struct Upload: View {
     }
 }
 
-#Preview {
+// MARK: - Async controller
+
+/// Reports upload progress in `0...1`. Marshal to the main actor by the caller
+/// (`await progress(p)` from a background task).
+public typealias UploadProgress = @MainActor (Double) -> Void
+
+/// The async work that uploads one file, periodically reporting progress.
+public typealias UploadOperation = (@escaping UploadProgress) async throws -> Void
+
+/// Drives the upload lifecycle for a list of files: each `upload(...)` adds a file
+/// in `.uploading(0)`, runs the async operation (reporting progress), then settles
+/// to `.done` or `.failed`. Mirrors the toast `toastTask` pattern. Bind it to the
+/// UI with `UploadList(controller:)`.
+@MainActor
+public final class UploadController: ObservableObject {
+
+    @Published public private(set) var files: [UploadFile] = []
+    private var operations: [UUID: UploadOperation] = [:]
+
+    public init() {}
+
+    /// Add a file and run its upload to completion (`.done` / `.failed`).
+    @discardableResult
+    public func upload(name: String, _ operation: @escaping UploadOperation) async -> UUID {
+        let id = UUID()
+        files.append(UploadFile(id: id, name: name, status: .uploading(0)))
+        operations[id] = operation
+        await run(id)
+        return id
+    }
+
+    /// Re-run a previously-added file's upload (e.g. after a failure).
+    public func retry(_ id: UUID) async {
+        guard operations[id] != nil else { return }
+        setStatus(id, .uploading(0))
+        await run(id)
+    }
+
+    public func remove(_ id: UUID) {
+        files.removeAll { $0.id == id }
+        operations[id] = nil
+    }
+
+    private func run(_ id: UUID) async {
+        guard let operation = operations[id] else { return }
+        do {
+            try await operation { [weak self] progress in
+                self?.setStatus(id, .uploading(min(max(progress, 0), 1)))
+            }
+            setStatus(id, .done)
+        } catch {
+            let reason = (error as? LocalizedError)?.errorDescription ?? String(themeKit: "Upload failed")
+            setStatus(id, .failed(reason))
+        }
+    }
+
+    private func setStatus(_ id: UUID, _ status: UploadStatus) {
+        guard let i = files.firstIndex(where: { $0.id == id }) else { return }
+        files[i] = UploadFile(id: id, name: files[i].name, status: status)
+    }
+}
+
+/// `Upload` wired to an `UploadController` — renders its files with remove + retry.
+public struct UploadList: View {
+    @ObservedObject private var controller: UploadController
+    private let prompt: String
+    private let buttonTitle: String
+    private let onPick: () -> Void
+
+    public init(
+        controller: UploadController,
+        prompt: String = String(themeKit: "Add a photo from your device or take one with the camera."),
+        buttonTitle: String = String(themeKit: "Upload Photo"),
+        onPick: @escaping () -> Void = {}
+    ) {
+        self.controller = controller
+        self.prompt = prompt
+        self.buttonTitle = buttonTitle
+        self.onPick = onPick
+    }
+
+    public var body: some View {
+        Upload(
+            prompt: prompt,
+            buttonTitle: buttonTitle,
+            files: controller.files,
+            onPick: onPick,
+            onRemove: { controller.remove($0.id) },
+            onRetry: { file in Task { await controller.retry(file.id) } }
+        )
+    }
+}
+
+#Preview("Static") {
     Upload(files: [
         UploadFile(name: "room-1.jpg", status: .uploading(0.6)),
         UploadFile(name: "room-2.jpg", status: .done),
         UploadFile(name: "huge-file.jpg", status: .failed("Dosya çok büyük")),
-    ])
+    ], onRetry: { _ in })
     .padding()
+}
+
+#Preview("Controller") {
+    struct Demo: View {
+        @StateObject private var uploads = UploadController()
+        var body: some View {
+            UploadList(controller: uploads) {
+                Task {
+                    await uploads.upload(name: "photo.jpg") { progress in
+                        for step in 1 ... 5 {
+                            try? await Task.sleep(nanoseconds: 200_000_000)
+                            progress(Double(step) / 5)
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+    }
+    return Demo()
 }

--- a/Tests/ThemeKitTests/AutocompleteTests.swift
+++ b/Tests/ThemeKitTests/AutocompleteTests.swift
@@ -1,0 +1,33 @@
+//
+//  AutocompleteTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Coverage for Autocomplete's static matcher (case-insensitive, capped, empty).
+//
+
+import XCTest
+@testable import ThemeKit
+
+final class AutocompleteTests: XCTestCase {
+
+    private let fruits = ["Apple", "Apricot", "Banana", "Cherry", "Avocado"]
+
+    func testEmptyQueryReturnsNothing() {
+        XCTAssertTrue(Autocomplete.staticMatches("", in: fruits, max: 5).isEmpty)
+    }
+
+    func testCaseInsensitiveMatch() {
+        let matches = Autocomplete.staticMatches("AP", in: fruits, max: 5)
+        XCTAssertEqual(matches, ["Apple", "Apricot"])
+    }
+
+    func testRespectsMaxResults() {
+        // "a" matches Apple, Apricot, Banana, Avocado — capped at 2.
+        XCTAssertEqual(Autocomplete.staticMatches("a", in: fruits, max: 2).count, 2)
+    }
+
+    func testNoMatch() {
+        XCTAssertTrue(Autocomplete.staticMatches("zzz", in: fruits, max: 5).isEmpty)
+    }
+}

--- a/Tests/ThemeKitTests/SheetPresenterTests.swift
+++ b/Tests/ThemeKitTests/SheetPresenterTests.swift
@@ -1,0 +1,40 @@
+//
+//  SheetPresenterTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Logic coverage for the imperative bottom-sheet presenter.
+//
+
+import SwiftUI
+import XCTest
+@testable import ThemeKit
+
+@MainActor
+final class SheetPresenterTests: XCTestCase {
+
+    func testPresentSetsCurrentWithDetents() {
+        let sheet = SheetPresenter()
+        XCTAssertFalse(sheet.isPresented)
+        sheet.present(detents: [.height(200), .large]) { Text("x") }
+        XCTAssertTrue(sheet.isPresented)
+        XCTAssertEqual(sheet.current?.detents, [.height(200), .large])
+        XCTAssertEqual(sheet.current?.showsDragIndicator, true)
+    }
+
+    func testPresentReplacesPrevious() {
+        let sheet = SheetPresenter()
+        sheet.present { Text("a") }
+        let first = sheet.current?.id
+        sheet.present { Text("b") }
+        XCTAssertNotEqual(sheet.current?.id, first)
+    }
+
+    func testDismissClears() {
+        let sheet = SheetPresenter()
+        sheet.present { Text("x") }
+        sheet.dismiss()
+        XCTAssertNil(sheet.current)
+        XCTAssertFalse(sheet.isPresented)
+    }
+}

--- a/Tests/ThemeKitTests/TableSortKeyTests.swift
+++ b/Tests/ThemeKitTests/TableSortKeyTests.swift
@@ -1,0 +1,36 @@
+//
+//  TableSortKeyTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Coverage for DataTable's comparable sort key (the core new sorting logic).
+//
+
+import Foundation
+import XCTest
+@testable import ThemeKit
+
+final class TableSortKeyTests: XCTestCase {
+
+    func testNumberOrdering() {
+        XCTAssertTrue(TableSortKey.number(1) < TableSortKey.number(2))
+        XCTAssertFalse(TableSortKey.number(2) < TableSortKey.number(1))
+    }
+
+    func testStringUsesNaturalNumericOrdering() {
+        // "item2" before "item10" (lexicographic would reverse these).
+        XCTAssertTrue(TableSortKey.string("item2") < TableSortKey.string("item10"))
+    }
+
+    func testDateOrdering() {
+        let earlier = Date(timeIntervalSince1970: 0)
+        let later = Date(timeIntervalSince1970: 100)
+        XCTAssertTrue(TableSortKey.date(earlier) < TableSortKey.date(later))
+    }
+
+    func testSortingRowsByKey() {
+        let values = [3.0, 1.0, 2.0]
+        let sorted = values.sorted { TableSortKey.number($0) < TableSortKey.number($1) }
+        XCTAssertEqual(sorted, [1.0, 2.0, 3.0])
+    }
+}

--- a/Tests/ThemeKitTests/UploadControllerTests.swift
+++ b/Tests/ThemeKitTests/UploadControllerTests.swift
@@ -1,0 +1,55 @@
+//
+//  UploadControllerTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Lifecycle coverage for the async UploadController (success / failure /
+//  progress / remove / retry).
+//
+
+import Foundation
+import XCTest
+@testable import ThemeKit
+
+@MainActor
+final class UploadControllerTests: XCTestCase {
+
+    private struct TooBig: LocalizedError { var errorDescription: String? { "too big" } }
+
+    func testUploadSuccessMarksDone() async {
+        let controller = UploadController()
+        await controller.upload(name: "a.jpg") { _ in }
+        XCTAssertEqual(controller.files.count, 1)
+        XCTAssertEqual(controller.files.first?.status, .done)
+    }
+
+    func testUploadFailureUsesLocalizedDescription() async {
+        let controller = UploadController()
+        await controller.upload(name: "a.jpg") { _ in throw TooBig() }
+        XCTAssertEqual(controller.files.first?.status, .failed("too big"))
+    }
+
+    func testProgressSettlesToDone() async {
+        let controller = UploadController()
+        await controller.upload(name: "a.jpg") { progress in
+            progress(0.5)
+            progress(2.0)   // out-of-range value is clamped during upload
+        }
+        XCTAssertEqual(controller.files.first?.status, .done)
+    }
+
+    func testRemove() async {
+        let controller = UploadController()
+        let id = await controller.upload(name: "a.jpg") { _ in }
+        controller.remove(id)
+        XCTAssertTrue(controller.files.isEmpty)
+    }
+
+    func testRetryRerunsSameOperation() async {
+        let controller = UploadController()
+        let id = await controller.upload(name: "a.jpg") { _ in throw TooBig() }
+        XCTAssertEqual(controller.files.first?.status, .failed("too big"))
+        await controller.retry(id)
+        XCTAssertEqual(controller.files.first?.status, .failed("too big"))
+    }
+}


### PR DESCRIPTION
Applies the same "study a best-in-class reference, then extend our component" treatment as the toast work to four more components. Each change is **additive / backward-compatible** — existing call sites keep working. One commit per component.

## 1. BottomSheet — custom detents + imperative presenter (`8cea4ce`)
- `BottomSheetDetent`: `.medium` / `.large` / `.height(CGFloat)` / `.fraction(Double)`
- `.bottomSheet(isPresented:detents:showsDragIndicator:)` — declarative, now configurable
- **`SheetPresenter` + `.sheetHost()`** — present a sheet from anywhere without a local binding (mirrors the toast `feedbackHost` pattern)

## 2. DataTable — sortable, selectable, custom cells (`27e0ed6`)
- `TableSortKey` (number/string/date, natural numeric string ordering); a column with `sortKey:` becomes tap-to-sort with an asc/desc chevron
- Custom-view cells via a `@ViewBuilder` column init (String `value:` init kept)
- Row selection via `selection: Binding<Set<Row.ID>>` (+ `onRowTap`); empty-state placeholder

## 3. Autocomplete — async suggestions (`6bb855f`)
- New init taking `suggest: (String) async -> [String]` (debounced, in-flight cancellation)
- Loading spinner + empty "No results" state; static list path unchanged
- `staticMatches(_:in:max:)` extracted as a pure, tested matcher

## 4. Upload — async controller (`e3a775c`)
- **`UploadController`** (`@MainActor`): `upload(name:) { progress in … }` runs the async upload, reports clamped progress, settles to `.done`/`.failed`; plus `retry` / `remove`
- `UploadList` binds a controller to the UI; `Upload` gains an optional `onRetry` (retry button on failed rows)

## Verification
- `swift build` green (core + Lottie), warning-free
- **81 tests pass** (65 baseline + 16 new across the four components)
- New API is compile-checked via per-file `#Preview`s; Xcode Demo not built here.

## Notes
- Demo gallery wiring intentionally left out to keep these self-contained and avoid `OrganismDemos.swift` churn — can follow up.
- DataTable sticky-header was deliberately skipped to not fight callers that already wrap the table in their own `ScrollView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)