### PR TITLE
feat(theme): \.theme environment injection — per-subtree theming (audit P0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,21 @@ changes, so every view re-reads the regenerated tokens.
   `.themeKit(reactToRuntimeChanges: false)` so the editor isn't torn down,
   and scope `.id(Theme.shared.revision)` onto just the live-preview subtree.
 
+### Per-subtree theming (`\.theme`)
+
+Components also read the theme from the `\.theme` environment value, which
+**defaults to `Theme.shared`** (so unthemed components never crash). Inject a
+different `Theme` instance to re-theme a branch — a second brand in one screen, or
+a pinned theme in a preview/snapshot — without mutating global state:
+
+```swift
+SomeComponent()
+    .theme(brandBTheme)        // this subtree only
+```
+
+This is migrating in: pilot components (`Card`, `Tag`) read `\.theme` today; the
+rest still read `Theme.shared` directly and are moving over incrementally.
+
 ### Fonts
 
 `Montserrat` is bundled. `System` / `SystemRounded` / `SystemSerif` / `SystemMono`

--- a/Sources/ThemeKit/Components/Atoms/Tag.swift
+++ b/Sources/ThemeKit/Components/Atoms/Tag.swift
@@ -20,6 +20,8 @@ public struct Tag: View {
     private let variant: FillVariant
     private let onRemove: (() -> Void)?
 
+    @Environment(\.theme) private var theme
+
     public init(
         _ text: String,
         leadingSystemImage: String? = nil,
@@ -56,7 +58,7 @@ public struct Tag: View {
     }
 
     private var foreground: Color {
-        guard let style else { return Theme.shared.text(.textHero) }
+        guard let style else { return theme.text(.textHero) }
         switch variant {
         case .soft: return style.foreground
         case .solid: return style.semantic.onSolid
@@ -65,7 +67,7 @@ public struct Tag: View {
     }
 
     private var background: Color {
-        guard let style else { return Theme.shared.background(.bgElevatorTertiary) }
+        guard let style else { return theme.background(.bgElevatorTertiary) }
         switch variant {
         case .soft: return style.background
         case .solid: return style.semantic.solid

--- a/Sources/ThemeKit/Components/Organisms/Card.swift
+++ b/Sources/ThemeKit/Components/Organisms/Card.swift
@@ -25,6 +25,8 @@ public struct Card<Content: View>: View {
     private let action: (() -> Void)?
     private let content: () -> Content
 
+    @Environment(\.theme) private var theme
+
     public init(
         elevation: CardElevation = .soft,
         padding: CGFloat = 16,
@@ -54,16 +56,16 @@ public struct Card<Content: View>: View {
         HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.sm.value) {
             VStack(alignment: .leading, spacing: 2) {
                 if let title {
-                    Text(title).textStyle(.labelLg600).foregroundStyle(Theme.shared.text(.textPrimary))
+                    Text(title).textStyle(.labelLg600).foregroundStyle(theme.text(.textPrimary))
                 }
                 if let subtitle {
-                    Text(subtitle).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+                    Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
                 }
             }
             Spacer(minLength: 0)
             if let extraTitle, let onExtra {
                 Button(action: onExtra) {
-                    Text(extraTitle).textStyle(.labelSm600).foregroundStyle(Theme.shared.foreground(.fgHero))
+                    Text(extraTitle).textStyle(.labelSm600).foregroundStyle(theme.foreground(.fgHero))
                 }
                 .buttonStyle(.plain)
             }
@@ -94,11 +96,11 @@ public struct Card<Content: View>: View {
             .padding(padding)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .background(Theme.shared.background(.bgWhite),
+        .background(theme.background(.bgWhite),
                    in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous)
-                .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: elevation == .none ? 1 : 0)
+                .strokeBorder(theme.border(.borderPrimary), lineWidth: elevation == .none ? 1 : 0)
         )
         .modifier(CardShadow(elevation: elevation))
     }

--- a/Sources/ThemeKit/Theme/ThemeContext.swift
+++ b/Sources/ThemeKit/Theme/ThemeContext.swift
@@ -27,3 +27,32 @@ public struct ThemeContext: DynamicProperty {
 
     public var wrappedValue: Theme { theme }
 }
+
+// MARK: - Environment injection
+
+private struct ThemeEnvironmentKey: EnvironmentKey {
+    /// Falls back to the shared singleton, so a component reads a working theme even
+    /// when nothing injected one — the singleton design stays crash-proof — while a
+    /// subtree (or a preview/test) can override it with `.theme(_:)`.
+    static var defaultValue: Theme { Theme.shared }
+}
+
+public extension EnvironmentValues {
+    /// The active `Theme`. Defaults to `Theme.shared`; override per-subtree with
+    /// `.theme(_:)`. Components read this instead of touching the singleton directly,
+    /// so they can be re-themed in isolation (different brand in a subtree, a fixed
+    /// theme in a preview/snapshot) without mutating global state.
+    var theme: Theme {
+        get { self[ThemeEnvironmentKey.self] }
+        set { self[ThemeEnvironmentKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Re-theme this view and its descendants with a specific `Theme` instance.
+    /// At the app root prefer `.themeKit()`; use this to scope a different theme to
+    /// a branch, or to pin a theme in a preview/test.
+    func theme(_ theme: Theme) -> some View {
+        environment(\.theme, theme)
+    }
+}

--- a/Tests/ThemeKitTests/ThemeEnvironmentTests.swift
+++ b/Tests/ThemeKitTests/ThemeEnvironmentTests.swift
@@ -1,0 +1,29 @@
+//
+//  ThemeEnvironmentTests.swift
+//  ThemeKitTests
+//
+//  The `\.theme` environment value: defaults to the shared singleton (so unthemed
+//  components never crash) and is overridable per-subtree (so a component can be
+//  re-themed in isolation — a different brand in a branch, a pinned theme in a
+//  preview/snapshot — without mutating global state).
+//
+
+import XCTest
+import SwiftUI
+@testable import ThemeKit
+
+final class ThemeEnvironmentTests: XCTestCase {
+
+    func testEnvironmentThemeDefaultsToSharedSingleton() {
+        XCTAssertTrue(EnvironmentValues().theme === Theme.shared,
+                      "\\.theme must default to Theme.shared so a component reads a working theme when none is injected")
+    }
+
+    func testEnvironmentThemeIsOverridablePerSubtree() {
+        var env = EnvironmentValues()
+        let custom = Theme()
+        env.theme = custom
+        XCTAssertTrue(env.theme === custom)
+        XCTAssertFalse(env.theme === Theme.shared)
+    }
+}


### PR DESCRIPTION
## What (audit P0 — the one structural lever)
Components resolved tokens from the `Theme.shared` **singleton** (690 sites) — works, but can't re-theme a subtree and can't preview/test a component under a fixed theme without mutating global state.

Adds a **safe enabling layer**, not a mass-rewrite:
- **`EnvironmentValues.theme`** with `defaultValue = Theme.shared` → no injection required (stays **crash-proof**, fully backward compatible), but a subtree/preview/test can override via **`.theme(_:)`**.
- **Pilot:** `Card` + `Tag` read `\.theme` in their view bodies (enum/style/static-token references stay on the singleton). Reactivity (`.themeKit`'s `.id(revision)` repaint) is unchanged.
- **+2 tests** (default `=== Theme.shared`; overridable per subtree). README documents per-subtree theming.

## Why staged
The singleton is a **deliberate, documented design** (see `ThemeKit.swift`). This opens per-subtree theming + isolated testing without a risky 690-site rewrite; the rest migrate incrementally.

## Tests
`swift build` + full suite green (**160 tests**, +2). No regression — pilot components render identically when no theme is injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)