### PR TITLE
feat(motion): micro-animation switch — theme-wide + per-component

### DIFF
--- a/Demo/Demo/DemoApp.swift
+++ b/Demo/Demo/DemoApp.swift
@@ -10,10 +10,14 @@ import ThemeKit
 @main
 struct DemoApp: App {
     @StateObject private var themeStore = DemoThemeStore()
+    // Theme-wide micro-animation switch (toggled from the Configurator). Reduce
+    // Motion always wins on top of this. Per-component override: `.microAnimations(false)`.
+    @AppStorage("themekit.microAnimations") private var microAnimations = true
 
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .microAnimations(microAnimations)
                 .environmentObject(themeStore)
                 .feedbackHost()       // installs the shared FeedbackPresenter + overlays
                 .sheetHost()          // installs the shared SheetPresenter

--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -91,6 +91,7 @@ enum ComponentRegistry {
         .knob("Stat", .molecules, demo: StatDemo(), usage: #"Stat(title: "Bookings", value: "1,284", systemImage: "ticket", trend: .up("+12%"))"#),
         .knob("Steps", .molecules, demo: StepsDemo(), usage: #"Steps([.init("Cart", description: "2 items", state: .done), .init("Pay", state: .error)]) { active = $0 }"#),
         .knob("QuantityStepper", .molecules, demo: QuantityStepperDemo(), usage: #"QuantityStepper(value: $qty, range: 0...10)"#),
+        .knob("Micro-motion", .molecules, demo: MicroMotionDemo(), usage: #"View().microAnimations(false)   // theme-wide at root, or per-component"#),
         .knob("RadioButton", .molecules, demo: RadioButtonDemo(), usage: #"RadioButton(isSelected: $on)"#),
         .knob("RadioGroup", .molecules, demo: RadioGroupDemo(), usage: #"RadioGroup(options: items, selection: $sel) { $0 }"#),
         .knob("RangeSlider", .molecules, demo: RangeSliderDemo(), usage: #"RangeSlider(lowerValue: $lo, upperValue: $hi, in: 0...1000, step: 50, marks: [0, 500, 1000], onChangeEnd: search)"#),

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -1854,3 +1854,33 @@ struct ProgressIndicatorDemo: View {
         }
     }
 }
+
+// MARK: - Micro-motion (system)
+
+struct MicroMotionDemo: View {
+    @State private var enabled = true
+    @State private var on = false
+    @State private var sel = 0
+    var body: some View {
+        ComponentStage("Micro-motion", inspector: [("microAnimations", "\(enabled)")]) {
+            VStack(spacing: 18) {
+                Text("Bu alt-ağaç: .microAnimations(\(enabled ? "true" : "false")) — basınca scale, seçimde kayma.")
+                    .font(.footnote).foregroundStyle(.secondary).multilineTextAlignment(.center)
+                PrimaryButton("Bana bas (micro press)", isContentWidth: true) { flash("Tap") }
+                SegmentedControl(["Gün", "Hafta", "Ay"], selection: $sel)
+                ThemeToggle(isOn: $on)
+
+                DividerView(size: .small)
+                Text("Per-component override — bu buton her zaman kapalı:")
+                    .font(.footnote).foregroundStyle(.secondary).multilineTextAlignment(.center)
+                SecondaryButton("Hareketsiz (.microAnimations(false))", isContentWidth: true) { flash("Tap") }
+                    .microAnimations(false)
+            }
+            .microAnimations(enabled)
+        } knobs: {
+            Toggle("Micro-animations (bu alt-ağaç)", isOn: $enabled)
+            Text("Tema geneli için: Configurator → “Micro-animations”. Reduce Motion her zaman kazanır.")
+                .font(.footnote).foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Demo/Demo/Views/ThemeConfiguratorView.swift
+++ b/Demo/Demo/Views/ThemeConfiguratorView.swift
@@ -19,6 +19,8 @@ struct ThemeConfiguratorView: View {
 
     @State private var config = ConfigState()
     @State private var chipOn = true
+    // Theme-wide micro-animation switch — shared with the app root via the same key.
+    @AppStorage("themekit.microAnimations") private var microAnimations = true
 
     private let fonts = ["Montserrat", "System", "SystemRounded", "SystemSerif", "SystemMono"]
 
@@ -97,6 +99,7 @@ struct ThemeConfiguratorView: View {
                 ColorPicker("Primary color", selection: $config.primary, supportsOpacity: false)
                 sliderRow("Tint (re-skin strength)", $config.tint, 0...0.25, "%.2f")
                 Toggle("Dark mode", isOn: $config.dark)
+                Toggle("Micro-animations (theme-wide)", isOn: $microAnimations)
             }
         }
     }

--- a/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
@@ -161,13 +161,26 @@ public struct ThemeButton: View {
 
 /// Tactile press/active feedback (the iOS equivalent of Ant Design's hover/active
 /// interaction states). Used by the preset button family in `Buttons.swift`.
+/// The press *scale* + its tween are gated by `microAnimations` + Reduce Motion;
+/// the opacity dim (a state, not motion) stays as a press affordance.
 public struct PressFeedbackStyle: ButtonStyle {
     public init() {}
     public func makeBody(configuration: Configuration) -> some View {
+        PressFeedbackBody(configuration: configuration)
+    }
+}
+
+private struct PressFeedbackBody: View {
+    let configuration: ButtonStyleConfiguration
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var on: Bool { micro && !reduceMotion }
+
+    var body: some View {
         configuration.label
             .opacity(configuration.isPressed ? 0.88 : 1)
-            .scaleEffect(configuration.isPressed ? 0.97 : 1)
-            .animation(Motion.instant.animation, value: configuration.isPressed)
+            .scaleEffect(on && configuration.isPressed ? 0.97 : 1)
+            .animation(on ? Motion.instant.animation : nil, value: configuration.isPressed)
     }
 }
 
@@ -178,12 +191,24 @@ public struct RowPressStyle: ButtonStyle {
     private let cornerRadius: CGFloat
     public init(cornerRadius: CGFloat = 0) { self.cornerRadius = cornerRadius }
     public func makeBody(configuration: Configuration) -> some View {
+        RowPressBody(configuration: configuration, cornerRadius: cornerRadius)
+    }
+}
+
+private struct RowPressBody: View {
+    let configuration: ButtonStyleConfiguration
+    let cornerRadius: CGFloat
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var on: Bool { micro && !reduceMotion }
+
+    var body: some View {
         configuration.label
             .background(
                 configuration.isPressed ? Theme.shared.background(.bgElevatorTertiary) : .clear,
                 in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
             )
-            .animation(Motion.instant.animation, value: configuration.isPressed)
+            .animation(on ? Motion.instant.animation : nil, value: configuration.isPressed)
     }
 }
 
@@ -197,11 +222,26 @@ struct FillButtonStyle: ButtonStyle {
     let stroke: Color?
 
     func makeBody(configuration: Configuration) -> some View {
+        FillButtonBody(configuration: configuration, shape: shape, resting: resting, pressed: pressed, stroke: stroke)
+    }
+}
+
+private struct FillButtonBody: View {
+    let configuration: ButtonStyleConfiguration
+    let shape: AnyShape
+    let resting: Color
+    let pressed: Color
+    let stroke: Color?
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var on: Bool { micro && !reduceMotion }
+
+    var body: some View {
         configuration.label
             .background(configuration.isPressed ? pressed : resting, in: shape)
             .overlay { if let stroke { shape.stroke(stroke, lineWidth: 1.5) } }
-            .scaleEffect(configuration.isPressed ? 0.97 : 1)
-            .animation(Motion.instant.animation, value: configuration.isPressed)
+            .scaleEffect(on && configuration.isPressed ? 0.97 : 1)
+            .animation(on ? Motion.instant.animation : nil, value: configuration.isPressed)
     }
 }
 

--- a/Sources/ThemeKit/Theme/MicroMotion.swift
+++ b/Sources/ThemeKit/Theme/MicroMotion.swift
@@ -1,0 +1,85 @@
+//
+//  MicroMotion.swift
+//  ThemeKit
+//  Created by İsa Mercan on 26.06.2026.
+//
+//  Theme-wide + per-component switch for the library's built-in micro-animations.
+//  Components animate only *micro* state changes — a press scale, a selection
+//  slide, a value tick — never showy motion. This switch turns that motion off
+//  globally or for one component; the system Reduce Motion setting always wins.
+//
+//    RootView().microAnimations(false)   // theme-wide off
+//    SomeComponent().microAnimations(false)   // just this one off
+//
+//  Inside a component, resolve the effective animation with:
+//    @Environment(\.microAnimations) var micro
+//    @Environment(\.accessibilityReduceMotion) var reduceMotion
+//    .animation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion), value: state)
+//
+
+import SwiftUI
+
+private struct MicroAnimationsKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
+public extension EnvironmentValues {
+    /// Whether ThemeKit components play their built-in micro-animations.
+    /// Defaults to `true`. Set it once at the app root for a theme-wide switch,
+    /// or on any view/component to override just that subtree. The system
+    /// **Reduce Motion** setting disables motion regardless of this flag.
+    var microAnimations: Bool {
+        get { self[MicroAnimationsKey.self] }
+        set { self[MicroAnimationsKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Enable or disable ThemeKit micro-animations for this view and its children.
+    ///
+    /// - At the app root it's a **theme-wide** switch.
+    /// - On a single component it overrides **just that one**.
+    ///
+    /// Reduce Motion still wins, so motion-sensitive users are always honored.
+    func microAnimations(_ enabled: Bool) -> some View {
+        environment(\.microAnimations, enabled)
+    }
+}
+
+/// Resolves the effective micro-animation, honoring both the `microAnimations`
+/// switch and the system Reduce Motion setting.
+public enum MicroMotion {
+    /// The animation to use, or `nil` when motion is off (switch off *or* Reduce
+    /// Motion on). Pass the result straight to `.animation(_:value:)` — a `nil`
+    /// animation makes the state change apply instantly, with no motion.
+    public static func animation(
+        _ token: Motion = .fast,
+        enabled: Bool,
+        reduceMotion: Bool
+    ) -> Animation? {
+        (enabled && !reduceMotion) ? token.animation : nil
+    }
+}
+
+/// A subtle, gated press-scale for tappable surfaces that aren't already driven by
+/// a ThemeKit `ButtonStyle`. Micro by design (default 0.97). Reads `microAnimations`
+/// + Reduce Motion from the environment and snaps (no motion) when either is off.
+public extension View {
+    func microPressScale(_ isPressed: Bool, scale: CGFloat = 0.97) -> some View {
+        modifier(MicroPressScale(isPressed: isPressed, scale: scale))
+    }
+}
+
+private struct MicroPressScale: ViewModifier {
+    let isPressed: Bool
+    let scale: CGFloat
+    @Environment(\.microAnimations) private var enabled
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var on: Bool { enabled && !reduceMotion }
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(on && isPressed ? scale : 1)
+            .animation(on ? Motion.instant.animation : nil, value: isPressed)
+    }
+}

--- a/docs/MOTION.md
+++ b/docs/MOTION.md
@@ -1,0 +1,65 @@
+# Micro-motion
+
+ThemeKit components animate **micro** state changes — a press scale, a selection
+slide, a value tick — and nothing showy. Every bit of that motion is switchable, at
+two scopes, and the system **Reduce Motion** setting always overrides both.
+
+## Turning it off
+
+```swift
+// Theme-wide — one switch at the app root disables motion everywhere downstream.
+RootView()
+    .microAnimations(false)
+
+// Per-component — override just one component (or one subtree).
+PrimaryButton("Still") { … }
+    .microAnimations(false)
+```
+
+`microAnimations` is a SwiftUI `EnvironmentValues` flag (default `true`) read by the
+shared button styles and by individual components. Because it's environment-based,
+the **same modifier** does both jobs: set it high for a global switch, set it low to
+override a branch. The effective rule is:
+
+```
+animate  ==  microAnimations  &&  !accessibilityReduceMotion
+```
+
+So a Reduce-Motion user never sees motion regardless of the flag, and you can still
+force a specific component still even when motion is on globally.
+
+## Using it in a component
+
+```swift
+@Environment(\.microAnimations) private var micro
+@Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+someView
+    .animation(
+        MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion),
+        value: state
+    )
+```
+
+`MicroMotion.animation(_:enabled:reduceMotion:)` returns `nil` when motion is off,
+and a `nil` animation makes the state change apply instantly (no motion) — so the UI
+stays fully functional, it just stops moving.
+
+For a tappable surface that isn't already a ThemeKit `ButtonStyle`, the gated
+press-scale helper:
+
+```swift
+myView.microPressScale(isPressed)   // 0.97 by default, snaps when motion is off
+```
+
+## Design rules (what "micro" means here)
+
+- **Durations** come from the `Motion` tokens — `instant` (0.10s) for press,
+  `fast` (0.20s) for state/selection. Nothing slower for interaction feedback.
+- **Magnitudes** stay small: ~0.97 scale, opacity, 2–4 pt offset. No bounce, no
+  overshoot, no attention-grabbing springs.
+- **Static** atoms (Divider, Kbd, InlineText) get no animation — motion is reserved
+  for interactive and stateful components.
+
+Try it live: **Gallery → Micro-motion** (per-component override) and **Configurator →
+Micro-animations** (theme-wide switch).


### PR DESCRIPTION
## What
The foundation for ThemeKit **micro-animations**: a single switch that turns the library's built-in motion on/off, at two scopes, honoring accessibility.

- **`\.microAnimations`** environment flag (default `true`).
- **`.microAnimations(false)`** — at the app root it's **theme-wide**; on one component it overrides **just that subtree**. One modifier, both scopes (SwiftUI environment cascade).
- **`MicroMotion.animation(_:enabled:reduceMotion:)`** resolves the effective animation → `nil` (instant, no motion) when the switch is off **or** system Reduce Motion is on. **Reduce Motion always wins.**
- **`.microPressScale(_:)`** — gated press-scale for non-Button tappables.

The three shared button styles (`PressFeedbackStyle` / `RowPressStyle` / `FillButtonStyle`) now read the flag, so **every component built on them honors the switch immediately** (buttons, cards, rows, chips, select panels…). Press *opacity* stays as a state affordance; the scale + tween are what gate.

## Design rules
Micro only: `instant` (0.10s) press, `fast` (0.20s) state; ~0.97 scale / opacity / 2–4pt — no bounce. Static atoms get no motion. See `docs/MOTION.md`.

## Demo
- **Gallery → Micro-motion** — per-component override (a button forced still next to live ones).
- **Configurator → Micro-animations** — theme-wide toggle (`@AppStorage`, applied at the app root).

## Verification
`make ci` (local, $0): **✓ all gates green — 156 tests**, lint clean.

> Next phases gate each component family's state transitions (selection/input, overlays, value, navigation) on the same flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)