### PR TITLE
feat(inputnumber): editable entry, step & unit suffix (Ant InputNumber)

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -74,7 +74,7 @@ enum ComponentRegistry {
         .knob("ThemeButton", .molecules, demo: ThemeButtonDemo(), usage: #"ThemeButton("Save", color: .success, variant: .soft, size: .medium, shape: .pill) { }"#),
         .knob("Checkbox", .molecules, demo: CheckboxDemo(), usage: #"Checkbox("Accept terms", isChecked: $on, infoMessages: error ? [.init("Required", kind: .error)] : [])"#),
         .knob("CheckboxGroup", .molecules, demo: CheckboxGroupDemo(), usage: #"CheckboxGroup(options: items, selection: $set) { $0 }"#),
-        .knob("InputNumber", .molecules, demo: InputNumberDemo(), usage: #"InputNumber(label: "Guests", value: $count, range: 1...9)"#),
+        .knob("InputNumber", .molecules, demo: InputNumberDemo(), usage: #"InputNumber(label: "Max price", value: $n, range: 0...10000, step: 50, unit: "₺")"#),
         .knob("MultiLineTextInput", .molecules, demo: MultiLineDemo(), usage: #"MultiLineTextInput("Notes", text: $text, characterLimit: 200)"#),
         .knob("OTPInput", .molecules, demo: OTPDemo(), usage: #"OTPInput(code: $code, digitCount: 6, isSecure: true,\n         onComplete: { verify($0) }, resendInterval: 30, onResend: { resend() })"#),
         .knob("Breadcrumbs", .molecules, demo: BreadcrumbsDemo(), usage: #"Breadcrumbs([.init("Home", action: { }), .init("Current")])"#),

--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -286,17 +286,29 @@ struct InputNumberDemo: View {
     @State private var value = 2
     @State private var large = true
     @State private var showError = false
+    @State private var editable = true
+    @State private var priceMode = false   // toggles a step:50 + "₺" unit config
 
     var body: some View {
-        ComponentStage("InputNumber", inspector: [("value", "\(value)")]) {
-            InputNumber(label: "Guests", value: $value, range: 1...9,
-                        hint: showError ? nil : "Max 9 guests",
-                        errorText: showError ? "Too many" : nil, large: large)
+        ComponentStage("InputNumber", inspector: [("value", "\(value)"), ("editable", "\(editable)")]) {
+            if priceMode {
+                InputNumber(label: "Max price", value: $value, range: 0...10000, step: 50, unit: "₺",
+                            editable: editable, hint: "Type or step by 50", large: large)
+            } else {
+                InputNumber(label: "Guests", value: $value, range: 1...9, unit: "kişi",
+                            editable: editable,
+                            hint: showError ? nil : "Type a number or use ± ",
+                            errorText: showError ? "Too many" : nil, large: large)
+            }
         } knobs: {
-            Stepper("Value: \(value)", value: $value, in: 1...9)
+            Text("editable = type the value directly (Ant InputNumber); ± steps by `step`.").font(.caption).foregroundStyle(.secondary)
+            Stepper("Value: \(value)", value: $value, in: 0...10000)
+            Toggle("Editable (type to enter)", isOn: $editable)
+            Toggle("Price mode (step 50, ₺)", isOn: $priceMode)
             Toggle("Large", isOn: $large)
             Toggle("Error state", isOn: $showError)
         }
+        .onChange(of: priceMode) { _, price in value = price ? 500 : 2 }
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/InputNumber.swift
+++ b/Sources/ThemeKit/Components/Molecules/InputNumber.swift
@@ -7,6 +7,10 @@
 //  text and default / disabled / error states. (Form-field counterpart of the
 //  pill-shaped QuantityStepper.)
 //
+//  Reference: Ant Design `InputNumber` / Chakra `NumberInput` — the value is
+//  directly editable (type a number, clamped to `range` on commit), steppers move
+//  by `step`, and an optional `unit` suffix labels the value (e.g. "kişi", "₺").
+//
 
 import SwiftUI
 
@@ -14,18 +18,31 @@ public struct InputNumber: View {
     private let label: String?
     @Binding private var value: Int
     private let range: ClosedRange<Int>
+    private let step: Int
+    private let unit: String?
+    private let editable: Bool
     private let hint: String?
     private let errorText: String?
+    private let hasInfo: Bool
+    private let onChange: ((Int) -> Void)?
     private let accessibilityID: String?
     private let isEnabled: Bool
     private let height: CGFloat
+
+    @FocusState private var isFocused: Bool
+    @State private var textValue: String
 
     public init(
         label: String? = nil,
         value: Binding<Int>,
         range: ClosedRange<Int> = 0...99,
+        step: Int = 1,
+        unit: String? = nil,
+        editable: Bool = true,
         hint: String? = nil,
         errorText: String? = nil,
+        hasInfo: Bool = false,
+        onChange: ((Int) -> Void)? = nil,
         accessibilityID: String? = nil,
         isEnabled: Bool = true,
         large: Bool = false
@@ -33,11 +50,17 @@ public struct InputNumber: View {
         self.label = label
         self._value = value
         self.range = range
+        self.step = step
+        self.unit = unit
+        self.editable = editable
         self.hint = hint
         self.errorText = errorText
+        self.hasInfo = hasInfo
+        self.onChange = onChange
         self.accessibilityID = accessibilityID
         self.isEnabled = isEnabled
         self.height = large ? 48 : 40
+        self._textValue = State(initialValue: String(value.wrappedValue))
     }
 
     private var hasError: Bool { errorText != nil }
@@ -47,28 +70,29 @@ public struct InputNumber: View {
             if let label {
                 HStack(spacing: 4) {
                     Text(label).textStyle(.labelSm600).foregroundStyle(labelColor)
-                    Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(Theme.shared.text(.textTertiary))
+                    if hasInfo {
+                        Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(Theme.shared.text(.textTertiary))
+                    }
                 }
             }
 
             HStack(spacing: Theme.SpacingKey.sm.value) {
-                stepper("minus", enabled: value > range.lowerBound) { value = max(range.lowerBound, value - 1) }
-                Spacer(minLength: 0)
-                Text("\(value)")
-                    .textStyle(.labelMd600)
-                    .monospacedDigit()
-                    .foregroundStyle(isEnabled ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textDisabled))
-                Spacer(minLength: 0)
-                stepper("plus", enabled: value < range.upperBound) { value = min(range.upperBound, value + 1) }
+                stepper("minus", label: String(themeKit: "Decrease"), enabled: value > range.lowerBound) {
+                    setValue(value - step)
+                }
+                middle
+                    .frame(maxWidth: .infinity)
+                stepper("plus", label: String(themeKit: "Increase"), enabled: value < range.upperBound) {
+                    setValue(value + step)
+                }
             }
             .padding(.horizontal, Theme.SpacingKey.xs.value)
             .frame(height: height)
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                    .strokeBorder(borderColor, lineWidth: hasError ? 1.5 : 1)
+                    .strokeBorder(borderColor, lineWidth: hasError || isFocused ? 1.5 : 1)
             )
             .a11y(A11yElement.Control.stepper, in: accessibilityID)
-            .accessibilityLabel(label ?? "")
             .accessibilityValue("\(value)")
 
             if let message = errorText ?? hint {
@@ -77,9 +101,50 @@ public struct InputNumber: View {
                     .foregroundStyle(hasError ? Theme.shared.foreground(.systemcolorsFgError) : Theme.shared.text(.textTertiary))
             }
         }
+        .onChange(of: value) { _, newValue in
+            // Reflect stepper / external changes back into the editable text.
+            let normalized = String(newValue)
+            if textValue != normalized && !isFocused { textValue = normalized }
+        }
+        .onChange(of: textValue) { _, newText in
+            // Live-apply a valid in-range entry; full clamp happens on commit.
+            guard editable, let parsed = Self.parse(newText, range: range) else { return }
+            let clamped = Self.clamp(parsed, to: range)
+            if clamped == parsed, clamped != value { value = clamped; onChange?(clamped) }
+        }
+        .onChange(of: isFocused) { _, focused in
+            if !focused { commit() }
+        }
     }
 
-    private func stepper(_ systemName: String, enabled: Bool, action: @escaping () -> Void) -> some View {
+    @ViewBuilder
+    private var middle: some View {
+        HStack(spacing: 2) {
+            if editable {
+                TextField("", text: $textValue)
+                    .multilineTextAlignment(.center)
+                    .focused($isFocused)
+                    .disabled(!isEnabled)
+                    .submitLabel(.done)
+                    .onSubmit { commit() }
+                    .numericKeyboard(allowsNegative: range.lowerBound < 0)
+                    .a11y(A11yElement.Field.field, in: accessibilityID)
+                    .accessibilityLabel(label ?? String(themeKit: "Value"))
+            } else {
+                Text("\(value)")
+            }
+            if let unit {
+                Text(unit)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(Theme.shared.text(.textTertiary))
+            }
+        }
+        .textStyle(.labelMd600)
+        .monospacedDigit()
+        .foregroundStyle(isEnabled ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textDisabled))
+    }
+
+    private func stepper(_ systemName: String, label: String, enabled: Bool, action: @escaping () -> Void) -> some View {
         let active = enabled && isEnabled
         return Button(action: action) {
             Image(systemName: systemName)
@@ -91,13 +156,57 @@ public struct InputNumber: View {
         }
         .buttonStyle(.plain)
         .disabled(!active)
+        .accessibilityLabel(label)
+    }
+
+    private func setValue(_ new: Int) {
+        let clamped = Self.clamp(new, to: range)
+        if clamped != value { value = clamped; onChange?(clamped) }
+        textValue = String(clamped)
+    }
+
+    private func commit() {
+        let clamped = Self.clamp(Self.parse(textValue, range: range) ?? value, to: range)
+        if clamped != value { value = clamped; onChange?(clamped) }
+        textValue = String(clamped)
     }
 
     private var labelColor: Color {
         hasError ? Theme.shared.foreground(.systemcolorsFgError) : Theme.shared.text(.textPrimary)
     }
     private var borderColor: Color {
-        hasError ? Theme.shared.border(.systemcolorsBorderError) : Theme.shared.border(.borderPrimary)
+        if hasError { return Theme.shared.border(.systemcolorsBorderError) }
+        if isFocused { return Theme.shared.border(.borderHero) }
+        return Theme.shared.border(.borderPrimary)
+    }
+
+    // MARK: - Pure helpers (extracted for testing)
+
+    /// Constrains `value` to `range`.
+    static func clamp(_ value: Int, to range: ClosedRange<Int>) -> Int {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+
+    /// Parses user text into an Int, keeping only digits (and a leading minus when
+    /// the range admits negatives). Returns nil for empty / non-numeric input.
+    static func parse(_ text: String, range: ClosedRange<Int>) -> Int? {
+        let negative = range.lowerBound < 0 && text.trimmingCharacters(in: .whitespaces).hasPrefix("-")
+        let digits = text.filter(\.isNumber)
+        guard !digits.isEmpty, let magnitude = Int(digits) else { return nil }
+        return negative ? -magnitude : magnitude
+    }
+}
+
+private extension View {
+    /// Numeric keyboard (iOS only). Uses a punctuation keyboard when negatives are
+    /// allowed so the user can type a leading minus.
+    @ViewBuilder
+    func numericKeyboard(allowsNegative: Bool) -> some View {
+        #if os(iOS)
+        self.keyboardType(allowsNegative ? .numbersAndPunctuation : .numberPad)
+        #else
+        self
+        #endif
     }
 }
 
@@ -105,10 +214,12 @@ public struct InputNumber: View {
     struct Demo: View {
         @State var a = 1
         @State var b = 1
+        @State var price = 500
         var body: some View {
             VStack(spacing: 16) {
-                InputNumber(label: "Adults", value: $a, range: 1...9, hint: "This is a hint text.", large: true)
+                InputNumber(label: "Adults", value: $a, range: 1...9, unit: "kişi", hint: "Type or step.", large: true)
                 InputNumber(label: "Children", value: $b, errorText: "Too many")
+                InputNumber(label: "Max price", value: $price, range: 0...10000, step: 50, unit: "₺")
             }
             .padding()
         }

--- a/Tests/ThemeKitTests/InputNumberTests.swift
+++ b/Tests/ThemeKitTests/InputNumberTests.swift
@@ -1,0 +1,49 @@
+//
+//  InputNumberTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Coverage for InputNumber's clamp + text parsing (digits-only, optional sign).
+//
+
+import XCTest
+@testable import ThemeKit
+
+final class InputNumberTests: XCTestCase {
+
+    // MARK: - clamp
+
+    func testClampBelowLowerBound() {
+        XCTAssertEqual(InputNumber.clamp(-3, to: 0...9), 0)
+    }
+
+    func testClampAboveUpperBound() {
+        XCTAssertEqual(InputNumber.clamp(42, to: 0...9), 9)
+    }
+
+    func testClampWithinRange() {
+        XCTAssertEqual(InputNumber.clamp(5, to: 0...9), 5)
+    }
+
+    // MARK: - parse
+
+    func testParseDigits() {
+        XCTAssertEqual(InputNumber.parse("12", range: 0...99), 12)
+    }
+
+    func testParseStripsNonDigits() {
+        XCTAssertEqual(InputNumber.parse("1a2", range: 0...99), 12)
+        XCTAssertEqual(InputNumber.parse("007", range: 0...99), 7)
+    }
+
+    func testParseEmptyReturnsNil() {
+        XCTAssertNil(InputNumber.parse("", range: 0...99))
+        XCTAssertNil(InputNumber.parse("abc", range: 0...99))
+    }
+
+    func testParseNegativeOnlyWhenRangeAllows() {
+        XCTAssertEqual(InputNumber.parse("-5", range: -10...10), -5)
+        // Range has no negatives → the minus is ignored, magnitude kept.
+        XCTAssertEqual(InputNumber.parse("-5", range: 0...10), 5)
+    }
+}


### PR DESCRIPTION
## What

Additive, backward-compatible extension of `InputNumber` (Molecule) toward **Ant Design `InputNumber`** / **Chakra `NumberInput`** — the value becomes directly editable, steppers move by `step`, and an optional `unit` labels the value.

## Changes

- **Editable text entry** — type the number directly (numeric keyboard, clamped to `range` on commit). Previously the value was a read-only `Text` and only the ± steppers worked. `editable: true` by default; pass `false` for the old stepper-only field.
- **`step`** — stepper increment/decrement amount (was hardcoded `1`).
- **`unit`** — optional suffix label for the value (e.g. `"kişi"`, `"₺"`).
- **`onChange`** callback; ± buttons gain VoiceOver labels (Increase/Decrease).
- Fixed the hardcoded `info.circle` label marker (now opt-in via `hasInfo`), matching the DateField fix.

## Backward compatibility

All new params are defaulted. Existing call sites keep their range/steppers; the only behavioral change is the value is now tap-to-edit (set `editable: false` to opt out).

## Tests & demo

Pure `clamp(_:to:)` / `parse(_:range:)` helpers extracted → **7 unit tests**. Demo + registry updated (editable toggle, price `step: 50` + `₺` unit).

- `swift build` (macOS) ✓ · iOS Simulator ✓ · Demo app ✓ · `swift test` → 117 passing ✓ · SwiftLint clean ✓

> ⚠️ CI may show red due to the GitHub Actions **billing** block (account-level, unrelated to this code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
