### PR TITLE
feat(radiogroup): per-option & whole-group disabled (Ant Radio.Group)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -324,19 +324,24 @@ struct CheckboxGroupDemo: View {
 struct RadioGroupDemo: View {
     @State private var sel: String? = "Economy"
     @State private var styleIdx = 0   // 0 stacked, 1 button-solid, 2 button-outline
+    @State private var enabled = true
+    @State private var disableFirst = false
+    private var optionEnabled: ((String) -> Bool)? { disableFirst ? { $0 != "First" } : nil }
 
     var body: some View {
-        ComponentStage("RadioGroup", inspector: [("selection", sel ?? "nil"), ("style", styleIdx == 0 ? "stacked" : styleIdx == 1 ? "button/solid" : "button/outline")]) {
+        ComponentStage("RadioGroup", inspector: [("selection", sel ?? "nil"), ("style", styleIdx == 0 ? "stacked" : styleIdx == 1 ? "button/solid" : "button/outline"), ("enabled", "\(enabled)")]) {
             switch styleIdx {
             case 1:
-                RadioButtonGroup(options: ["Economy", "Business", "First"], selection: $sel, style: .solid, expandsHorizontally: true) { $0 }
+                RadioButtonGroup(options: ["Economy", "Business", "First"], selection: $sel, style: .solid, expandsHorizontally: true, isEnabled: enabled, isOptionEnabled: optionEnabled) { $0 }
             case 2:
-                RadioButtonGroup(options: ["Economy", "Business", "First"], selection: $sel, style: .outline, expandsHorizontally: true) { $0 }
+                RadioButtonGroup(options: ["Economy", "Business", "First"], selection: $sel, style: .outline, expandsHorizontally: true, isEnabled: enabled, isOptionEnabled: optionEnabled) { $0 }
             default:
-                RadioGroup(title: "Class", options: ["Economy", "Business", "First"], selection: $sel) { $0 }
+                RadioGroup(title: "Class", options: ["Economy", "Business", "First"], selection: $sel, isEnabled: enabled, isOptionEnabled: optionEnabled) { $0 }
             }
         } knobs: {
             Picker("Style", selection: $styleIdx) { Text("Stacked").tag(0); Text("Button solid").tag(1); Text("Button outline").tag(2) }.pickerStyle(.segmented)
+            Toggle("Enabled (whole group)", isOn: $enabled)
+            Toggle("Disable “First” option", isOn: $disableFirst)
             Button("Clear") { sel = nil }
         }
     }

--- a/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
@@ -14,6 +14,8 @@ public struct RadioGroup<Option: Hashable>: View {
     private let options: [Option]
     @Binding private var selection: Option?
     private let infoMessages: [InfoMessage]
+    private let isEnabled: Bool
+    private let isOptionEnabled: ((Option) -> Bool)?
     private let label: (Option) -> String
     private let accessibilityID: String?
 
@@ -22,6 +24,8 @@ public struct RadioGroup<Option: Hashable>: View {
         options: [Option],
         selection: Binding<Option?>,
         infoMessages: [InfoMessage] = [],
+        isEnabled: Bool = true,
+        isOptionEnabled: ((Option) -> Bool)? = nil,
         accessibilityID: String? = nil,
         label: @escaping (Option) -> String
     ) {
@@ -29,9 +33,13 @@ public struct RadioGroup<Option: Hashable>: View {
         self.options = options
         self._selection = selection
         self.infoMessages = infoMessages
+        self.isEnabled = isEnabled
+        self.isOptionEnabled = isOptionEnabled
         self.accessibilityID = accessibilityID
         self.label = label
     }
+
+    private func optionEnabled(_ option: Option) -> Bool { isEnabled && (isOptionEnabled?(option) ?? true) }
 
     private var titleColor: Color {
         switch infoMessages.dominantKind {
@@ -47,6 +55,7 @@ public struct RadioGroup<Option: Hashable>: View {
                 Text(title).textStyle(.labelMd600).foregroundStyle(titleColor)
             }
             ForEach(Array(options.enumerated()), id: \.element) { index, option in
+                let enabled = optionEnabled(option)
                 Button {
                     selection = option
                 } label: {
@@ -60,6 +69,8 @@ public struct RadioGroup<Option: Hashable>: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .disabled(!enabled)
+                .opacity(enabled ? 1 : 0.4)
                 .a11y("option.\(index)", in: accessibilityID)
                 .accessibilityLabel(label(option))
                 .accessibilityAddTraits(selection == option ? .isSelected : [])
@@ -81,6 +92,8 @@ public struct RadioButtonGroup<Option: Hashable>: View {
     @Binding private var selection: Option?
     private let style: RadioGroupButtonStyle
     private let expandsHorizontally: Bool
+    private let isEnabled: Bool
+    private let isOptionEnabled: ((Option) -> Bool)?
     private let label: (Option) -> String
     private let accessibilityID: String?
 
@@ -89,6 +102,8 @@ public struct RadioButtonGroup<Option: Hashable>: View {
         selection: Binding<Option?>,
         style: RadioGroupButtonStyle = .solid,
         expandsHorizontally: Bool = false,
+        isEnabled: Bool = true,
+        isOptionEnabled: ((Option) -> Bool)? = nil,
         accessibilityID: String? = nil,
         label: @escaping (Option) -> String
     ) {
@@ -96,16 +111,20 @@ public struct RadioButtonGroup<Option: Hashable>: View {
         self._selection = selection
         self.style = style
         self.expandsHorizontally = expandsHorizontally
+        self.isEnabled = isEnabled
+        self.isOptionEnabled = isOptionEnabled
         self.accessibilityID = accessibilityID
         self.label = label
     }
 
     private var radius: CGFloat { Theme.RadiusKey.sm.value }
+    private func optionEnabled(_ option: Option) -> Bool { isEnabled && (isOptionEnabled?(option) ?? true) }
 
     public var body: some View {
         HStack(spacing: 0) {
             ForEach(Array(options.enumerated()), id: \.element) { index, option in
                 let isSelected = selection == option
+                let enabled = optionEnabled(option)
                 Button { selection = option } label: {
                     Text(label(option))
                         .textStyle(isSelected ? .labelBase700 : .labelBase600)
@@ -122,6 +141,8 @@ public struct RadioButtonGroup<Option: Hashable>: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .disabled(!enabled)
+                .opacity(enabled ? 1 : 0.4)
                 .a11y("option.\(index)", in: accessibilityID)
                 .accessibilityLabel(label(option))
                 .accessibilityAddTraits(isSelected ? .isSelected : [])


### PR DESCRIPTION
## What
Adds disabled support to **both** radio variants — additive, backward-compatible.
- **isEnabled** disables the whole group.
- **isOptionEnabled: ((Option) -> Bool)?** disables individual options (dimmed `0.4` + non-tappable) — the same idiom Select / Autocomplete / TreeSelect use.
- Applied to the stacked `RadioGroup` and the button-style `RadioButtonGroup`.

## Why
Button-style radios already existed (`RadioButtonGroup` `style: .solid/.outline`); the genuine gap was disabled state, which rounds out the radio family with the library-wide disabled-options pattern.

## Compatibility
All new params default to enabled; existing call sites compile and render identically.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo gains whole-group + per-option disable knobs across all three styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)