### PR TITLE
feat(notificationcard): semantic type icon & closable (Ant notification)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -532,12 +532,16 @@ struct ListRowDemo: View {
 struct NotificationDemo: View {
     @State private var unread = true
     @State private var actions = true
+    @State private var closable = false
+    @State private var typed = false
+    private var type: FeedbackKind? { typed ? .success : nil }
     var body: some View {
-        ComponentStage("NotificationCard", inspector: [("isUnread", "\(unread)")]) {
+        ComponentStage("NotificationCard", inspector: [("isUnread", "\(unread)"), ("type", typed ? "success" : "default")]) {
             if actions {
                 NotificationCard(title: "Tatilinle İlgili Bir Önerimiz Var",
                                  message: "Hilton İstanbul rezervasyonuna 24 gün kaldı.",
-                                 date: "5 Aralık 2024", isUnread: unread) {
+                                 date: "5 Aralık 2024", isUnread: unread, type: type,
+                                 onClose: closable ? { flash("Notification kapatıldı") } : nil) {
                     ButtonGroup(.horizontal) {
                         SecondaryButton("Sonra", size: .small, isContentWidth: true) { flash("Notification: Sonra") }
                         PrimaryButton("İncele", size: .small, isContentWidth: true) { flash("Notification: İncele") }
@@ -546,11 +550,14 @@ struct NotificationDemo: View {
             } else {
                 NotificationCard(title: "Tatilinle İlgili Bir Önerimiz Var",
                                  message: "Hilton İstanbul rezervasyonuna 24 gün kaldı.",
-                                 date: "5 Aralık 2024", isUnread: unread)
+                                 date: "5 Aralık 2024", isUnread: unread, type: type,
+                                 onClose: closable ? { flash("Notification kapatıldı") } : nil)
             }
         } knobs: {
             Toggle("Unread", isOn: $unread)
             Toggle("Actions", isOn: $actions)
+            Toggle("Type (success icon)", isOn: $typed)
+            Toggle("Closable", isOn: $closable)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
@@ -14,6 +14,8 @@ public struct NotificationCard<Actions: View>: View {
     private let message: String?
     private let date: String?
     private let isUnread: Bool
+    private let type: FeedbackKind?
+    private let onClose: (() -> Void)?
     private let actions: Actions?
 
     public init(
@@ -21,19 +23,26 @@ public struct NotificationCard<Actions: View>: View {
         message: String? = nil,
         date: String? = nil,
         isUnread: Bool = false,
+        type: FeedbackKind? = nil,
+        onClose: (() -> Void)? = nil,
         @ViewBuilder actions: () -> Actions
     ) {
         self.title = title
         self.message = message
         self.date = date
         self.isUnread = isUnread
+        self.type = type
+        self.onClose = onClose
         self.actions = actions()
     }
+
+    private var iconName: String { type?.systemImage ?? "bell" }
+    private var iconColor: Color { type?.semanticColor.accent ?? Theme.shared.foreground(.fgHero) }
 
     public var body: some View {
         Card {
             HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
-                Icon(systemName: "bell", size: .sm, color: Theme.shared.foreground(.fgHero))
+                Icon(systemName: iconName, size: .sm, color: iconColor)
 
                 VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
                     if let date {
@@ -57,14 +66,29 @@ public struct NotificationCard<Actions: View>: View {
                     }
                 }
                 Spacer(minLength: 0)
+                if let onClose {
+                    Button(action: onClose) {
+                        Icon(systemName: "xmark", size: .xs, color: Theme.shared.text(.textTertiary))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(String(themeKit: "Dismiss"))
+                }
             }
         }
     }
 }
 
 public extension NotificationCard where Actions == EmptyView {
-    init(title: String, message: String? = nil, date: String? = nil, isUnread: Bool = false) {
-        self.init(title: title, message: message, date: date, isUnread: isUnread) { EmptyView() }
+    init(
+        title: String,
+        message: String? = nil,
+        date: String? = nil,
+        isUnread: Bool = false,
+        type: FeedbackKind? = nil,
+        onClose: (() -> Void)? = nil
+    ) {
+        self.init(title: title, message: message, date: date, isUnread: isUnread,
+                  type: type, onClose: onClose) { EmptyView() }
     }
 }
 


### PR DESCRIPTION
## What
Extends **NotificationCard** toward Ant notification — additive, backward-compatible.
- **type** — `FeedbackKind?` swaps the default bell for the semantic status glyph (success / info / warning / error) in its accent color; `nil` keeps the bell.
- **closable** — `onClose` adds a top-trailing dismiss `✕` (VoiceOver "Dismiss").

## Compatibility
Both params added to the main and the `EmptyView` convenience init; both default to `nil`, so existing notifications render identically.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo gains type + closable knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)