### PR TITLE
feat(motion): gate overlay appear animations (Phase 2)

### DIFF
--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -106,6 +106,32 @@ private struct TooltipPlacement: ViewModifier {
     }
 }
 
+/// Binding-driven tooltip presentation — gates its fade on `microAnimations`.
+private struct BindingTooltip: ViewModifier {
+    let text: String
+    @Binding var isPresented: Bool
+    let edge: TooltipEdge
+    let style: BadgeStyle?
+    let maxWidth: CGFloat?
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: edge.alignment) {
+                if isPresented {
+                    TooltipBubble(text: text, edge: edge, style: style, maxWidth: maxWidth)
+                        .fixedSize(horizontal: maxWidth == nil, vertical: true)
+                        .modifier(TooltipPlacement(edge: edge))
+                        .transition(.opacity)
+                        .zIndex(1)
+                }
+            }
+            .animation(motion, value: isPresented)
+    }
+}
+
 /// Wraps an anchor so a tap toggles its own tooltip — no external binding needed.
 private struct SelfTooltip: ViewModifier {
     let text: String
@@ -134,16 +160,7 @@ public extension View {
         style: BadgeStyle? = nil,
         maxWidth: CGFloat? = nil
     ) -> some View {
-        overlay(alignment: edge.alignment) {
-            if isPresented.wrappedValue {
-                TooltipBubble(text: text, edge: edge, style: style, maxWidth: maxWidth)
-                    .fixedSize(horizontal: maxWidth == nil, vertical: true)
-                    .modifier(TooltipPlacement(edge: edge))
-                    .transition(.opacity)
-                    .zIndex(1)
-            }
-        }
-        .animation(Motion.fast.animation, value: isPresented.wrappedValue)
+        modifier(BindingTooltip(text: text, isPresented: isPresented, edge: edge, style: style, maxWidth: maxWidth))
     }
 
     /// Self-managed tooltip: tap the anchor to toggle it (tap again to dismiss).

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -88,6 +88,9 @@ private struct DialogModifier: ViewModifier {
     let width: CGFloat?
 
     @State private var primaryLoading = false
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
 
     func body(content: Content) -> some View {
         content.overlay {
@@ -123,7 +126,7 @@ private struct DialogModifier: ViewModifier {
                 .zIndex(1)
             }
         }
-        .animation(Motion.fast.animation, value: isPresented)
+        .animation(motion, value: isPresented)
     }
 }
 
@@ -162,6 +165,10 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
     let afterClose: (() -> Void)?
     let dialogContent: () -> DialogContent
     let footer: () -> Footer
+
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
 
     private func close() {
         isPresented = false
@@ -216,7 +223,7 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
                 .zIndex(1)
             }
         }
-        .animation(Motion.fast.animation, value: isPresented)
+        .animation(motion, value: isPresented)
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/Drawer.swift
+++ b/Sources/ThemeKit/Components/Organisms/Drawer.swift
@@ -23,6 +23,9 @@ private struct DrawerContainer<DrawerContent: View>: View {
     @ViewBuilder let content: () -> DrawerContent
 
     @State private var dragX: CGFloat = 0
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
 
     var body: some View {
         ZStack(alignment: edge == .leading ? .leading : .trailing) {
@@ -58,7 +61,7 @@ private struct DrawerContainer<DrawerContent: View>: View {
                 if abs(dragX) > width * 0.33 {
                     onDismiss()
                 } else {
-                    withAnimation(Motion.fast.animation) { dragX = 0 }
+                    withAnimation(motion) { dragX = 0 }
                 }
             }
     }
@@ -71,6 +74,10 @@ private struct DrawerModifier<DrawerContent: View>: ViewModifier {
     let dismissOnScrimTap: Bool
     @ViewBuilder let content: () -> DrawerContent
 
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion) }
+
     func body(content base: Content) -> some View {
         base.overlay {
             if isPresented {
@@ -78,7 +85,7 @@ private struct DrawerModifier<DrawerContent: View>: ViewModifier {
                                 onDismiss: { isPresented = false }, content: content)
             }
         }
-        .animation(Motion.base.animation, value: isPresented)
+        .animation(motion, value: isPresented)
     }
 }
 
@@ -136,6 +143,9 @@ public final class DrawerPresenter: ObservableObject {
 
 private struct DrawerHostModifier: ViewModifier {
     @StateObject private var presenter = DrawerPresenter()
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion) }
 
     func body(content: Content) -> some View {
         content
@@ -147,7 +157,7 @@ private struct DrawerHostModifier: ViewModifier {
                                     onDismiss: { presenter.dismiss() }) { request.content }
                 }
             }
-            .animation(Motion.base.animation, value: presenter.current?.id)
+            .animation(motion, value: presenter.current?.id)
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
+++ b/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
@@ -24,6 +24,9 @@ private struct PopconfirmModifier: ViewModifier {
     let onCancel: (() -> Void)?
 
     @State private var loading = false
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
 
     func body(content: Content) -> some View {
         content.overlay(alignment: edge.alignment) {
@@ -35,7 +38,7 @@ private struct PopconfirmModifier: ViewModifier {
                     .zIndex(1)
             }
         }
-        .animation(Motion.fast.animation, value: isPresented)
+        .animation(motion, value: isPresented)
     }
 
     private var card: some View {

--- a/Sources/ThemeKit/Components/Organisms/Toast.swift
+++ b/Sources/ThemeKit/Components/Organisms/Toast.swift
@@ -16,6 +16,10 @@ private struct ToastModifier: ViewModifier {
     let type: AlertToastType
     let autoDismiss: Double?
 
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion) }
+
     func body(content: Content) -> some View {
         content.overlay(alignment: .bottom) {
             if isPresented {
@@ -29,7 +33,7 @@ private struct ToastModifier: ViewModifier {
                     }
             }
         }
-        .animation(Motion.base.animation, value: isPresented)
+        .animation(motion, value: isPresented)
     }
 }
 


### PR DESCRIPTION
## What
Phase 2 of the micro-motion rollout — overlay present/dismiss transitions now resolve through `\.microAnimations` (+ Reduce Motion), so they snap instantly when motion is off.
- **Dialog** (confirm + custom-footer modifiers), **Popconfirm**, **Toast**, **Drawer** (panel slide, drag snap-back, presenter host) — gated.
- **Tooltip**: the binding-driven `.tooltip(_:isPresented:…)` was a free function (can't read the environment) — refactored into a `BindingTooltip` ViewModifier so its fade gates too.

## Compatibility
The transitions themselves (opacity / move / scale) are unchanged when motion is on; the switch only swaps the resolved animation for `nil`. The `.tooltip` API is identical.

## Tests
`make ci`: **✓ all gates green — 156 tests**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)