### PR TITLE
feat(listview): empty state (Ant List empty)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -1579,11 +1579,12 @@ struct ListDemo: View {
     @State private var bordered = true
     @State private var split = true
     @State private var loading = false
+    @State private var empty = false
 
     var body: some View {
-        ComponentStage("List", inspector: [("count", "\(rows.count)"), ("bordered", "\(bordered)"), ("loading", "\(loading)")]) {
-            ListView(rows, header: withHeader ? "Ayarlar" : nil, footer: withHeader ? "\(rows.count) öğe" : nil,
-                     bordered: bordered, loading: loading, split: split) { row in
+        ComponentStage("List", inspector: [("count", "\(empty ? 0 : rows.count)"), ("bordered", "\(bordered)"), ("empty", "\(empty)")]) {
+            ListView(empty ? [] : rows, header: withHeader ? "Ayarlar" : nil, footer: withHeader ? "\(empty ? 0 : rows.count) öğe" : nil,
+                     bordered: bordered, loading: loading, split: split, emptyText: "Henüz ayar yok") { row in
                 ListRow(row.title, subtitle: row.subtitle, leadingSystemImage: row.icon, action: { flash("List: \(row.title)") })
             }
         } knobs: {
@@ -1591,6 +1592,7 @@ struct ListDemo: View {
             Toggle("Bordered", isOn: $bordered)
             Toggle("Split (dividers)", isOn: $split)
             Toggle("Loading (skeleton)", isOn: $loading)
+            Toggle("Empty (no items)", isOn: $empty)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/ListView.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListView.swift
@@ -17,6 +17,7 @@ public struct ListView<Item: Identifiable, Row: View>: View {
     private let bordered: Bool
     private let loading: Bool
     private let split: Bool
+    private let emptyText: String?
     private let rowContent: (Item) -> Row
 
     public init(
@@ -26,6 +27,7 @@ public struct ListView<Item: Identifiable, Row: View>: View {
         bordered: Bool = true,
         loading: Bool = false,
         split: Bool = true,
+        emptyText: String? = nil,
         @ViewBuilder row: @escaping (Item) -> Row
     ) {
         self.items = items
@@ -34,6 +36,7 @@ public struct ListView<Item: Identifiable, Row: View>: View {
         self.bordered = bordered
         self.loading = loading
         self.split = split
+        self.emptyText = emptyText
         self.rowContent = row
     }
 
@@ -54,6 +57,8 @@ public struct ListView<Item: Identifiable, Row: View>: View {
                     skeletonRow
                     if split && index < 2 { DividerView(size: .small).padding(.leading, Theme.SpacingKey.md.value) }
                 }
+            } else if items.isEmpty {
+                emptyRow
             } else {
                 ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
                     rowContent(item)
@@ -83,6 +88,15 @@ public struct ListView<Item: Identifiable, Row: View>: View {
                     .stroke(Theme.shared.border(.borderPrimary), lineWidth: 1)
             }
         }
+    }
+
+    private var emptyRow: some View {
+        Text(emptyText ?? String(themeKit: "No data"))
+            .textStyle(.bodySm400)
+            .foregroundStyle(Theme.shared.text(.textTertiary))
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, Theme.SpacingKey.md.value)
+            .padding(.vertical, Theme.SpacingKey.lg.value)
     }
 
     private var skeletonRow: some View {


### PR DESCRIPTION
## What
Adds an **empty state** to **ListView** — additive, backward-compatible.
- When `items` is empty and not loading, a centered placeholder row renders instead of a collapsed gap. `emptyText: String?` customizes the message (defaults to a localized "No data").

## Why
ListView already had a loading skeleton; the empty case is its natural pair (Ant List shows an Empty when there's no data), and matches the empty-state idiom used across Select / Autocomplete / TreeSelect.

## Compatibility
`emptyText` defaults to `nil` and the empty branch only triggers on an empty list, so existing populated lists render identically.

## Tests
`swift build` + full suite green (**156 tests**); lint clean. Demo gains an "empty" knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)