### PR TITLE
feat(tag): semantic color variants (Ant Tag colors)

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -61,7 +61,7 @@ enum ComponentRegistry {
         .knob("ScoreBadge", .atoms, demo: ScoreBadgeDemo(), usage: #"ScoreBadge(9.0, large: false)"#),
         .knob("Skeleton", .atoms, demo: SkeletonDemo(), usage: #"Text("Loading…").skeleton(isLoading)"#),
         .knob("Spinner", .atoms, demo: SpinnerDemo(), usage: #"Spinner(size: 24, lineWidth: 3)"#),
-        .knob("Tag", .atoms, demo: TagDemo(), usage: #"Tag("İstanbul", onRemove: { })"#),
+        .knob("Tag", .atoms, demo: TagDemo(), usage: #"Tag("Sold out", style: .error, variant: .solid, onRemove: { })"#),
         .knob("Title", .atoms, demo: TitleDemo(), usage: #"Title("Section", subtitle: "Sub", actionTitle: "See all", action: { })"#),
         .static("InlineText", .atoms, usage: #"InlineText("Accept the Terms.", links: [("Terms", { })])"#) {
             InlineText("By continuing you accept the Terms and the Privacy Policy.", links: [("Terms", {}), ("Privacy Policy", {})])

--- a/Demo/Demo/Gallery/Demos/AtomDemos.swift
+++ b/Demo/Demo/Gallery/Demos/AtomDemos.swift
@@ -213,12 +213,26 @@ struct TagDemo: View {
     @State private var text = "İstanbul"
     @State private var removable = true
     @State private var icon = false
+    @State private var styleIdx = 0   // 0 = neutral (no style)
+    @State private var variant: FillVariant = .soft
+
+    private let styles: [(String, BadgeStyle?)] = [
+        ("Neutral", nil), ("Success", .success), ("Warning", .warning), ("Error", .error), ("Info", .info),
+    ]
 
     var body: some View {
-        ComponentStage("Tag", inspector: [("removable", "\(removable)")]) {
-            Tag(text, leadingSystemImage: icon ? "mappin" : nil, onRemove: removable ? { flash("Tag silindi") } : nil)
+        ComponentStage("Tag", inspector: [("style", styles[styleIdx].0), ("variant", "\(variant)")]) {
+            Tag(text, leadingSystemImage: icon ? "mappin" : nil,
+                style: styles[styleIdx].1, variant: variant,
+                onRemove: removable ? { flash("Tag silindi") } : nil)
         } knobs: {
             TextField("Text", text: $text).textFieldStyle(.roundedBorder)
+            Picker("Style", selection: $styleIdx) {
+                ForEach(Array(styles.enumerated()), id: \.offset) { i, s in Text(s.0).tag(i) }
+            }.pickerStyle(.segmented)
+            Picker("Variant", selection: $variant) {
+                Text("Soft").tag(FillVariant.soft); Text("Solid").tag(FillVariant.solid); Text("Outline").tag(FillVariant.outline)
+            }.pickerStyle(.segmented)
             Toggle("Removable", isOn: $removable)
             Toggle("Leading icon", isOn: $icon)
         }

--- a/Sources/ThemeKit/Components/Atoms/Tag.swift
+++ b/Sources/ThemeKit/Components/Atoms/Tag.swift
@@ -6,17 +6,31 @@
 //  Atom. A compact label, optionally removable. Distinct from Badge (status) and
 //  Chip (selectable): Tag represents an applied keyword/filter.
 //
+//  An optional semantic `style` + `variant` colors the tag (Ant Tag colors),
+//  reusing Badge's `BadgeStyle` / `FillVariant`. With no `style` it keeps the
+//  original neutral keyword look.
+//
 
 import SwiftUI
 
 public struct Tag: View {
     private let text: String
     private let leadingSystemImage: String?
+    private let style: BadgeStyle?
+    private let variant: FillVariant
     private let onRemove: (() -> Void)?
 
-    public init(_ text: String, leadingSystemImage: String? = nil, onRemove: (() -> Void)? = nil) {
+    public init(
+        _ text: String,
+        leadingSystemImage: String? = nil,
+        style: BadgeStyle? = nil,
+        variant: FillVariant = .soft,
+        onRemove: (() -> Void)? = nil
+    ) {
         self.text = text
         self.leadingSystemImage = leadingSystemImage
+        self.style = style
+        self.variant = variant
         self.onRemove = onRemove
     }
 
@@ -31,20 +45,53 @@ public struct Tag: View {
                     Image(systemName: "xmark").font(.system(size: 10, weight: .semibold))
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(String(themeKit: "Remove \(text)"))
             }
         }
-        .foregroundStyle(Theme.shared.text(.textHero))
+        .foregroundStyle(foreground)
         .padding(.horizontal, Theme.SpacingKey.sm.value)
         .frame(height: 28)
-        .background(Theme.shared.background(.bgElevatorTertiary), in: Capsule())
+        .background(background, in: Capsule())
+        .overlay(Capsule().strokeBorder(border, lineWidth: border == .clear ? 0 : 1))
+    }
+
+    private var foreground: Color {
+        guard let style else { return Theme.shared.text(.textHero) }
+        switch variant {
+        case .soft: return style.foreground
+        case .solid: return style.semantic.onSolid
+        case .outline, .ghost: return style.semantic.accent
+        }
+    }
+
+    private var background: Color {
+        guard let style else { return Theme.shared.background(.bgElevatorTertiary) }
+        switch variant {
+        case .soft: return style.background
+        case .solid: return style.semantic.solid
+        case .outline, .ghost: return .clear
+        }
+    }
+
+    private var border: Color {
+        guard let style, variant == .outline else { return .clear }
+        return style.semantic.border
     }
 }
 
 #Preview {
-    HStack {
-        Tag("İstanbul", onRemove: {})
-        Tag("Beach", leadingSystemImage: "beach.umbrella")
-        Tag("5 stars")
+    VStack(alignment: .leading, spacing: 12) {
+        HStack {
+            Tag("İstanbul", onRemove: {})
+            Tag("Beach", leadingSystemImage: "beach.umbrella")
+            Tag("5 stars")
+        }
+        HStack {
+            Tag("Success", style: .success)
+            Tag("Warning", style: .warning)
+            Tag("Error", style: .error, variant: .solid)
+            Tag("Info", style: .info, variant: .outline)
+        }
     }
     .padding()
 }


### PR DESCRIPTION
## What

Additive, backward-compatible extension of `Tag` (Atom) toward **Ant Design Tag** colors.

## Changes

- **`style: BadgeStyle?`** — optional semantic color (neutral / info / success / warning / error / pink / orange / turquoise / purple).
- **`variant: FillVariant`** — soft (default) / solid / outline.

Reuses Badge's existing `BadgeStyle` / `FillVariant` so Tag and Badge share one color system.

## Backward compatibility

With no `style` (the default), the tag keeps its original neutral keyword look — existing call sites and the recorded Tag snapshot are unaffected.

## Notes

Visual-only change (no new branching logic), verified by build + the gallery demo (style / variant pickers). Registry usage updated.

- `swift build` ✓ · Demo app (iOS) ✓ · `swift test` → 153 passing ✓ · SwiftLint clean ✓

> ⚠️ CI may show red due to the GitHub Actions **billing** block (account-level, unrelated to this code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
