### PR TITLE
feat(slider): onChangeEnd commit & VoiceOver adjustable action (Ant Slider)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -221,16 +221,19 @@ struct SliderDemo: View {
     @State private var tooltip = true
     @State private var enabled = true
     @State private var vertical = false
+    @State private var committed = "—"
 
     var body: some View {
-        ComponentStage("Slider", inspector: [("value", "\(Int(value))"), ("axis", vertical ? "vertical" : "horizontal")]) {
+        ComponentStage("Slider", inspector: [("value", "\(Int(value))"), ("axis", vertical ? "vertical" : "horizontal"), ("onChangeEnd", committed)]) {
             if vertical {
                 ThemeKit.Slider(value: $value, in: 0...8, step: 1, label: "Guests \(Int(value))",
-                                          axis: .vertical, verticalHeight: 180, isEnabled: enabled)
+                                          axis: .vertical, verticalHeight: 180, isEnabled: enabled,
+                                          onChangeEnd: { committed = "\(Int($0))" })
             } else {
                 ThemeKit.Slider(value: $value, in: 0...8, step: 1, label: "Guests \(Int(value))",
                                           marks: marks ? [0: "0", 4: "4", 8: "8"] : [:],
-                                          isEnabled: enabled, showValueTooltip: tooltip)
+                                          isEnabled: enabled, showValueTooltip: tooltip,
+                                          onChangeEnd: { committed = "\(Int($0))" })
             }
         } knobs: {
             HStack { Text("Value"); SwiftUI.Slider(value: $value, in: 0...8, step: 1) }
@@ -238,6 +241,7 @@ struct SliderDemo: View {
             Toggle("Marks", isOn: $marks)
             Toggle("Value tooltip", isOn: $tooltip)
             Toggle("Enabled", isOn: $enabled)
+            Text("Drag & release → onChangeEnd fires.").font(.footnote).foregroundStyle(.secondary)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Slider.swift
+++ b/Sources/ThemeKit/Components/Molecules/Slider.swift
@@ -21,6 +21,7 @@ public struct Slider: View {
     private let accessibilityID: String?
     private let isEnabled: Bool
     private let showValueTooltip: Bool
+    private let onChangeEnd: ((Double) -> Void)?
 
     @State private var dragging = false
     @State private var dragStartValue: Double?
@@ -38,7 +39,8 @@ public struct Slider: View {
         verticalHeight: CGFloat = 160,
         accessibilityID: String? = nil,
         isEnabled: Bool = true,
-        showValueTooltip: Bool = false
+        showValueTooltip: Bool = false,
+        onChangeEnd: ((Double) -> Void)? = nil
     ) {
         self._value = value
         self.bounds = bounds
@@ -50,6 +52,15 @@ public struct Slider: View {
         self.accessibilityID = accessibilityID
         self.isEnabled = isEnabled
         self.showValueTooltip = showValueTooltip
+        self.onChangeEnd = onChangeEnd
+    }
+
+    /// Clamp + snap to step, commit, and fire the change-end callback (used by the
+    /// VoiceOver adjustable action).
+    private func commit(_ raw: Double) {
+        let snapped = min(max(bounds.lowerBound, (raw / step).rounded() * step), bounds.upperBound)
+        value = snapped
+        onChangeEnd?(snapped)
     }
 
     private var span: Double { bounds.upperBound - bounds.lowerBound }
@@ -85,6 +96,14 @@ public struct Slider: View {
         .a11y(A11yElement.Control.slider, in: accessibilityID)
         .accessibilityLabel(label ?? "")
         .accessibilityValue(valueText(value))
+        .accessibilityAdjustableAction { direction in
+            guard isEnabled else { return }
+            switch direction {
+            case .increment: commit(value + step)
+            case .decrement: commit(value - step)
+            @unknown default: break
+            }
+        }
     }
 
     private var horizontalBody: some View {
@@ -137,6 +156,14 @@ public struct Slider: View {
         .a11y(A11yElement.Control.slider, in: accessibilityID)
         .accessibilityLabel(label ?? "")
         .accessibilityValue(valueText(value))
+        .accessibilityAdjustableAction { direction in
+            guard isEnabled else { return }
+            switch direction {
+            case .increment: commit(value + step)
+            case .decrement: commit(value - step)
+            @unknown default: break
+            }
+        }
     }
 
     private var thumb: some View {
@@ -173,7 +200,7 @@ public struct Slider: View {
                 let raw = bounds.lowerBound + ratio * span
                 value = min(max(bounds.lowerBound, (raw / step).rounded() * step), bounds.upperBound)
             }
-            .onEnded { _ in dragging = false }
+            .onEnded { _ in dragging = false; onChangeEnd?(value) }
     }
 
     /// Vertical drag uses translation (up = increase) so the math stays correct
@@ -189,7 +216,7 @@ public struct Slider: View {
                 let raw = start + deltaRatio * span
                 value = min(max(bounds.lowerBound, (raw / step).rounded() * step), bounds.upperBound)
             }
-            .onEnded { _ in dragging = false; dragStartValue = nil }
+            .onEnded { _ in dragging = false; dragStartValue = nil; onChangeEnd?(value) }
     }
 }
 


### PR DESCRIPTION
## What
Closes **Slider**'s remaining RangeSlider-parity gap — additive, backward-compatible.
- **onChangeEnd** — `((Double) -> Void)?` fires once when a drag ends (both axes), so callers can commit / persist without reacting to every intermediate value (RangeSlider already had this).
- **VoiceOver** — `accessibilityAdjustableAction` lets users increment / decrement by `step` (swipe up/down); the discrete change also fires `onChangeEnd` via `commit()`.

## Why
Slider already shipped marks, step, vertical axis, disabled and a drag tooltip. `onChangeEnd` (commit-on-release) and an adjustable a11y action were the parts RangeSlider had that Slider lacked.

## Compatibility
New param defaults to `nil`; existing call sites compile and render identically.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo shows the last committed value across both axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)