### PR TITLE
feat(quantitystepper): configurable step (Ant InputNumber step)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -336,13 +336,15 @@ struct InputNumberDemo: View {
 }
 
 struct QuantityStepperDemo: View {
-    @State private var value = 1
+    @State private var value = 0
+    @State private var bigStep = false
 
     var body: some View {
-        ComponentStage("QuantityStepper", inspector: [("value", "\(value)")]) {
-            QuantityStepper(value: $value, range: 0...10)
+        ComponentStage("QuantityStepper", inspector: [("value", "\(value)"), ("step", bigStep ? "5" : "1")]) {
+            QuantityStepper(value: $value, range: 0...100, step: bigStep ? 5 : 1)
         } knobs: {
-            Stepper("Value: \(value)", value: $value, in: 0...10)
+            Toggle("Step 5", isOn: $bigStep)
+            Stepper("Value: \(value)", value: $value, in: 0...100)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/QuantityStepper.swift
+++ b/Sources/ThemeKit/Components/Molecules/QuantityStepper.swift
@@ -11,12 +11,14 @@ import SwiftUI
 public struct QuantityStepper: View {
     @Binding private var value: Int
     private let range: ClosedRange<Int>
+    private let step: Int
     private let accessibilityID: String?
     private let isEnabled: Bool
 
-    public init(value: Binding<Int>, range: ClosedRange<Int> = 0...99, accessibilityID: String? = nil, isEnabled: Bool = true) {
+    public init(value: Binding<Int>, range: ClosedRange<Int> = 0...99, step: Int = 1, accessibilityID: String? = nil, isEnabled: Bool = true) {
         self._value = value
         self.range = range
+        self.step = max(1, step)
         self.accessibilityID = accessibilityID
         self.isEnabled = isEnabled
     }
@@ -24,7 +26,7 @@ public struct QuantityStepper: View {
     public var body: some View {
         HStack(spacing: Theme.SpacingKey.md.value) {
             stepButton(systemName: "minus", enabled: value > range.lowerBound) {
-                value = max(range.lowerBound, value - 1)
+                value = max(range.lowerBound, value - step)
             }
 
             Text("\(value)")
@@ -34,7 +36,7 @@ public struct QuantityStepper: View {
                 .monospacedDigit()
 
             stepButton(systemName: "plus", enabled: value < range.upperBound) {
-                value = min(range.upperBound, value + 1)
+                value = min(range.upperBound, value + step)
             }
         }
         .padding(.horizontal, Theme.SpacingKey.sm.value)

--- a/Sources/ThemeKit/Components/Molecules/QuantityStepper.swift
+++ b/Sources/ThemeKit/Components/Molecules/QuantityStepper.swift
@@ -15,7 +15,13 @@ public struct QuantityStepper: View {
     private let accessibilityID: String?
     private let isEnabled: Bool
 
-    public init(value: Binding<Int>, range: ClosedRange<Int> = 0...99, step: Int = 1, accessibilityID: String? = nil, isEnabled: Bool = true) {
+    public init(
+        value: Binding<Int>,
+        range: ClosedRange<Int> = 0...99,
+        step: Int = 1,
+        accessibilityID: String? = nil,
+        isEnabled: Bool = true
+    ) {
         self._value = value
         self.range = range
         self.step = max(1, step)


### PR DESCRIPTION
## What
Adds a configurable **step** to **QuantityStepper** — additive, backward-compatible.
- `step: Int = 1` sets how much `−` / `+` change the value; clamped to the range and guarded to ≥ 1.

## Why
The stepper only moved by 1; a step is the standard Ant InputNumber knob (e.g. quantities in 5s, price in 50s).

## Compatibility
Defaults to `1`; existing `QuantityStepper(value:range:)` call sites behave identically.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo gains a "step 5" toggle over a 0...100 range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)