### PR TITLE
ci: cut Actions cost (lint on Linux, api-breakage PR-only, docs manual)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
-# Every push to main and every PR runs the full matrix. A component library is
-# someone else's dependency: nothing merges unless it builds and tests green on
-# both platforms we ship (iOS 17+, macOS 14+) and passes lint.
+# PRs run the full matrix; main pushes run build + test + lint (api-breakage is
+# PR-only). Lint runs on Linux (1× minutes); the build/test gates run on macOS for
+# the two platforms we ship (iOS 17+, macOS 14+). A component library is someone
+# else's dependency: nothing merges unless it's green.
 on:
   push:
     branches: [main]
@@ -97,16 +98,19 @@ jobs:
   # ---------------------------------------------------------------------------
   lint:
     name: SwiftLint
-    runs-on: macos-15
+    # Lint needs no Xcode/SDK, so run it on Linux (1× minutes) via the official
+    # SwiftLint Docker image instead of an expensive macOS runner (10×).
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install SwiftLint
-        run: brew install swiftlint
       # Non-strict: error-level violations block the PR; warnings surface as
       # annotations and are burned down over time (see .swiftlint.yml). New code
       # that introduces an error-level violation fails here.
       - name: Lint
-        run: swiftlint lint --reporter github-actions-logging
+        run: |
+          docker run --rm -v "$PWD:/work" -w /work \
+            ghcr.io/realm/swiftlint:latest \
+            swiftlint lint --reporter github-actions-logging
 
   # ---------------------------------------------------------------------------
   # Public-API breakage detection. Informational on PRs (a breaking change is
@@ -115,6 +119,9 @@ jobs:
   # ---------------------------------------------------------------------------
   api-breakage:
     name: API breakage check
+    # PR-only: it diffs the public API against the PR base. On a main push there's
+    # no base to diff against, so skip it there and save an expensive macOS runner.
+    if: github.event_name == 'pull_request'
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,12 @@
 name: Docs
 
-# Build the DocC documentation on every push to main and upload it as a
-# downloadable artifact. The repo is PRIVATE, so GitHub Pages isn't available on
-# the current plan — docs are not published; build them locally with:
+# Build the DocC documentation on demand and upload it as a downloadable
+# artifact. The repo is PRIVATE, so GitHub Pages isn't available on the current
+# plan — docs are not published. DocC builds on an expensive macOS runner (10×),
+# so this is MANUAL-only (workflow_dispatch) rather than on every push to main —
+# trigger it from the Actions tab when you want a fresh archive, or build locally:
 #   swift package --disable-sandbox preview-documentation --target ThemeKit
-# This job's value is catching broken doc comments / DocC links in CI, and
-# producing a browsable archive reviewers can download.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The repo is private, so GitHub Actions minutes are metered and **macOS runners bill at 10×**. This trims the macOS footprint without dropping any gate that matters.

## Changes
- **SwiftLint**: `macos-15` → `ubuntu-latest`, run via the official `ghcr.io/realm/swiftlint` Docker image. Lint needs no Xcode/SDK, so this drops it from 10× to 1×.
- **API breakage check**: now `if: github.event_name == 'pull_request'`. A `main` push has no PR base to diff against, so it was spinning an expensive macOS runner for nothing on every merge.
- **Docs (DocC) workflow**: `workflow_dispatch` only (was every push to `main`). DocC is a heavy macOS build and the artifact isn't even published (private repo, no Pages) — trigger it manually from the Actions tab when you want a fresh archive.

## Effect per merge to `main`
- **Before**: 4 macOS CI jobs + 1 macOS Docs job.
- **After**: 2 macOS jobs (SPM macOS + iOS Simulator build/test) + 1 Linux job (lint). api-breakage and docs no longer run on push.

The build/test gates on both shipped platforms (iOS 17+, macOS 14+) are unchanged.

## ⚠️ Important
This **lowers ongoing cost but does not unblock CI by itself**. The current failures are billing — *"the job was not started because recent account payments have failed or your spending limit needs to be increased."* Resolve that first in **Settings → Billing and plans** (fix payment method and/or raise the Actions spending limit); then these changes keep the burn rate low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)