### PR TITLE
feat(pageheader): status tags next to the title (Ant PageHeader)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -559,14 +559,17 @@ struct PageHeaderDemo: View {
     @State private var back = true
     @State private var subtitle = true
     @State private var actions = true
+    @State private var tags = false
     var body: some View {
         ComponentStage("PageHeader") {
             PageHeader("Search results", subtitle: subtitle ? "128 hotels" : nil,
+                       tags: tags ? [.init("Aktif", style: .success), .init("Beta", style: .info)] : [],
                        onBack: back ? { flash("PageHeader: geri") } : nil,
                        actions: actions ? [.init(systemImage: "slider.horizontal.3", handler: { flash("PageHeader: filtre") }), .init(systemImage: "heart", handler: { flash("PageHeader: favori") })] : [])
         } knobs: {
             Toggle("Back button", isOn: $back)
             Toggle("Subtitle", isOn: $subtitle)
+            Toggle("Status tags", isOn: $tags)
             Toggle("Actions", isOn: $actions)
         }
     }

--- a/Sources/ThemeKit/Components/Organisms/PageHeader.swift
+++ b/Sources/ThemeKit/Components/Organisms/PageHeader.swift
@@ -24,15 +24,29 @@ public struct PageHeader: View {
     private let subtitle: String?
     private let onBack: (() -> Void)?
     private let actions: [Action]
+    private let tags: [Tag]
+
+    /// A status tag shown next to the title. (Ant PageHeader `tags`.)
+    public struct Tag: Identifiable {
+        public let id = UUID()
+        let text: String
+        let style: BadgeStyle?
+        public init(_ text: String, style: BadgeStyle? = nil) {
+            self.text = text
+            self.style = style
+        }
+    }
 
     public init(
         _ title: String,
         subtitle: String? = nil,
+        tags: [Tag] = [],
         onBack: (() -> Void)? = nil,
         actions: [Action] = []
     ) {
         self.title = title
         self.subtitle = subtitle
+        self.tags = tags
         self.onBack = onBack
         self.actions = actions
     }
@@ -48,9 +62,14 @@ public struct PageHeader: View {
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .textStyle(.headingSm)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                HStack(spacing: Theme.SpacingKey.xs.value) {
+                    Text(title)
+                        .textStyle(.headingSm)
+                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                    ForEach(tags) { tag in
+                        ThemeKit.Tag(tag.text, style: tag.style)
+                    }
+                }
                 if let subtitle {
                     Text(subtitle)
                         .textStyle(.bodySm400)


### PR DESCRIPTION
## What
Adds **status tags** to **PageHeader** — additive, backward-compatible.
- `tags: [PageHeader.Tag]` renders semantic status chips inline after the title, each driven by the `Tag` atom's `BadgeStyle` (success / info / warning / …).

## Why
PageHeader had title / subtitle / back / icon-actions but no status tags — Ant PageHeader's `tags` are a common need (e.g. "Active" / "Beta" next to a screen title). (Original Sprint-3 slot was SegmentedTabBar, which is already feature-complete — card/line type, closable, addable — so this navigation-themed gap took its place.)

## Compatibility
`tags` defaults to empty; existing `PageHeader(...)` call sites render identically. The nested `PageHeader.Tag` is disambiguated from the `Tag` atom via `ThemeKit.Tag` at the render site.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo gains a status-tags knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)