### PR TITLE
feat(autocomplete): per-suggestion disabled state (Ant AutoComplete)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -351,19 +351,24 @@ struct ToggleGroupDemo: View {
 struct AutocompleteDemo: View {
     @State private var text = ""
     @State private var asyncMode = false
+    @State private var disableSoldOut = false
     private let cities = ["İstanbul", "İzmir", "İzmit", "Ankara", "Antalya", "Bursa"]
+    private var enabledPredicate: ((String) -> Bool)? {
+        disableSoldOut ? { $0 != "İzmit" } : nil
+    }
     var body: some View {
-        ComponentStage("Autocomplete", inspector: [("text", "\"\(text)\""), ("mode", asyncMode ? "async" : "static")]) {
+        ComponentStage("Autocomplete", inspector: [("text", "\"\(text)\""), ("mode", asyncMode ? "async" : "static"), ("disabled", disableSoldOut ? "İzmit" : "—")]) {
             if asyncMode {
                 Autocomplete(label: "Destination", text: $text, suggest: { query in
                     try? await Task.sleep(nanoseconds: 400_000_000)   // simulate network
                     return cities.filter { $0.localizedCaseInsensitiveContains(query) }
-                })
+                }, isSuggestionEnabled: enabledPredicate)
             } else {
-                Autocomplete(label: "Destination", text: $text, suggestions: cities)
+                Autocomplete(label: "Destination", text: $text, suggestions: cities, isSuggestionEnabled: enabledPredicate)
             }
         } knobs: {
             Toggle("Async (remote-style)", isOn: $asyncMode)
+            Toggle("Disable “İzmit”", isOn: $disableSoldOut)
             Text("Type to filter suggestions.").font(.footnote).foregroundStyle(.secondary)
         }
     }

--- a/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
+++ b/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
@@ -28,6 +28,7 @@ public struct Autocomplete: View {
     private let debounce: TimeInterval
     private let accessibilityID: String?
     private let isEnabled: Bool
+    private let isSuggestionEnabled: ((String) -> Bool)?
     private let onSelect: (String) -> Void
     private let onSearch: ((String) -> Void)?
 
@@ -46,6 +47,7 @@ public struct Autocomplete: View {
         debounce: TimeInterval = 0,
         accessibilityID: String? = nil,
         isEnabled: Bool = true,
+        isSuggestionEnabled: ((String) -> Bool)? = nil,
         onSelect: @escaping (String) -> Void = { _ in },
         onSearch: ((String) -> Void)? = nil
     ) {
@@ -57,6 +59,7 @@ public struct Autocomplete: View {
         self.debounce = debounce
         self.accessibilityID = accessibilityID
         self.isEnabled = isEnabled
+        self.isSuggestionEnabled = isSuggestionEnabled
         self.onSelect = onSelect
         self.onSearch = onSearch
     }
@@ -73,6 +76,7 @@ public struct Autocomplete: View {
         debounce: TimeInterval = 0.3,
         accessibilityID: String? = nil,
         isEnabled: Bool = true,
+        isSuggestionEnabled: ((String) -> Bool)? = nil,
         onSelect: @escaping (String) -> Void = { _ in }
     ) {
         self.label = label
@@ -83,6 +87,7 @@ public struct Autocomplete: View {
         self.debounce = debounce
         self.accessibilityID = accessibilityID
         self.isEnabled = isEnabled
+        self.isSuggestionEnabled = isSuggestionEnabled
         self.onSelect = onSelect
         self.onSearch = nil
     }
@@ -92,6 +97,8 @@ public struct Autocomplete: View {
         guard !query.isEmpty else { return [] }
         return all.filter { $0.localizedCaseInsensitiveContains(query) }.prefix(max).map { $0 }
     }
+
+    private func suggestionEnabled(_ suggestion: String) -> Bool { isSuggestionEnabled?(suggestion) ?? true }
 
     private var showsDropdown: Bool {
         isFocused && !text.isEmpty && (isLoading || !results.isEmpty || isEmptyResult)
@@ -152,6 +159,7 @@ public struct Autocomplete: View {
                 row { Text(String(themeKit: "No results")).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary)) }
             } else {
                 ForEach(results, id: \.self) { suggestion in
+                    let enabled = suggestionEnabled(suggestion)
                     Button {
                         text = suggestion
                         results = []
@@ -164,6 +172,8 @@ public struct Autocomplete: View {
                         } }
                     }
                     .buttonStyle(.plain)
+                    .disabled(!enabled)
+                    .opacity(enabled ? 1 : 0.4)
                     if suggestion != results.last { DividerView(size: .small).padding(.leading, Theme.SpacingKey.md.value) }
                 }
             }


### PR DESCRIPTION
## What

Completes **Autocomplete**'s Select-family parity by adding the one missing piece — **disabled options**.

- `isSuggestionEnabled: ((String) -> Bool)?` on both the static and async initializers. Rows where the predicate returns `false` are dimmed (`0.4` opacity) and non-tappable — the exact idiom Select uses (`.disabled(!enabled).opacity(...)`).

Autocomplete already shipped the rest of the trio: a loading spinner, a "no results" empty state, and in-flight request cancellation.

## Why

Select gained per-option disabling in #17; Autocomplete is its typeahead sibling and should match (e.g. show a "sold-out"/ineligible suggestion without letting the user pick it).

## Compatibility

New parameter is defaulted to `nil` on both initializers; existing call sites compile unchanged.

## Tests

- `swift build` + full suite green (**153 tests**). Existing `AutocompleteTests` cover the static matcher; the disabled flow is view-level dimming (no new pure logic, consistent with Select's disabled-option PR). Gallery demo gains a "Disable İzmit" knob across both sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)