### PR TITLE
feat(otpinput): auto-submit, secure entry & resend countdown

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -76,7 +76,7 @@ enum ComponentRegistry {
         .knob("CheckboxGroup", .molecules, demo: CheckboxGroupDemo(), usage: #"CheckboxGroup(options: items, selection: $set) { $0 }"#),
         .knob("InputNumber", .molecules, demo: InputNumberDemo(), usage: #"InputNumber(label: "Guests", value: $count, range: 1...9)"#),
         .knob("MultiLineTextInput", .molecules, demo: MultiLineDemo(), usage: #"MultiLineTextInput("Notes", text: $text, characterLimit: 200)"#),
-        .knob("OTPInput", .molecules, demo: OTPDemo(), usage: #"OTPInput(code: $code, digitCount: 6)"#),
+        .knob("OTPInput", .molecules, demo: OTPDemo(), usage: #"OTPInput(code: $code, digitCount: 6, isSecure: true,\n         onComplete: { verify($0) }, resendInterval: 30, onResend: { resend() })"#),
         .knob("Breadcrumbs", .molecules, demo: BreadcrumbsDemo(), usage: #"Breadcrumbs([.init("Home", action: { }), .init("Current")])"#),
         .knob("Calendar", .molecules, demo: CalendarDemo(), usage: #"CalendarView(selection: $date)"#),
         .knob("Fieldset", .molecules, demo: FieldsetDemo(), usage: #"Fieldset("Contact", helper: "…") { inputs }"#),

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -223,12 +223,25 @@ struct OTPDemo: View {
     @State private var code = "12"
     @State private var six = false
     @State private var error = false
+    @State private var secure = false
+    @State private var resend = false
+    @State private var lastComplete = "—"
     var body: some View {
-        ComponentStage("OTPInput", inspector: [("code", "\"\(code)\""), ("digits", six ? "6" : "4")]) {
-            OTPInput(code: $code, digitCount: six ? 6 : 4, errorText: error ? "Invalid code" : nil)
+        ComponentStage("OTPInput", inspector: [("code", "\"\(code)\""), ("completed", lastComplete)]) {
+            OTPInput(
+                code: $code,
+                digitCount: six ? 6 : 4,
+                isSecure: secure,
+                errorText: error ? "Invalid code" : nil,
+                onComplete: { lastComplete = $0 },
+                resendInterval: resend ? 30 : nil,
+                onResend: resend ? { lastComplete = "resent" } : nil
+            )
         } knobs: {
             Toggle("6 digits", isOn: $six)
+            Toggle("Secure entry", isOn: $secure)
             Toggle("Error state", isOn: $error)
+            Toggle("Resend timer", isOn: $resend)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/OTPInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/OTPInput.swift
@@ -15,27 +15,47 @@ public struct OTPInput: View {
     private let messages: [InfoMessage]
     private let accessibilityID: String?
     private let isEnabled: Bool
+    private let isSecure: Bool
+    private let onComplete: ((String) -> Void)?
+    private let resendInterval: TimeInterval?
+    private let onResend: (() -> Void)?
 
     @FocusState private var isFocused: Bool
+    @State private var lastFired = ""
+    @State private var secondsLeft = 0
+    @State private var resendID = 0
 
     public init(
         code: Binding<String>,
         digitCount: Int = 6,
+        isSecure: Bool = false,
         errorText: String? = nil,
         infoMessages: [InfoMessage] = [],
         accessibilityID: String? = nil,
-        isEnabled: Bool = true
+        isEnabled: Bool = true,
+        onComplete: ((String) -> Void)? = nil,
+        resendInterval: TimeInterval? = nil,
+        onResend: (() -> Void)? = nil
     ) {
         self._code = code
         self.digitCount = digitCount
+        self.isSecure = isSecure
         var messages = infoMessages
         if let errorText { messages.append(InfoMessage(errorText, kind: .error)) }
         self.messages = messages
         self.accessibilityID = accessibilityID
         self.isEnabled = isEnabled
+        self.onComplete = onComplete
+        self.resendInterval = resendInterval
+        self.onResend = onResend
     }
 
     private var hasError: Bool { messages.dominantKind == .error }
+
+    /// Keeps only digits and caps the length (extracted for testing).
+    static func sanitize(_ raw: String, digitCount: Int) -> String {
+        String(raw.filter(\.isNumber).prefix(digitCount))
+    }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
@@ -47,7 +67,8 @@ public struct OTPInput: View {
                             isActive: isFocused && code.count == index,
                             isFilled: index < code.count,
                             hasError: hasError,
-                            isEnabled: isEnabled
+                            isEnabled: isEnabled,
+                            isSecure: isSecure
                         )
                     }
                 }
@@ -68,7 +89,20 @@ public struct OTPInput: View {
                     .frame(width: 1, height: 1)
                     .disabled(!isEnabled)
                     .onChange(of: code) { _, newValue in
-                        code = String(newValue.filter(\.isNumber).prefix(digitCount))
+                        let sanitized = Self.sanitize(newValue, digitCount: digitCount)
+                        if sanitized != code { code = sanitized }
+                        if sanitized.count == digitCount {
+                            // Fire once per completion; re-arms after an edit.
+                            if sanitized != lastFired {
+                                lastFired = sanitized
+                                if onComplete != nil {
+                                    isFocused = false
+                                    onComplete?(sanitized)
+                                }
+                            }
+                        } else {
+                            lastFired = ""
+                        }
                     }
                     .a11y(A11yElement.Field.field, in: accessibilityID)
                     .accessibilityLabel(String(themeKit: "Verification code"))
@@ -78,6 +112,40 @@ public struct OTPInput: View {
             if !messages.isEmpty {
                 InfoMessageList(messages)
                     .a11y(A11yElement.Field.message, in: accessibilityID)
+            }
+
+            if let resendInterval, let onResend {
+                resendRow(interval: resendInterval, onResend: onResend)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func resendRow(interval: TimeInterval, onResend: @escaping () -> Void) -> some View {
+        Group {
+            if secondsLeft > 0 {
+                Text(String(themeKit: "Resend code in \(secondsLeft)s"))
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(Theme.shared.text(.textTertiary))
+            } else {
+                Button {
+                    onResend()
+                    resendID += 1   // restarts the countdown task
+                } label: {
+                    Text(String(themeKit: "Resend code"))
+                        .textStyle(.labelSm700)
+                        .foregroundStyle(Theme.shared.text(.textHero))
+                }
+                .buttonStyle(.plain)
+                .disabled(!isEnabled)
+            }
+        }
+        .task(id: resendID) {
+            secondsLeft = Int(interval)
+            while secondsLeft > 0 {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                if Task.isCancelled { return }
+                secondsLeft -= 1
             }
         }
     }
@@ -106,6 +174,7 @@ private struct OTPDigitBox: View {
     let isFilled: Bool
     let hasError: Bool
     let isEnabled: Bool
+    let isSecure: Bool
 
     @State private var caretOn = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -122,18 +191,20 @@ private struct OTPDigitBox: View {
                 // Dynamic Type is capped at the container via dynamicTypeClamp().
                 .frame(height: 56)
 
-            if digit.isEmpty, isActive {
-                Rectangle()
-                    .fill(Theme.shared.foreground(.fgHero))
-                    .frame(width: 2, height: 24)
-                    .opacity(reduceMotion ? 1 : (caretOn ? 1 : 0))
-                    .onAppear {
-                        // Honor Reduce Motion: a solid caret, no blink.
-                        guard !reduceMotion else { return }
-                        withAnimation(Motion.slower.animation.repeatForever()) { caretOn = true }
-                    }
+            if digit.isEmpty {
+                if isActive {
+                    Rectangle()
+                        .fill(Theme.shared.foreground(.fgHero))
+                        .frame(width: 2, height: 24)
+                        .opacity(reduceMotion ? 1 : (caretOn ? 1 : 0))
+                        .onAppear {
+                            // Honor Reduce Motion: a solid caret, no blink.
+                            guard !reduceMotion else { return }
+                            withAnimation(Motion.slower.animation.repeatForever()) { caretOn = true }
+                        }
+                }
             } else {
-                Text(digit)
+                Text(isSecure ? "●" : digit)
                     .textStyle(.headingBase)
                     .foregroundStyle(textColor)
             }
@@ -157,9 +228,12 @@ private struct OTPDigitBox: View {
 #Preview {
     struct Demo: View {
         @State var code = "123"
+        @State var lastComplete = "—"
         var body: some View {
             VStack(spacing: 24) {
-                OTPInput(code: $code)
+                OTPInput(code: $code, onComplete: { lastComplete = $0 }, resendInterval: 30, onResend: {})
+                Text("Completed: \(lastComplete)").textStyle(.bodySm400)
+                OTPInput(code: .constant("4321"), digitCount: 4, isSecure: true)
                 OTPInput(code: .constant("12"), digitCount: 4, errorText: "Invalid code")
             }
             .padding()

--- a/Tests/ThemeKitTests/OTPInputTests.swift
+++ b/Tests/ThemeKitTests/OTPInputTests.swift
@@ -1,0 +1,30 @@
+//
+//  OTPInputTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Coverage for OTPInput's input sanitizer (digits-only, length cap).
+//
+
+import XCTest
+@testable import ThemeKit
+
+final class OTPInputTests: XCTestCase {
+
+    func testFiltersNonDigits() {
+        XCTAssertEqual(OTPInput.sanitize("12ab34", digitCount: 6), "1234")
+    }
+
+    func testCapsToDigitCount() {
+        XCTAssertEqual(OTPInput.sanitize("123456789", digitCount: 6), "123456")
+    }
+
+    func testEmptyWhenNoDigits() {
+        XCTAssertEqual(OTPInput.sanitize("abc-!", digitCount: 4), "")
+    }
+
+    func testPastedCodeIsAccepted() {
+        // Simulates pasting a full code with stray formatting.
+        XCTAssertEqual(OTPInput.sanitize("1 2-3 4", digitCount: 4), "1234")
+    }
+}


### PR DESCRIPTION
Extends `OTPInput` with the UX a one-time-code field is expected to have, drawing on the iOS one-time-code pattern. All additive — existing call sites keep working.

## Added
- **`onComplete`** — fires once when the code reaches `digitCount` (re-arms after an edit) and resigns the keyboard. Paste / SMS autofill already flows through the same sanitizer, so a pasted code auto-submits too.
- **`isSecure`** — render filled digits as dots (●).
- **`resendInterval` + `onResend`** — a built-in "Resend code in Ns" countdown that enables a tappable "Resend code" at zero and restarts on tap.
- **`sanitize(_:digitCount:)`** extracted as a pure, tested input rule (digits-only, length cap).

## Demo
`OTPDemo` gains **Secure** / **Resend** toggles and a completed-code readout — wired into the gallery and **verified with `xcodebuild` (BUILD SUCCEEDED)**.

## Verification
- `swift build` green; **85 tests pass** (81 + 4 new for the sanitizer)
- Demo app compiles for the iOS Simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)