### PR TITLE
feat(fileinput): validation messages & clear button (Ant Upload field)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -1126,12 +1126,21 @@ struct FieldsetDemo: View {
 
 struct FileInputDemo: View {
     @State private var picked = false
+    @State private var error = false
+    @State private var clearable = true
+    private var messages: [InfoMessage] {
+        error ? [InfoMessage("Dosya 5 MB'tan küçük olmalı", kind: .error)] : []
+    }
     var body: some View {
-        ComponentStage("FileInput", inspector: [("fileName", picked ? "passport-scan.jpg" : "nil")]) {
-            FileInput(label: "Passport", fileName: picked ? "passport-scan.jpg" : nil) { picked.toggle(); flash("FileInput: dosya seçildi") }
+        ComponentStage("FileInput", inspector: [("fileName", picked ? "passport-scan.jpg" : "nil"), ("error", "\(error)")]) {
+            FileInput(label: "Passport", fileName: picked ? "passport-scan.jpg" : nil,
+                      infoMessages: messages,
+                      onPick: { picked = true; flash("FileInput: dosya seçildi") },
+                      onClear: clearable ? { picked = false; flash("FileInput: temizlendi") } : nil)
         } knobs: {
             Toggle("File chosen", isOn: $picked)
-            Text("Tap 'Choose file' to toggle.").font(.footnote).foregroundStyle(.secondary)
+            Toggle("Validation error", isOn: $error)
+            Toggle("Clearable", isOn: $clearable)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/FileInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/FileInput.swift
@@ -15,7 +15,9 @@ public struct FileInput: View {
     private let buttonTitle: String
     private let placeholder: String
     private let isEnabled: Bool
+    private let infoMessages: [InfoMessage]
     private let onPick: () -> Void
+    private let onClear: (() -> Void)?
 
     public init(
         label: String? = nil,
@@ -23,14 +25,26 @@ public struct FileInput: View {
         buttonTitle: String = "Choose file",
         placeholder: String = "No file chosen",
         isEnabled: Bool = true,
-        onPick: @escaping () -> Void
+        infoMessages: [InfoMessage] = [],
+        onPick: @escaping () -> Void,
+        onClear: (() -> Void)? = nil
     ) {
         self.label = label
         self.fileName = fileName
         self.buttonTitle = buttonTitle
         self.placeholder = placeholder
         self.isEnabled = isEnabled
+        self.infoMessages = infoMessages
         self.onPick = onPick
+        self.onClear = onClear
+    }
+
+    private var fieldBorder: Color {
+        switch infoMessages.dominantKind {
+        case .error: return Theme.shared.border(.systemcolorsBorderError)
+        case .warning: return Theme.shared.border(.systemcolorsBorderWarning)
+        default: return Theme.shared.border(.borderPrimary)
+        }
     }
 
     public var body: some View {
@@ -58,11 +72,24 @@ public struct FileInput: View {
                     .padding(.horizontal, Theme.SpacingKey.md.value)
 
                 Spacer(minLength: 0)
+
+                if fileName != nil, let onClear {
+                    Button(action: onClear) {
+                        Icon(systemName: "xmark.circle.fill", size: .sm, color: Theme.shared.text(.textTertiary))
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.trailing, Theme.SpacingKey.md.value)
+                    .accessibilityLabel(String(themeKit: "Remove"))
+                }
             }
             .frame(height: 48)
             .background(Theme.shared.background(.bgWhite))
             .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
-            .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).stroke(Theme.shared.border(.borderPrimary), lineWidth: 1))
+            .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).stroke(fieldBorder, lineWidth: infoMessages.dominantKind != nil ? 1.5 : 1))
+
+            if !infoMessages.isEmpty {
+                InfoMessageList(infoMessages)
+            }
         }
     }
 }


### PR DESCRIPTION
## What
Extends **FileInput** with validation + clear — additive, backward-compatible.
- **infoMessages** — `[InfoMessage]` drives an error/warning border (1.5pt) and a message list below the field, the same idiom `TextInput` / `Select` use.
- **onClear** — a trailing `✕` appears once a file is chosen, to remove it.

## Why
FileInput had no validation surface or way to clear a selection — both are standard for a form file field.

## Compatibility
Both default to empty / `nil`; existing `FileInput(...)` call sites compile and render identically.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo gains validation-error and clearable knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)