### PR TITLE
feat(upload): maxCount limit (Ant Upload)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -633,14 +633,21 @@ struct UploadDemo: View {
 
     @StateObject private var uploads = UploadController()
     @State private var counter = 0
+    @State private var picked: [UploadFile] = []
 
     var body: some View {
-        ComponentStage("Upload", inspector: [("files", "\(uploads.files.count)")]) {
-            UploadList(controller: uploads) { start(fail: false) }
+        ComponentStage("Upload", inspector: [("files", "\(uploads.files.count)"), ("picked", "\(picked.count)/3")]) {
+            VStack(spacing: 20) {
+                UploadList(controller: uploads) { start(fail: false) }
+                Upload(prompt: "En fazla 3 fotoğraf yükleyebilirsin.", buttonTitle: "Fotoğraf ekle",
+                       files: picked, maxCount: 3,
+                       onPick: { picked.append(.init(name: "img-\(picked.count + 1).jpg", status: .done)) },
+                       onRemove: { file in picked.removeAll { $0.id == file.id } })
+            }
         } knobs: {
             Button("Simulate upload") { start(fail: false) }
             Button("Simulate failure") { start(fail: true) }
-            Button("Clear") { uploads.files.map(\.id).forEach { uploads.remove($0) } }
+            Button("Clear") { uploads.files.map(\.id).forEach { uploads.remove($0) }; picked = [] }
         }
     }
 

--- a/Sources/ThemeKit/Components/Organisms/Upload.swift
+++ b/Sources/ThemeKit/Components/Organisms/Upload.swift
@@ -30,6 +30,7 @@ public struct Upload: View {
     private let prompt: String
     private let buttonTitle: String
     private let files: [UploadFile]
+    private let maxCount: Int?
     private let onPick: () -> Void
     private let onRemove: (UploadFile) -> Void
     private let onRetry: ((UploadFile) -> Void)?
@@ -38,6 +39,7 @@ public struct Upload: View {
         prompt: String = String(themeKit: "Add a photo from your device or take one with the camera."),
         buttonTitle: String = String(themeKit: "Upload Photo"),
         files: [UploadFile] = [],
+        maxCount: Int? = nil,
         onPick: @escaping () -> Void = {},
         onRemove: @escaping (UploadFile) -> Void = { _ in },
         onRetry: ((UploadFile) -> Void)? = nil
@@ -45,17 +47,26 @@ public struct Upload: View {
         self.prompt = prompt
         self.buttonTitle = buttonTitle
         self.files = files
+        self.maxCount = maxCount
         self.onPick = onPick
         self.onRemove = onRemove
         self.onRetry = onRetry
     }
+
+    /// True once the file count reaches `maxCount` (if set) — the picker is then disabled.
+    private var atLimit: Bool { maxCount.map { files.count >= $0 } ?? false }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             Text(prompt)
                 .textStyle(.bodySm400)
                 .foregroundStyle(Theme.shared.text(.textSecondary))
-            PrimaryButton(buttonTitle, isContentWidth: true) { onPick() }
+            PrimaryButton(buttonTitle, isContentWidth: true, isEnabled: .constant(!atLimit)) { onPick() }
+            if let maxCount {
+                Text("\(files.count)/\(maxCount)")
+                    .textStyle(.overline400)
+                    .foregroundStyle(Theme.shared.text(.textTertiary))
+            }
 
             if !files.isEmpty {
                 VStack(spacing: 0) {


### PR DESCRIPTION
## What
Adds **maxCount** to the prompt-style **Upload** — additive, backward-compatible.
- `maxCount: Int?` caps the number of files; once reached, the picker button disables and a `count/max` caption appears. `nil` keeps the unlimited default.

## Why
Upload already had per-file status / retry / remove; a count cap is Ant Upload's `maxCount` and a common requirement (e.g. "up to 3 photos").

## Compatibility
New param defaults to `nil`; existing `Upload(...)` call sites render identically. (The controller-based `UploadList` is unchanged.)

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo pairs `UploadList` with a `maxCount: 3` Upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)