### PR TITLE
perf(list): lazy row stacks in ListView & DataTable (audit P1)

### DIFF
--- a/Sources/ThemeKit/Components/Organisms/DataTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/DataTable.swift
@@ -135,8 +135,12 @@ public struct DataTable<Row: Identifiable>: View {
             } else if displayRows.isEmpty {
                 emptyRow
             } else {
-                ForEach(Array(pagedRows.enumerated()), id: \.element.id) { index, row in
-                    dataRow(row, index: index)
+                // Lazy so an unpaginated table (pageSize == nil) over many rows only
+                // builds visible rows when scrolled; a no-op when paged/standalone.
+                LazyVStack(spacing: 0) {
+                    ForEach(Array(pagedRows.enumerated()), id: \.element.id) { index, row in
+                        dataRow(row, index: index)
+                    }
                 }
             }
         }

--- a/Sources/ThemeKit/Components/Organisms/ListView.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListView.swift
@@ -60,12 +60,16 @@ public struct ListView<Item: Identifiable, Row: View>: View {
             } else if items.isEmpty {
                 emptyRow
             } else {
-                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
-                    rowContent(item)
-                        .padding(.horizontal, Theme.SpacingKey.md.value)
-                        .padding(.vertical, Theme.SpacingKey.sm.value)
-                    if split && index < items.count - 1 {
-                        DividerView(size: .small).padding(.leading, Theme.SpacingKey.md.value)
+                // Lazy so a long list inside a ScrollView only builds visible rows
+                // (a no-op cost when used standalone / unscrolled).
+                LazyVStack(spacing: 0) {
+                    ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                        rowContent(item)
+                            .padding(.horizontal, Theme.SpacingKey.md.value)
+                            .padding(.vertical, Theme.SpacingKey.sm.value)
+                        if split && index < items.count - 1 {
+                            DividerView(size: .small).padding(.leading, Theme.SpacingKey.md.value)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What
Wrap the row `ForEach` in `LazyVStack` in **ListView** and **DataTable**, so a long list / an unpaginated table inside a `ScrollView` only builds visible rows. Header / footer / loading / empty branches stay eager.

## Honest scope
- **Equatable isn't viable** here: these are generic, **closure-driven** containers (`rowContent`), and closures aren't `Equatable`, so `==` can't be synthesised. `LazyVStack` is the real, applicable lever.
- The `.sorted()` calls in Slider/Pagination run on **tiny** collections (slider marks, page numbers) — not worth hoisting; that'd be churn for no measurable gain.
- DataTable is usually paged (`pageSize`), where lazy is a no-op; the win is the `pageSize == nil` large-dataset case.

## Tests
`swift build` + full suite green (**160 tests**). Rendering unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)