### PR TITLE
feat(breadcrumbs): maxItems collapse with overflow menu

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -77,7 +77,7 @@ enum ComponentRegistry {
         .knob("InputNumber", .molecules, demo: InputNumberDemo(), usage: #"InputNumber(label: "Max price", value: $n, range: 0...10000, step: 50, unit: "₺")"#),
         .knob("MultiLineTextInput", .molecules, demo: MultiLineDemo(), usage: #"MultiLineTextInput("Notes", text: $text, characterLimit: 200)"#),
         .knob("OTPInput", .molecules, demo: OTPDemo(), usage: #"OTPInput(code: $code, digitCount: 6, isSecure: true,\n         onComplete: { verify($0) }, resendInterval: 30, onResend: { resend() })"#),
-        .knob("Breadcrumbs", .molecules, demo: BreadcrumbsDemo(), usage: #"Breadcrumbs([.init("Home", action: { }), .init("Current")])"#),
+        .knob("Breadcrumbs", .molecules, demo: BreadcrumbsDemo(), usage: #"Breadcrumbs([.init("Home", action: { }), .init("Current")], maxItems: 4)"#),
         .knob("Calendar", .molecules, demo: CalendarDemo(), usage: #"CalendarView(selection: $date)"#),
         .knob("DateField", .molecules, demo: DateFieldDemo(), usage: ##"DateField(label: "Check-in", date: $date, style: .custom("EEE, d MMM"), allowClear: true)"##),
         .knob("Fieldset", .molecules, demo: FieldsetDemo(), usage: #"Fieldset("Contact", helper: "…") { inputs }"#),

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -721,13 +721,16 @@ struct StepsDemo: View {
 }
 
 struct BreadcrumbsDemo: View {
-    @State private var depth = 4.0
-    private let all = ["Home", "Hotels", "İstanbul", "Grand Hotel"]
+    @State private var depth = 6.0
+    @State private var collapse = true
+    private let all = ["Home", "Hotels", "Turkey", "Marmara", "İstanbul", "Grand Hotel"]
     var body: some View {
-        ComponentStage("Breadcrumbs", inspector: [("depth", "\(Int(depth))")]) {
-            Breadcrumbs(all.prefix(Int(depth)).enumerated().map { i, t in .init(t, action: i < Int(depth) - 1 ? { flash("Breadcrumb: \(t)") } : nil) })
+        ComponentStage("Breadcrumbs", inspector: [("depth", "\(Int(depth))"), ("maxItems", collapse ? "4" : "—")]) {
+            Breadcrumbs(all.prefix(Int(depth)).enumerated().map { i, t in .init(t, action: i < Int(depth) - 1 ? { flash("Breadcrumb: \(t)") } : nil) },
+                        maxItems: collapse ? 4 : nil)
         } knobs: {
-            Stepper("Depth: \(Int(depth))", value: $depth, in: 1...4)
+            Stepper("Depth: \(Int(depth))", value: $depth, in: 1...6)
+            Toggle("Collapse middle (maxItems 4 → …)", isOn: $collapse)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Breadcrumbs.swift
+++ b/Sources/ThemeKit/Components/Molecules/Breadcrumbs.swift
@@ -4,7 +4,10 @@
 //  Created by İsa Mercan on 23.06.2026.
 //
 //  Molecule. Horizontal navigation path with chevron separators; the last crumb
-//  is the current page. (daisyUI "Breadcrumbs".)
+//  is the current page. (daisyUI "Breadcrumbs" / Ant Design "Breadcrumb".)
+//
+//  When `maxItems` is set and exceeded, the middle crumbs collapse into a "…"
+//  menu that still navigates to any hidden crumb.
 //
 
 import SwiftUI
@@ -17,36 +20,97 @@ public struct Breadcrumbs: View {
         public init(_ title: String, action: (() -> Void)? = nil) { self.title = title; self.action = action }
     }
 
-    private let crumbs: [Crumb]
+    /// A rendered position: a real crumb, or an ellipsis standing in for hidden ones.
+    enum Entry: Equatable {
+        case crumb(Int)
+        case ellipsis([Int])
+    }
 
-    public init(_ crumbs: [Crumb]) { self.crumbs = crumbs }
+    private let crumbs: [Crumb]
+    private let maxItems: Int?
+
+    public init(_ crumbs: [Crumb], maxItems: Int? = nil) {
+        self.crumbs = crumbs
+        self.maxItems = maxItems
+    }
+
+    private var entries: [Entry] { Self.collapse(count: crumbs.count, maxItems: maxItems) }
 
     public var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: Theme.SpacingKey.xs.value) {
-                ForEach(Array(crumbs.enumerated()), id: \.element.id) { index, crumb in
-                    let isLast = index == crumbs.count - 1
-                    Button { crumb.action?() } label: {
-                        Text(crumb.title)
-                            .textStyle(isLast ? .labelSm700 : .labelSm600)
-                            .foregroundStyle(isLast ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textHero))
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(isLast || crumb.action == nil)
-
-                    if !isLast {
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 10, weight: .semibold))
-                            .foregroundStyle(Theme.shared.text(.textTertiary))
-                            .mirrorsInRTL()
-                    }
+                ForEach(Array(entries.enumerated()), id: \.offset) { position, entry in
+                    entryView(entry)
+                    if position < entries.count - 1 { separator }
                 }
             }
         }
     }
+
+    @ViewBuilder
+    private func entryView(_ entry: Entry) -> some View {
+        switch entry {
+        case .crumb(let index):
+            let isLast = index == crumbs.count - 1
+            Button { crumbs[index].action?() } label: {
+                Text(crumbs[index].title)
+                    .textStyle(isLast ? .labelSm700 : .labelSm600)
+                    .foregroundStyle(isLast ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textHero))
+            }
+            .buttonStyle(.plain)
+            .disabled(isLast || crumbs[index].action == nil)
+
+        case .ellipsis(let hidden):
+            Menu {
+                ForEach(hidden, id: \.self) { index in
+                    Button(crumbs[index].title) { crumbs[index].action?() }
+                }
+            } label: {
+                Text("…")
+                    .textStyle(.labelSm700)
+                    .foregroundStyle(Theme.shared.text(.textHero))
+                    .frame(minWidth: 20)
+            }
+            .accessibilityLabel(String(themeKit: "Show hidden breadcrumbs"))
+        }
+    }
+
+    private var separator: some View {
+        Image(systemName: "chevron.right")
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(Theme.shared.text(.textTertiary))
+            .mirrorsInRTL()
+    }
+
+    // MARK: - Pure collapse (extracted for testing)
+
+    /// Builds the rendered entries. With no `maxItems` (or when it isn't exceeded),
+    /// every crumb shows. Otherwise the first crumb and the last `maxItems - 2`
+    /// crumbs stay, and the middle collapses into one `.ellipsis` carrying the
+    /// hidden indices.
+    static func collapse(count: Int, maxItems: Int?) -> [Entry] {
+        guard let maxItems, maxItems >= 1, count > maxItems else {
+            return (0..<count).map { .crumb($0) }
+        }
+        let head = 1
+        let tail = max(1, maxItems - head - 1)
+        guard head + tail < count else { return (0..<count).map { .crumb($0) } }
+
+        let hidden = Array(head..<(count - tail))
+        var result: [Entry] = (0..<head).map { .crumb($0) }
+        result.append(.ellipsis(hidden))
+        result.append(contentsOf: ((count - tail)..<count).map { .crumb($0) })
+        return result
+    }
 }
 
 #Preview {
-    Breadcrumbs([.init("Home", action: {}), .init("Hotels", action: {}), .init("İstanbul", action: {}), .init("Grand Hotel")])
-        .padding()
+    VStack(alignment: .leading, spacing: 16) {
+        Breadcrumbs([.init("Home", action: {}), .init("Hotels", action: {}), .init("İstanbul", action: {}), .init("Grand Hotel")])
+        Breadcrumbs([
+            .init("Home", action: {}), .init("Hotels", action: {}), .init("Turkey", action: {}),
+            .init("Marmara", action: {}), .init("İstanbul", action: {}), .init("Grand Hotel"),
+        ], maxItems: 4)
+    }
+    .padding()
 }

--- a/Tests/ThemeKitTests/BreadcrumbsTests.swift
+++ b/Tests/ThemeKitTests/BreadcrumbsTests.swift
@@ -1,0 +1,42 @@
+//
+//  BreadcrumbsTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Coverage for Breadcrumbs' pure collapse logic (middle → "…").
+//
+
+import XCTest
+@testable import ThemeKit
+
+final class BreadcrumbsTests: XCTestCase {
+
+    private typealias Entry = Breadcrumbs.Entry
+
+    func testNoMaxItemsShowsAll() {
+        XCTAssertEqual(Breadcrumbs.collapse(count: 4, maxItems: nil),
+                       [.crumb(0), .crumb(1), .crumb(2), .crumb(3)])
+    }
+
+    func testWithinLimitShowsAll() {
+        XCTAssertEqual(Breadcrumbs.collapse(count: 3, maxItems: 4),
+                       [.crumb(0), .crumb(1), .crumb(2)])
+    }
+
+    func testCollapsesMiddleKeepingFirstAndLast() {
+        // 5 crumbs, max 3 → first + ellipsis(1,2,3) + last.
+        XCTAssertEqual(Breadcrumbs.collapse(count: 5, maxItems: 3),
+                       [.crumb(0), .ellipsis([1, 2, 3]), .crumb(4)])
+    }
+
+    func testKeepsMoreTailWhenMaxItemsLarger() {
+        // 6 crumbs, max 4 → first + ellipsis(1,2,3) + last two.
+        XCTAssertEqual(Breadcrumbs.collapse(count: 6, maxItems: 4),
+                       [.crumb(0), .ellipsis([1, 2, 3]), .crumb(4), .crumb(5)])
+    }
+
+    func testTinyMaxItemsStillKeepsEnds() {
+        XCTAssertEqual(Breadcrumbs.collapse(count: 5, maxItems: 1),
+                       [.crumb(0), .ellipsis([1, 2, 3]), .crumb(4)])
+    }
+}


### PR DESCRIPTION
## What

Additive, backward-compatible extension of `Breadcrumbs` (Molecule) toward **Ant Design Breadcrumb** — middle-crumb collapse.

## Changes

- **`maxItems`** — when the path exceeds it, the middle crumbs collapse into a single "…" menu that still navigates to any hidden crumb. The first crumb and the last `maxItems - 2` stay visible.

## Backward compatibility

Defaults to `nil` (no collapse) — existing breadcrumbs render exactly as before.

## Tests & demo

Collapse logic extracted into pure `Breadcrumbs.collapse(count:maxItems:)` returning `.crumb` / `.ellipsis(hidden)` entries → **5 unit tests**. Demo (6-deep path + collapse toggle) + registry updated.

- `swift build` ✓ · Demo app (iOS) ✓ · `swift test` → 153 passing ✓ · SwiftLint clean ✓

> ⚠️ CI may show red due to the GitHub Actions **billing** block (account-level, unrelated to this code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
