### PR TITLE
feat(avatar): presence / status dot

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -38,7 +38,7 @@ struct ComponentEntry: Identifiable {
 enum ComponentRegistry {
     static let all: [ComponentEntry] = [
         // MARK: Atoms
-        .knob("Avatar", .atoms, demo: AvatarDemo(), usage: #"Avatar(.initials("AB"), size: .md, background: .blue)"#),
+        .knob("Avatar", .atoms, demo: AvatarDemo(), usage: #"Avatar(.initials("AB"), size: .md, presence: .online)"#),
         .knob("Badge", .atoms, demo: BadgeDemo(), usage: #"Badge("Label", style: .info, leadingSystemImage: "star.fill")"#),
         .knob("Chip", .atoms, demo: ChipDemo(), usage: #"Chip("Recommended", isSelected: $selected, selectionStyle: .tonal)"#),
         .knob("Color Palette", .atoms, demo: ColorLadderDemo(), usage: #"SemanticColor.primary.shade(.s500)   // base · .bg .hover .active .strong"#),

--- a/Demo/Demo/Gallery/Demos/AtomDemos.swift
+++ b/Demo/Demo/Gallery/Demos/AtomDemos.swift
@@ -17,19 +17,28 @@ struct AvatarDemo: View {
     @State private var square = false
     @State private var group = false
     @State private var numeric = 0.0   // 0 = use enum tier; >0 = custom point size
+    @State private var presenceIdx = 1   // 0 = none
+
+    private let presences: [(String, StatusKind?)] = [
+        ("None", nil), ("Online", .online), ("Away", .away), ("Busy", .busy), ("Offline", .offline),
+    ]
+    private var presence: StatusKind? { presences[presenceIdx].1 }
 
     var body: some View {
         ComponentStage("Avatar", inspector: [
-            ("size", numeric > 0 ? "\(Int(numeric))pt" : "\(Int(size.rawValue))"), ("shape", square ? "square" : "circle"),
+            ("size", numeric > 0 ? "\(Int(numeric))pt" : "\(Int(size.rawValue))"), ("presence", presences[presenceIdx].0),
         ]) {
             if group {
                 AvatarGroup([.initials("AB"), .initials("CD"), .initials("EF"), .icon("person.fill"), .initials("GH"), .initials("IJ")], size: size, max: 4)
             } else if numeric > 0 {
-                Avatar(initials ? .initials("AB") : .icon("person.fill"), dimension: numeric, background: background, shape: square ? .square : .circle)
+                Avatar(initials ? .initials("AB") : .icon("person.fill"), dimension: numeric, background: background, shape: square ? .square : .circle, presence: presence, presencePulse: presence == .online)
             } else {
-                Avatar(initials ? .initials("AB") : .icon("person.fill"), size: size, background: background, shape: square ? .square : .circle)
+                Avatar(initials ? .initials("AB") : .icon("person.fill"), size: size, background: background, shape: square ? .square : .circle, presence: presence, presencePulse: presence == .online)
             }
         } knobs: {
+            Picker("Presence", selection: $presenceIdx) {
+                ForEach(Array(presences.enumerated()), id: \.offset) { i, p in Text(p.0).tag(i) }
+            }.pickerStyle(.segmented).disabled(group)
             Picker("Size", selection: $size) {
                 ForEach(AvatarSize.allCases, id: \.self) { Text("\(Int($0.rawValue))").tag($0) }
             }.pickerStyle(.segmented).disabled(numeric > 0)

--- a/Sources/ThemeKit/Components/Atoms/Avatar.swift
+++ b/Sources/ThemeKit/Components/Atoms/Avatar.swift
@@ -53,22 +53,42 @@ public struct Avatar: View {
     private let customDimension: CGFloat?
     private let background: AvatarBackground
     private let shape: AvatarShape
+    private let presence: StatusKind?
+    private let presencePulse: Bool
 
-    public init(_ content: AvatarContent, size: AvatarSize = .md, background: AvatarBackground = .blue, shape: AvatarShape = .circle) {
+    public init(
+        _ content: AvatarContent,
+        size: AvatarSize = .md,
+        background: AvatarBackground = .blue,
+        shape: AvatarShape = .circle,
+        presence: StatusKind? = nil,
+        presencePulse: Bool = false
+    ) {
         self.content = content
         self.size = size
         self.customDimension = nil
         self.background = background
         self.shape = shape
+        self.presence = presence
+        self.presencePulse = presencePulse
     }
 
     /// Arbitrary point-size avatar (Ant numeric `size`), overriding the enum tiers.
-    public init(_ content: AvatarContent, dimension: CGFloat, background: AvatarBackground = .blue, shape: AvatarShape = .circle) {
+    public init(
+        _ content: AvatarContent,
+        dimension: CGFloat,
+        background: AvatarBackground = .blue,
+        shape: AvatarShape = .circle,
+        presence: StatusKind? = nil,
+        presencePulse: Bool = false
+    ) {
         self.content = content
         self.size = .md
         self.customDimension = dimension
         self.background = background
         self.shape = shape
+        self.presence = presence
+        self.presencePulse = presencePulse
     }
 
     private var dim: CGFloat { customDimension ?? size.dimension }
@@ -90,6 +110,24 @@ public struct Avatar: View {
         }
         .frame(width: dim, height: dim)
         .clipShape(clip)
+        .overlay(alignment: .bottomTrailing) { presenceDot }
+    }
+
+    /// Corner presence dot (online / away / busy …), ringed in the surface color so
+    /// it reads against the avatar. Drawn outside the clip so it isn't masked.
+    @ViewBuilder
+    private var presenceDot: some View {
+        if let presence {
+            let dot = max(8, dim * 0.28)
+            let ring = max(1.5, dim * 0.05)
+            ZStack {
+                Circle().fill(Theme.shared.background(.bgWhite))
+                    .frame(width: dot + ring * 2, height: dot + ring * 2)
+                StatusDot(presence, size: dot, pulse: presencePulse)
+            }
+            .offset(x: shape == .circle ? -dim * 0.15 : -dim * 0.02,
+                    y: shape == .circle ? -dim * 0.15 : -dim * 0.02)
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## What

Additive, backward-compatible extension of `Avatar` (Atom) toward **Ant Design Avatar + Badge** — a corner presence/status dot.

## Changes

- **`presence: StatusKind?`** — online / away / busy / offline / neutral dot in the bottom-trailing corner, ringed in the surface color so it reads against the avatar. Reuses the `StatusDot` atom (color + VoiceOver status) and is drawn outside the clip so it isn't masked. Sized relative to the avatar; positioned correctly on both circle and square shapes.
- **`presencePulse`** — animates the dot (honors Reduce Motion via `StatusDot`).

Added to both initializers (enum-size and numeric `dimension`).

## Backward compatibility

Defaults to `nil` — existing avatars (including the recorded `testAvatar_group` snapshot) are unchanged.

## Notes

Visual addition (reuses `StatusDot`'s logic/a11y), verified by build + the gallery demo (presence picker). Registry usage updated.

- `swift build` ✓ · Demo app (iOS) ✓ · `swift test` → 153 passing ✓ · SwiftLint clean ✓

> ⚠️ CI may show red due to the GitHub Actions **billing** block (account-level, unrelated to this code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
