### PR TITLE
feat(motion): gate nav/container micro-animations (Phase 4)

### DIFF
--- a/Sources/ThemeKit/Components/Organisms/Accordion.swift
+++ b/Sources/ThemeKit/Components/Organisms/Accordion.swift
@@ -52,6 +52,9 @@ public struct Accordion<Content: View>: View {
     private let content: () -> Content
 
     @State private var expanded: Bool
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion) }
 
     public init(
         _ title: String,
@@ -82,7 +85,7 @@ public struct Accordion<Content: View>: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             Button {
-                withAnimation(Motion.base.animation) { expanded.toggle() }
+                withAnimation(motion) { expanded.toggle() }
             } label: {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
                     if let number {

--- a/Sources/ThemeKit/Components/Organisms/AccordionGroup.swift
+++ b/Sources/ThemeKit/Components/Organisms/AccordionGroup.swift
@@ -19,6 +19,9 @@ public struct AccordionGroup<Item: Identifiable, Content: View>: View {
     private let content: (Item) -> Content
 
     @State private var expanded: Set<Item.ID> = []
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
 
     public init(
         _ items: [Item],
@@ -63,7 +66,7 @@ public struct AccordionGroup<Item: Identifiable, Content: View>: View {
         }
         .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous).stroke(Theme.shared.border(.borderPrimary), lineWidth: 1))
-        .animation(Motion.fast.animation, value: expanded)
+        .animation(motion, value: expanded)
     }
 
     private func toggle(_ id: Item.ID) {

--- a/Sources/ThemeKit/Components/Organisms/SegmentedTabBar.swift
+++ b/Sources/ThemeKit/Components/Organisms/SegmentedTabBar.swift
@@ -36,6 +36,9 @@ public struct SegmentedTabBar: View {
     private let accessibilityID: String?
 
     @Namespace private var underline
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
 
     public init(_ items: [TabItem], selection: Binding<Int>, scrollable: Bool = false,
                 style: SegmentedTabBarStyle = .underline,
@@ -103,7 +106,7 @@ public struct SegmentedTabBar: View {
         let isActive = index == selection
         return HStack(spacing: Theme.SpacingKey.xs.value) {
             Button {
-                withAnimation(Motion.fast.animation) { selection = index }
+                withAnimation(motion) { selection = index }
             } label: {
                 HStack(spacing: Theme.SpacingKey.xs.value) {
                     if let icon = item.systemImage {
@@ -144,7 +147,7 @@ public struct SegmentedTabBar: View {
     private func tab(index: Int, item: TabItem) -> some View {
         let isActive = index == selection
         return Button {
-            withAnimation(Motion.fast.animation) { selection = index }
+            withAnimation(motion) { selection = index }
         } label: {
             VStack(spacing: Theme.SpacingKey.sm.value) {
                 VStack(spacing: 1) {


### PR DESCRIPTION
## What
Final phase of the micro-motion rollout.
- **Accordion / AccordionGroup** — expand/collapse `withAnimation` + group height animation gated.
- **SegmentedTabBar** — the matched-geometry underline slide (both tap sites) gated.

Steps & Breadcrumbs carry no library-driven motion (system Menu disclosure), so they're left as-is.

## Result
Every interactive/stateful component family now resolves its motion through `\.microAnimations` (+ Reduce Motion) — **theme-wide and per-component**, Reduce Motion always winning. See `docs/MOTION.md`.

## Tests
`make ci`: **✓ all gates green — 156 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)