### PR TITLE
feat(emptystate): secondary action button (Ant Empty)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -407,6 +407,7 @@ struct CardDemo: View {
 
 struct EmptyStateDemo: View {
     @State private var hasButton = true
+    @State private var secondary = false
     @State private var customImage = false
     @State private var tintIcon = false
     @State private var animated = false
@@ -428,13 +429,15 @@ struct EmptyStateDemo: View {
                            iconCircleSize: tintIcon ? 104 : 88,
                            title: "No results found",
                            message: "Try adjusting your search or filters.",
-                           buttonTitle: hasButton ? "Clear filters" : nil, action: hasButton ? { flash("EmptyState: Clear filters") } : nil)
+                           buttonTitle: hasButton ? "Clear filters" : nil, action: hasButton ? { flash("EmptyState: Clear filters") } : nil,
+                           secondaryTitle: secondary ? "Learn more" : nil, onSecondary: secondary ? { flash("EmptyState: Learn more") } : nil)
             }
         } knobs: {
             Toggle("Animated illustration (GIF, native)", isOn: $animated)
             Toggle("Custom illustration", isOn: $customImage)
             Toggle("Tinted + larger icon", isOn: $tintIcon)
             Toggle("Action button", isOn: $hasButton)
+            Toggle("Secondary action (symbol)", isOn: $secondary)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/EmptyState.swift
+++ b/Sources/ThemeKit/Components/Organisms/EmptyState.swift
@@ -22,6 +22,8 @@ public struct EmptyState: View {
     private let message: String?
     private let buttonTitle: String?
     private let action: (() -> Void)?
+    private let secondaryTitle: String?
+    private let onSecondary: (() -> Void)?
 
     public init(
         systemImage: String = "tray",
@@ -31,7 +33,9 @@ public struct EmptyState: View {
         title: String? = nil,
         message: String? = nil,
         buttonTitle: String? = nil,
-        action: (() -> Void)? = nil
+        action: (() -> Void)? = nil,
+        secondaryTitle: String? = nil,
+        onSecondary: (() -> Void)? = nil
     ) {
         self.systemImage = systemImage
         self.image = nil
@@ -44,6 +48,8 @@ public struct EmptyState: View {
         self.message = message
         self.buttonTitle = buttonTitle
         self.action = action
+        self.secondaryTitle = secondaryTitle
+        self.onSecondary = onSecondary
     }
 
     /// Custom illustration instead of the SF Symbol badge. Pass any `Image`
@@ -54,7 +60,9 @@ public struct EmptyState: View {
         title: String? = nil,
         message: String? = nil,
         buttonTitle: String? = nil,
-        action: (() -> Void)? = nil
+        action: (() -> Void)? = nil,
+        secondaryTitle: String? = nil,
+        onSecondary: (() -> Void)? = nil
     ) {
         self.systemImage = "tray"
         self.image = image
@@ -67,6 +75,8 @@ public struct EmptyState: View {
         self.message = message
         self.buttonTitle = buttonTitle
         self.action = action
+        self.secondaryTitle = secondaryTitle
+        self.onSecondary = onSecondary
     }
 
     /// Animated illustration (GIF / APNG) via the native `AnimatedImage` — the
@@ -77,7 +87,9 @@ public struct EmptyState: View {
         title: String? = nil,
         message: String? = nil,
         buttonTitle: String? = nil,
-        action: (() -> Void)? = nil
+        action: (() -> Void)? = nil,
+        secondaryTitle: String? = nil,
+        onSecondary: (() -> Void)? = nil
     ) {
         self.systemImage = "tray"
         self.image = nil
@@ -90,6 +102,8 @@ public struct EmptyState: View {
         self.message = message
         self.buttonTitle = buttonTitle
         self.action = action
+        self.secondaryTitle = secondaryTitle
+        self.onSecondary = onSecondary
     }
 
     public var body: some View {
@@ -128,8 +142,15 @@ public struct EmptyState: View {
                 }
             }
 
-            if let buttonTitle, let action {
-                PrimaryButton(buttonTitle, action: action)
+            if buttonTitle != nil || secondaryTitle != nil {
+                VStack(spacing: Theme.SpacingKey.sm.value) {
+                    if let buttonTitle, let action {
+                        PrimaryButton(buttonTitle, action: action)
+                    }
+                    if let secondaryTitle, let onSecondary {
+                        SecondaryButton(secondaryTitle, action: onSecondary)
+                    }
+                }
             }
         }
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## What
Adds a **secondary action** to **EmptyState** — additive, backward-compatible.
- `secondaryTitle` / `onSecondary` render a `SecondaryButton` beneath the primary action (e.g. "Create" + "Learn more"), on all three initializers (SF Symbol / custom `Image` / animated URL).

## Why
EmptyState supported only a single primary button; a secondary action is Ant Empty's multi-action footer pattern and a common real need ("primary CTA + secondary link").

## Compatibility
Both new params default to `nil`; the footer renders only when an action exists, so existing single-button / button-less empty states are unchanged.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo gains a secondary-action knob on the symbol variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)