### PR TITLE
feat(textinput): keyboard/autofill config & soft character limit

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -100,7 +100,7 @@ enum ComponentRegistry {
         .knob("TreeSelect", .molecules, demo: TreeSelectDemo(), usage: #"TreeSelect(label: "Cities", nodes: tree, selection: $set, initiallyExpanded: ["tr"])"#),
         .knob("SelectBox", .molecules, demo: SelectBoxDemo(), usage: #"SelectBox(label: "Country", options: items, selection: $sel) { $0 }"#),
         .knob("Slider", .molecules, demo: SliderDemo(), usage: #"Slider(value: $v, in: 0...8, marks: [0: "0", 8: "Max"], showValueTooltip: true)"#),
-        .knob("TextInput", .molecules, demo: TextInputDemo(), usage: ##"TextInput(TextInputModel(label: "Email", infoMessages: Validator.validate(t, [.required(), .email()]), accessibilityID: "email"), text: $t)"##),
+        .knob("TextInput", .molecules, demo: TextInputDemo(), usage: ##"TextInput("Email", text: $t, keyboardType: .emailAddress, textContentType: .emailAddress, submitLabel: .next)"##),
         .knob("ThemeToggle", .molecules, demo: ToggleDemo(), usage: #"ThemeToggle(isOn: $on, isLoading: false, onSystemImage: "checkmark")"#),
         .knob("ToggleGroup", .molecules, demo: ToggleGroupDemo(), usage: #"ToggleGroup(options: items, selection: $set, label: { $0 })"#),
         .knob("Tooltip", .molecules, demo: TooltipDemo(), usage: #"anchorView.tooltip("Hint", isPresented: $shown, edge: .top)"#),

--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -154,7 +154,7 @@ struct ToggleDemo: View {
 }
 
 struct TextInputDemo: View {
-    private enum Mode: String, CaseIterable { case email, card, phone, currency, addons }
+    private enum Mode: String, CaseIterable { case email, password, bio, card, phone, currency, addons }
     @State private var text = ""
     @State private var mode: Mode = .email
     @State private var loggedIn = false
@@ -168,7 +168,16 @@ struct TextInputDemo: View {
                                     links: [("Giriş yap", { loggedIn = true })])]
             }
             return TextInputModel(label: "E-posta", placeholder: "ad@sirket.com", leadingSystemImage: "envelope",
-                                  allowClear: true, infoMessages: msgs, accessibilityID: "demoEmail")
+                                  allowClear: true, infoMessages: msgs, accessibilityID: "demoEmail",
+                                  keyboardType: .emailAddress, textContentType: .emailAddress,
+                                  submitLabel: .next, autocapitalization: .never, autocorrectionDisabled: true)
+        case .password:
+            return TextInputModel(label: "Şifre", isSecure: true, maxLength: 24, showCount: true,
+                                  accessibilityID: "demoPassword", textContentType: .password, submitLabel: .go)
+        case .bio:
+            // Soft limit: typing past 80 is allowed; the counter turns red instead of truncating.
+            return TextInputModel(label: "Hakkımda", placeholder: "Kısaca kendinden bahset", maxLength: 80,
+                                  showCount: true, accessibilityID: "demoBio", hardLimit: false, countStyle: .remaining)
         case .card:
             return TextInputModel(label: "Kart No", placeholder: "0000 0000 0000 0000", leadingSystemImage: "creditcard",
                                   formatter: .creditCard(), accessibilityID: "demoCard")
@@ -188,7 +197,7 @@ struct TextInputDemo: View {
         ComponentStage("TextInput", inspector: [("mode", mode.rawValue), ("value", "\"\(text)\""), ("login", "\(loggedIn)")]) {
             TextInput(model, text: $text)
         } knobs: {
-            Text("email = .required + .email validation (with clickable link). card/phone/currency = format-as-you-type masks.").font(.caption).foregroundStyle(.secondary)
+            Text("email = keyboard/autofill + validation. password = password-manager autofill. bio = soft limit (exceed 80 → red counter). card/phone/currency = format-as-you-type masks.").font(.caption).foregroundStyle(.secondary)
             Picker("Mode", selection: $mode) { ForEach(Mode.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) } }.pickerStyle(.segmented)
             Button("Reset") { text = ""; loggedIn = false }
         }

--- a/Sources/ThemeKit/Components/Molecules/TextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInput.swift
@@ -9,6 +9,9 @@
 //
 
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 public enum TextInputSize {
     case xsmall, small, medium, large
@@ -20,6 +23,30 @@ public enum TextInputSize {
         case .large: return 64
         }
     }
+}
+
+/// Platform-neutral keyboard hint. Maps to `UIKeyboardType` on iOS; ignored on macOS.
+public enum TextInputKeyboard {
+    case `default`, asciiCapable, numberPad, decimalPad, phonePad
+    case emailAddress, url, numbersAndPunctuation, webSearch
+}
+
+/// Platform-neutral semantic content type for autofill / password managers.
+/// Maps to `UITextContentType` on iOS; ignored on macOS.
+public enum TextInputContentType {
+    case name, givenName, familyName, username, password, newPassword, oneTimeCode
+    case emailAddress, telephoneNumber, fullStreetAddress, postalCode, creditCardNumber, url
+}
+
+/// Platform-neutral autocapitalization behavior. Maps to `TextInputAutocapitalization`
+/// on iOS; ignored on macOS.
+public enum TextInputCapitalization {
+    case never, characters, words, sentences
+}
+
+/// How the character counter reads: `12/50` (or `12`) vs. `38 left`.
+public enum TextInputCountStyle {
+    case count, remaining
 }
 
 /// Bundled configuration for a `TextInput` (reference "UI model" pattern).
@@ -39,6 +66,14 @@ public struct TextInputModel {
     public var infoMessages: [InfoMessage]
     public var accessibilityID: String?
     public var isEnabled: Bool
+    public var keyboardType: TextInputKeyboard
+    public var textContentType: TextInputContentType?
+    public var submitLabel: SubmitLabel
+    public var autocapitalization: TextInputCapitalization?
+    public var autocorrectionDisabled: Bool
+    public var hardLimit: Bool
+    public var countStyle: TextInputCountStyle
+    public var onSubmit: (() -> Void)?
 
     public init(
         label: String,
@@ -55,7 +90,15 @@ public struct TextInputModel {
         formatter: TextInputFormatter? = nil,
         infoMessages: [InfoMessage] = [],
         accessibilityID: String? = nil,
-        isEnabled: Bool = true
+        isEnabled: Bool = true,
+        keyboardType: TextInputKeyboard = .default,
+        textContentType: TextInputContentType? = nil,
+        submitLabel: SubmitLabel = .return,
+        autocapitalization: TextInputCapitalization? = nil,
+        autocorrectionDisabled: Bool = false,
+        hardLimit: Bool = true,
+        countStyle: TextInputCountStyle = .count,
+        onSubmit: (() -> Void)? = nil
     ) {
         self.label = label
         self.placeholder = placeholder
@@ -72,6 +115,14 @@ public struct TextInputModel {
         self.infoMessages = infoMessages
         self.accessibilityID = accessibilityID
         self.isEnabled = isEnabled
+        self.keyboardType = keyboardType
+        self.textContentType = textContentType
+        self.submitLabel = submitLabel
+        self.autocapitalization = autocapitalization
+        self.autocorrectionDisabled = autocorrectionDisabled
+        self.hardLimit = hardLimit
+        self.countStyle = countStyle
+        self.onSubmit = onSubmit
     }
 }
 
@@ -112,7 +163,15 @@ public struct TextInput: View {
         infoMessages: [InfoMessage] = [],
         accessibilityID: String? = nil,
         externalFocus: Binding<Bool>? = nil,
-        isEnabled: Bool = true
+        isEnabled: Bool = true,
+        keyboardType: TextInputKeyboard = .default,
+        textContentType: TextInputContentType? = nil,
+        submitLabel: SubmitLabel = .return,
+        autocapitalization: TextInputCapitalization? = nil,
+        autocorrectionDisabled: Bool = false,
+        hardLimit: Bool = true,
+        countStyle: TextInputCountStyle = .count,
+        onSubmit: (() -> Void)? = nil
     ) {
         var messages = infoMessages
         if let errorText { messages.append(InfoMessage(errorText, kind: .error)) }
@@ -125,7 +184,10 @@ public struct TextInput: View {
             suffixSystemImage: suffixSystemImage, addonBefore: addonBefore, addonAfter: addonAfter,
             isSecure: isSecure, allowClear: allowClear,
             maxLength: maxLength, showCount: showCount, size: size, formatter: formatter,
-            infoMessages: messages, accessibilityID: accessibilityID, isEnabled: isEnabled
+            infoMessages: messages, accessibilityID: accessibilityID, isEnabled: isEnabled,
+            keyboardType: keyboardType, textContentType: textContentType, submitLabel: submitLabel,
+            autocapitalization: autocapitalization, autocorrectionDisabled: autocorrectionDisabled,
+            hardLimit: hardLimit, countStyle: countStyle, onSubmit: onSubmit
         )
     }
 
@@ -136,6 +198,26 @@ public struct TextInput: View {
     private var showsClear: Bool { model.allowClear && !text.isEmpty && model.isEnabled && !model.isSecure }
 
     private var hasAddons: Bool { model.addonBefore != nil || model.addonAfter != nil }
+    private var isOverLimit: Bool { Self.isOverLimit(count: text.count, maxLength: model.maxLength) }
+
+    /// Counter string for the given state (extracted for testing).
+    static func counterText(count: Int, maxLength: Int?, style: TextInputCountStyle) -> String {
+        switch style {
+        case .count:
+            if let maxLength { return "\(count)/\(maxLength)" }
+            return "\(count)"
+        case .remaining:
+            guard let maxLength else { return "\(count)" }
+            return String(themeKit: "\(maxLength - count) left")
+        }
+    }
+
+    /// Whether `count` exceeds `maxLength` — only reachable with a soft limit
+    /// (`hardLimit == false`), since a hard limit truncates before this is checked.
+    static func isOverLimit(count: Int, maxLength: Int?) -> Bool {
+        guard let maxLength else { return false }
+        return count > maxLength
+    }
 
     private var fieldContent: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
@@ -208,15 +290,15 @@ public struct TextInput: View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
             fieldBox
 
-            if !model.infoMessages.isEmpty || (model.showCount && model.maxLength != nil) {
+            if !model.infoMessages.isEmpty || model.showCount {
                 HStack(alignment: .firstTextBaseline) {
                     InfoMessageList(model.infoMessages)
                         .a11y(A11yElement.Field.message, in: model.accessibilityID)
                     Spacer(minLength: Theme.SpacingKey.sm.value)
-                    if model.showCount, let maxLength = model.maxLength {
-                        Text("\(text.count)/\(maxLength)")
+                    if model.showCount {
+                        Text(Self.counterText(count: text.count, maxLength: model.maxLength, style: model.countStyle))
                             .textStyle(.bodySm400)
-                            .foregroundStyle(Theme.shared.text(.textTertiary))
+                            .foregroundStyle(isOverLimit ? Theme.shared.foreground(.systemcolorsFgError) : Theme.shared.text(.textTertiary))
                             .monospacedDigit()
                     }
                 }
@@ -225,7 +307,7 @@ public struct TextInput: View {
         .onChange(of: text) { _, newValue in
             var v = newValue
             if let formatter = model.formatter { v = formatter(v) }
-            if let maxLength = model.maxLength, v.count > maxLength { v = String(v.prefix(maxLength)) }
+            if model.hardLimit, let maxLength = model.maxLength, v.count > maxLength { v = String(v.prefix(maxLength)) }
             if v != text { text = v }
         }
         .onChange(of: externalFocus?.wrappedValue ?? false) { _, want in
@@ -252,6 +334,12 @@ public struct TextInput: View {
         .foregroundStyle(model.isEnabled ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textDisabled))
         .tint(Theme.shared.foreground(.fgHero))
         .disabled(!model.isEnabled)
+        .submitLabel(model.submitLabel)
+        .autocorrectionDisabled(model.autocorrectionDisabled)
+        .textInputTraits(keyboard: model.keyboardType,
+                         contentType: model.textContentType,
+                         capitalization: model.autocapitalization)
+        .onSubmit { model.onSubmit?() }
         .accessibilityLabel(model.label)
         .accessibilityValue(model.isSecure ? "" : text)
     }
@@ -300,19 +388,97 @@ public struct TextInput: View {
     }
 }
 
+// MARK: - Platform keyboard traits
+
+private extension View {
+    /// Applies keyboard / autofill / capitalization traits (iOS only; no-op on macOS).
+    @ViewBuilder
+    func textInputTraits(
+        keyboard: TextInputKeyboard,
+        contentType: TextInputContentType?,
+        capitalization: TextInputCapitalization?
+    ) -> some View {
+        #if os(iOS)
+        self.keyboardType(keyboard.uiKeyboardType)
+            .textContentType(contentType?.uiTextContentType)
+            .textInputAutocapitalization(capitalization?.swiftUIValue)
+        #else
+        self
+        #endif
+    }
+}
+
+#if os(iOS)
+private extension TextInputKeyboard {
+    var uiKeyboardType: UIKeyboardType {
+        switch self {
+        case .default: return .default
+        case .asciiCapable: return .asciiCapable
+        case .numberPad: return .numberPad
+        case .decimalPad: return .decimalPad
+        case .phonePad: return .phonePad
+        case .emailAddress: return .emailAddress
+        case .url: return .URL
+        case .numbersAndPunctuation: return .numbersAndPunctuation
+        case .webSearch: return .webSearch
+        }
+    }
+}
+
+private extension TextInputContentType {
+    var uiTextContentType: UITextContentType {
+        switch self {
+        case .name: return .name
+        case .givenName: return .givenName
+        case .familyName: return .familyName
+        case .username: return .username
+        case .password: return .password
+        case .newPassword: return .newPassword
+        case .oneTimeCode: return .oneTimeCode
+        case .emailAddress: return .emailAddress
+        case .telephoneNumber: return .telephoneNumber
+        case .fullStreetAddress: return .fullStreetAddress
+        case .postalCode: return .postalCode
+        case .creditCardNumber: return .creditCardNumber
+        case .url: return .URL
+        }
+    }
+}
+
+private extension TextInputCapitalization {
+    var swiftUIValue: TextInputAutocapitalization {
+        switch self {
+        case .never: return .never
+        case .characters: return .characters
+        case .words: return .words
+        case .sentences: return .sentences
+        }
+    }
+}
+#endif
+
 #Preview {
     struct Demo: View {
         @State var email = ""
         @State var pass = ""
+        @State var bio = ""
         private var emailMessages: [InfoMessage] {
             Validator.validate(email, [.required(), .email()])
         }
         var body: some View {
             VStack(spacing: 16) {
+                // Email keyboard + autofill, no autocaps/autocorrect, "next" return key.
                 TextInput("Email", text: $email, leadingSystemImage: "envelope",
-                          allowClear: true, infoMessages: emailMessages, accessibilityID: "loginEmail")
+                          allowClear: true, infoMessages: emailMessages, accessibilityID: "loginEmail",
+                          keyboardType: .emailAddress, textContentType: .emailAddress,
+                          submitLabel: .next, autocapitalization: .never, autocorrectionDisabled: true)
+                // Password manager autofill on a secure field.
                 TextInput(TextInputModel(label: "Şifre", isSecure: true, maxLength: 24, showCount: true,
-                                         accessibilityID: "loginPass"), text: $pass)
+                                         accessibilityID: "loginPass", textContentType: .password,
+                                         submitLabel: .go), text: $pass)
+                // Soft limit: can exceed 80, counter turns red instead of truncating.
+                TextInput("Bio", text: $bio, maxLength: 80, showCount: true,
+                          hardLimit: false, countStyle: .remaining)
             }
             .padding()
         }

--- a/Tests/ThemeKitTests/TextInputTests.swift
+++ b/Tests/ThemeKitTests/TextInputTests.swift
@@ -1,0 +1,51 @@
+//
+//  TextInputTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Coverage for TextInput's character-counter formatting and soft-limit check.
+//
+
+import XCTest
+@testable import ThemeKit
+
+final class TextInputTests: XCTestCase {
+
+    // MARK: - counterText
+
+    func testCountStyleWithMaxLength() {
+        XCTAssertEqual(TextInput.counterText(count: 12, maxLength: 50, style: .count), "12/50")
+    }
+
+    func testCountStyleWithoutMaxLength() {
+        // No limit configured → plain character count.
+        XCTAssertEqual(TextInput.counterText(count: 7, maxLength: nil, style: .count), "7")
+    }
+
+    func testRemainingStyleWithMaxLength() {
+        XCTAssertEqual(TextInput.counterText(count: 12, maxLength: 50, style: .remaining), "38 left")
+    }
+
+    func testRemainingStyleCanGoNegativeWhenOver() {
+        // Soft limit lets the field exceed max; "remaining" reads negative.
+        XCTAssertEqual(TextInput.counterText(count: 55, maxLength: 50, style: .remaining), "-5 left")
+    }
+
+    func testRemainingStyleWithoutMaxLengthFallsBackToCount() {
+        XCTAssertEqual(TextInput.counterText(count: 7, maxLength: nil, style: .remaining), "7")
+    }
+
+    // MARK: - isOverLimit
+
+    func testNotOverLimitAtMax() {
+        XCTAssertFalse(TextInput.isOverLimit(count: 50, maxLength: 50))
+    }
+
+    func testOverLimit() {
+        XCTAssertTrue(TextInput.isOverLimit(count: 51, maxLength: 50))
+    }
+
+    func testNeverOverLimitWithoutMaxLength() {
+        XCTAssertFalse(TextInput.isOverLimit(count: 9999, maxLength: nil))
+    }
+}


### PR DESCRIPTION
## What

Additive, backward-compatible extension of `TextInput` / `TextInputModel` (Molecule) — keyboard & autofill configuration, plus a soft character limit.

> Note: clear button, character counter, secure reveal toggle, and prefix/suffix addons already existed — this PR adds what was genuinely missing.

## Changes

**Keyboard & autofill**
- `keyboardType`, `textContentType` (password-manager / autofill — important for secure fields), `submitLabel`, `autocapitalization`, `autocorrectionDisabled`, and an `onSubmit` callback.
- Exposed via **platform-neutral enums** (`TextInputKeyboard`, `TextInputContentType`, `TextInputCapitalization`) mapped to UIKit/SwiftUI types under `#if os(iOS)` — no-op on macOS, matching the existing `OTPInput` keyboard-trait pattern.

**Soft character limit**
- `hardLimit: false` lets text exceed `maxLength` instead of truncating, and the counter turns red when over.
- The counter now also renders without a `maxLength`, plus a `remaining` count style ("38 left").

## Backward compatibility

All new fields are defaulted (`submitLabel = .return`, `hardLimit = true`, etc.). Existing call sites — both the flat and `TextInputModel` initializers — are unaffected.

## Tests

Pure helpers `TextInput.counterText(...)` / `isOverLimit(...)` extracted and covered by **8 new unit tests** (`TextInputTests.swift`). Demo gallery (`TextInputDemo`) gains `password` (autofill) and `bio` (soft-limit) modes; registry usage updated.

- `swift build` (macOS) ✓ · `xcodebuild` (iOS Simulator) → BUILD SUCCEEDED ✓ · `swift test` → 96 passing ✓ · SwiftLint clean ✓

> ⚠️ CI checks may show red due to the GitHub Actions **billing** block (account-level, unrelated to this code) — same as the recently-merged #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
