### PR TITLE
feat(stat): prefix/suffix, loading & animated numeric value (Ant Statistic)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -688,14 +688,25 @@ struct StatDemo: View {
     enum Trend: String, CaseIterable { case up, down, none }
     @State private var trend: Trend = .up
     @State private var figure = true
+    @State private var loading = false
+    @State private var animated = false
+    @State private var count = 1284
+    private var statTrend: StatTrend? { trend == .up ? .up("+12%") : trend == .down ? .down("-3%") : nil }
     var body: some View {
-        ComponentStage("Stat", inspector: [("trend", trend.rawValue)]) {
-            Stat(title: "Total bookings", value: "1,284", description: "this month",
-                 systemImage: figure ? "ticket" : nil,
-                 trend: trend == .up ? .up("+12%") : trend == .down ? .down("-3%") : nil)
+        ComponentStage("Stat", inspector: [("trend", trend.rawValue), ("value", animated ? "\(count)" : "1,284"), ("loading", "\(loading)")]) {
+            if animated {
+                Stat(title: "Total bookings", value: count, suffix: "₺", isLoading: loading,
+                     description: "this month", systemImage: figure ? "ticket" : nil, trend: statTrend)
+            } else {
+                Stat(title: "Total bookings", value: "1,284", suffix: "₺", isLoading: loading,
+                     description: "this month", systemImage: figure ? "ticket" : nil, trend: statTrend)
+            }
         } knobs: {
             Picker("Trend", selection: $trend) { ForEach(Trend.allCases, id: \.self) { Text($0.rawValue).tag($0) } }.pickerStyle(.segmented)
             Toggle("Figure icon", isOn: $figure)
+            Toggle("Loading (skeleton)", isOn: $loading)
+            Toggle("Animated value (RollingNumber)", isOn: $animated)
+            if animated { Button("+1.000") { count += 1000 } }
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Stat.swift
+++ b/Sources/ThemeKit/Components/Molecules/Stat.swift
@@ -31,15 +31,45 @@ public enum StatTrend {
 }
 
 public struct Stat: View {
+    private enum Value { case text(String), number(Int) }
+
     private let title: String
-    private let value: String
+    private let value: Value
+    private let prefix: String?
+    private let suffix: String?
+    private let isLoading: Bool
     private let description: String?
     private let systemImage: String?
     private let trend: StatTrend?
 
-    public init(title: String, value: String, description: String? = nil, systemImage: String? = nil, trend: StatTrend? = nil) {
+    public init(
+        title: String, value: String,
+        prefix: String? = nil, suffix: String? = nil, isLoading: Bool = false,
+        description: String? = nil, systemImage: String? = nil, trend: StatTrend? = nil
+    ) {
+        self.init(title: title, value: .text(value), prefix: prefix, suffix: suffix,
+                  isLoading: isLoading, description: description, systemImage: systemImage, trend: trend)
+    }
+
+    /// Numeric value that animates (count-up / roll) on change, via `RollingNumber`.
+    public init(
+        title: String, value: Int,
+        prefix: String? = nil, suffix: String? = nil, isLoading: Bool = false,
+        description: String? = nil, systemImage: String? = nil, trend: StatTrend? = nil
+    ) {
+        self.init(title: title, value: .number(value), prefix: prefix, suffix: suffix,
+                  isLoading: isLoading, description: description, systemImage: systemImage, trend: trend)
+    }
+
+    private init(
+        title: String, value: Value, prefix: String?, suffix: String?,
+        isLoading: Bool, description: String?, systemImage: String?, trend: StatTrend?
+    ) {
         self.title = title
         self.value = value
+        self.prefix = prefix
+        self.suffix = suffix
+        self.isLoading = isLoading
         self.description = description
         self.systemImage = systemImage
         self.trend = trend
@@ -52,9 +82,7 @@ public struct Stat: View {
             }
             VStack(alignment: .leading, spacing: 2) {
                 Text(title).textStyle(.labelSm600).foregroundStyle(Theme.shared.text(.textTertiary))
-                Text(value).textStyle(.headingMd).foregroundStyle(Theme.shared.text(.textPrimary))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.6)
+                valueRow
                 HStack(spacing: Theme.SpacingKey.xs.value) {
                     if let trend {
                         HStack(spacing: 2) {
@@ -76,8 +104,46 @@ public struct Stat: View {
         .accessibilityLabel(Text(accessibilityLabel))
     }
 
+    private var valueRow: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 2) {
+            if let prefix {
+                Text(prefix).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textSecondary))
+            }
+            valueView
+            if let suffix {
+                Text(suffix).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textSecondary))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var valueView: some View {
+        if isLoading {
+            Skeleton(.capsule, width: 96, height: 26)
+        } else {
+            switch value {
+            case .text(let string):
+                Text(string).textStyle(.headingMd).foregroundStyle(Theme.shared.text(.textPrimary))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+            case .number(let number):
+                RollingNumber(number, size: 28, weight: .semibold, color: Theme.shared.text(.textPrimary))
+            }
+        }
+    }
+
+    private var valueString: String {
+        if isLoading { return String(themeKit: "Loading") }
+        let core: String
+        switch value {
+        case .text(let string): core = string
+        case .number(let number): core = "\(number)"
+        }
+        return [prefix, core, suffix].compactMap { $0 }.joined(separator: " ")
+    }
+
     private var accessibilityLabel: String {
-        [title, value, trend?.accessibleText, description]
+        [title, valueString, trend?.accessibleText, description]
             .compactMap { $0 }
             .joined(separator: ", ")
     }


### PR DESCRIPTION
## What
Extends **Stat** toward Ant Statistic — additive, backward-compatible.
- **prefix / suffix** around the value (currency / unit affix).
- **isLoading** → skeleton block for the value.
- **Animated value** — a numeric `init(title:value:Int…)` overload renders through the `RollingNumber` atom, counting up / rolling on change. The String-value init is untouched; both funnel through one private designated init.

## Why
Stat had only a static String value + trend; prefix/suffix, loading and an animated count-up are Ant Statistic's signature features (and `RollingNumber` already existed to drive the animation).

## Compatibility
New params default to `nil`/`false`; the existing `Stat(title:value:String…)` call sites compile and render identically. VoiceOver reads prefix + value + suffix (or "Loading") as one phrase.

## Tests
`swift build` + full suite green (**156 tests**); no new lint warnings. Demo gains loading + animated-value knobs and a "+1.000" trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)