### PR TITLE
feat(motion): gate value/data micro-animations (Phase 3)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/ProgressBar.swift
+++ b/Sources/ThemeKit/Components/Atoms/ProgressBar.swift
@@ -35,6 +35,10 @@ public struct ProgressBar: View {
     private let format: ((Double) -> String)?
     private let accessibilityLabelText: String?
 
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
+
     /// - Parameters:
     ///   - value: progress in 0...1.
     ///   - height: bar thickness in points.
@@ -119,6 +123,7 @@ public struct ProgressBar: View {
         .accessibilityLabel(Text(accessibilityLabelText ?? String(themeKit: "Progress")))
         .accessibilityValue(Text(percentText))
         .accessibilityAddTraits(status == .active ? .updatesFrequently : [])
+        .animation(motion, value: value)
     }
 
     @ViewBuilder
@@ -149,6 +154,10 @@ public struct StepIndicator: View {
     private let current: Int
     private let total: Int
 
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
+
     public init(current: Int, total: Int) {
         self.current = current
         self.total = total
@@ -160,7 +169,7 @@ public struct StepIndicator: View {
                 Capsule()
                     .fill(index == current ? Theme.shared.background(.bgHero) : Theme.shared.border(.borderPrimary))
                     .frame(width: index == current ? 20 : 6, height: 6)
-                    .animation(Motion.fast.animation, value: current)
+                    .animation(motion, value: current)
             }
         }
         // Position is conveyed only by the highlighted dot; speak it instead.

--- a/Sources/ThemeKit/Components/Atoms/RadialProgress.swift
+++ b/Sources/ThemeKit/Components/Atoms/RadialProgress.swift
@@ -19,6 +19,10 @@ public struct RadialProgress: View {
     private let tint: Color?
     private let accessibilityLabelText: String?
 
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion) }
+
     public init(
         value: Double,
         size: CGFloat = 64,
@@ -58,7 +62,7 @@ public struct RadialProgress: View {
                 .trim(from: 0, to: value * (1 - gap))
                 .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
                 .rotationEffect(.degrees(rotation))
-                .animation(Motion.base.animation, value: value)
+                .animation(motion, value: value)
             if showLabel {
                 if status == .success && value >= 1 {
                     Image(systemName: "checkmark").font(.system(size: size * 0.3, weight: .bold)).foregroundStyle(status.semantic.accent)

--- a/Sources/ThemeKit/Components/Atoms/Rating.swift
+++ b/Sources/ThemeKit/Components/Atoms/Rating.swift
@@ -33,6 +33,9 @@ public struct Rating: View {
     private let onRate: ((Double) -> Void)?
     private let onReviewTap: (() -> Void)?
 
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     public init(
         value: Double,
         maxValue: Int = 5,
@@ -80,6 +83,7 @@ public struct Rating: View {
             review
         }
         .opacity(isEnabled ? 1 : 0.5)
+        .animation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion), value: value)
     }
 
     /// The visual rating glyphs (the star row / number layouts), before any

--- a/Sources/ThemeKit/Components/Atoms/RollingNumber.swift
+++ b/Sources/ThemeKit/Components/Atoms/RollingNumber.swift
@@ -42,6 +42,7 @@ private struct DigitColumn: View {
     let color: Color?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.microAnimations) private var micro
 
     private var rowHeight: CGFloat { size * 1.25 }
 
@@ -54,8 +55,8 @@ private struct DigitColumn: View {
         .offset(y: -CGFloat(digit) * rowHeight)
         .frame(height: rowHeight, alignment: .top)
         .clipped()
-        // Honor Reduce Motion: snap to the new digit instead of rolling.
-        .animation(reduceMotion ? nil : Motion.base.spring, value: digit)
+        // Honor the micro-animations switch + Reduce Motion: snap instead of rolling.
+        .animation((micro && !reduceMotion) ? Motion.base.spring : nil, value: digit)
     }
 }
 


### PR DESCRIPTION
## What
Phase 3 — value-change motion now resolves through `\.microAnimations` (+ Reduce Motion).
- **RollingNumber** — the digit-roll spring (already Reduce-Motion-aware) now also honors the switch.
- **ProgressBar** — the fill width now **eases** on value change (gated; it used to jump); **StepIndicator**'s active-dot grow is gated.
- **RadialProgress** — the ring sweep is gated.
- **Rating** — the star-fill change eases on interactive re-rating (new, gated).

## Compatibility
Motion-on behaviour is unchanged except ProgressBar/Rating which gain a subtle (previously absent) ease; both snap when the switch or Reduce Motion is off.

## Tests
`make ci`: **✓ all gates green — 156 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)