### PR TITLE
feat(dialog): async / loading primary action (Ant Modal confirmLoading)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -1765,15 +1765,23 @@ struct ChipsDemo: View {
 struct DialogDemo: View {
     @State private var show = false
     @State private var accepted = false
+    @State private var showConfirm = false
+    @State private var deleted = false
     var body: some View {
-        ComponentStage("Dialog", inspector: [("accepted", "\(accepted)")]) {
+        ComponentStage("Dialog", inspector: [("accepted", "\(accepted)"), ("deleted", "\(deleted)")]) {
             VStack(spacing: 12) {
                 PrimaryButton("Sözleşmeyi aç", isContentWidth: true) { show = true; flash("Dialog açıldı") }
+                OutlineButton("Hesabı sil (async)", isContentWidth: true) { deleted = false; showConfirm = true }
                 Text(accepted ? "Kabul edildi ✓" : "Henüz onaylanmadı")
                     .textStyle(.labelSm600).foregroundStyle(Theme.shared.text(.textSecondary))
             }
             .frame(maxWidth: .infinity)
             .frame(height: 220)
+            .dialog(isPresented: $showConfirm, title: "Hesabı sil?", message: "Bu işlem geri alınamaz.",
+                    primaryTitle: "Sil", onPrimary: {
+                        try? await Task.sleep(nanoseconds: 1_200_000_000)   // async work; OK spins
+                        deleted = true; flash("Hesap silindi")
+                    }, secondaryTitle: "Vazgeç", onSecondary: { flash("Vazgeçildi") }, kind: .error)
             .dialog(isPresented: $show, title: "Kullanım Koşulları", afterClose: {}) {
                 VStack(alignment: .leading, spacing: 12) {
                     ForEach(1...8, id: \.self) { i in

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -25,6 +25,8 @@ struct DialogCard: View {
     var onClose: (() -> Void)? = nil
     /// Maximum card width (default 320).
     var width: CGFloat? = nil
+    /// While true the primary button spins and the secondary is disabled.
+    var isPrimaryLoading: Bool = false
 
     var body: some View {
         VStack(spacing: Theme.SpacingKey.md.value) {
@@ -46,12 +48,12 @@ struct DialogCard: View {
 
             VStack(spacing: Theme.SpacingKey.sm.value) {
                 if let primaryColor {
-                    ThemeButton(primaryTitle, color: primaryColor, block: true, action: onPrimary)
+                    ThemeButton(primaryTitle, color: primaryColor, block: true, isLoading: .constant(isPrimaryLoading), action: onPrimary)
                 } else {
-                    PrimaryButton(primaryTitle, isContentWidth: true, action: onPrimary)
+                    PrimaryButton(primaryTitle, isContentWidth: true, isLoading: .constant(isPrimaryLoading), action: onPrimary)
                 }
                 if let secondaryTitle, let onSecondary {
-                    OutlineButton(secondaryTitle, isContentWidth: true, action: onSecondary)
+                    OutlineButton(secondaryTitle, isContentWidth: true, isEnabled: .constant(!isPrimaryLoading), action: onSecondary)
                 }
             }
         }
@@ -77,7 +79,7 @@ private struct DialogModifier: ViewModifier {
     let title: String
     let message: String?
     let primaryTitle: String
-    let onPrimary: () -> Void
+    let onPrimary: () async -> Void
     let secondaryTitle: String?
     let onSecondary: (() -> Void)?
     let kind: FeedbackKind?
@@ -85,23 +87,35 @@ private struct DialogModifier: ViewModifier {
     let maskClosable: Bool
     let width: CGFloat?
 
+    @State private var primaryLoading = false
+
     func body(content: Content) -> some View {
         content.overlay {
             if isPresented {
                 ZStack {
                     Theme.shared.background(.bgTertiary).opacity(0.4)
                         .ignoresSafeArea()
-                        .onTapGesture { if maskClosable { isPresented = false } }
+                        .onTapGesture { if maskClosable, !primaryLoading { isPresented = false } }
                     DialogCard(
                         title: title, message: message,
                         primaryTitle: primaryTitle,
-                        onPrimary: { isPresented = false; onPrimary() },
+                        onPrimary: {
+                            // Keep the dialog open with a spinner until the (possibly
+                            // async) work resolves, then dismiss. (Ant Modal confirmLoading.)
+                            Task {
+                                primaryLoading = true
+                                await onPrimary()
+                                primaryLoading = false
+                                isPresented = false
+                            }
+                        },
                         secondaryTitle: secondaryTitle,
                         onSecondary: onSecondary.map { handler in { isPresented = false; handler() } },
                         primaryColor: kind?.semanticColor,
                         kind: kind,
-                        onClose: closable ? { isPresented = false } : nil,
-                        width: width
+                        onClose: (closable && !primaryLoading) ? { isPresented = false } : nil,
+                        width: width,
+                        isPrimaryLoading: primaryLoading
                     )
                     .padding(Theme.SpacingKey.lg.value)
                 }
@@ -119,7 +133,7 @@ public extension View {
         title: String,
         message: String? = nil,
         primaryTitle: String,
-        onPrimary: @escaping () -> Void = {},
+        onPrimary: @escaping () async -> Void = {},
         secondaryTitle: String? = nil,
         onSecondary: (() -> Void)? = nil,
         kind: FeedbackKind? = nil,


### PR DESCRIPTION
## What
The simple confirm **Dialog**'s primary action may now be **async** — additive, backward-compatible.
- `onPrimary` becomes `() async -> Void`. While it runs, the primary button spins, the secondary is disabled, and neither the scrim tap nor the close button can dismiss the dialog; it closes once the work resolves. (Ant Modal `confirmLoading`.)

## Why
Dialog already had close / mask-close / width / kind / a custom-footer variant; the missing piece was a loading confirm for actions that hit the network before the modal should close.

## Compatibility
Synchronous trailing closures still satisfy the `async onPrimary` (sync→async conversion); existing `.dialog(...)` call sites compile and behave identically. The custom-content+footer variant is untouched.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo gains an async "delete account" confirm that spins ~1.2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)