### PR TITLE
fix(record-gif): brace ${DEVICE} (unbound-variable crash)

### DIFF
--- a/scripts/record-gif.sh
+++ b/scripts/record-gif.sh
@@ -21,7 +21,7 @@ DEVICE="${RECORD_DEVICE:-iPhone 17 Pro}"
 DERIVED=".build/demo"
 mkdir -p Screenshots
 
-echo "▸ Booting $DEVICE…"
+echo "▸ Booting ${DEVICE}…"
 UDID=$(xcrun simctl list devices available | grep -F "$DEVICE (" | head -1 | grep -oE '[0-9A-Fa-f-]{36}')
 [ -n "$UDID" ] || { echo "✗ no available '$DEVICE' simulator"; exit 1; }
 xcrun simctl boot "$UDID" 2>/dev/null || true


### PR DESCRIPTION
One-line fix: `$DEVICE…` glued the multi-byte ellipsis into the variable name, so `set -u` aborted with *DEVICE…: unbound variable* before booting. Braced to `${DEVICE}…`. Scanned for other glued vars (none); `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)