### PR TITLE
feat(drawer): imperative DrawerPresenter + drag-to-dismiss

### DIFF
--- a/Demo/Demo/DemoApp.swift
+++ b/Demo/Demo/DemoApp.swift
@@ -17,6 +17,7 @@ struct DemoApp: App {
                 .environmentObject(themeStore)
                 .feedbackHost()       // installs the shared FeedbackPresenter + overlays
                 .sheetHost()          // installs the shared SheetPresenter
+                .drawerHost()         // installs the shared DrawerPresenter
                 // env-only (no root rebuild) so the in-session Configurator sheet
                 // isn't torn down mid-edit; screens observe Theme via @ThemeContext.
                 .themeKit(reactToRuntimeChanges: false)

--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -116,7 +116,7 @@ enum ComponentRegistry {
         .knob("ChatBubble", .organisms, demo: ChatBubbleDemo(), usage: #"ChatBubble("Hi!", side: .outgoing, time: "09:24", avatarSystemImage: "person.fill")"#),
         .knob("Counter", .organisms, demo: CounterDemo(), usage: #"Counter(days: 2, hours: 8, minutes: 45)"#),
         .knob("DataTable", .organisms, demo: DataTableDemo(), usage: #"DataTable(columns: [.init("Hotel", sortKey: { .string($0.hotel) }) { $0.hotel }], rows: rows, selection: $selected)"#),
-        .knob("Drawer", .organisms, demo: DrawerDemo(), usage: #"someView.drawer(isPresented: $open, edge: .leading) { menu }"#),
+        .knob("Drawer", .organisms, demo: DrawerDemo(), usage: #"someView.drawer(isPresented: $open, edge: .leading) { menu }\n// or imperative: install .drawerHost(); @EnvironmentObject var drawer: DrawerPresenter\ndrawer.present(edge: .leading) { menu }   // drag-to-dismiss built in"#),
         .knob("FAB", .organisms, demo: FABDemo(), usage: #"FloatingActionButton(systemImage: "plus", actions: [.init(systemImage: "camera", action: { })])"#),
         .knob("Hero", .organisms, demo: HeroDemo(), usage: #"Hero(title: "…", subtitle: "…", ctaTitle: "Explore", action: { })"#),
         .knob("Stack", .organisms, demo: CardStackDemo(), usage: #"CardStack(items) { item in cardView }"#),

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -749,6 +749,7 @@ struct ChatBubbleDemo: View {
 }
 
 struct DrawerDemo: View {
+    @EnvironmentObject private var drawer: DrawerPresenter
     @State private var open = false
     @State private var trailing = false
     var body: some View {
@@ -767,7 +768,20 @@ struct DrawerDemo: View {
                 }
         } knobs: {
             Toggle("Trailing edge", isOn: $trailing)
-            Button("Open") { open = true }
+            Button("Open (declarative)") { open = true }
+            Button("Open (imperative host)") {
+                drawer.present(edge: trailing ? .trailing : .leading) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Menu").textStyle(.headingSm)
+                        ListRow("Account", leadingSystemImage: "person.circle", action: { drawer.dismiss(); flash("Drawer: Account") })
+                        ListRow("Settings", leadingSystemImage: "gearshape", action: { drawer.dismiss(); flash("Drawer: Settings") })
+                        Spacer()
+                    }
+                    .padding()
+                    .padding(.top, 50)
+                }
+            }
+            Text("Drag the panel toward its edge to dismiss.").font(.footnote).foregroundStyle(.secondary)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/Drawer.swift
+++ b/Sources/ThemeKit/Components/Organisms/Drawer.swift
@@ -3,34 +3,79 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A side drawer that slides in over a dimmed scrim, presented via the
-//  `.drawer(...)` modifier. (daisyUI "Drawer".)
+//  Organism. A side drawer that slides in over a dimmed scrim. Two entry points:
+//    • `.drawer(isPresented:edge:)` — declarative, binding-driven.
+//    • `.drawerHost()` + `@EnvironmentObject DrawerPresenter` — imperative; open a
+//      drawer from anywhere without a local binding.
+//  Both support drag-toward-the-edge swipe-to-dismiss and scrim tap-to-dismiss.
+//  (daisyUI "Drawer".)
 //
 
 import SwiftUI
+
+/// Shared scrim + sliding panel with drag-to-dismiss; the scrim fades as the
+/// panel is dragged away. Used by both the declarative modifier and the host.
+private struct DrawerContainer<DrawerContent: View>: View {
+    let edge: HorizontalEdge
+    let width: CGFloat
+    let dismissOnScrimTap: Bool
+    let onDismiss: () -> Void
+    @ViewBuilder let content: () -> DrawerContent
+
+    @State private var dragX: CGFloat = 0
+
+    var body: some View {
+        ZStack(alignment: edge == .leading ? .leading : .trailing) {
+            Theme.shared.background(.bgTertiary).opacity(0.4 * scrimFactor)
+                .ignoresSafeArea()
+                .onTapGesture { if dismissOnScrimTap { onDismiss() } }
+
+            content()
+                .frame(maxWidth: width, maxHeight: .infinity, alignment: .topLeading)
+                .frame(maxHeight: .infinity)
+                .background(Theme.shared.background(.bgWhite))
+                .ignoresSafeArea()
+                .offset(x: dragX)
+                .gesture(dragGesture)
+                .transition(.move(edge: edge == .leading ? .leading : .trailing))
+        }
+        .zIndex(1)
+    }
+
+    /// Scrim opacity multiplier: 1 at rest, 0 when dragged a full width away.
+    private var scrimFactor: Double {
+        1 - min(abs(dragX) / width, 1)
+    }
+
+    private var dragGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                let dx = value.translation.width
+                // Only allow dragging toward the panel's own edge (i.e. to close).
+                dragX = edge == .leading ? min(0, dx) : max(0, dx)
+            }
+            .onEnded { _ in
+                if abs(dragX) > width * 0.33 {
+                    onDismiss()
+                } else {
+                    withAnimation(Motion.fast.animation) { dragX = 0 }
+                }
+            }
+    }
+}
 
 private struct DrawerModifier<DrawerContent: View>: ViewModifier {
     @Binding var isPresented: Bool
     let edge: HorizontalEdge
     let width: CGFloat
-    let content: () -> DrawerContent
+    let dismissOnScrimTap: Bool
+    @ViewBuilder let content: () -> DrawerContent
 
     func body(content base: Content) -> some View {
         base.overlay {
             if isPresented {
-                ZStack(alignment: edge == .leading ? .leading : .trailing) {
-                    Theme.shared.background(.bgTertiary).opacity(0.4)
-                        .ignoresSafeArea()
-                        .onTapGesture { isPresented = false }
-
-                    self.content()
-                        .frame(maxWidth: width, maxHeight: .infinity, alignment: .topLeading)
-                        .frame(maxHeight: .infinity)
-                        .background(Theme.shared.background(.bgWhite))
-                        .ignoresSafeArea()
-                        .transition(.move(edge: edge == .leading ? .leading : .trailing))
-                }
-                .zIndex(1)
+                DrawerContainer(edge: edge, width: width, dismissOnScrimTap: dismissOnScrimTap,
+                                onDismiss: { isPresented = false }, content: content)
             }
         }
         .animation(Motion.base.animation, value: isPresented)
@@ -38,18 +83,83 @@ private struct DrawerModifier<DrawerContent: View>: ViewModifier {
 }
 
 public extension View {
-    /// Presents `content` as a side drawer over a scrim.
+    /// Presents `content` as a side drawer over a scrim. Drag the panel toward its
+    /// edge (or tap the scrim) to dismiss.
     func drawer<DrawerContent: View>(
         isPresented: Binding<Bool>,
         edge: HorizontalEdge = .leading,
         width: CGFloat = 300,
+        dismissOnScrimTap: Bool = true,
         @ViewBuilder content: @escaping () -> DrawerContent
     ) -> some View {
-        modifier(DrawerModifier(isPresented: isPresented, edge: edge, width: width, content: content))
+        modifier(DrawerModifier(isPresented: isPresented, edge: edge, width: width,
+                                dismissOnScrimTap: dismissOnScrimTap, content: content))
     }
 }
 
-#Preview {
+// MARK: - Imperative presenter
+
+/// Imperative side-drawer presenter. Install once with `.drawerHost()`, then from
+/// any descendant view:
+///
+///     @EnvironmentObject var drawer: DrawerPresenter
+///     drawer.present(edge: .leading) { MenuView() }
+///     drawer.dismiss()
+public final class DrawerPresenter: ObservableObject {
+
+    struct Request: Identifiable {
+        let id = UUID()
+        let edge: HorizontalEdge
+        let width: CGFloat
+        let dismissOnScrimTap: Bool
+        let content: AnyView
+    }
+
+    @Published var current: Request?
+
+    public init() {}
+
+    /// Open a drawer. Replaces any visible drawer.
+    public func present<C: View>(
+        edge: HorizontalEdge = .leading,
+        width: CGFloat = 300,
+        dismissOnScrimTap: Bool = true,
+        @ViewBuilder _ content: () -> C
+    ) {
+        current = Request(edge: edge, width: width, dismissOnScrimTap: dismissOnScrimTap, content: AnyView(content()))
+    }
+
+    public func dismiss() { current = nil }
+
+    public var isPresented: Bool { current != nil }
+}
+
+private struct DrawerHostModifier: ViewModifier {
+    @StateObject private var presenter = DrawerPresenter()
+
+    func body(content: Content) -> some View {
+        content
+            .environmentObject(presenter)
+            .overlay {
+                if let request = presenter.current {
+                    DrawerContainer(edge: request.edge, width: request.width,
+                                    dismissOnScrimTap: request.dismissOnScrimTap,
+                                    onDismiss: { presenter.dismiss() }) { request.content }
+                }
+            }
+            .animation(Motion.base.animation, value: presenter.current?.id)
+    }
+}
+
+public extension View {
+    /// Installs the shared `DrawerPresenter`. Apply once near the app root, above
+    /// any view that calls `drawer.present(…)`.
+    func drawerHost() -> some View {
+        modifier(DrawerHostModifier())
+    }
+}
+
+#Preview("Declarative") {
     struct Demo: View {
         @State private var open = false
         var body: some View {
@@ -70,4 +180,24 @@ public extension View {
         }
     }
     return Demo()
+}
+
+#Preview("Imperative host") {
+    struct Demo: View {
+        @EnvironmentObject var drawer: DrawerPresenter
+        var body: some View {
+            PrimaryButton("Present (trailing)") {
+                drawer.present(edge: .trailing) {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Filters").textStyle(.headingSm)
+                        Spacer()
+                    }
+                    .padding()
+                    .padding(.top, 60)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+    return Demo().drawerHost()
 }

--- a/Tests/ThemeKitTests/DrawerPresenterTests.swift
+++ b/Tests/ThemeKitTests/DrawerPresenterTests.swift
@@ -1,0 +1,41 @@
+//
+//  DrawerPresenterTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Logic coverage for the imperative side-drawer presenter.
+//
+
+import SwiftUI
+import XCTest
+@testable import ThemeKit
+
+@MainActor
+final class DrawerPresenterTests: XCTestCase {
+
+    func testPresentSetsCurrentWithEdgeAndWidth() {
+        let drawer = DrawerPresenter()
+        XCTAssertFalse(drawer.isPresented)
+        drawer.present(edge: .trailing, width: 280) { Text("x") }
+        XCTAssertTrue(drawer.isPresented)
+        XCTAssertEqual(drawer.current?.edge, .trailing)
+        XCTAssertEqual(drawer.current?.width, 280)
+        XCTAssertEqual(drawer.current?.dismissOnScrimTap, true)
+    }
+
+    func testPresentReplacesPrevious() {
+        let drawer = DrawerPresenter()
+        drawer.present { Text("a") }
+        let first = drawer.current?.id
+        drawer.present { Text("b") }
+        XCTAssertNotEqual(drawer.current?.id, first)
+    }
+
+    func testDismissClears() {
+        let drawer = DrawerPresenter()
+        drawer.present { Text("x") }
+        drawer.dismiss()
+        XCTAssertNil(drawer.current)
+        XCTAssertFalse(drawer.isPresented)
+    }
+}


### PR DESCRIPTION
Picked by **importance × gap**: Drawer is a core navigation pattern (side menu) and was the thinnest remaining component (binding-only, no presenter, no gesture). Extended to match the toast/sheet presenter pattern. Additive / backward-compatible.

## Added
- **Shared `DrawerContainer`** with **drag-to-dismiss** — drag the panel toward its own edge to close; the scrim fades as it is dragged away.
- **`DrawerPresenter` + `.drawerHost()`** — open a drawer imperatively from anywhere, no local binding (`drawer.present(edge:width:) { … }` / `drawer.dismiss()`).
- `.drawer(isPresented:edge:width:dismissOnScrimTap:)` — declarative path now exposes a scrim-tap toggle.

## Demo
`DrawerDemo` gains an **"Open (imperative host)"** button; `DemoApp` installs `.drawerHost()` (alongside `feedbackHost` / `sheetHost`). **Verified with `xcodebuild` (BUILD SUCCEEDED).**

## Verification
- `swift build` green; **88 tests pass** (85 + 3 new for the presenter)
- Demo compiles for the iOS Simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)