### PR TITLE
feat(keyvaluetable): title header & bordered container (Ant Descriptions)

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -156,8 +156,8 @@ enum ComponentRegistry {
         .knob("Carousel", .organisms, demo: CarouselDemo(), usage: #"Carousel(items, autoplay: 2, showsArrows: true) { item in mediaView }"#),
         .knob("PagingCarousel", .organisms, demo: PagingCarouselDemo(), usage: #"PagingCarousel(items, peek: 36, autoplay: 2) { item in mediaView }"#),
         .knob("VideoPlayer", .organisms, demo: VideoPlayerDemo(), usage: #"VideoPlayerView(url, autoplay: true, loop: true, muted: true)"#),
-        .static("KeyValueTable", .organisms, usage: #"KeyValueTable(rows: [.init("Status", value: "Aktif", style: .success)])"#) {
-            KeyValueTable(rows: [.init("Status", value: "Aktif", style: .success), .init("Old price", value: "5.000 TL", style: .strikethrough), .init("Total", value: "4.250 TL")])
+        .static("KeyValueTable", .organisms, usage: #"KeyValueTable(rows: [...], title: "Özet", bordered: true)"#) {
+            KeyValueTable(rows: [.init("Status", value: "Aktif", style: .success), .init("Old price", value: "5.000 TL", style: .strikethrough), .init("Total", value: "4.250 TL")], title: "Rezervasyon özeti", bordered: true)
         },
     ]
 

--- a/Sources/ThemeKit/Components/Organisms/KeyValueTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/KeyValueTable.swift
@@ -36,12 +36,37 @@ public struct KeyValueTable: View {
     }
 
     private let rows: [Row]
+    private let title: String?
+    private let bordered: Bool
 
-    public init(rows: [Row]) {
+    public init(rows: [Row], title: String? = nil, bordered: Bool = false) {
         self.rows = rows
+        self.title = title
+        self.bordered = bordered
     }
 
     public var body: some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+            if let title {
+                Text(title)
+                    .textStyle(.labelLg600)
+                    .foregroundStyle(Theme.shared.text(.textPrimary))
+            }
+            if bordered {
+                table
+                    .background(Theme.shared.background(.bgWhite),
+                                in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
+                            .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                    )
+            } else {
+                table
+            }
+        }
+    }
+
+    private var table: some View {
         VStack(spacing: 0) {
             ForEach(rows) { row in
                 HStack {
@@ -56,6 +81,7 @@ public struct KeyValueTable: View {
                         .multilineTextAlignment(.trailing)
                 }
                 .padding(.vertical, Theme.SpacingKey.sm.value)
+                .padding(.horizontal, bordered ? Theme.SpacingKey.md.value : 0)
                 if row.id != rows.last?.id { DividerView(size: .small) }
             }
         }


### PR DESCRIPTION
## What
Extends **KeyValueTable** toward Ant Descriptions — additive, backward-compatible.
- **title** — a header above the rows.
- **bordered** — wraps the rows in a rounded, outlined surface with inset row padding (the boxed "descriptions" look); the borderless default is untouched.

## Why
KeyValueTable was a bare divided list; `title` + `bordered` are Ant Descriptions' most-used presentation options. (Multi-column grid layout is left for a follow-up.)

## Compatibility
Both params default (`nil` / `false`); existing `KeyValueTable(rows:)` call sites render identically. The row layout was factored into a private `table` view shared by both modes.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Registry sample shows the bordered + titled variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)