### PR TITLE
feat(tooltip): 4-way placement, color variants & self-trigger (Ant Tooltip)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -274,14 +274,21 @@ struct OTPDemo: View {
 struct TooltipDemo: View {
     @State private var shown = true
     @State private var edge: TooltipEdge = .top
+    @State private var colored = false
     var body: some View {
-        ComponentStage("Tooltip", inspector: [("isPresented", "\(shown)"), ("edge", "\(edge)")]) {
+        ComponentStage("Tooltip", inspector: [("isPresented", "\(shown)"), ("edge", "\(edge)"), ("style", colored ? "info" : "default")]) {
             Icon(systemName: "info.circle", size: .lg, color: Theme.shared.foreground(.fgHero))
-                .tooltip("Helpful hint", isPresented: $shown, edge: edge)
-                .padding(.vertical, 40)
+                .tooltip("Helpful hint", isPresented: $shown, edge: edge, style: colored ? .info : nil)
+                .padding(60)
         } knobs: {
             Toggle("Presented", isOn: $shown)
-            Picker("Edge", selection: $edge) { Text("Top").tag(TooltipEdge.top); Text("Bottom").tag(TooltipEdge.bottom) }.pickerStyle(.segmented)
+            Toggle("Colored (info)", isOn: $colored)
+            Picker("Edge", selection: $edge) {
+                Text("Top").tag(TooltipEdge.top)
+                Text("Bottom").tag(TooltipEdge.bottom)
+                Text("Leading").tag(TooltipEdge.leading)
+                Text("Trailing").tag(TooltipEdge.trailing)
+            }.pickerStyle(.segmented)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -3,65 +3,158 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A small dark bubble with an arrow, attached above/below an anchor
-//  via the `.tooltip(...)` modifier.
+//  Molecule. A small bubble with an arrow, attached to one of four edges of an
+//  anchor via the `.tooltip(...)` modifier. Defaults to the original dark bubble;
+//  an optional semantic `style` recolors it (Ant Tooltip `color`), and `maxWidth`
+//  lets the text wrap onto multiple lines. Two entry points: a binding-driven
+//  modifier and a self-managed tap-to-toggle convenience. (Ant Tooltip parity.)
 //
 
 import SwiftUI
 
+/// Placement of the tooltip bubble relative to its anchor. (Ant Tooltip `placement`.)
 public enum TooltipEdge: Sendable {
-    case top, bottom
-}
+    case top, bottom, leading, trailing
 
-private struct TooltipBubble: View {
-    let text: String
-    let edge: TooltipEdge
+    /// `true` for the vertically-stacked edges (bubble above/below the anchor).
+    var isVertical: Bool { self == .top || self == .bottom }
 
-    var body: some View {
-        VStack(spacing: -1) {
-            if edge == .bottom { arrow.rotationEffect(.degrees(180)) }
-            Text(text)
-                .textStyle(.bodySm400)
-                .foregroundStyle(Theme.shared.foreground(.fgSecondary))
-                .padding(.horizontal, Theme.SpacingKey.sm.value)
-                .padding(.vertical, Theme.SpacingKey.xs.value)
-                .background(Theme.shared.background(.bgTertiary),
-                           in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
-            if edge == .top { arrow }
+    /// The overlay alignment that pins the bubble to this edge of the anchor.
+    var alignment: Alignment {
+        switch self {
+        case .top: return .top
+        case .bottom: return .bottom
+        case .leading: return .leading
+        case .trailing: return .trailing
         }
     }
-
-    private var arrow: some View {
-        Triangle()
-            .fill(Theme.shared.background(.bgTertiary))
-            .frame(width: 12, height: 6)
-    }
 }
 
-private struct Triangle: Shape {
+/// A triangle whose apex points toward the anchor for the given edge.
+private struct TooltipArrow: Shape {
+    let edge: TooltipEdge
+
     func path(in rect: CGRect) -> Path {
         var p = Path()
-        p.move(to: CGPoint(x: rect.midX, y: rect.maxY))
-        p.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
-        p.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        switch edge {
+        case .top: // bubble above the anchor → point down
+            p.move(to: CGPoint(x: rect.midX, y: rect.maxY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        case .bottom: // bubble below → point up
+            p.move(to: CGPoint(x: rect.midX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        case .leading: // bubble to the left → point right
+            p.move(to: CGPoint(x: rect.maxX, y: rect.midY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        case .trailing: // bubble to the right → point left
+            p.move(to: CGPoint(x: rect.minX, y: rect.midY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        }
         p.closeSubpath()
         return p
     }
 }
 
+private struct TooltipBubble: View {
+    let text: String
+    let edge: TooltipEdge
+    let style: BadgeStyle?
+    let maxWidth: CGFloat?
+
+    private var bubbleColor: Color { style?.semantic.solid ?? Theme.shared.background(.bgTertiary) }
+    private var textColor: Color { style?.semantic.onSolid ?? Theme.shared.foreground(.fgSecondary) }
+
+    var body: some View {
+        let bubble = Text(text)
+            .textStyle(.bodySm400)
+            .foregroundStyle(textColor)
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: maxWidth, alignment: .leading)
+            .padding(.horizontal, Theme.SpacingKey.sm.value)
+            .padding(.vertical, Theme.SpacingKey.xs.value)
+            .background(bubbleColor,
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
+
+        let arrow = TooltipArrow(edge: edge)
+            .fill(bubbleColor)
+            .frame(width: edge.isVertical ? 12 : 6, height: edge.isVertical ? 6 : 12)
+
+        switch edge {
+        case .top: VStack(spacing: -1) { bubble; arrow }
+        case .bottom: VStack(spacing: -1) { arrow; bubble }
+        case .leading: HStack(spacing: -1) { bubble; arrow }
+        case .trailing: HStack(spacing: -1) { arrow; bubble }
+        }
+    }
+}
+
+/// Pushes the bubble just outside the chosen edge of the anchor.
+private struct TooltipPlacement: ViewModifier {
+    let edge: TooltipEdge
+
+    func body(content: Content) -> some View {
+        switch edge {
+        case .top: content.offset(y: -8).alignmentGuide(.top) { $0[.bottom] }
+        case .bottom: content.offset(y: 8).alignmentGuide(.bottom) { $0[.top] }
+        case .leading: content.offset(x: -8).alignmentGuide(.leading) { $0[.trailing] }
+        case .trailing: content.offset(x: 8).alignmentGuide(.trailing) { $0[.leading] }
+        }
+    }
+}
+
+/// Wraps an anchor so a tap toggles its own tooltip — no external binding needed.
+private struct SelfTooltip: ViewModifier {
+    let text: String
+    let edge: TooltipEdge
+    let style: BadgeStyle?
+    let maxWidth: CGFloat?
+    @State private var shown = false
+
+    func body(content: Content) -> some View {
+        content
+            .tooltip(text, isPresented: $shown, edge: edge, style: style, maxWidth: maxWidth)
+            .contentShape(Rectangle())
+            .onTapGesture { shown.toggle() }
+            .accessibilityHint(Text(text))
+    }
+}
+
 public extension View {
-    func tooltip(_ text: String, isPresented: Binding<Bool>, edge: TooltipEdge = .top) -> some View {
-        overlay(alignment: edge == .top ? .top : .bottom) {
+    /// Binding-driven tooltip. `edge` chooses which side of the anchor it points
+    /// from; `style` recolors the bubble (nil keeps the dark default); `maxWidth`
+    /// lets long text wrap.
+    func tooltip(
+        _ text: String,
+        isPresented: Binding<Bool>,
+        edge: TooltipEdge = .top,
+        style: BadgeStyle? = nil,
+        maxWidth: CGFloat? = nil
+    ) -> some View {
+        overlay(alignment: edge.alignment) {
             if isPresented.wrappedValue {
-                TooltipBubble(text: text, edge: edge)
-                    .fixedSize()
-                    .offset(y: edge == .top ? -8 : 8)
-                    .alignmentGuide(edge == .top ? .top : .bottom) { d in edge == .top ? d[.bottom] : d[.top] }
+                TooltipBubble(text: text, edge: edge, style: style, maxWidth: maxWidth)
+                    .fixedSize(horizontal: maxWidth == nil, vertical: true)
+                    .modifier(TooltipPlacement(edge: edge))
                     .transition(.opacity)
                     .zIndex(1)
             }
         }
         .animation(Motion.fast.animation, value: isPresented.wrappedValue)
+    }
+
+    /// Self-managed tooltip: tap the anchor to toggle it (tap again to dismiss).
+    /// No external state required — use for simple hint glyphs.
+    func tooltip(
+        _ text: String,
+        edge: TooltipEdge = .top,
+        style: BadgeStyle? = nil,
+        maxWidth: CGFloat? = nil
+    ) -> some View {
+        modifier(SelfTooltip(text: text, edge: edge, style: style, maxWidth: maxWidth))
     }
 }
 
@@ -69,9 +162,17 @@ public extension View {
     struct Demo: View {
         @State var show = true
         var body: some View {
-            Icon(systemName: "info.circle", size: .md, color: Theme.shared.foreground(.fgHero))
-                .tooltip("Helpful hint", isPresented: $show)
-                .padding(60)
+            VStack(spacing: 64) {
+                Icon(systemName: "info.circle", size: .md, color: Theme.shared.foreground(.fgHero))
+                    .tooltip("Helpful hint", isPresented: $show)
+                HStack(spacing: 56) {
+                    Icon(systemName: "questionmark.circle", size: .md, color: Theme.shared.foreground(.fgHero))
+                        .tooltip("On the trailing side", edge: .trailing, style: .info)
+                    Icon(systemName: "exclamationmark.triangle", size: .md, color: Theme.shared.foreground(.fgHero))
+                        .tooltip("A longer hint that wraps onto several lines", edge: .leading, style: .warning, maxWidth: 140)
+                }
+            }
+            .padding(80)
         }
     }
     return Demo()

--- a/Tests/ThemeKitTests/TooltipTests.swift
+++ b/Tests/ThemeKitTests/TooltipTests.swift
@@ -1,0 +1,31 @@
+//
+//  TooltipTests.swift
+//  ThemeKitTests
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Coverage for TooltipEdge placement geometry (orientation + anchor alignment).
+//
+
+import SwiftUI
+import XCTest
+@testable import ThemeKit
+
+final class TooltipTests: XCTestCase {
+
+    func testVerticalEdgesAreVertical() {
+        XCTAssertTrue(TooltipEdge.top.isVertical)
+        XCTAssertTrue(TooltipEdge.bottom.isVertical)
+    }
+
+    func testHorizontalEdgesAreNotVertical() {
+        XCTAssertFalse(TooltipEdge.leading.isVertical)
+        XCTAssertFalse(TooltipEdge.trailing.isVertical)
+    }
+
+    func testEachEdgeAlignsToItsOwnSide() {
+        XCTAssertEqual(TooltipEdge.top.alignment, .top)
+        XCTAssertEqual(TooltipEdge.bottom.alignment, .bottom)
+        XCTAssertEqual(TooltipEdge.leading.alignment, .leading)
+        XCTAssertEqual(TooltipEdge.trailing.alignment, .trailing)
+    }
+}


### PR DESCRIPTION
## What

Extends **Tooltip** toward Ant Design Tooltip parity — additive and backward-compatible.

- **4-way placement** — `TooltipEdge` gains `.leading` / `.trailing` next to `.top` / `.bottom`. A new directional `TooltipArrow` shape points at the anchor from any side; the bubble stacks vertically or horizontally to match.
- **Color variants** — `style: BadgeStyle?` recolors the bubble through the shared semantic palette (`solid` background + `onSolid` text). `nil` keeps the original dark default.
- **Multiline** — `maxWidth` lets long hints wrap; the bubble only `fixedSize`s when no width is given.
- **Self-trigger** — a new `.tooltip(_:edge:style:maxWidth:)` overload toggles on tap with no external `@State`, for simple hint glyphs. The binding-driven overload is untouched.

## Why

Tooltip was the thinnest of the high-value components: top/bottom only, manual binding, fixed dark bubble. These are the obvious Ant Tooltip gaps. Expanding `TooltipEdge` also unblocks 4-way placement for **Popconfirm**, which reuses the same enum (follow-up PR).

## Compatibility

All new parameters are defaulted; every existing call site (including Popconfirm) compiles unchanged.

## Tests

- `swift build` + full suite green (**156 tests**, +3 new `TooltipTests` for `TooltipEdge` geometry).
- Gallery `TooltipDemo` updated with leading/trailing edges and a color knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)