### PR TITLE
feat(datatable): built-in pagination & loading state (Ant Table)

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -116,7 +116,7 @@ enum ComponentRegistry {
         .knob("Card", .organisms, demo: CardDemo(), usage: #"Card(elevation: .soft) { content }"#),
         .knob("ChatBubble", .organisms, demo: ChatBubbleDemo(), usage: #"ChatBubble("Hi!", side: .outgoing, time: "09:24", avatarSystemImage: "person.fill")"#),
         .knob("Counter", .organisms, demo: CounterDemo(), usage: #"Counter(days: 2, hours: 8, minutes: 45)"#),
-        .knob("DataTable", .organisms, demo: DataTableDemo(), usage: #"DataTable(columns: [.init("Hotel", sortKey: { .string($0.hotel) }) { $0.hotel }], rows: rows, selection: $selected)"#),
+        .knob("DataTable", .organisms, demo: DataTableDemo(), usage: #"DataTable(columns: cols, rows: rows, selection: $selected, pageSize: 10)"#),
         .knob("Drawer", .organisms, demo: DrawerDemo(), usage: #"someView.drawer(isPresented: $open, edge: .leading) { menu }\n// or imperative: install .drawerHost(); @EnvironmentObject var drawer: DrawerPresenter\ndrawer.present(edge: .leading) { menu }   // drag-to-dismiss built in"#),
         .knob("FAB", .organisms, demo: FABDemo(), usage: #"FloatingActionButton(systemImage: "plus", actions: [.init(systemImage: "camera", action: { })])"#),
         .knob("Hero", .organisms, demo: HeroDemo(), usage: #"Hero(title: "…", subtitle: "…", ctaTitle: "Explore", action: { })"#),

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -966,25 +966,33 @@ struct DateFieldDemo: View {
 
 struct DataTableDemo: View {
     private struct Booking: Identifiable { let id = UUID(); let hotel: String; let nights: Int; let price: Double }
-    private let rows = [
-        Booking(hotel: "Grand Hotel", nights: 3, price: 4250),
-        Booking(hotel: "Sea Resort", nights: 5, price: 7800),
-        Booking(hotel: "City Inn", nights: 2, price: 1900),
-    ]
+    private let rows: [Booking] = [
+        ("Grand Hotel", 3, 4250), ("Sea Resort", 5, 7800), ("City Inn", 2, 1900),
+        ("Pine Lodge", 4, 5200), ("Bay Suites", 6, 9100), ("Old Town B&B", 1, 1200),
+        ("Sky Tower", 3, 6400), ("Garden Palace", 7, 11800), ("Harbor View", 2, 3300),
+        ("Mountain Cabin", 5, 4700),
+    ].map { Booking(hotel: $0.0, nights: $0.1, price: $0.2) }
+
     @State private var striped = true
     @State private var selectable = false
+    @State private var paged = true
+    @State private var loading = false
     @State private var selected: Set<UUID> = []
+
     var body: some View {
-        ComponentStage("DataTable", inspector: [("rows", "\(rows.count)"), ("selected", "\(selected.count)")]) {
+        ComponentStage("DataTable", inspector: [("rows", "\(rows.count)"), ("paged", paged ? "4/page" : "off")]) {
             DataTable(columns: [
                 .init("Hotel", sortKey: { .string($0.hotel) }) { $0.hotel },
                 .init("Nights", align: .center, sortKey: { .number(Double($0.nights)) }) { "\($0.nights)" },
                 .init("Price", align: .trailing, sortKey: { .number($0.price) }) { "₺\(Int($0.price))" },
-            ], rows: rows, striped: striped, selection: selectable ? $selected : nil)
+            ], rows: rows, striped: striped, selection: selectable ? $selected : nil,
+               pageSize: paged ? 4 : nil, isLoading: loading)
         } knobs: {
             Toggle("Striped", isOn: $striped)
             Toggle("Selectable rows", isOn: $selectable)
-            Text("Tap a column header to sort.").font(.footnote).foregroundStyle(.secondary)
+            Toggle("Paginated (4 / page)", isOn: $paged)
+            Toggle("Loading", isOn: $loading)
+            Text("Tap a column header to sort; the page resets to 1.").font(.footnote).foregroundStyle(.secondary)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/DataTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/DataTable.swift
@@ -73,22 +73,29 @@ public struct DataTable<Row: Identifiable>: View {
     private let rows: [Row]
     private let striped: Bool
     private let selection: Binding<Set<Row.ID>>?
+    private let pageSize: Int?
+    private let isLoading: Bool
     private let onRowTap: ((Row) -> Void)?
 
     @State private var sortColumn: Int?
     @State private var sortAscending = true
+    @State private var currentPage = 1
 
     public init(
         columns: [Column],
         rows: [Row],
         striped: Bool = true,
         selection: Binding<Set<Row.ID>>? = nil,
+        pageSize: Int? = nil,
+        isLoading: Bool = false,
         onRowTap: ((Row) -> Void)? = nil
     ) {
         self.columns = columns
         self.rows = rows
         self.striped = striped
         self.selection = selection
+        self.pageSize = pageSize
+        self.isLoading = isLoading
         self.onRowTap = onRowTap
     }
 
@@ -100,19 +107,44 @@ public struct DataTable<Row: Identifiable>: View {
 
     private var isInteractive: Bool { selection != nil || onRowTap != nil }
 
+    private var pageCount: Int { Self.pageCount(rowCount: displayRows.count, pageSize: pageSize) }
+    private var pagedRows: [Row] {
+        Array(displayRows[Self.pageRange(rowCount: displayRows.count, pageSize: pageSize, page: currentPage)])
+    }
+    private func clampPage() { if currentPage > pageCount { currentPage = pageCount } }
+
     public var body: some View {
+        VStack(spacing: Theme.SpacingKey.sm.value) {
+            tableCard
+            if pageSize != nil, pageCount > 1 {
+                HStack {
+                    Spacer()
+                    Pagination(current: $currentPage, total: pageCount)
+                }
+            }
+        }
+        .onChange(of: rows.count) { _, _ in clampPage() }
+        .onChange(of: sortColumn) { _, _ in currentPage = 1 }
+    }
+
+    private var tableCard: some View {
         VStack(spacing: 0) {
             headerRow
-            if displayRows.isEmpty {
+            if isLoading {
+                loadingRow
+            } else if displayRows.isEmpty {
                 emptyRow
             } else {
-                ForEach(Array(displayRows.enumerated()), id: \.element.id) { index, row in
+                ForEach(Array(pagedRows.enumerated()), id: \.element.id) { index, row in
                     dataRow(row, index: index)
                 }
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).stroke(Theme.shared.border(.borderPrimary), lineWidth: 1))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
+                .stroke(Theme.shared.border(.borderPrimary), lineWidth: 1)
+        )
     }
 
     // MARK: - Header
@@ -198,6 +230,34 @@ public struct DataTable<Row: Identifiable>: View {
             .frame(maxWidth: .infinity)
             .padding(.vertical, Theme.SpacingKey.lg.value)
             .background(Theme.shared.background(.bgWhite))
+    }
+
+    private var loadingRow: some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            Spinner(size: IconSize.sm.value, lineWidth: 2)
+            Text(String(themeKit: "Loading…"))
+                .textStyle(.bodyBase400)
+                .foregroundStyle(Theme.shared.text(.textTertiary))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.SpacingKey.lg.value)
+        .background(Theme.shared.background(.bgWhite))
+    }
+
+    // MARK: - Pure paging (extracted for testing)
+
+    /// Number of pages for `rowCount` items at `pageSize` (1 when paging is off).
+    static func pageCount(rowCount: Int, pageSize: Int?) -> Int {
+        guard let size = pageSize, size > 0, rowCount > 0 else { return 1 }
+        return (rowCount + size - 1) / size
+    }
+
+    /// Index range of the rows shown on `page` (clamped); the full range when off.
+    static func pageRange(rowCount: Int, pageSize: Int?, page: Int) -> Range<Int> {
+        guard let size = pageSize, size > 0, rowCount > 0 else { return 0..<rowCount }
+        let clamped = min(max(page, 1), pageCount(rowCount: rowCount, pageSize: size))
+        let start = (clamped - 1) * size
+        return start..<min(start + size, rowCount)
     }
 }
 

--- a/Tests/ThemeKitTests/DataTablePagingTests.swift
+++ b/Tests/ThemeKitTests/DataTablePagingTests.swift
@@ -1,0 +1,62 @@
+//
+//  DataTablePagingTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Coverage for DataTable's pure paging math (page count + per-page index range).
+//
+
+import XCTest
+@testable import ThemeKit
+
+final class DataTablePagingTests: XCTestCase {
+
+    private struct TableRow: Identifiable { let id: Int }
+    private typealias Table = DataTable<TableRow>
+
+    // MARK: - pageCount
+
+    func testPageCountOffWhenNoPageSize() {
+        XCTAssertEqual(Table.pageCount(rowCount: 10, pageSize: nil), 1)
+        XCTAssertEqual(Table.pageCount(rowCount: 10, pageSize: 0), 1)
+    }
+
+    func testPageCountRoundsUp() {
+        XCTAssertEqual(Table.pageCount(rowCount: 10, pageSize: 3), 4)
+        XCTAssertEqual(Table.pageCount(rowCount: 9, pageSize: 3), 3)
+    }
+
+    func testPageCountFewerRowsThanPageSize() {
+        XCTAssertEqual(Table.pageCount(rowCount: 3, pageSize: 5), 1)
+    }
+
+    func testPageCountEmpty() {
+        XCTAssertEqual(Table.pageCount(rowCount: 0, pageSize: 5), 1)
+    }
+
+    // MARK: - pageRange
+
+    func testFirstPageRange() {
+        XCTAssertEqual(Table.pageRange(rowCount: 10, pageSize: 3, page: 1), 0..<3)
+    }
+
+    func testMiddlePageRange() {
+        XCTAssertEqual(Table.pageRange(rowCount: 10, pageSize: 3, page: 2), 3..<6)
+    }
+
+    func testLastPageIsPartial() {
+        XCTAssertEqual(Table.pageRange(rowCount: 10, pageSize: 3, page: 4), 9..<10)
+    }
+
+    func testPageBeyondEndClampsToLast() {
+        XCTAssertEqual(Table.pageRange(rowCount: 10, pageSize: 3, page: 99), 9..<10)
+    }
+
+    func testPageBelowOneClampsToFirst() {
+        XCTAssertEqual(Table.pageRange(rowCount: 10, pageSize: 3, page: 0), 0..<3)
+    }
+
+    func testRangeIsFullWhenPagingOff() {
+        XCTAssertEqual(Table.pageRange(rowCount: 10, pageSize: nil, page: 1), 0..<10)
+    }
+}


### PR DESCRIPTION
## What

Additive, backward-compatible extension of `DataTable` (Organism) toward **Ant Design Table** — the long-list features it was missing.

## Changes

- **`pageSize`** — when set, the table shows one page at a time and renders the `Pagination` control below it (reuses the `Pagination` molecule). The page resets to 1 on sort and clamps when the row count shrinks.
- **`isLoading`** — a spinner + "Loading…" row in place of the body.

## Backward compatibility

Both default off (`pageSize: nil`, `isLoading: false`) — existing tables (sort / striping / selection / empty state) render exactly as before.

## Tests & demo

Paging math extracted into pure `DataTable.pageCount(rowCount:pageSize:)` / `pageRange(rowCount:pageSize:page:)` → **10 unit tests** (round-up, partial last page, clamping, paging-off). Demo expanded to 10 rows with `pageSize` / loading knobs; registry updated.

- `swift build` (macOS) ✓ · iOS Simulator ✓ · Demo app ✓ · `swift test` → 148 passing ✓ · SwiftLint clean (exit 0; pre-existing warnings on untouched lines left as-is)

> ⚠️ CI may show red due to the GitHub Actions **billing** block (account-level, unrelated to this code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
