### PR TITLE
docs(gallery): simulator recording pipeline for native presentations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build/
 /docs-out/
 Screenshots/manifest.tsv
 Screenshots/gifs.tsv
+Screenshots/_rec_*.mov

--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,8 @@ hooks: ## Install the pre-push CI hook
 screenshots: ## Render component screenshots + rebuild the README gallery
 	@bash scripts/gen-screenshots.sh
 
+record-gif: ## Record a Demo-app interaction → GIF (NAME=SelectBox [SECS=7]); tap the component during recording
+	@bash scripts/record-gif.sh "$(NAME)" "$(SECS)"
+
 clean: ## Remove build artifacts
 	rm -rf .build .ci-test.log

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ BottomSheet…) and media components are best seen live in the [Demo app](#demo)
 
 ### Overlays (animated)
 
-_Entrance previews rendered from the live components. SelectBox, BottomSheet, Tour and Feedback use OS-owned presentations and are best seen in the [Demo app](#demo)._
+_Entrance previews rendered from the live components. SelectBox, BottomSheet, Tour and Feedback use OS-owned presentations (native `Menu` / `.sheet`) that no offscreen renderer can capture — record them from the running app with `make record-gif NAME=SelectBox` (boots the simulator, you tap to open the dropdown; see [docs/SCREENSHOTS.md](docs/SCREENSHOTS.md))._
 
 <table>
 <tr>

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -1,0 +1,51 @@
+# Component gallery — screenshots, GIFs & recordings
+
+The README gallery is generated from the library itself. Three tiers, by how much
+of a component can be captured headlessly.
+
+## 1. Static stills (most components)
+
+`make screenshots` renders ~86 components to `Screenshots/<Name>.png` via SwiftUI
+`ImageRenderer` on macOS — no simulator — and rebuilds the README gallery between
+the `<!-- GALLERY -->` markers.
+
+- Source: `Tests/ThemeKitTests/ScreenshotGenerator.swift` (gated by
+  `GENERATE_SCREENSHOTS=1`, so it never runs in the normal suite).
+- **Text fields:** `ImageRenderer` can't draw `TextField`/`TextEditor` headlessly
+  (yellow placeholder), so those examples use `hosted: true` — rendered in a real
+  offscreen `NSWindow` (`NSHostingView` + `cacheDisplay`).
+
+## 2. Synthesised overlay GIFs (custom overlays)
+
+`make screenshots` also runs `GifGenerator`, which renders each custom overlay's
+**presented** state via the offscreen-window path and synthesises a fade+scale
+entrance into `Screenshots/<Name>.gif` (Core Graphics → ImageIO, no ffmpeg):
+**Dialog, Drawer, Popconfirm, AlertToast, Tooltip**.
+
+## 3. Real recordings (OS-owned presentations)
+
+Some components present through **the OS, outside the SwiftUI view tree** — a
+native `Menu` popup (**SelectBox**) or a `.sheet` (**BottomSheet**), plus the
+presenter overlays **Tour** / **Feedback**. No offscreen renderer can capture
+these; they must be recorded from the running app.
+
+```bash
+make record-gif NAME=SelectBox          # or: scripts/record-gif.sh SelectBox 7
+```
+
+What it does (all automatic except one tap):
+
+1. Boots the **iPhone 17 Pro** simulator (override with `RECORD_DEVICE`).
+2. Builds + installs + launches the **Demo** app.
+3. Brings the Simulator window forward and records the screen for N seconds.
+4. Converts the `.mov` → `Screenshots/<Name>.gif` via `Tools/mov2gif.swift`
+   (AVFoundation + ImageIO — **no ffmpeg dependency**).
+
+**The one manual step:** during the recording window, tap the component in the
+simulator (e.g. open the SelectBox dropdown). There is no headless tap injection
+available here (no `idb` / `cliclick` / XCUITest target) and a SwiftUI `Menu` can't
+be opened programmatically — so that single tap is yours. Everything around it is
+scripted.
+
+Then drop the new GIF into the gallery (add it to `gifs.tsv` or the generator) and
+run `make screenshots` to rebuild the README.

--- a/scripts/gen-screenshots.sh
+++ b/scripts/gen-screenshots.sh
@@ -50,7 +50,7 @@ if [ -f "Screenshots/gifs.tsv" ]; then
         echo
         echo "### Overlays (animated)"
         echo
-        echo "_Entrance previews rendered from the live components. SelectBox, BottomSheet, Tour and Feedback use OS-owned presentations and are best seen in the [Demo app](#demo)._"
+        echo "_Entrance previews rendered from the live components. SelectBox, BottomSheet, Tour and Feedback use OS-owned presentations (native \`Menu\` / \`.sheet\`) that no offscreen renderer can capture — record them from the running app with \`make record-gif NAME=SelectBox\` (boots the simulator, you tap to open the dropdown; see [docs/SCREENSHOTS.md](docs/SCREENSHOTS.md))._"
         echo
         echo "<table>"
         i=0

--- a/scripts/record-gif.sh
+++ b/scripts/record-gif.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Record a real Demo-app interaction on the iOS Simulator and convert it to an
+# animated GIF — for components that can't be captured as a static frame or by the
+# offscreen renderer (native Menu / .sheet presentations: SelectBox, BottomSheet…).
+#
+#   scripts/record-gif.sh SelectBox [seconds]     # default 7s
+#   make record-gif NAME=SelectBox
+#
+# The simulator window is brought to the front; during the recording window, TAP
+# the component (e.g. open the SelectBox dropdown). There is no headless way to
+# inject that tap here (no idb/cliclick/UI-test target), so it's the one manual
+# step. Everything else — boot, build, install, launch, record, GIF — is automatic.
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+NAME="${1:?usage: record-gif.sh <ComponentName> [seconds]}"
+SECS="${2:-7}"
+DEVICE="${RECORD_DEVICE:-iPhone 17 Pro}"
+DERIVED=".build/demo"
+mkdir -p Screenshots
+
+echo "▸ Booting $DEVICE…"
+UDID=$(xcrun simctl list devices available | grep -F "$DEVICE (" | head -1 | grep -oE '[0-9A-Fa-f-]{36}')
+[ -n "$UDID" ] || { echo "✗ no available '$DEVICE' simulator"; exit 1; }
+xcrun simctl boot "$UDID" 2>/dev/null || true
+xcrun simctl bootstatus "$UDID" -b >/dev/null
+
+echo "▸ Building + installing the Demo app (first build is slow)…"
+xcodebuild -project Demo/Demo.xcodeproj -scheme Demo \
+    -destination "id=$UDID" -derivedDataPath "$DERIVED" \
+    -quiet build
+APP=$(find "$DERIVED/Build/Products" -maxdepth 2 -name "*.app" | head -1)
+[ -n "$APP" ] || { echo "✗ built .app not found"; exit 1; }
+BUNDLE=$(/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" "$APP/Info.plist")
+xcrun simctl install "$UDID" "$APP"
+xcrun simctl launch "$UDID" "$BUNDLE" >/dev/null
+open -a Simulator
+
+MOV="Screenshots/_rec_${NAME}.mov"
+echo "▸ Recording ${SECS}s → now open '$NAME' in the simulator…"
+xcrun simctl io "$UDID" recordVideo --codec=h264 --force "$MOV" &
+REC=$!
+sleep "$SECS"
+kill -INT "$REC" 2>/dev/null || true
+wait "$REC" 2>/dev/null || true
+
+echo "▸ Converting to GIF…"
+swift Tools/mov2gif.swift "$MOV" "Screenshots/${NAME}.gif" 12 480
+rm -f "$MOV"
+echo "✓ Screenshots/${NAME}.gif — add it to the gallery, then 'make screenshots' to rebuild the README."

--- a/tools/mov2gif.swift
+++ b/tools/mov2gif.swift
@@ -1,0 +1,57 @@
+#!/usr/bin/env swift
+//
+//  mov2gif.swift — convert a screen recording (.mov) to an animated GIF using
+//  AVFoundation + ImageIO, so the recording pipeline needs no ffmpeg.
+//
+//      swift Tools/mov2gif.swift <input.mov> <output.gif> [fps] [maxWidth] [start] [end]
+//
+//  start/end (seconds) trim the clip; defaults capture the whole thing.
+//
+
+import AVFoundation
+import ImageIO
+import CoreGraphics
+import UniformTypeIdentifiers
+import Foundation
+
+let args = CommandLine.arguments
+guard args.count >= 3 else {
+    FileHandle.standardError.write(Data("usage: mov2gif <in.mov> <out.gif> [fps] [maxWidth] [start] [end]\n".utf8))
+    exit(2)
+}
+let input = URL(fileURLWithPath: args[1])
+let output = URL(fileURLWithPath: args[2])
+let fps = args.count > 3 ? (Double(args[3]) ?? 12) : 12
+let maxWidth = args.count > 4 ? (Double(args[4]) ?? 480) : 480
+
+let asset = AVURLAsset(url: input)
+let total = CMTimeGetSeconds(asset.duration)
+let start = args.count > 5 ? (Double(args[5]) ?? 0) : 0
+let end = args.count > 6 ? (Double(args[6]) ?? total) : total
+guard end > start else { FileHandle.standardError.write(Data("empty range\n".utf8)); exit(1) }
+
+let gen = AVAssetImageGenerator(asset: asset)
+gen.appliesPreferredTrackTransform = true
+gen.requestedTimeToleranceBefore = .zero
+gen.requestedTimeToleranceAfter = .zero
+gen.maximumSize = CGSize(width: maxWidth, height: maxWidth * 4)
+
+let frameCount = max(1, Int((end - start) * fps))
+guard let dest = CGImageDestinationCreateWithURL(output as CFURL, UTType.gif.identifier as CFString, frameCount, nil) else {
+    FileHandle.standardError.write(Data("could not create GIF\n".utf8)); exit(1)
+}
+CGImageDestinationSetProperties(dest, [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFLoopCount: 0]] as CFDictionary)
+let frameProps = [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: 1.0 / fps]] as CFDictionary
+
+var written = 0
+for i in 0..<frameCount {
+    let t = CMTime(seconds: start + Double(i) / fps, preferredTimescale: 600)
+    if let cg = try? gen.copyCGImage(at: t, actualTime: nil) {
+        CGImageDestinationAddImage(dest, cg, frameProps)
+        written += 1
+    }
+}
+guard written > 0, CGImageDestinationFinalize(dest) else {
+    FileHandle.standardError.write(Data("no frames extracted\n".utf8)); exit(1)
+}
+print("✓ \(output.lastPathComponent) — \(written) frames @ \(Int(fps))fps")


### PR DESCRIPTION
## What
SelectBox (native `Menu`), BottomSheet (native `.sheet`), Tour and Feedback present **through the OS, outside the SwiftUI view tree** — so neither `ImageRenderer` nor the hosted-`NSWindow` path can capture them. This adds a **real-device recording pipeline**.

- **`make record-gif NAME=SelectBox`** (`scripts/record-gif.sh`) — boots the iPhone 17 Pro simulator, builds + installs + launches the Demo app, records the screen, converts to `Screenshots/<Name>.gif`.
- **`Tools/mov2gif.swift`** — `.mov` → animated GIF via **AVFoundation + ImageIO** (no ffmpeg).
- **`docs/SCREENSHOTS.md`** — documents all three capture tiers.

## The one manual step
During the recording window you **tap the component** (open the dropdown). No headless tap injection is available (no `idb`/`cliclick`/UI-test target) and a SwiftUI `Menu` can't be opened programmatically — so that tap is manual; everything else is scripted.

## Verified
Demo app **builds for the simulator** → records → `mov2gif` → valid 12fps GIF (proven on the live gallery screen). `make ci` green (158 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)