### PR TITLE
feat(timeline): mode (left/right/alternate) & reverse order (Ant Timeline)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -752,20 +752,32 @@ struct TimelineDemo: View {
     @State private var pending = true
     @State private var failed = false
     @State private var horizontal = false
+    @State private var mode: TimelineMode = .left
+    @State private var reverse = false
+    private var modeLabel: String {
+        switch mode { case .left: return "left"; case .right: return "right"; case .alternate: return "alternate" }
+    }
     var body: some View {
-        ComponentStage("Timeline", inspector: [("active", "\(Int(step))"), ("axis", horizontal ? "horizontal" : "vertical")]) {
+        ComponentStage("Timeline", inspector: [("active", "\(Int(step))"), ("axis", horizontal ? "horizontal" : "vertical"), ("mode", modeLabel), ("reverse", "\(reverse)")]) {
             Timeline([
                 .init(title: "Sipariş", time: "09:24", systemImage: "cart", state: .done, color: .success),
                 .init(title: "Hazırlanıyor", time: "09:40", systemImage: "shippingbox", state: Int(step) > 1 ? .done : .active),
                 failed
                     ? .init(title: "Hata", time: "09:45", description: horizontal ? nil : "Kartı tekrar dene.", state: .error)
                     : .init(title: "Yolda", time: "—", systemImage: "truck.box", state: Int(step) > 2 ? .done : Int(step) == 2 ? .active : .todo),
-            ], axis: horizontal ? .horizontal : .vertical, pending: (!horizontal && pending) ? "Kurye bekleniyor…" : nil)
+            ], axis: horizontal ? .horizontal : .vertical, mode: mode, reverse: reverse,
+               pending: (!horizontal && pending) ? "Kurye bekleniyor…" : nil)
         } knobs: {
             Stepper("Active: \(Int(step))", value: $step, in: 0...3)
             Toggle("Horizontal", isOn: $horizontal)
             Toggle("Pending node (vertical)", isOn: $pending)
             Toggle("Error item", isOn: $failed)
+            Toggle("Reverse order", isOn: $reverse)
+            Picker("Mode (vertical)", selection: $mode) {
+                Text("Left").tag(TimelineMode.left)
+                Text("Right").tag(TimelineMode.right)
+                Text("Alternate").tag(TimelineMode.alternate)
+            }.pickerStyle(.segmented)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/Timeline.swift
+++ b/Sources/ThemeKit/Components/Organisms/Timeline.swift
@@ -5,10 +5,21 @@
 //
 //  Organism. Vertical timeline of events with a connecting rail, dot/icon
 //  markers, done / active / todo / error states, optional per-item color and a
-//  trailing "pending" (loading) node. (Ant Timeline parity.)
+//  trailing "pending" (loading) node. `mode` places the content left, right or
+//  alternating around the rail; `reverse` flips the order. (Ant Timeline parity.)
 //
 
 import SwiftUI
+
+/// Where item content sits relative to the rail (vertical axis only). (Ant Timeline `mode`.)
+public enum TimelineMode: Sendable {
+    /// Content to the right of the rail (default).
+    case left
+    /// Content to the left of the rail.
+    case right
+    /// Content alternates side to side; the time moves to the opposite side.
+    case alternate
+}
 
 public struct Timeline: View {
     public struct Item: Identifiable {
@@ -27,26 +38,40 @@ public struct Timeline: View {
     private let items: [Item]
     private let pending: String?
     private let axis: Axis
+    private let mode: TimelineMode
+    private let reverse: Bool
 
-    public init(_ items: [Item], axis: Axis = .vertical, pending: String? = nil) {
+    public init(_ items: [Item], axis: Axis = .vertical, mode: TimelineMode = .left, reverse: Bool = false, pending: String? = nil) {
         self.items = items
         self.axis = axis
+        self.mode = mode
+        self.reverse = reverse
         self.pending = pending
     }
 
-    private var hasPending: Bool { pending != nil }
-    private var lastIndex: Int { items.count - 1 + (hasPending ? 1 : 0) }
+    private enum DisplayRow {
+        case item(Item)
+        case pending(String)
+    }
+
+    /// Items (+ optional pending node), in display order.
+    private var displayRows: [DisplayRow] {
+        var rows: [DisplayRow] = items.map { .item($0) }
+        if let pending { rows.append(.pending(pending)) }
+        return reverse ? Array(rows.reversed()) : rows
+    }
 
     public var body: some View {
         if axis == .horizontal { horizontalBody } else { verticalBody }
     }
 
     private var horizontalBody: some View {
-        HStack(alignment: .top, spacing: 0) {
-            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+        let ordered = reverse ? Array(items.reversed()) : items
+        return HStack(alignment: .top, spacing: 0) {
+            ForEach(Array(ordered.enumerated()), id: \.element.id) { index, item in
                 VStack(spacing: Theme.SpacingKey.xs.value) {
                     ZStack {
-                        if index < items.count - 1 {
+                        if index < ordered.count - 1 {
                             Rectangle().fill(railColor(item)).frame(height: 2).offset(x: 14)
                         }
                         marker(item)
@@ -69,39 +94,89 @@ public struct Timeline: View {
 
     private var verticalBody: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
-                row(index: index, marker: marker(item), railOn: railColor(item)) {
-                    if let time = item.time {
-                        Text(time).textStyle(.overline400).foregroundStyle(Theme.shared.text(.textTertiary))
-                    }
-                    Text(item.title).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textPrimary))
-                    if let description = item.description {
-                        Text(description).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
-                    }
-                }
-            }
-            if let pending {
-                row(index: items.count, marker: pendingMarker, railOn: .clear) {
-                    Text(pending).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textTertiary))
+            ForEach(Array(displayRows.enumerated()), id: \.offset) { position, row in
+                let isLast = position == displayRows.count - 1
+                switch row {
+                case .item(let item):
+                    verticalRow(position: position, isLast: isLast, marker: marker(item), rail: railColor(item),
+                                main: { itemMain(item, showTime: mode != .alternate) },
+                                opposite: { oppositeContent(item) })
+                case .pending(let text):
+                    verticalRow(position: position, isLast: isLast, marker: pendingMarker, rail: .clear,
+                                main: { pendingMain(text) }, opposite: { EmptyView() })
                 }
             }
         }
     }
 
     @ViewBuilder
-    private func row<Content: View>(index: Int, marker: some View, railOn: Color, @ViewBuilder content: () -> Content) -> some View {
-        HStack(alignment: .top, spacing: Theme.SpacingKey.md.value) {
-            VStack(spacing: 0) {
-                marker
-                if index < lastIndex {
-                    Rectangle().fill(railOn).frame(width: 2).frame(maxHeight: .infinity)
-                }
+    private func verticalRow<Marker: View, Main: View, Opposite: View>(
+        position: Int, isLast: Bool, marker: Marker, rail: Color,
+        @ViewBuilder main: () -> Main, @ViewBuilder opposite: () -> Opposite
+    ) -> some View {
+        switch mode {
+        case .left:
+            HStack(alignment: .top, spacing: Theme.SpacingKey.md.value) {
+                railColumn(marker: marker, rail: rail, isLast: isLast)
+                VStack(alignment: .leading, spacing: 2) { main() }
+                    .multilineTextAlignment(.leading)
+                    .padding(.bottom, isLast ? 0 : Theme.SpacingKey.md.value)
+                Spacer(minLength: 0)
             }
-            .frame(width: 28)
-            VStack(alignment: .leading, spacing: 2, content: content)
-                .padding(.bottom, index < lastIndex ? Theme.SpacingKey.md.value : 0)
-            Spacer(minLength: 0)
+        case .right:
+            HStack(alignment: .top, spacing: Theme.SpacingKey.md.value) {
+                Spacer(minLength: 0)
+                VStack(alignment: .trailing, spacing: 2) { main() }
+                    .multilineTextAlignment(.trailing)
+                    .padding(.bottom, isLast ? 0 : Theme.SpacingKey.md.value)
+                railColumn(marker: marker, rail: rail, isLast: isLast)
+            }
+        case .alternate:
+            let mainTrailing = position.isMultiple(of: 2)
+            HStack(alignment: .top, spacing: Theme.SpacingKey.md.value) {
+                VStack(alignment: .trailing, spacing: 2) { if mainTrailing { opposite() } else { main() } }
+                    .multilineTextAlignment(.trailing)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .padding(.bottom, isLast ? 0 : Theme.SpacingKey.md.value)
+                railColumn(marker: marker, rail: rail, isLast: isLast)
+                VStack(alignment: .leading, spacing: 2) { if mainTrailing { main() } else { opposite() } }
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.bottom, isLast ? 0 : Theme.SpacingKey.md.value)
+            }
         }
+    }
+
+    private func railColumn(marker: some View, rail: Color, isLast: Bool) -> some View {
+        VStack(spacing: 0) {
+            marker
+            if !isLast {
+                Rectangle().fill(rail).frame(width: 2).frame(maxHeight: .infinity)
+            }
+        }
+        .frame(width: 28)
+    }
+
+    @ViewBuilder
+    private func itemMain(_ item: Item, showTime: Bool) -> some View {
+        if showTime, let time = item.time {
+            Text(time).textStyle(.overline400).foregroundStyle(Theme.shared.text(.textTertiary))
+        }
+        Text(item.title).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textPrimary))
+        if let description = item.description {
+            Text(description).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+        }
+    }
+
+    @ViewBuilder
+    private func oppositeContent(_ item: Item) -> some View {
+        if let time = item.time {
+            Text(time).textStyle(.overline400).foregroundStyle(Theme.shared.text(.textTertiary))
+        }
+    }
+
+    private func pendingMain(_ text: String) -> some View {
+        Text(text).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textTertiary))
     }
 
     private func railColor(_ item: Item) -> Color {
@@ -137,10 +212,20 @@ public struct Timeline: View {
 }
 
 #Preview {
-    Timeline([
-        .init(title: "Order placed", time: "09:24", description: "We received your order.", systemImage: "cart", state: .done),
-        .init(title: "Payment failed", time: "09:30", description: "Retry your card.", state: .error),
-        .init(title: "Preparing", time: "09:40", systemImage: "shippingbox", state: .done, color: .success),
-    ], pending: "Awaiting courier…")
-    .padding()
+    ScrollView {
+        VStack(spacing: 40) {
+            Timeline([
+                .init(title: "Order placed", time: "09:24", description: "We received your order.", systemImage: "cart", state: .done),
+                .init(title: "Payment failed", time: "09:30", description: "Retry your card.", state: .error),
+                .init(title: "Preparing", time: "09:40", systemImage: "shippingbox", state: .done, color: .success),
+            ], pending: "Awaiting courier…")
+
+            Timeline([
+                .init(title: "Departure", time: "08:00", description: "İstanbul (IST)", systemImage: "airplane.departure", state: .done),
+                .init(title: "Layover", time: "12:30", description: "Munich (MUC)", systemImage: "clock", state: .active),
+                .init(title: "Arrival", time: "16:45", description: "Barcelona (BCN)", systemImage: "airplane.arrival", state: .todo),
+            ], mode: .alternate)
+        }
+        .padding()
+    }
 }


### PR DESCRIPTION
## What

Extends **Timeline** toward Ant Design Timeline — additive and backward-compatible.

- **`mode`** (`TimelineMode`) — places vertical content to the **right** of the rail (`.left`, the current default), to the **left** (`.right`), or **alternating** side to side (`.alternate`) around a centered rail. In alternate mode the item's `time` moves to the opposite side, giving Ant's classic date-vs-content split.
- **`reverse`** — flips the display order (the pending node moves to the top), on both axes.

## Why

`mode` is Timeline's signature Ant feature and the only thing it was missing (it already had axis, states, per-item color/icon, and a pending node). Alternate timelines fit the travel domain well — multi-leg itineraries, booking status history.

## How

The vertical body routes every row through a single mode-aware `verticalRow`. Markers, rail colors, the pending node, and the horizontal axis are unchanged. `mode` applies to the vertical axis only (Ant has no horizontal-alternate).

## Compatibility

All new parameters default to today's behavior (`mode: .left`, `reverse: false`); existing call sites compile and render identically.

## Tests

- `swift build` + full suite green (**156 tests**). The change is layout-only (no new pure logic, consistent with the original Timeline, which shipped without unit tests). Verified via the gallery demo's new mode picker + reverse toggle and the `.alternate` flight-itinerary preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)