### PR TITLE
feat(callout): closable, action & showIcon (Ant Alert compact)

### DIFF
--- a/Demo/Demo/Gallery/Demos/OrganismDemos.swift
+++ b/Demo/Demo/Gallery/Demos/OrganismDemos.swift
@@ -41,15 +41,30 @@ struct AccordionDemo: View {
 struct CalloutDemo: View {
     @State private var type: CalloutType = .success
     @State private var soft = false
+    @State private var showIcon = true
+    @State private var action = false
+    @State private var closable = false
+    @State private var dismissed = false
 
     var body: some View {
-        ComponentStage("Callout", inspector: [("type", "\(type)"), ("style", soft ? "soft" : "plain")]) {
-            Callout("Lorem ipsum placeholder text.", type: type, style: soft ? .soft : .plain)
+        ComponentStage("Callout", inspector: [("type", "\(type)"), ("style", soft ? "soft" : "plain"), ("dismissed", "\(dismissed)")]) {
+            if dismissed {
+                Button("Reset") { dismissed = false }.buttonStyle(.plain).foregroundStyle(Theme.shared.foreground(.fgHero))
+            } else {
+                Callout("Lorem ipsum placeholder text.", type: type, style: soft ? .soft : .plain,
+                        showIcon: showIcon,
+                        actionTitle: action ? "Undo" : nil,
+                        onAction: action ? { flash("Callout action") } : nil,
+                        onClose: closable ? { dismissed = true } : nil)
+            }
         } knobs: {
             Picker("Type", selection: $type) {
                 Text("Neutral").tag(CalloutType.neutral); Text("Info").tag(CalloutType.info); Text("Success").tag(CalloutType.success); Text("Warning").tag(CalloutType.warning); Text("Error").tag(CalloutType.error)
             }
             Toggle("Soft surface", isOn: $soft)
+            Toggle("Show icon", isOn: $showIcon)
+            Toggle("Action (Undo)", isOn: $action)
+            Toggle("Closable", isOn: $closable)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/Callout.swift
+++ b/Sources/ThemeKit/Components/Organisms/Callout.swift
@@ -50,19 +50,56 @@ public struct Callout: View {
     private let text: String
     private let type: CalloutType
     private let style: CalloutStyle
+    private let showIcon: Bool
+    private let actionTitle: String?
+    private let onAction: (() -> Void)?
+    private let onClose: (() -> Void)?
 
-    public init(_ text: String, type: CalloutType = .info, style: CalloutStyle = .plain) {
+    public init(
+        _ text: String,
+        type: CalloutType = .info,
+        style: CalloutStyle = .plain,
+        showIcon: Bool = true,
+        actionTitle: String? = nil,
+        onAction: (() -> Void)? = nil,
+        onClose: (() -> Void)? = nil
+    ) {
         self.text = text
         self.type = type
         self.style = style
+        self.showIcon = showIcon
+        self.actionTitle = actionTitle
+        self.onAction = onAction
+        self.onClose = onClose
     }
+
+    private var hasAction: Bool { actionTitle != nil && onAction != nil }
+    private var hasTrailing: Bool { hasAction || onClose != nil }
 
     public var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.xs.value) {
-            Image(systemName: type.systemImage)
-                .font(.system(size: 14))
+            if showIcon {
+                Image(systemName: type.systemImage)
+                    .font(.system(size: 14))
+            }
             Text(text)
                 .textStyle(.bodySm400)
+            if hasTrailing {
+                Spacer(minLength: Theme.SpacingKey.sm.value)
+                if let actionTitle, let onAction {
+                    Button(action: onAction) {
+                        Text(actionTitle).textStyle(.labelSm600)
+                    }
+                    .buttonStyle(.plain)
+                }
+                if let onClose {
+                    Button(action: onClose) {
+                        Image(systemName: "xmark").font(.system(size: 11, weight: .semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(String(themeKit: "Dismiss"))
+                }
+            }
         }
         .foregroundStyle(type.accent)
         .padding(.horizontal, style == .soft ? Theme.SpacingKey.sm.value : 0)


### PR DESCRIPTION
## What
Extends **Callout** toward Ant Alert's compact mode — additive, backward-compatible.
- **closable** — `onClose` renders a trailing dismiss `✕` (VoiceOver "Dismiss").
- **action** — `actionTitle` / `onAction` render a trailing inline link.
- **showIcon** (default `true`) — can hide the leading status glyph.

## Why
Callout was a static single-line status. Closable + action + showIcon are Ant Alert's compact-mode features. Description/banner are deliberately left to **InfoBanner** (Sprint 4) to avoid overlap.

## Compatibility
All new params default to `nil`/`true`; the trailing cluster (and its `Spacer`) only appears when an action or close is supplied, so existing inline Callouts stay compact and render identically.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo gains icon / action / closable knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)