### PR TITLE
docs(docc): symbol /// doc comments for 86 component structs (audit P2)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/AnimatedImage.swift
+++ b/Sources/ThemeKit/Components/Atoms/AnimatedImage.swift
@@ -3,15 +3,14 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Animated GIF / APNG playback with NO third-party dependency — frames and
-//  per-frame delays are decoded natively via ImageIO (`CGImageSource`) and driven
-//  by a `TimelineView(.animation)`. Handles variable frame durations and loops.
-//  (Reference AVIFAnimatedImage / animated `ImageView` role, native.)
-//
 
 import SwiftUI
 import ImageIO
 
+/// Animated GIF / APNG playback with NO third-party dependency — frames and
+/// per-frame delays are decoded natively via ImageIO (`CGImageSource`) and driven
+/// by a `TimelineView(.animation)`. Handles variable frame durations and loops.
+/// (Reference AVIFAnimatedImage / animated `ImageView` role, native.)
 public struct AnimatedImage: View {
     private let url: URL?
     private let contentMode: ContentMode

--- a/Sources/ThemeKit/Components/Atoms/Avatar.swift
+++ b/Sources/ThemeKit/Components/Atoms/Avatar.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. Represents a person/business as an icon, initials or image, in a circle
-//  or square, plus an `AvatarGroup` that stacks avatars with a +N overflow.
-//  (Ant Avatar parity.) Figma sizes 24/32/40/48.
-//
 
 import SwiftUI
 
@@ -47,6 +43,9 @@ public enum AvatarContent {
     case image(Image)
 }
 
+/// Atom. Represents a person/business as an icon, initials or image, in a circle
+/// or square, plus an `AvatarGroup` that stacks avatars with a +N overflow.
+/// (Ant Avatar parity.) Figma sizes 24/32/40/48.
 public struct Avatar: View {
     private let content: AvatarContent
     private let size: AvatarSize

--- a/Sources/ThemeKit/Components/Atoms/Badge.swift
+++ b/Sources/ThemeKit/Components/Atoms/Badge.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Improved, token-bound rewrite of the reference BadgeView. Styling is driven
-//  by a semantic `BadgeStyle` (system + brand variants) instead of
-//  component-specific color lookups, and icons use SF Symbols.
-//
 
 import SwiftUI
 
@@ -107,6 +103,9 @@ public enum BadgeShape {
     case rounded
 }
 
+/// Improved, token-bound rewrite of the reference BadgeView. Styling is driven
+/// by a semantic `BadgeStyle` (system + brand variants) instead of
+/// component-specific color lookups, and icons use SF Symbols.
 public struct Badge: View {
     private let text: String
     private let style: BadgeStyle

--- a/Sources/ThemeKit/Components/Atoms/Chip.swift
+++ b/Sources/ThemeKit/Components/Atoms/Chip.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Improved, token-bound rewrite of the reference BasicChip — a single clear
-//  selection API (tonal / solid) instead of the reference's nested
-//  status × mode × fullSelect × isExist matrix.
-//
 
 import SwiftUI
 
@@ -33,6 +29,9 @@ public enum ChipSelectionStyle {
     case solid   // hero fill + white text
 }
 
+/// Improved, token-bound rewrite of the reference BasicChip — a single clear
+/// selection API (tonal / solid) instead of the reference's nested
+/// status × mode × fullSelect × isExist matrix.
 public struct Chip: View {
     @Binding private var isSelected: Bool
     private let title: String

--- a/Sources/ThemeKit/Components/Atoms/DividerView.swift
+++ b/Sources/ThemeKit/Components/Atoms/DividerView.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  A theme-driven divider: horizontal / vertical, solid / dashed, with an
-//  optional inline text label (left / center / right). (Ant Divider parity.)
-//  Colors come exclusively from the active theme.
-//
 
 import SwiftUI
 
@@ -27,6 +23,9 @@ public enum DividerViewSize {
 public enum DividerAxis { case horizontal, vertical }
 public enum DividerTextAlign { case leading, center, trailing }
 
+/// A theme-driven divider: horizontal / vertical, solid / dashed, with an
+/// optional inline text label (left / center / right). (Ant Divider parity.)
+/// Colors come exclusively from the active theme.
 public struct DividerView: View {
     private let size: DividerViewSize
     private let axis: DividerAxis

--- a/Sources/ThemeKit/Components/Atoms/Icon.swift
+++ b/Sources/ThemeKit/Components/Atoms/Icon.swift
@@ -3,11 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Icon system. The Figma design system uses Font Awesome Pro, which is a
-//  licensed font and cannot be bundled here. `Icon` renders an SF Symbol by
-//  default; to switch to Font Awesome, bundle the FA Pro `.ttf` and render a
-//  glyph with `IconSize.font` instead.
-//
 
 import SwiftUI
 
@@ -31,6 +26,10 @@ public enum IconSize: String, CaseIterable {
     }
 }
 
+/// Icon system. The Figma design system uses Font Awesome Pro, which is a
+/// licensed font and cannot be bundled here. `Icon` renders an SF Symbol by
+/// default; to switch to Font Awesome, bundle the FA Pro `.ttf` and render a
+/// glyph with `IconSize.font` instead.
 public struct Icon: View {
     private let systemName: String
     private let size: IconSize

--- a/Sources/ThemeKit/Components/Atoms/InlineText.swift
+++ b/Sources/ThemeKit/Components/Atoms/InlineText.swift
@@ -3,13 +3,12 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. Body text with tappable inline links. Improves on the reference
-//  UnderlineText by using AttributedString + openURL routing instead of manual
-//  NSRange math.
-//
 
 import SwiftUI
 
+/// Atom. Body text with tappable inline links. Improves on the reference
+/// UnderlineText by using AttributedString + openURL routing instead of manual
+/// NSRange math.
 public struct InlineText: View {
     private let text: String
     private let links: [(substring: String, action: () -> Void)]

--- a/Sources/ThemeKit/Components/Atoms/InputLabel.swift
+++ b/Sources/ThemeKit/Components/Atoms/InputLabel.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. A form field label: text + optional required asterisk + optional info
-//  glyph. Shared by the input components.
-//
 
 import SwiftUI
 
+/// Atom. A form field label: text + optional required asterisk + optional info
+/// glyph. Shared by the input components.
 public struct InputLabel: View {
     private let text: String
     private let isRequired: Bool

--- a/Sources/ThemeKit/Components/Atoms/Kbd.swift
+++ b/Sources/ThemeKit/Components/Atoms/Kbd.swift
@@ -3,11 +3,10 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. A keyboard key cap. (daisyUI "Kbd".)
-//
 
 import SwiftUI
 
+/// Atom. A keyboard key cap. (daisyUI "Kbd".)
 public struct Kbd: View {
     private let text: String
 

--- a/Sources/ThemeKit/Components/Atoms/ProgressBar.swift
+++ b/Sources/ThemeKit/Components/Atoms/ProgressBar.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Linear determinate progress with status colors, an optional ladder gradient,
-//  a segmented (steps) variant and a custom format label. (Ant Progress parity.)
-//  Plus a segmented `StepIndicator`.
-//
 
 import SwiftUI
 
@@ -22,6 +18,9 @@ public enum ProgressStatus {
     }
 }
 
+/// Linear determinate progress with status colors, an optional ladder gradient,
+/// a segmented (steps) variant and a custom format label. (Ant Progress parity.)
+/// Plus a segmented `StepIndicator`.
 public struct ProgressBar: View {
     private let value: Double
     private let height: CGFloat

--- a/Sources/ThemeKit/Components/Atoms/RadialProgress.swift
+++ b/Sources/ThemeKit/Components/Atoms/RadialProgress.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. Circular determinate progress with status colors and an optional
-//  dashboard (gapped) variant. (Ant Progress type="circle"/"dashboard".)
-//
 
 import SwiftUI
 
+/// Atom. Circular determinate progress with status colors and an optional
+/// dashboard (gapped) variant. (Ant Progress type="circle"/"dashboard".)
 public struct RadialProgress: View {
     private let value: Double
     private let size: CGFloat

--- a/Sources/ThemeKit/Components/Atoms/Rating.swift
+++ b/Sources/ThemeKit/Components/Atoms/Rating.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Star rating with two layouts (stars / numeric-leading), continuous fractional
-//  fill (display) or half-step interaction, a tappable review count, a custom
-//  character and a disabled state. (Reference RatingView parity + interactive.)
-//
 
 import SwiftUI
 
@@ -20,6 +16,9 @@ public enum RatingLayout {
     case rateNumberText
 }
 
+/// Star rating with two layouts (stars / numeric-leading), continuous fractional
+/// fill (display) or half-step interaction, a tappable review count, a custom
+/// character and a disabled state. (Reference RatingView parity + interactive.)
 public struct Rating: View {
     private let value: Double
     private let maxValue: Int

--- a/Sources/ThemeKit/Components/Atoms/RemoteImage.swift
+++ b/Sources/ThemeKit/Components/Atoms/RemoteImage.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Async remote image on native `AsyncImage` (no Kingfisher dependency): URL +
-//  aspect ratio (number or "16:9" string) + shimmer placeholder + failure state.
-//  Covers the reference `ImageView`/`CustomImageView` role.
-//
 
 import SwiftUI
 
@@ -31,6 +27,9 @@ public enum RemoteImageRatio {
     }
 }
 
+/// Async remote image on native `AsyncImage` (no Kingfisher dependency): URL +
+/// aspect ratio (number or "16:9" string) + shimmer placeholder + failure state.
+/// Covers the reference `ImageView`/`CustomImageView` role.
 public struct RemoteImage: View {
     private let url: URL?
     private let aspectRatio: CGFloat?

--- a/Sources/ThemeKit/Components/Atoms/RollingNumber.swift
+++ b/Sources/ThemeKit/Components/Atoms/RollingNumber.swift
@@ -3,13 +3,12 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Odometer / slot-machine number — each digit column rolls vertically to its
-//  new value when `value` changes (reference `RollingText`). Good for prices,
-//  counters, live stats.
-//
 
 import SwiftUI
 
+/// Odometer / slot-machine number — each digit column rolls vertically to its
+/// new value when `value` changes (reference `RollingText`). Good for prices,
+/// counters, live stats.
 public struct RollingNumber: View {
     private let value: Int
     private let size: CGFloat

--- a/Sources/ThemeKit/Components/Atoms/ScoreBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/ScoreBadge.swift
@@ -3,11 +3,10 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. A numeric rating score in a filled rounded box (e.g. "9.0").
-//
 
 import SwiftUI
 
+/// Atom. A numeric rating score in a filled rounded box (e.g. "9.0").
 public struct ScoreBadge: View {
     private let score: Double
     private let large: Bool

--- a/Sources/ThemeKit/Components/Atoms/Spinner.swift
+++ b/Sources/ThemeKit/Components/Atoms/Spinner.swift
@@ -3,11 +3,10 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. Indeterminate circular loading indicator (token-tinted).
-//
 
 import SwiftUI
 
+/// Atom. Indeterminate circular loading indicator (token-tinted).
 public struct Spinner: View {
     private let size: CGFloat
     private let lineWidth: CGFloat

--- a/Sources/ThemeKit/Components/Atoms/StatusDot.swift
+++ b/Sources/ThemeKit/Components/Atoms/StatusDot.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. A small status indicator dot with an optional pulse + label.
-//  (daisyUI "Status".)
-//
 
 import SwiftUI
 
@@ -35,6 +32,8 @@ public enum StatusKind {
     }
 }
 
+/// Atom. A small status indicator dot with an optional pulse + label.
+/// (daisyUI "Status".)
 public struct StatusDot: View {
     private let kind: StatusKind
     private let size: CGFloat

--- a/Sources/ThemeKit/Components/Atoms/Swap.swift
+++ b/Sources/ThemeKit/Components/Atoms/Swap.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. Animated toggle between two SF Symbols (e.g. menu↔close, sun↔moon).
-//  (daisyUI "Swap".)
-//
 
 import SwiftUI
 
+/// Atom. Animated toggle between two SF Symbols (e.g. menu↔close, sun↔moon).
+/// (daisyUI "Swap".)
 public struct Swap: View {
     @Binding private var isOn: Bool
     private let onSystemImage: String

--- a/Sources/ThemeKit/Components/Atoms/Tag.swift
+++ b/Sources/ThemeKit/Components/Atoms/Tag.swift
@@ -3,16 +3,14 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. A compact label, optionally removable. Distinct from Badge (status) and
-//  Chip (selectable): Tag represents an applied keyword/filter.
-//
-//  An optional semantic `style` + `variant` colors the tag (Ant Tag colors),
-//  reusing Badge's `BadgeStyle` / `FillVariant`. With no `style` it keeps the
-//  original neutral keyword look.
-//
 
 import SwiftUI
 
+/// Atom. A compact label, optionally removable. Distinct from Badge (status) and
+/// Chip (selectable): Tag represents an applied keyword/filter.
+/// An optional semantic `style` + `variant` colors the tag (Ant Tag colors),
+/// reusing Badge's `BadgeStyle` / `FillVariant`. With no `style` it keeps the
+/// original neutral keyword look.
 public struct Tag: View {
     private let text: String
     private let leadingSystemImage: String?

--- a/Sources/ThemeKit/Components/Atoms/TextLink.swift
+++ b/Sources/ThemeKit/Components/Atoms/TextLink.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. A standalone tappable text link. (daisyUI "Link"; for links inside a
-//  paragraph use InlineText, for a button use LinkButton.)
-//
 
 import SwiftUI
 
+/// Atom. A standalone tappable text link. (daisyUI "Link"; for links inside a
+/// paragraph use InlineText, for a button use LinkButton.)
 public struct TextLink: View {
     private let title: String
     private let underline: Bool

--- a/Sources/ThemeKit/Components/Atoms/Title.swift
+++ b/Sources/ThemeKit/Components/Atoms/Title.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Atom. A section title: optional eyebrow, title + optional subtitle, and an
-//  optional trailing action (e.g. "See all").
-//
 
 import SwiftUI
 
+/// Atom. A section title: optional eyebrow, title + optional subtitle, and an
+/// optional trailing action (e.g. "See all").
 public struct Title: View {
     private let text: String
     private let subtitle: String?

--- a/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
+++ b/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
@@ -3,15 +3,14 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A typeahead text field with a suggestion list. Two sources:
-//    • a static `[String]` filtered locally as the user types, or
-//    • an async `suggest` provider (remote search) with debounce, a loading
-//      spinner, an empty "no results" state, and in-flight cancellation.
-//  State (the bound text) is owned by the caller.
-//
 
 import SwiftUI
 
+/// Molecule. A typeahead text field with a suggestion list. Two sources:
+///   • a static `[String]` filtered locally as the user types, or
+///   • an async `suggest` provider (remote search) with debounce, a loading
+///     spinner, an empty "no results" state, and in-flight cancellation.
+/// State (the bound text) is owned by the caller.
 public struct Autocomplete: View {
 
     /// Where suggestions come from.

--- a/Sources/ThemeKit/Components/Molecules/Breadcrumbs.swift
+++ b/Sources/ThemeKit/Components/Molecules/Breadcrumbs.swift
@@ -3,15 +3,13 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. Horizontal navigation path with chevron separators; the last crumb
-//  is the current page. (daisyUI "Breadcrumbs" / Ant Design "Breadcrumb".)
-//
-//  When `maxItems` is set and exceeded, the middle crumbs collapse into a "…"
-//  menu that still navigates to any hidden crumb.
-//
 
 import SwiftUI
 
+/// Molecule. Horizontal navigation path with chevron separators; the last crumb
+/// is the current page. (daisyUI "Breadcrumbs" / Ant Design "Breadcrumb".)
+/// When `maxItems` is set and exceeded, the middle crumbs collapse into a "…"
+/// menu that still navigates to any hidden crumb.
 public struct Breadcrumbs: View {
     public struct Crumb: Identifiable {
         public let id = UUID()

--- a/Sources/ThemeKit/Components/Molecules/ButtonGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/ButtonGroup.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. Lays out related buttons in a vertical stack or an equal-width
-//  horizontal row. Pass buttons with `isContentWidth: true`.
-//
 
 import SwiftUI
 
@@ -13,6 +10,8 @@ public enum ButtonGroupAxis {
     case vertical, horizontal
 }
 
+/// Molecule. Lays out related buttons in a vertical stack or an equal-width
+/// horizontal row. Pass buttons with `isContentWidth: true`.
 public struct ButtonGroup<Content: View>: View {
     private let axis: ButtonGroupAxis
     private let spacing: CGFloat

--- a/Sources/ThemeKit/Components/Molecules/CalendarView.swift
+++ b/Sources/ThemeKit/Components/Molecules/CalendarView.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. An inline month calendar with day selection + month navigation.
-//  (daisyUI "Calendar"; complements DateField which presents a popover.)
-//
 
 import SwiftUI
 
+/// Molecule. An inline month calendar with day selection + month navigation.
+/// (daisyUI "Calendar"; complements DateField which presents a popover.)
 public struct CalendarView: View {
     @Binding private var selection: Date?
     @State private var displayed: Date

--- a/Sources/ThemeKit/Components/Molecules/Checkbox.swift
+++ b/Sources/ThemeKit/Components/Molecules/Checkbox.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Figma "Control Items" → Checkboxes. Sizes Small (20) / Medium (24);
-//  states checked / disabled / indeterminate. Colors from theme tokens.
-//
 
 import SwiftUI
 
@@ -32,6 +29,8 @@ public enum CheckboxType: Equatable {
     case customInner(color: Color)
 }
 
+/// Figma "Control Items" → Checkboxes. Sizes Small (20) / Medium (24);
+/// states checked / disabled / indeterminate. Colors from theme tokens.
 public struct Checkbox: View {
     @Binding private var isChecked: Bool
     private let label: String?

--- a/Sources/ThemeKit/Components/Molecules/CheckboxGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/CheckboxGroup.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A labelled, multi-select group composed from the Checkbox atom.
-//  Selection state is owned by the caller (single Set binding — no per-row state).
-//
 
 import SwiftUI
 
+/// Molecule. A labelled, multi-select group composed from the Checkbox atom.
+/// Selection state is owned by the caller (single Set binding — no per-row state).
 public struct CheckboxGroup<Option: Hashable>: View {
     private let title: String?
     private let options: [Option]

--- a/Sources/ThemeKit/Components/Molecules/DateField.swift
+++ b/Sources/ThemeKit/Components/Molecules/DateField.swift
@@ -3,14 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A date input field that presents a theme-tinted graphical calendar
-//  in a popover. (Form-field wrapper around the system date picker.)
-//
-//  Presentation mirrors TextInput's form chrome — info/error messages with a
-//  matching border, an optional clear button, a disabled state, and a leading
-//  icon. The displayed value is formatter-driven: pick a `DateFieldStyle` (or a
-//  custom pattern), a `locale`, and which `components` (date / time) to show.
-//
 
 import SwiftUI
 
@@ -29,6 +21,12 @@ public enum DateFieldComponents {
     case date, dateAndTime, time
 }
 
+/// Molecule. A date input field that presents a theme-tinted graphical calendar
+/// in a popover. (Form-field wrapper around the system date picker.)
+/// Presentation mirrors TextInput's form chrome — info/error messages with a
+/// matching border, an optional clear button, a disabled state, and a leading
+/// icon. The displayed value is formatter-driven: pick a `DateFieldStyle` (or a
+/// custom pattern), a `locale`, and which `components` (date / time) to show.
 public struct DateField: View {
     private let label: String?
     @Binding private var date: Date?

--- a/Sources/ThemeKit/Components/Molecules/Fieldset.swift
+++ b/Sources/ThemeKit/Components/Molecules/Fieldset.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A bordered form group with a legend + optional helper text.
-//  (daisyUI "Fieldset".)
-//
 
 import SwiftUI
 
+/// Molecule. A bordered form group with a legend + optional helper text.
+/// (daisyUI "Fieldset".)
 public struct Fieldset<Content: View>: View {
     private let title: String
     private let helper: String?

--- a/Sources/ThemeKit/Components/Molecules/FileInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/FileInput.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A styled file-picker field: a "Choose file" segment + the selected
-//  filename. (daisyUI "File Input"; complements the list-based Upload.)
-//
 
 import SwiftUI
 
+/// Molecule. A styled file-picker field: a "Choose file" segment + the selected
+/// filename. (daisyUI "File Input"; complements the list-based Upload.)
 public struct FileInput: View {
     private let label: String?
     private let fileName: String?

--- a/Sources/ThemeKit/Components/Molecules/FilterGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/FilterGroup.swift
@@ -3,11 +3,10 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A single-select chip filter with a reset control. (daisyUI "Filter".)
-//
 
 import SwiftUI
 
+/// Molecule. A single-select chip filter with a reset control. (daisyUI "Filter".)
 public struct FilterGroup<Option: Hashable>: View {
     private let title: String?
     private let options: [Option]

--- a/Sources/ThemeKit/Components/Molecules/InputNumber.swift
+++ b/Sources/ThemeKit/Components/Molecules/InputNumber.swift
@@ -3,17 +3,15 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A labelled numeric field with filled − / + steppers, hint / error
-//  text and default / disabled / error states. (Form-field counterpart of the
-//  pill-shaped QuantityStepper.)
-//
-//  Reference: Ant Design `InputNumber` / Chakra `NumberInput` — the value is
-//  directly editable (type a number, clamped to `range` on commit), steppers move
-//  by `step`, and an optional `unit` suffix labels the value (e.g. "kişi", "₺").
-//
 
 import SwiftUI
 
+/// Molecule. A labelled numeric field with filled − / + steppers, hint / error
+/// text and default / disabled / error states. (Form-field counterpart of the
+/// pill-shaped QuantityStepper.)
+/// Reference: Ant Design `InputNumber` / Chakra `NumberInput` — the value is
+/// directly editable (type a number, clamped to `range` on commit), steppers move
+/// by `step`, and an optional `unit` suffix labels the value (e.g. "kişi", "₺").
 public struct InputNumber: View {
     private let label: String?
     @Binding private var value: Int

--- a/Sources/ThemeKit/Components/Molecules/MultiLineTextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiLineTextInput.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Improved, token-bound rewrite of the reference MultiLineInput — a bordered
-//  TextEditor with header label, placeholder, character counter and error state.
-//
 
 import SwiftUI
 
+/// Improved, token-bound rewrite of the reference MultiLineInput — a bordered
+/// TextEditor with header label, placeholder, character counter and error state.
 public struct MultiLineTextInput: View {
     @Binding private var text: String
     private let label: String

--- a/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
@@ -3,14 +3,13 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Multiple / tags select with optional search (Ant Select mode="multiple").
-//  Selected options render as removable tag chips; the dropdown is a token-bound
-//  panel with a search field and checkable rows. The single-value `Select`
-//  remains for the simple case.
-//
 
 import SwiftUI
 
+/// Multiple / tags select with optional search (Ant Select mode="multiple").
+/// Selected options render as removable tag chips; the dropdown is a token-bound
+/// panel with a search field and checkable rows. The single-value `Select`
+/// remains for the simple case.
 public struct MultiSelect<Option: Hashable>: View {
     private let label: String?
     private let options: [Option]

--- a/Sources/ThemeKit/Components/Molecules/OTPInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/OTPInput.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Improved, token-bound rewrite of the reference OTPInputView. A row of digit
-//  boxes backed by a single hidden field, with focus caret + error state.
-//
 
 import SwiftUI
 
+/// Improved, token-bound rewrite of the reference OTPInputView. A row of digit
+/// boxes backed by a single hidden field, with focus caret + error state.
 public struct OTPInput: View {
     @Binding private var code: String
     private let digitCount: Int

--- a/Sources/ThemeKit/Components/Molecules/Pagination.swift
+++ b/Sources/ThemeKit/Components/Molecules/Pagination.swift
@@ -3,17 +3,15 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. Numbered pagination with prev / next, windowed around the current
-//  page, plus a simple mode, an optional total label and a disabled state.
-//  (Ant Pagination / MUI Pagination parity.) Selection owned by the caller.
-//
-//  The window is configurable: `boundaryCount` pages always show at each end and
-//  `siblingCount` pages on each side of the current page; gaps collapse to an
-//  ellipsis. An optional quick-jumper field jumps straight to a page.
-//
 
 import SwiftUI
 
+/// Molecule. Numbered pagination with prev / next, windowed around the current
+/// page, plus a simple mode, an optional total label and a disabled state.
+/// (Ant Pagination / MUI Pagination parity.) Selection owned by the caller.
+/// The window is configurable: `boundaryCount` pages always show at each end and
+/// `siblingCount` pages on each side of the current page; gaps collapse to an
+/// ellipsis. An optional quick-jumper field jumps straight to a page.
 public struct Pagination: View {
     @Binding private var current: Int   // 1-based
     private let total: Int

--- a/Sources/ThemeKit/Components/Molecules/ProgressIndicator.swift
+++ b/Sources/ThemeKit/Components/Molecules/ProgressIndicator.swift
@@ -3,12 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Segmented position/progress indicator (Reference ProgressIndicator parity).
-//  `.carousel` = one segment per page (filled up to the current one); `.video` =
-//  the active segment fills by `videoProgress`; `.progress` = a single
-//  continuous bar. Optional "3 / 10" or "01 | 05" step text. Distinct from the
-//  dot-style `StepIndicator` and the value-driven `ProgressBar`.
-//
 
 import SwiftUI
 
@@ -29,6 +23,11 @@ public enum ProgressIndicatorSize {
 /// Step-count caption format. (Reference "3/10" / "01 | 05".)
 public enum ProgressStepText { case none, slash, padded }
 
+/// Segmented position/progress indicator (Reference ProgressIndicator parity).
+/// `.carousel` = one segment per page (filled up to the current one); `.video` =
+/// the active segment fills by `videoProgress`; `.progress` = a single
+/// continuous bar. Optional "3 / 10" or "01 | 05" step text. Distinct from the
+/// dot-style `StepIndicator` and the value-driven `ProgressBar`.
 public struct ProgressIndicator: View {
     private let variant: ProgressIndicatorVariant
     private let current: Int   // 1-based active step

--- a/Sources/ThemeKit/Components/Molecules/QuantityStepper.swift
+++ b/Sources/ThemeKit/Components/Molecules/QuantityStepper.swift
@@ -3,11 +3,10 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  A token-bound quantity stepper (− value +), bounded by a range.
-//
 
 import SwiftUI
 
+/// A token-bound quantity stepper (− value +), bounded by a range.
 public struct QuantityStepper: View {
     @Binding private var value: Int
     private let range: ClosedRange<Int>

--- a/Sources/ThemeKit/Components/Molecules/RadioButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioButton.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Figma "Control Items" → Radioboxes. Sizes Small (20) / Medium (24);
-//  states selected / disabled. Colors from theme tokens.
-//
 
 import SwiftUI
 
@@ -37,6 +34,8 @@ public enum RadioButtonPadding {
     }
 }
 
+/// Figma "Control Items" → Radioboxes. Sizes Small (20) / Medium (24);
+/// states selected / disabled. Colors from theme tokens.
 public struct RadioButton: View {
     @Binding private var isSelected: Bool
     private let label: String?

--- a/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A labelled, single-select group composed from the RadioButton atom.
-//  Selection state is owned by the caller (single optional binding).
-//
 
 import SwiftUI
 
+/// Molecule. A labelled, single-select group composed from the RadioButton atom.
+/// Selection state is owned by the caller (single optional binding).
 public struct RadioGroup<Option: Hashable>: View {
     private let title: String?
     private let options: [Option]

--- a/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
+++ b/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
@@ -3,17 +3,15 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Improved, token-bound rewrite of the reference RangeSliderView — a
-//  self-contained dual-thumb slider over a numeric range (decoupled from the
-//  reference's text-field wiring).
-//
-//  Reference: Ant Design `Slider` (range) / MUI `Slider` — optional `marks`
-//  (labeled ticks), a disabled state, an `onChangeEnd` commit callback (fire the
-//  search on release, not on every drag tick), and VoiceOver-adjustable thumbs.
-//
 
 import SwiftUI
 
+/// Improved, token-bound rewrite of the reference RangeSliderView — a
+/// self-contained dual-thumb slider over a numeric range (decoupled from the
+/// reference's text-field wiring).
+/// Reference: Ant Design `Slider` (range) / MUI `Slider` — optional `marks`
+/// (labeled ticks), a disabled state, an `onChangeEnd` commit callback (fire the
+/// search on release, not on every drag tick), and VoiceOver-adjustable thumbs.
 public struct RangeSlider: View {
     @Binding private var lowerValue: Double
     @Binding private var upperValue: Double

--- a/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
+++ b/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. Enclosed single-select control — the selected segment is a raised
-//  white pill. Options can carry an icon and a disabled state. (Ant Segmented.)
-//
 
 import SwiftUI
 
@@ -31,6 +28,8 @@ public enum SegmentedSize {
     }
 }
 
+/// Molecule. Enclosed single-select control — the selected segment is a raised
+/// white pill. Options can carry an icon and a disabled state. (Ant Segmented.)
 public struct SegmentedControl: View {
     private let items: [SegmentItem]
     @Binding private var selection: Int

--- a/Sources/ThemeKit/Components/Molecules/SelectBox.swift
+++ b/Sources/ThemeKit/Components/Molecules/SelectBox.swift
@@ -3,13 +3,12 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A form-style dropdown field (label above, chevron, hint / error,
-//  default / focused / error / disabled states). Covers Figma SelectBox /
-//  Combobox / DropDown field. Single-select via native Menu.
-//
 
 import SwiftUI
 
+/// Molecule. A form-style dropdown field (label above, chevron, hint / error,
+/// default / focused / error / disabled states). Covers Figma SelectBox /
+/// Combobox / DropDown field. Single-select via native Menu.
 public struct SelectBox<Option: Hashable>: View {
     private let label: String?
     private let options: [Option]

--- a/Sources/ThemeKit/Components/Molecules/Slider.swift
+++ b/Sources/ThemeKit/Components/Molecules/Slider.swift
@@ -3,13 +3,12 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. Single-thumb value slider with optional labeled marks, a drag
-//  value tooltip and a disabled state. (Ant Slider parity.) Shares the visual
-//  language of RangeSlider (token track / fill / thumb).
-//
 
 import SwiftUI
 
+/// Molecule. Single-thumb value slider with optional labeled marks, a drag
+/// value tooltip and a disabled state. (Ant Slider parity.) Shares the visual
+/// language of RangeSlider (token track / fill / thumb).
 public struct Slider: View {
     @Binding private var value: Double
     private let bounds: ClosedRange<Double>

--- a/Sources/ThemeKit/Components/Molecules/Stat.swift
+++ b/Sources/ThemeKit/Components/Molecules/Stat.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A single statistic block: title, value, optional description,
-//  figure icon and trend. (daisyUI "Stat".)
-//
 
 import SwiftUI
 
@@ -30,6 +27,8 @@ public enum StatTrend {
     var systemImage: String { switch self { case .up: return "arrow.up.right"; case .down: return "arrow.down.right" } }
 }
 
+/// Molecule. A single statistic block: title, value, optional description,
+/// figure icon and trend. (daisyUI "Stat".)
 public struct Stat: View {
     private enum Value { case text(String), number(Int) }
 

--- a/Sources/ThemeKit/Components/Molecules/TextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInput.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Single floating-label text field. Carries the reference's production layers:
-//  a `TextInputModel` config struct, a structured `[InfoMessage]` validation
-//  model, and namespaced accessibility identifiers — alongside the flat init.
-//
 
 import SwiftUI
 #if canImport(UIKit)
@@ -126,6 +122,9 @@ public struct TextInputModel {
     }
 }
 
+/// Single floating-label text field. Carries the reference's production layers:
+/// a `TextInputModel` config struct, a structured `[InfoMessage]` validation
+/// model, and namespaced accessibility identifiers — alongside the flat init.
 public struct TextInput: View {
     @Binding private var text: String
     private let model: TextInputModel

--- a/Sources/ThemeKit/Components/Molecules/ThemeController.swift
+++ b/Sources/ThemeKit/Components/Molecules/ThemeController.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. A packaged theme switcher: selecting an option loads that theme via
-//  `Theme.shared.loadTheme(named:)`. (daisyUI "Theme Controller".)
-//
 
 import SwiftUI
 
+/// Molecule. A packaged theme switcher: selecting an option loads that theme via
+/// `Theme.shared.loadTheme(named:)`. (daisyUI "Theme Controller".)
 public struct ThemeController: View {
     public struct Option: Identifiable {
         public let id = UUID()

--- a/Sources/ThemeKit/Components/Molecules/ThemeToggle.swift
+++ b/Sources/ThemeKit/Components/Molecules/ThemeToggle.swift
@@ -3,13 +3,12 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Figma "Control Items" → Switch Toggles. Sizes Medium (40×24) / Small (32×20);
-//  states active / disabled / loading, with optional on/off glyphs in the knob.
-//  (Ant Switch parity.) Colors + motion from theme tokens.
-//
 
 import SwiftUI
 
+/// Figma "Control Items" → Switch Toggles. Sizes Medium (40×24) / Small (32×20);
+/// states active / disabled / loading, with optional on/off glyphs in the knob.
+/// (Ant Switch parity.) Colors + motion from theme tokens.
 public struct ThemeToggle: View {
     @Binding private var isOn: Bool
     private let size: ControlSize

--- a/Sources/ThemeKit/Components/Molecules/ToggleGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/ToggleGroup.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Molecule. Rows of labelled switches with optional supporting text. Multi-state
-//  owned by the caller (single Set binding).
-//
 
 import SwiftUI
 
+/// Molecule. Rows of labelled switches with optional supporting text. Multi-state
+/// owned by the caller (single Set binding).
 public struct ToggleGroup<Option: Hashable>: View {
     private let title: String?
     private let options: [Option]

--- a/Sources/ThemeKit/Components/Molecules/TreeSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/TreeSelect.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Hierarchical (nested) select with expand/collapse and multi-selection.
-//  (Ant TreeSelect.) Nodes are a simple value tree; selection is a set of node ids.
-//
 
 import SwiftUI
 
@@ -19,6 +16,8 @@ public struct TreeNode: Identifiable {
     }
 }
 
+/// Hierarchical (nested) select with expand/collapse and multi-selection.
+/// (Ant TreeSelect.) Nodes are a simple value tree; selection is a set of node ids.
 public struct TreeSelect: View {
     private let label: String?
     private let nodes: [TreeNode]

--- a/Sources/ThemeKit/Components/Organisms/Accordion.swift
+++ b/Sources/ThemeKit/Components/Organisms/Accordion.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Improved, token-bound rewrite of the reference AccordionView — a single
-//  expandable row with a @ViewBuilder body instead of type-erased AnyView models.
-//
 
 import SwiftUI
 
@@ -39,6 +36,8 @@ public enum AccordionPaddingSize {
     }
 }
 
+/// Improved, token-bound rewrite of the reference AccordionView — a single
+/// expandable row with a @ViewBuilder body instead of type-erased AnyView models.
 public struct Accordion<Content: View>: View {
     private let title: String
     private let subtitle: String?

--- a/Sources/ThemeKit/Components/Organisms/AccordionGroup.swift
+++ b/Sources/ThemeKit/Components/Organisms/AccordionGroup.swift
@@ -3,15 +3,14 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  A group of accordion rows with single- or multiple-open behavior (the
-//  reference `AccordionView` tracks a `Set` of open ids). Single mode collapses
-//  the others when one opens.
-//
 
 import SwiftUI
 
 public enum AccordionExpandMode { case single, multiple }
 
+/// A group of accordion rows with single- or multiple-open behavior (the
+/// reference `AccordionView` tracks a `Set` of open ids). Single mode collapses
+/// the others when one opens.
 public struct AccordionGroup<Item: Identifiable, Content: View>: View {
     private let items: [Item]
     private let mode: AccordionExpandMode

--- a/Sources/ThemeKit/Components/Organisms/AlertToast.swift
+++ b/Sources/ThemeKit/Components/Organisms/AlertToast.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Improved, token-bound rewrite of the reference AlertView — a solid-fill
-//  status banner (complements the light-surface InfoBanner).
-//
 
 import SwiftUI
 
@@ -51,6 +48,8 @@ public struct ToastAction {
     }
 }
 
+/// Improved, token-bound rewrite of the reference AlertView — a solid-fill
+/// status banner (complements the light-surface InfoBanner).
 public struct AlertToast: View {
     private let title: String
     private let message: String?

--- a/Sources/ThemeKit/Components/Organisms/BlogCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/BlogCard.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. An article card: media + title + excerpt + read-more link, with a
-//  compact (media-left) variant. Media supplied via a ViewBuilder.
-//
 
 import SwiftUI
 
+/// Organism. An article card: media + title + excerpt + read-more link, with a
+/// compact (media-left) variant. Media supplied via a ViewBuilder.
 public struct BlogCard<Media: View>: View {
     private let title: String
     private let excerpt: String?

--- a/Sources/ThemeKit/Components/Organisms/Callout.swift
+++ b/Sources/ThemeKit/Components/Organisms/Callout.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. Inline status text with a leading icon. More compact than
-//  InfoBanner — used to highlight a single line of information.
-//  Figma: success / error / info / warning / neutral; plain or soft style.
-//
 
 import SwiftUI
 
@@ -46,6 +42,9 @@ public enum CalloutStyle {
     case soft    // light tinted surface
 }
 
+/// Organism. Inline status text with a leading icon. More compact than
+/// InfoBanner — used to highlight a single line of information.
+/// Figma: success / error / info / warning / neutral; plain or soft style.
 public struct Callout: View {
     private let text: String
     private let type: CalloutType

--- a/Sources/ThemeKit/Components/Organisms/Card.swift
+++ b/Sources/ThemeKit/Components/Organisms/Card.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A surface container with token padding / radius / elevation. An
-//  optional header (title / subtitle + a trailing `extra` action, divided from
-//  the body) and an `isLoading` skeleton bring it toward Ant Card.
-//
 
 import SwiftUI
 
@@ -14,6 +10,9 @@ public enum CardElevation {
     case none, soft, elevated
 }
 
+/// Organism. A surface container with token padding / radius / elevation. An
+/// optional header (title / subtitle + a trailing `extra` action, divided from
+/// the body) and an `isLoading` skeleton bring it toward Ant Card.
 public struct Card<Content: View>: View {
     private let elevation: CardElevation
     private let padding: CGFloat

--- a/Sources/ThemeKit/Components/Organisms/CardStack.swift
+++ b/Sources/ThemeKit/Components/Organisms/CardStack.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. Layers items into a stacked "deck" with offset + scale.
-//  (daisyUI "Stack".)
-//
 
 import SwiftUI
 
+/// Organism. Layers items into a stacked "deck" with offset + scale.
+/// (daisyUI "Stack".)
 public struct CardStack<Item: Identifiable, Content: View>: View {
     private let items: [Item]
     private let content: (Item) -> Content

--- a/Sources/ThemeKit/Components/Organisms/Carousel.swift
+++ b/Sources/ThemeKit/Components/Organisms/Carousel.swift
@@ -3,14 +3,13 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  A generic paging carousel with dot indicators, optional autoplay and optional
-//  prev/next arrows. Supports seamless infinite looping (clone-edge technique), a
-//  two-way `currentIndex` binding, and an active-gating content variant so video
-//  pages can play only while visible. (Ant Carousel parity.)
-//
 
 import SwiftUI
 
+/// A generic paging carousel with dot indicators, optional autoplay and optional
+/// prev/next arrows. Supports seamless infinite looping (clone-edge technique), a
+/// two-way `currentIndex` binding, and an active-gating content variant so video
+/// pages can play only while visible. (Ant Carousel parity.)
 public struct Carousel<Item: Identifiable, Content: View>: View {
     private let items: [Item]
     private let autoplay: TimeInterval?

--- a/Sources/ThemeKit/Components/Organisms/ChatBubble.swift
+++ b/Sources/ThemeKit/Components/Organisms/ChatBubble.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A chat message bubble (incoming / outgoing) with optional avatar,
-//  author and timestamp. (daisyUI "Chat bubble".)
-//
 
 import SwiftUI
 
@@ -13,6 +10,8 @@ public enum ChatSide {
     case incoming, outgoing
 }
 
+/// Organism. A chat message bubble (incoming / outgoing) with optional avatar,
+/// author and timestamp. (daisyUI "Chat bubble".)
 public struct ChatBubble: View {
     private let text: String
     private let side: ChatSide

--- a/Sources/ThemeKit/Components/Organisms/Counter.swift
+++ b/Sources/ThemeKit/Components/Organisms/Counter.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. Displays numeric values in labelled boxes — e.g. a countdown
-//  (Gün / Saat / Dakika).
-//
 
 import SwiftUI
 
+/// Organism. Displays numeric values in labelled boxes — e.g. a countdown
+/// (Gün / Saat / Dakika).
 public struct Counter: View {
     public struct Segment: Identifiable {
         public let id = UUID()

--- a/Sources/ThemeKit/Components/Organisms/Coupon.swift
+++ b/Sources/ThemeKit/Components/Organisms/Coupon.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. Displays a promo code with a copy action. Styles: filled / outlined
-//  (dashed) / plain.
-//
 
 import SwiftUI
 
@@ -13,6 +10,8 @@ public enum CouponStyle {
     case filled, outlined, plain
 }
 
+/// Organism. Displays a promo code with a copy action. Styles: filled / outlined
+/// (dashed) / plain.
 public struct Coupon: View {
     private let code: String
     private let label: String

--- a/Sources/ThemeKit/Components/Organisms/DataTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/DataTable.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A multi-column data table with a header and optional zebra striping.
-//  Supports tap-to-sort columns, row selection, and fully custom cell views.
-//  (daisyUI "Table"; complements the label/value KeyValueTable.)
-//
 
 import SwiftUI
 
@@ -34,6 +30,9 @@ public enum TableSortKey: Comparable {
     }
 }
 
+/// Organism. A multi-column data table with a header and optional zebra striping.
+/// Supports tap-to-sort columns, row selection, and fully custom cell views.
+/// (daisyUI "Table"; complements the label/value KeyValueTable.)
 public struct DataTable<Row: Identifiable>: View {
     public struct Column {
         let title: String

--- a/Sources/ThemeKit/Components/Organisms/Diff.swift
+++ b/Sources/ThemeKit/Components/Organisms/Diff.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. Before / after comparison with a draggable divider that reveals the
-//  two layers. (daisyUI "Diff".)
-//
 
 import SwiftUI
 
+/// Organism. Before / after comparison with a draggable divider that reveals the
+/// two layers. (daisyUI "Diff".)
 public struct Diff<Before: View, After: View>: View {
     private let aspectRatio: CGFloat
     private let before: () -> Before

--- a/Sources/ThemeKit/Components/Organisms/EmptyState.swift
+++ b/Sources/ThemeKit/Components/Organisms/EmptyState.swift
@@ -3,13 +3,12 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Improved, token-bound rewrite of the reference EmptyCardView. An SF Symbol in
-//  a faded circle, title, message and an optional primary action. (Lottie /
-//  AppIcon dependencies dropped.)
-//
 
 import SwiftUI
 
+/// Improved, token-bound rewrite of the reference EmptyCardView. An SF Symbol in
+/// a faded circle, title, message and an optional primary action. (Lottie /
+/// AppIcon dependencies dropped.)
 public struct EmptyState: View {
     private let systemImage: String
     private let image: Image?

--- a/Sources/ThemeKit/Components/Organisms/FloatingActionButton.swift
+++ b/Sources/ThemeKit/Components/Organisms/FloatingActionButton.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A floating action button with an optional speed-dial of sub-actions.
-//  (daisyUI "FAB / Speed Dial".)
-//
 
 import SwiftUI
 
@@ -23,6 +20,8 @@ public struct FABAction: Identifiable {
 
 public enum FABShape { case circle, square }
 
+/// Organism. A floating action button with an optional speed-dial of sub-actions.
+/// (daisyUI "FAB / Speed Dial".)
 public struct FloatingActionButton: View {
     private let systemImage: String
     private let actions: [FABAction]

--- a/Sources/ThemeKit/Components/Organisms/Footer.swift
+++ b/Sources/ThemeKit/Components/Organisms/Footer.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A page footer: columns of titled links + an optional bottom note.
-//  (daisyUI "Footer".)
-//
 
 import SwiftUI
 
+/// Organism. A page footer: columns of titled links + an optional bottom note.
+/// (daisyUI "Footer".)
 public struct Footer: View {
     public struct Item: Identifiable {
         public let id = UUID()

--- a/Sources/ThemeKit/Components/Organisms/Gallery.swift
+++ b/Sources/ThemeKit/Components/Organisms/Gallery.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A grid of media items rendered at a fixed aspect ratio (uses the
-//  AspectRatioToken + GridLayout tokens). Generic over the cell content.
-//
 
 import SwiftUI
 
+/// Organism. A grid of media items rendered at a fixed aspect ratio (uses the
+/// AspectRatioToken + GridLayout tokens). Generic over the cell content.
 public struct Gallery<Item: Identifiable, Content: View>: View {
     private let items: [Item]
     private let columns: Int

--- a/Sources/ThemeKit/Components/Organisms/Hero.swift
+++ b/Sources/ThemeKit/Components/Organisms/Hero.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A prominent hero section: centered title + subtitle + optional CTA
-//  over a color or custom background. (daisyUI "Hero".)
-//
 
 import SwiftUI
 
+/// Organism. A prominent hero section: centered title + subtitle + optional CTA
+/// over a color or custom background. (daisyUI "Hero".)
 public struct Hero<Background: View>: View {
     private let title: String
     private let subtitle: String?

--- a/Sources/ThemeKit/Components/Organisms/ImageCollage.swift
+++ b/Sources/ThemeKit/Components/Organisms/ImageCollage.swift
@@ -3,13 +3,12 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  A gallery collage of remote images with count-aware layouts (1 / 2 / 3 / 4+)
-//  and a "+N" overlay on the last visible tile. Brand-neutral, token-bound; uses
-//  `RemoteImage` (native AsyncImage), no asset/Kingfisher dependency.
-//
 
 import SwiftUI
 
+/// A gallery collage of remote images with count-aware layouts (1 / 2 / 3 / 4+)
+/// and a "+N" overlay on the last visible tile. Brand-neutral, token-bound; uses
+/// `RemoteImage` (native AsyncImage), no asset/Kingfisher dependency.
 public struct ImageCollage: View {
     private let urls: [URL]
     private let height: CGFloat

--- a/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
@@ -3,10 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Improved, token-bound rewrite of the reference InfoMessage. Semantic types
-//  drive a light-surface banner with a colored icon, optional title and an
-//  optional dismiss action.
-//
 
 import SwiftUI
 
@@ -53,6 +49,9 @@ public enum InfoBannerType {
     }
 }
 
+/// Improved, token-bound rewrite of the reference InfoMessage. Semantic types
+/// drive a light-surface banner with a colored icon, optional title and an
+/// optional dismiss action.
 public struct InfoBanner: View {
     private let type: InfoBannerType
     private let title: String?

--- a/Sources/ThemeKit/Components/Organisms/KeyValueTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/KeyValueTable.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A label/value table (Figma "Table"). Values can carry a status
-//  style (plain / success / error / muted / strikethrough).
-//
 
 import SwiftUI
 
@@ -22,6 +19,8 @@ public enum TableValueStyle {
     }
 }
 
+/// Organism. A label/value table (Figma "Table"). Values can carry a status
+/// style (plain / success / error / muted / strikethrough).
 public struct KeyValueTable: View {
     public struct Row: Identifiable {
         public let id = UUID()

--- a/Sources/ThemeKit/Components/Organisms/ListRow.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListRow.swift
@@ -3,13 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  A flexible list row that consolidates the reference ListItem family
-//  (Default / Chevron / Checkbox / Radio / Menu / Quick-action) into one
-//  token-bound view. Leading: SF Symbol, remote image, number badge or a radio
-//  selector. Trailing: chevron / value / toggle / checkmark / bound checkbox /
-//  inline button / price block / status text. Plus a per-row meta line (rating,
-//  sentiment, comment count), an active-selected background and an info button.
-//
 
 import SwiftUI
 
@@ -79,6 +72,12 @@ public struct ListRowInfo: Identifiable {
     }
 }
 
+/// A flexible list row that consolidates the reference ListItem family
+/// (Default / Chevron / Checkbox / Radio / Menu / Quick-action) into one
+/// token-bound view. Leading: SF Symbol, remote image, number badge or a radio
+/// selector. Trailing: chevron / value / toggle / checkmark / bound checkbox /
+/// inline button / price block / status text. Plus a per-row meta line (rating,
+/// sentiment, comment count), an active-selected background and an info button.
 public struct ListRow: View {
     private let title: String
     private let subtitle: String?

--- a/Sources/ThemeKit/Components/Organisms/ListView.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListView.swift
@@ -3,13 +3,12 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Ant-style List container: optional header/footer, bordered surface, row
-//  dividers (split), and a loading (skeleton) state. Generic over the item +
-//  row content; pairs naturally with `ListRow`.
-//
 
 import SwiftUI
 
+/// Ant-style List container: optional header/footer, bordered surface, row
+/// dividers (split), and a loading (skeleton) state. Generic over the item +
+/// row content; pairs naturally with `ListRow`.
 public struct ListView<Item: Identifiable, Row: View>: View {
     private let items: [Item]
     private let header: String?

--- a/Sources/ThemeKit/Components/Organisms/MenuCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/MenuCard.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A grouped list of navigable menu links inside a card surface.
-//  (Named MenuCard to avoid shadowing SwiftUI.Menu.)
-//
 
 import SwiftUI
 
+/// Organism. A grouped list of navigable menu links inside a card surface.
+/// (Named MenuCard to avoid shadowing SwiftUI.Menu.)
 public struct MenuCard: View {
     public struct Item: Identifiable {
         public let id = UUID()

--- a/Sources/ThemeKit/Components/Organisms/NavigationBar.swift
+++ b/Sources/ThemeKit/Components/Organisms/NavigationBar.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. Floating bottom tab bar. Active item uses a filled glyph + hero
-//  underline. Selection owned by the caller.
-//
 
 import SwiftUI
 
+/// Organism. Floating bottom tab bar. Active item uses a filled glyph + hero
+/// underline. Selection owned by the caller.
 public struct NavigationBar: View {
     public struct Item: Identifiable {
         public let id = UUID()

--- a/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A notification surface: bell icon, optional unread dot + timestamp,
-//  title, message and optional actions.
-//
 
 import SwiftUI
 
+/// Organism. A notification surface: bell icon, optional unread dot + timestamp,
+/// title, message and optional actions.
 public struct NotificationCard<Actions: View>: View {
     private let title: String
     private let message: String?

--- a/Sources/ThemeKit/Components/Organisms/PageHeader.swift
+++ b/Sources/ThemeKit/Components/Organisms/PageHeader.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. Screen header: optional back button, title + subtitle, trailing
-//  icon actions.
-//
 
 import SwiftUI
 
+/// Organism. Screen header: optional back button, title + subtitle, trailing
+/// icon actions.
 public struct PageHeader: View {
     public struct Action: Identifiable {
         public let id = UUID()

--- a/Sources/ThemeKit/Components/Organisms/PagingCarousel.swift
+++ b/Sources/ThemeKit/Components/Organisms/PagingCarousel.swift
@@ -3,14 +3,13 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Custom drag-paging carousel with PEEKING neighbors + threshold snap (the
-//  reference `PagingScrollView`). Distinct from `Carousel` (full-width TabView):
-//  here the active tile is narrower so the previous/next peek at the edges.
-//  Optional autoplay wraps around.
-//
 
 import SwiftUI
 
+/// Custom drag-paging carousel with PEEKING neighbors + threshold snap (the
+/// reference `PagingScrollView`). Distinct from `Carousel` (full-width TabView):
+/// here the active tile is narrower so the previous/next peek at the edges.
+/// Optional autoplay wraps around.
 public struct PagingCarousel<Item: Identifiable, Content: View>: View {
     private let items: [Item]
     private let peek: CGFloat

--- a/Sources/ThemeKit/Components/Organisms/PromoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/PromoBanner.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A promotional banner (campaign / offer). Distinct from InfoBanner
-//  (status). Leading visual + title + subtitle + optional CTA, on a tinted card.
-//
 
 import SwiftUI
 
@@ -33,6 +30,8 @@ public enum PromoBannerTint {
     }
 }
 
+/// Organism. A promotional banner (campaign / offer). Distinct from InfoBanner
+/// (status). Leading visual + title + subtitle + optional CTA, on a tinted card.
 public struct PromoBanner: View {
     private let title: String
     private let subtitle: String?

--- a/Sources/ThemeKit/Components/Organisms/RatingSummary.swift
+++ b/Sources/ThemeKit/Components/Organisms/RatingSummary.swift
@@ -3,12 +3,11 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A review summary row: score badge + qualitative label + review
-//  count link. (Star display lives in the Rating atom.)
-//
 
 import SwiftUI
 
+/// Organism. A review summary row: score badge + qualitative label + review
+/// count link. (Star display lives in the Rating atom.)
 public struct RatingSummary: View {
     private let score: Double
     private let label: String?

--- a/Sources/ThemeKit/Components/Organisms/ResultView.swift
+++ b/Sources/ThemeKit/Components/Organisms/ResultView.swift
@@ -3,11 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Ant-style "Result" template: a full-page status view for the outcome of an
-//  operation (success / info / warning / error) or an exception page
-//  (404 / 403 / 500), with up to two actions. Generalizes `EmptyState`.
-//  See docs/result-templates.md.
-//
 
 import SwiftUI
 
@@ -51,6 +46,10 @@ public enum ResultStatus: String, CaseIterable {
     }
 }
 
+/// Ant-style "Result" template: a full-page status view for the outcome of an
+/// operation (success / info / warning / error) or an exception page
+/// (404 / 403 / 500), with up to two actions. Generalizes `EmptyState`.
+/// See docs/result-templates.md.
 public struct ResultView: View {
     private let status: ResultStatus
     private let title: String

--- a/Sources/ThemeKit/Components/Organisms/SegmentedTabBar.swift
+++ b/Sources/ThemeKit/Components/Organisms/SegmentedTabBar.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Tab bar with a selection binding and an animated underline. Tabs can carry an
-//  icon, a count badge and a disabled state. (Ant Tabs parity.)
-//
 
 import SwiftUI
 
@@ -26,6 +23,8 @@ public struct TabItem {
 /// Visual style of `SegmentedTabBar` (Ant Tabs `type`).
 public enum SegmentedTabBarStyle { case underline, card }
 
+/// Tab bar with a selection binding and an animated underline. Tabs can carry an
+/// icon, a count badge and a disabled state. (Ant Tabs parity.)
 public struct SegmentedTabBar: View {
     private let items: [TabItem]
     @Binding private var selection: Int

--- a/Sources/ThemeKit/Components/Organisms/SelectionCards.swift
+++ b/Sources/ThemeKit/Components/Organisms/SelectionCards.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organisms. Card-shaped selectable controls (radio / checkbox) — selected
-//  state raises a hero border + tinted surface. State owned by the caller.
-//
 
 import SwiftUI
 
@@ -49,6 +46,8 @@ private struct SelectionCard<Control: View>: View {
     }
 }
 
+/// Organisms. Card-shaped selectable controls (radio / checkbox) — selected
+/// state raises a hero border + tinted surface. State owned by the caller.
 public struct RadioCard: View {
     private let title: String
     private let description: String?

--- a/Sources/ThemeKit/Components/Organisms/Timeline.swift
+++ b/Sources/ThemeKit/Components/Organisms/Timeline.swift
@@ -3,11 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. Vertical timeline of events with a connecting rail, dot/icon
-//  markers, done / active / todo / error states, optional per-item color and a
-//  trailing "pending" (loading) node. `mode` places the content left, right or
-//  alternating around the rail; `reverse` flips the order. (Ant Timeline parity.)
-//
 
 import SwiftUI
 
@@ -21,6 +16,10 @@ public enum TimelineMode: Sendable {
     case alternate
 }
 
+/// Organism. Vertical timeline of events with a connecting rail, dot/icon
+/// markers, done / active / todo / error states, optional per-item color and a
+/// trailing "pending" (loading) node. `mode` places the content left, right or
+/// alternating around the rail; `reverse` flips the order. (Ant Timeline parity.)
 public struct Timeline: View {
     public struct Item: Identifiable {
         public let id = UUID()

--- a/Sources/ThemeKit/Components/Organisms/Upload.swift
+++ b/Sources/ThemeKit/Components/Organisms/Upload.swift
@@ -3,9 +3,6 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Organism. A file-upload prompt plus a list of files with per-item status
-//  (uploading / done / failed). State owned by the caller.
-//
 
 import SwiftUI
 
@@ -26,6 +23,8 @@ public struct UploadFile: Identifiable, Equatable {
     }
 }
 
+/// Organism. A file-upload prompt plus a list of files with per-item status
+/// (uploading / done / failed). State owned by the caller.
 public struct Upload: View {
     private let prompt: String
     private let buttonTitle: String

--- a/Sources/ThemeKit/Components/Organisms/VideoPlayerView.swift
+++ b/Sources/ThemeKit/Components/Organisms/VideoPlayerView.swift
@@ -3,16 +3,15 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Inline video on AVKit (reference `InlineVideoPlayerView`): autoplay, loop,
-//  mute, aspect-fill, and active-gating (only the visible item plays). Optional
-//  depth: a `progress` binding (0…1), resume-from-last-position, a tap overlay
-//  that toggles play/pause, and a mute toggle button. Controls hidden by default.
-//  iOS uses AVPlayerViewController; macOS falls back to the SwiftUI `VideoPlayer`.
-//
 
 import SwiftUI
 import AVKit
 
+/// Inline video on AVKit (reference `InlineVideoPlayerView`): autoplay, loop,
+/// mute, aspect-fill, and active-gating (only the visible item plays). Optional
+/// depth: a `progress` binding (0…1), resume-from-last-position, a tap overlay
+/// that toggles play/pause, and a mute toggle button. Controls hidden by default.
+/// iOS uses AVPlayerViewController; macOS falls back to the SwiftUI `VideoPlayer`.
 public struct VideoPlayerView: View {
     private let url: URL?
     private let autoplay: Bool


### PR DESCRIPTION
## What
DocC renders `///` symbol docs but **ignores `//` file-header prose** — so every component had a written description the generated reference never showed. This **relocates** each component's header description into a `///` doc comment on its primary `View` struct. No new prose; the existing description moves to where DocC reads it. The file header keeps its metadata.

## Scope
- **86 component structs** (Atoms / Molecules / Organisms) now carry `///` symbol docs.
- **6 already-documented** structs (style hosts) untouched.
- **16 modifier/enum-fronted** components (`Tooltip`, `Dialog`, `Drawer`, `Toast`, `Tour`, `BottomSheet`, …) were already `///`-documented at their real public entry — nothing to move.

## Safety
- **Comments only** — public API surface unchanged.
- `swift package generate-documentation` builds with **no symbol warnings**.
- Full suite green (**160 tests**).

Closes the DocC `///` item in `docs/AUDIT.md` (P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)