### PR TITLE
feat(popconfirm): 4-way placement & async/loading confirm (Ant Popconfirm)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -1343,18 +1343,28 @@ struct BorderBeamDemo: View {
 
 struct PopconfirmDemo: View {
     @State private var show = false
-    @State private var edgeTop = false
+    @State private var edge: TooltipEdge = .bottom
+    @State private var asyncConfirm = false
     @State private var last = "—"
     var body: some View {
-        ComponentStage("Popconfirm", inspector: [("isPresented", "\(show)"), ("last", last)]) {
+        ComponentStage("Popconfirm", inspector: [("isPresented", "\(show)"), ("edge", "\(edge)"), ("last", last)]) {
             ThemeButton("Sil", systemImage: "trash", color: .error, variant: .soft) { show.toggle() }
                 .popconfirm(isPresented: $show, title: "Bu öğeyi sil?", message: "Bu işlem geri alınamaz.",
-                            confirmTitle: "Sil", cancelTitle: "Vazgeç", edge: edgeTop ? .top : .bottom,
-                            onConfirm: { last = "confirmed"; flash("Popconfirm onaylandı") }, onCancel: { last = "cancelled"; flash("Popconfirm iptal edildi") })
-                .padding(.vertical, 80)
+                            confirmTitle: "Sil", cancelTitle: "Vazgeç", edge: edge,
+                            onConfirm: {
+                                if asyncConfirm { try? await Task.sleep(nanoseconds: 1_200_000_000) }
+                                last = "confirmed"; flash("Popconfirm onaylandı")
+                            },
+                            onCancel: { last = "cancelled"; flash("Popconfirm iptal edildi") })
+                .padding(80)
         } knobs: {
-            Toggle("Anchor above", isOn: $edgeTop)
-            Button(show ? "Hide" : "Show") { show.toggle() }
+            Toggle("Async confirm (1.2s)", isOn: $asyncConfirm)
+            Picker("Edge", selection: $edge) {
+                Text("Top").tag(TooltipEdge.top)
+                Text("Bottom").tag(TooltipEdge.bottom)
+                Text("Leading").tag(TooltipEdge.leading)
+                Text("Trailing").tag(TooltipEdge.trailing)
+            }.pickerStyle(.segmented)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
+++ b/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
@@ -5,7 +5,9 @@
 //
 //  A lightweight confirmation popover anchored to its trigger element — unlike
 //  the full-screen modal `Dialog`, it points at what you're confirming.
-//  (Ant Popconfirm.) Apply with `.popconfirm(...)`.
+//  (Ant Popconfirm.) Apply with `.popconfirm(...)`. Anchors to any of the four
+//  edges (reusing `TooltipEdge`); the confirm closure may be async, in which case
+//  the OK button shows a spinner and the popover stays open until it resolves.
 //
 
 import SwiftUI
@@ -18,17 +20,17 @@ private struct PopconfirmModifier: ViewModifier {
     let cancelTitle: String
     let confirmKind: FeedbackKind
     let edge: TooltipEdge
-    let onConfirm: () -> Void
+    let onConfirm: () async -> Void
     let onCancel: (() -> Void)?
 
+    @State private var loading = false
+
     func body(content: Content) -> some View {
-        content.overlay(alignment: edge == .top ? .top : .bottom) {
+        content.overlay(alignment: edge.alignment) {
             if isPresented {
                 card
                     .fixedSize()
-                    .alignmentGuide(edge == .top ? .top : .bottom) { d in
-                        edge == .top ? d[.bottom] + 8 : d[.top] - 8
-                    }
+                    .modifier(PopconfirmPlacement(edge: edge))
                     .transition(.opacity.combined(with: .scale(scale: 0.96)))
                     .zIndex(1)
             }
@@ -49,11 +51,16 @@ private struct PopconfirmModifier: ViewModifier {
             }
             HStack(spacing: Theme.SpacingKey.sm.value) {
                 Spacer(minLength: 0)
-                ThemeButton(cancelTitle, variant: .outline, size: .small) {
+                ThemeButton(cancelTitle, variant: .outline, size: .small, isEnabled: .constant(!loading)) {
                     isPresented = false; onCancel?()
                 }
-                ThemeButton(confirmTitle, color: confirmKind.semanticColor, size: .small) {
-                    isPresented = false; onConfirm()
+                ThemeButton(confirmTitle, color: confirmKind.semanticColor, size: .small, isLoading: $loading) {
+                    Task {
+                        loading = true
+                        await onConfirm()
+                        loading = false
+                        isPresented = false
+                    }
                 }
             }
         }
@@ -65,8 +72,25 @@ private struct PopconfirmModifier: ViewModifier {
     }
 }
 
+/// Pushes the confirm card just outside the chosen edge of its trigger.
+private struct PopconfirmPlacement: ViewModifier {
+    let edge: TooltipEdge
+
+    func body(content: Content) -> some View {
+        switch edge {
+        case .top: content.alignmentGuide(.top) { $0[.bottom] + 8 }
+        case .bottom: content.alignmentGuide(.bottom) { $0[.top] - 8 }
+        case .leading: content.alignmentGuide(.leading) { $0[.trailing] + 8 }
+        case .trailing: content.alignmentGuide(.trailing) { $0[.leading] - 8 }
+        }
+    }
+}
+
 public extension View {
-    /// Anchored confirmation popover. `edge` chooses above (.top) or below (.bottom) the trigger.
+    /// Anchored confirmation popover. `edge` chooses which side of the trigger the
+    /// card points from (top / bottom / leading / trailing). `onConfirm` may be
+    /// async — while it runs the OK button spins, Cancel is disabled, and the
+    /// popover stays open; it dismisses once the work completes.
     func popconfirm(
         isPresented: Binding<Bool>,
         title: String,
@@ -75,7 +99,7 @@ public extension View {
         cancelTitle: String = String(themeKit: "No"),
         confirmKind: FeedbackKind = .error,
         edge: TooltipEdge = .top,
-        onConfirm: @escaping () -> Void,
+        onConfirm: @escaping () async -> Void,
         onCancel: (() -> Void)? = nil
     ) -> some View {
         modifier(PopconfirmModifier(


### PR DESCRIPTION
## What

Rounds out **Popconfirm** toward Ant Design Popconfirm — building on the expanded `TooltipEdge` from #24.

- **4-way placement** — the card anchors to `.top` / `.bottom` / `.leading` / `.trailing` (was above/below only), via a shared `PopconfirmPlacement` alignment guide.
- **Async / loading confirm** — `onConfirm` is now `async`. While it runs, the OK button shows a spinner (`ThemeButton.isLoading`), Cancel is disabled, and the popover stays open until the work resolves, then dismisses. Mirrors Ant's promise-returning `onConfirm`.

## Why

Popconfirm shared `TooltipEdge` with Tooltip, so it inherited the same top/bottom-only limitation; #24 unblocked the other two edges. Async confirm is the other obvious Ant gap — destructive actions usually hit the network before the popover should close.

## Compatibility

Synchronous trailing closures still satisfy the `async onConfirm` (sync→async conversion), and `edge` still defaults to `.top`. Existing call sites compile unchanged.

> **Stacked on #24** — base is `feat/tooltip-placement` (needs the `TooltipEdge.leading/.trailing` cases). Merge #24 first; GitHub will retarget this to `main`.

## Tests

- `swift build` + full suite green (**156 tests**). Placement geometry is covered by #24's `TooltipTests`; the async/loading flow is behavioral (no pure unit, consistent with prior UI-state PRs). Verified via the gallery demo (4-way picker + async knob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)