### PR TITLE
refactor(theme): migrate Atoms to @Environment(\.theme) (rollout 1/3)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/AnimatedImage.swift
+++ b/Sources/ThemeKit/Components/Atoms/AnimatedImage.swift
@@ -12,6 +12,8 @@ import ImageIO
 /// by a `TimelineView(.animation)`. Handles variable frame durations and loops.
 /// (Reference AVIFAnimatedImage / animated `ImageView` role, native.)
 public struct AnimatedImage: View {
+    @Environment(\.theme) private var theme
+
     private let url: URL?
     private let contentMode: ContentMode
     private let cornerRadius: CGFloat
@@ -49,8 +51,8 @@ public struct AnimatedImage: View {
                 .aspectRatio(contentMode: contentMode)
         } else {
             ZStack {
-                Theme.shared.background(.bgSecondaryLight)
-                if failed { Icon(systemName: "photo", size: .lg, color: Theme.shared.text(.textTertiary)) }
+                theme.background(.bgSecondaryLight)
+                if failed { Icon(systemName: "photo", size: .lg, color: theme.text(.textTertiary)) }
             }
             .skeleton(!failed)
         }

--- a/Sources/ThemeKit/Components/Atoms/Avatar.swift
+++ b/Sources/ThemeKit/Components/Atoms/Avatar.swift
@@ -47,6 +47,8 @@ public enum AvatarContent {
 /// or square, plus an `AvatarGroup` that stacks avatars with a +N overflow.
 /// (Ant Avatar parity.) Figma sizes 24/32/40/48.
 public struct Avatar: View {
+    @Environment(\.theme) private var theme
+
     private let content: AvatarContent
     private let size: AvatarSize
     private let customDimension: CGFloat?
@@ -103,7 +105,7 @@ public struct Avatar: View {
         ZStack {
             clip.fill(background.fill)
             if background.hasBorder {
-                clip.stroke(Theme.shared.border(.borderPrimary), lineWidth: 2)
+                clip.stroke(theme.border(.borderPrimary), lineWidth: 2)
             }
             contentView
         }
@@ -120,7 +122,7 @@ public struct Avatar: View {
             let dot = max(8, dim * 0.28)
             let ring = max(1.5, dim * 0.05)
             ZStack {
-                Circle().fill(Theme.shared.background(.bgWhite))
+                Circle().fill(theme.background(.bgWhite))
                     .frame(width: dot + ring * 2, height: dot + ring * 2)
                 StatusDot(presence, size: dot, pulse: presencePulse)
             }
@@ -148,6 +150,8 @@ public struct Avatar: View {
 
 /// Overlapping stack of avatars with a "+N" overflow bubble. (Ant Avatar.Group.)
 public struct AvatarGroup: View {
+    @Environment(\.theme) private var theme
+
     private let avatars: [AvatarContent]
     private let size: AvatarSize
     private let max: Int
@@ -166,11 +170,11 @@ public struct AvatarGroup: View {
         HStack(spacing: -size.dimension * 0.35) {
             ForEach(Array(avatars.prefix(max).enumerated()), id: \.offset) { _, content in
                 Avatar(content, size: size, background: background)
-                    .overlay(Circle().strokeBorder(Theme.shared.background(.bgWhite), lineWidth: 2))
+                    .overlay(Circle().strokeBorder(theme.background(.bgWhite), lineWidth: 2))
             }
             if overflow > 0 {
                 Avatar(.initials("+\(overflow)"), size: size, background: .dark)
-                    .overlay(Circle().strokeBorder(Theme.shared.background(.bgWhite), lineWidth: 2))
+                    .overlay(Circle().strokeBorder(theme.background(.bgWhite), lineWidth: 2))
             }
         }
     }

--- a/Sources/ThemeKit/Components/Atoms/Chip.swift
+++ b/Sources/ThemeKit/Components/Atoms/Chip.swift
@@ -33,6 +33,8 @@ public enum ChipSelectionStyle {
 /// selection API (tonal / solid) instead of the reference's nested
 /// status × mode × fullSelect × isExist matrix.
 public struct Chip: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var isSelected: Bool
     private let title: String
     private let size: ChipSize
@@ -79,12 +81,12 @@ public struct Chip: View {
                 if let rating {
                     HStack(spacing: 2) {
                         Image(systemName: "star.fill").font(.system(size: 11))
-                            .foregroundStyle(Theme.shared.foreground(.systemcolorsFgWarning))
+                            .foregroundStyle(theme.foreground(.systemcolorsFgWarning))
                         Text(String(format: "%.1f", rating)).textStyle(.labelSm700)
                     }
                 }
                 Text(title).textStyle(.labelBase600)
-                    .strikethrough(!isExist, color: Theme.shared.text(.textTertiary))
+                    .strikethrough(!isExist, color: theme.text(.textTertiary))
             }
             .foregroundStyle(foreground)
             .frame(maxWidth: expandsHorizontally ? .infinity : nil)
@@ -100,29 +102,29 @@ public struct Chip: View {
     }
 
     private var foreground: Color {
-        if !isEnabled || !isExist { return Theme.shared.text(.textDisabled) }
-        guard isSelected else { return Theme.shared.text(.textSecondary) }
+        if !isEnabled || !isExist { return theme.text(.textDisabled) }
+        guard isSelected else { return theme.text(.textSecondary) }
         switch selectionStyle {
-        case .tonal: return Theme.shared.text(.textHero)
-        case .solid: return Theme.shared.foreground(.fgSecondary)
+        case .tonal: return theme.text(.textHero)
+        case .solid: return theme.foreground(.fgSecondary)
         }
     }
 
     private var background: Color {
-        if !isEnabled || !isExist { return Theme.shared.background(.bgSecondaryLight) }
-        guard isSelected else { return Theme.shared.background(.bgWhite) }
+        if !isEnabled || !isExist { return theme.background(.bgSecondaryLight) }
+        guard isSelected else { return theme.background(.bgWhite) }
         switch selectionStyle {
-        case .tonal: return Theme.shared.background(.bgElevatorTertiary)
-        case .solid: return Theme.shared.background(.bgHero)
+        case .tonal: return theme.background(.bgElevatorTertiary)
+        case .solid: return theme.background(.bgHero)
         }
     }
 
     private var border: Color {
-        if !isEnabled { return Theme.shared.border(.borderPrimary) }
-        guard isSelected else { return Theme.shared.border(.borderPrimary) }
+        if !isEnabled { return theme.border(.borderPrimary) }
+        guard isSelected else { return theme.border(.borderPrimary) }
         switch selectionStyle {
-        case .tonal: return Theme.shared.border(.borderHero)
-        case .solid: return Theme.shared.background(.bgHero)
+        case .tonal: return theme.border(.borderHero)
+        case .solid: return theme.background(.bgHero)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Atoms/DividerView.swift
+++ b/Sources/ThemeKit/Components/Atoms/DividerView.swift
@@ -27,6 +27,8 @@ public enum DividerTextAlign { case leading, center, trailing }
 /// optional inline text label (left / center / right). (Ant Divider parity.)
 /// Colors come exclusively from the active theme.
 public struct DividerView: View {
+    @Environment(\.theme) private var theme
+
     private let size: DividerViewSize
     private let axis: DividerAxis
     private let dashed: Bool
@@ -59,7 +61,7 @@ public struct DividerView: View {
                     line(vertical: false).frame(maxWidth: .infinity).frame(width: titleAlign == .leading ? 16 : nil)
                     Text(title)
                         .textStyle(.labelSm600)
-                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                        .foregroundStyle(theme.text(.textTertiary))
                         .fixedSize()
                     line(vertical: false).frame(maxWidth: .infinity).frame(width: titleAlign == .trailing ? 16 : nil)
                 }
@@ -76,17 +78,17 @@ public struct DividerView: View {
         VStack(spacing: 0) {
             switch size {
             case .small:
-                Theme.shared.border(.borderPrimary).frame(height: 1)
+                theme.border(.borderPrimary).frame(height: 1)
             case .medium, .large:
-                Theme.shared.border(.borderPrimary).frame(height: 1)
-                Theme.shared.background(.bgElevatorPrimary).frame(height: size.height - 1)
+                theme.border(.borderPrimary).frame(height: 1)
+                theme.background(.bgElevatorPrimary).frame(height: size.height - 1)
             }
         }
     }
 
     private func line(vertical: Bool) -> some View {
         LineShape(vertical: vertical)
-            .stroke(Theme.shared.border(.borderPrimary),
+            .stroke(theme.border(.borderPrimary),
                     style: StrokeStyle(lineWidth: 1, dash: dashed ? [4, 4] : []))
     }
 }

--- a/Sources/ThemeKit/Components/Atoms/InlineText.swift
+++ b/Sources/ThemeKit/Components/Atoms/InlineText.swift
@@ -10,6 +10,8 @@ import SwiftUI
 /// UnderlineText by using AttributedString + openURL routing instead of manual
 /// NSRange math.
 public struct InlineText: View {
+    @Environment(\.theme) private var theme
+
     private let text: String
     private let links: [(substring: String, action: () -> Void)]
     private let baseColor: Color?
@@ -37,10 +39,10 @@ public struct InlineText: View {
     private var attributed: AttributedString {
         var string = AttributedString(text)
         string.font = style.font
-        string.foregroundColor = baseColor ?? Theme.shared.text(.textSecondary)
+        string.foregroundColor = baseColor ?? theme.text(.textSecondary)
         for (index, link) in links.enumerated() {
             if let range = string.range(of: link.substring) {
-                string[range].foregroundColor = Theme.shared.text(.textHero)
+                string[range].foregroundColor = theme.text(.textHero)
                 string[range].underlineStyle = .single
                 string[range].link = URL(string: "inline:\(index)")
             }

--- a/Sources/ThemeKit/Components/Atoms/InputLabel.swift
+++ b/Sources/ThemeKit/Components/Atoms/InputLabel.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Atom. A form field label: text + optional required asterisk + optional info
 /// glyph. Shared by the input components.
 public struct InputLabel: View {
+    @Environment(\.theme) private var theme
+
     private let text: String
     private let isRequired: Bool
     private let hasInfo: Bool
@@ -25,12 +27,12 @@ public struct InputLabel: View {
         HStack(spacing: 4) {
             Text(text)
                 .textStyle(.labelSm600)
-                .foregroundStyle(hasError ? Theme.shared.foreground(.systemcolorsFgError) : Theme.shared.text(.textPrimary))
+                .foregroundStyle(hasError ? theme.foreground(.systemcolorsFgError) : theme.text(.textPrimary))
             if isRequired {
-                Text("*").textStyle(.labelSm600).foregroundStyle(Theme.shared.foreground(.systemcolorsFgError))
+                Text("*").textStyle(.labelSm600).foregroundStyle(theme.foreground(.systemcolorsFgError))
             }
             if hasInfo {
-                Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(Theme.shared.text(.textTertiary))
+                Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(theme.text(.textTertiary))
             }
         }
     }

--- a/Sources/ThemeKit/Components/Atoms/Kbd.swift
+++ b/Sources/ThemeKit/Components/Atoms/Kbd.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 /// Atom. A keyboard key cap. (daisyUI "Kbd".)
 public struct Kbd: View {
+    @Environment(\.theme) private var theme
+
     private let text: String
 
     public init(_ text: String) { self.text = text }
@@ -15,18 +17,18 @@ public struct Kbd: View {
     public var body: some View {
         Text(text)
             .font(.system(.footnote, design: .monospaced).weight(.semibold))
-            .foregroundStyle(Theme.shared.text(.textPrimary))
+            .foregroundStyle(theme.text(.textPrimary))
             .padding(.horizontal, Theme.SpacingKey.sm.value)
             .frame(minWidth: 28, minHeight: 28)
-            .background(Theme.shared.background(.bgElevatorPrimary),
+            .background(theme.background(.bgElevatorPrimary),
                        in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous)
-                    .stroke(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                    .stroke(theme.border(.borderPrimary), lineWidth: 1)
             )
             .overlay(alignment: .bottom) {
                 RoundedRectangle(cornerRadius: 1)
-                    .fill(Theme.shared.border(.borderPrimary))
+                    .fill(theme.border(.borderPrimary))
                     .frame(height: 2)
                     .padding(.horizontal, 4)
                     .offset(y: 1)

--- a/Sources/ThemeKit/Components/Atoms/ProgressBar.swift
+++ b/Sources/ThemeKit/Components/Atoms/ProgressBar.swift
@@ -22,6 +22,8 @@ public enum ProgressStatus {
 /// a segmented (steps) variant and a custom format label. (Ant Progress parity.)
 /// Plus a segmented `StepIndicator`.
 public struct ProgressBar: View {
+    @Environment(\.theme) private var theme
+
     private let value: Double
     private let height: CGFloat
     private let showPercentage: Bool
@@ -77,7 +79,7 @@ public struct ProgressBar: View {
         self.accessibilityLabelText = accessibilityLabel
     }
 
-    private var trackColor: Color { trailColor ?? Theme.shared.border(.borderPrimary) }
+    private var trackColor: Color { trailColor ?? theme.border(.borderPrimary) }
 
     /// Spoken/displayed percentage. Rounded mid-range (0.756 → "76%", not "75%"),
     /// but capped at 99% until the value is actually complete, so the label can
@@ -132,7 +134,7 @@ public struct ProgressBar: View {
         } else if showPercentage {
             Text(percentText)
                 .textStyle(.labelSm600)
-                .foregroundStyle(Theme.shared.text(.textPrimary))
+                .foregroundStyle(theme.text(.textPrimary))
                 .frame(minWidth: 40, alignment: .trailing)
         }
     }
@@ -150,6 +152,8 @@ public struct ProgressBar: View {
 
 /// Segmented step indicator (e.g. carousels / onboarding).
 public struct StepIndicator: View {
+    @Environment(\.theme) private var theme
+
     private let current: Int
     private let total: Int
 
@@ -166,7 +170,7 @@ public struct StepIndicator: View {
         HStack(spacing: Theme.SpacingKey.xs.value) {
             ForEach(0..<max(total, 0), id: \.self) { index in
                 Capsule()
-                    .fill(index == current ? Theme.shared.background(.bgHero) : Theme.shared.border(.borderPrimary))
+                    .fill(index == current ? theme.background(.bgHero) : theme.border(.borderPrimary))
                     .frame(width: index == current ? 20 : 6, height: 6)
                     .animation(motion, value: current)
             }

--- a/Sources/ThemeKit/Components/Atoms/RadialProgress.swift
+++ b/Sources/ThemeKit/Components/Atoms/RadialProgress.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Atom. Circular determinate progress with status colors and an optional
 /// dashboard (gapped) variant. (Ant Progress type="circle"/"dashboard".)
 public struct RadialProgress: View {
+    @Environment(\.theme) private var theme
+
     private let value: Double
     private let size: CGFloat
     private let lineWidth: CGFloat
@@ -55,7 +57,7 @@ public struct RadialProgress: View {
         ZStack {
             Circle()
                 .trim(from: 0, to: 1 - gap)
-                .stroke(Theme.shared.border(.borderPrimary), style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
                 .rotationEffect(.degrees(rotation))
             Circle()
                 .trim(from: 0, to: value * (1 - gap))
@@ -70,7 +72,7 @@ public struct RadialProgress: View {
                 } else {
                     Text("\(percent)%")
                         .font(.system(size: size * 0.26, weight: .semibold))
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                 }
             }
         }

--- a/Sources/ThemeKit/Components/Atoms/Rating.swift
+++ b/Sources/ThemeKit/Components/Atoms/Rating.swift
@@ -20,6 +20,8 @@ public enum RatingLayout {
 /// fill (display) or half-step interaction, a tappable review count, a custom
 /// character and a disabled state. (Reference RatingView parity + interactive.)
 public struct Rating: View {
+    @Environment(\.theme) private var theme
+
     private let value: Double
     private let maxValue: Int
     private let size: CGFloat
@@ -95,19 +97,19 @@ public struct Rating: View {
         case .numberRate:
             Text(String(format: "%.1f", value))
                 .font(.system(size: size * 1.15, weight: .bold))
-                .foregroundStyle(Theme.shared.text(.textPrimary))
+                .foregroundStyle(theme.text(.textPrimary))
             Image(systemName: "\(systemImage).fill")
                 .font(.system(size: size))
-                .foregroundStyle(Theme.shared.foreground(.systemcolorsFgWarning))
+                .foregroundStyle(theme.foreground(.systemcolorsFgWarning))
         case .rateNumberText:
             Text(String(format: "%.1f", value))
                 .font(.system(size: size * 1.15, weight: .bold))
-                .foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                .foregroundStyle(theme.foreground(.fgSecondary))
                 .padding(.horizontal, 6).padding(.vertical, 2)
-                .background(Theme.shared.background(.bgHero), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
+                .background(theme.background(.bgHero), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
             Text(resolvedSentiment)
                 .font(.system(size: size, weight: .semibold))
-                .foregroundStyle(Theme.shared.text(.textPrimary))
+                .foregroundStyle(theme.text(.textPrimary))
         }
     }
 
@@ -191,7 +193,7 @@ public struct Rating: View {
             ForEach(1...maxValue, id: \.self) { _ in
                 Image(systemName: filled ? "\(systemImage).fill" : systemImage)
                     .font(.system(size: size))
-                    .foregroundStyle(filled ? Theme.shared.foreground(.systemcolorsFgWarning) : Theme.shared.border(.borderPrimary))
+                    .foregroundStyle(filled ? theme.foreground(.systemcolorsFgWarning) : theme.border(.borderPrimary))
             }
         }
     }
@@ -202,11 +204,11 @@ public struct Rating: View {
             let text = Text(countLabel).textStyle(.bodySm400)
             if let onReviewTap {
                 Button(action: onReviewTap) {
-                    text.underline().foregroundStyle(Theme.shared.text(.textHero))
+                    text.underline().foregroundStyle(theme.text(.textHero))
                 }
                 .buttonStyle(.plain)
             } else {
-                text.foregroundStyle(Theme.shared.text(.textTertiary))
+                text.foregroundStyle(theme.text(.textTertiary))
             }
         }
     }
@@ -223,8 +225,8 @@ public struct Rating: View {
 
     private func color(for index: Int) -> Color {
         value >= Double(index) - 0.5
-            ? Theme.shared.foreground(.systemcolorsFgWarning)
-            : Theme.shared.border(.borderPrimary)
+            ? theme.foreground(.systemcolorsFgWarning)
+            : theme.border(.borderPrimary)
     }
 
     private func star(for index: Int) -> Image {

--- a/Sources/ThemeKit/Components/Atoms/RemoteImage.swift
+++ b/Sources/ThemeKit/Components/Atoms/RemoteImage.swift
@@ -31,6 +31,8 @@ public enum RemoteImageRatio {
 /// aspect ratio (number or "16:9" string) + shimmer placeholder + failure state.
 /// Covers the reference `ImageView`/`CustomImageView` role.
 public struct RemoteImage: View {
+    @Environment(\.theme) private var theme
+
     private let url: URL?
     private let aspectRatio: CGFloat?
     private let contentMode: ContentMode
@@ -96,8 +98,8 @@ public struct RemoteImage: View {
     @ViewBuilder
     private func placeholder(icon: String?) -> some View {
         ZStack {
-            Theme.shared.background(.bgSecondaryLight)
-            if let icon { Icon(systemName: icon, size: .lg, color: Theme.shared.text(.textTertiary)) }
+            theme.background(.bgSecondaryLight)
+            if let icon { Icon(systemName: icon, size: .lg, color: theme.text(.textTertiary)) }
         }
         .skeleton(icon == nil)
     }

--- a/Sources/ThemeKit/Components/Atoms/ScoreBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/ScoreBadge.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 /// Atom. A numeric rating score in a filled rounded box (e.g. "9.0").
 public struct ScoreBadge: View {
+    @Environment(\.theme) private var theme
+
     private let score: Double
     private let large: Bool
 
@@ -19,10 +21,10 @@ public struct ScoreBadge: View {
     public var body: some View {
         Text(String(format: "%.1f", score))
             .textStyle(large ? .labelMd700 : .labelSm700)
-            .foregroundStyle(Theme.shared.foreground(.fgSecondary))
+            .foregroundStyle(theme.foreground(.fgSecondary))
             .padding(.horizontal, large ? Theme.SpacingKey.sm.value : Theme.SpacingKey.xs.value)
             .frame(minWidth: large ? 40 : 32, minHeight: large ? 32 : 24)
-            .background(Theme.shared.background(.bgTurquoise),
+            .background(theme.background(.bgTurquoise),
                        in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
             // Give the bare number context: VoiceOver reads "Score: 9.0".
             .accessibilityElement(children: .ignore)

--- a/Sources/ThemeKit/Components/Atoms/Skeleton.swift
+++ b/Sources/ThemeKit/Components/Atoms/Skeleton.swift
@@ -29,19 +29,21 @@ public enum SkeletonShape: Equatable {
 
 /// The shimmering fill, reused by the modifier and the standalone view.
 struct SkeletonShimmer: View {
+    @Environment(\.theme) private var theme
+
     let shape: SkeletonShape
     @State private var animate = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         shape.anyShape
-            .fill(Theme.shared.background(.skeletonBgSkeletonBase))
+            .fill(theme.background(.skeletonBgSkeletonBase))
             .overlay {
                 // Honor Reduce Motion: a static placeholder, no traveling sweep.
                 if !reduceMotion {
                     GeometryReader { geo in
                         LinearGradient(
-                            colors: [.clear, Theme.shared.background(.bgWhite).opacity(0.7), .clear],
+                            colors: [.clear, theme.background(.bgWhite).opacity(0.7), .clear],
                             startPoint: .leading, endPoint: .trailing
                         )
                         .frame(width: geo.size.width * 0.5)

--- a/Sources/ThemeKit/Components/Atoms/Spinner.swift
+++ b/Sources/ThemeKit/Components/Atoms/Spinner.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 /// Atom. Indeterminate circular loading indicator (token-tinted).
 public struct Spinner: View {
+    @Environment(\.theme) private var theme
+
     private let size: CGFloat
     private let lineWidth: CGFloat
     private let color: Color?
@@ -24,7 +26,7 @@ public struct Spinner: View {
         Circle()
             .trim(from: 0, to: 0.75)
             .stroke(
-                (color ?? Theme.shared.foreground(.fgHero)),
+                (color ?? theme.foreground(.fgHero)),
                 style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
             )
             .frame(width: size, height: size)

--- a/Sources/ThemeKit/Components/Atoms/StatusDot.swift
+++ b/Sources/ThemeKit/Components/Atoms/StatusDot.swift
@@ -35,6 +35,8 @@ public enum StatusKind {
 /// Atom. A small status indicator dot with an optional pulse + label.
 /// (daisyUI "Status".)
 public struct StatusDot: View {
+    @Environment(\.theme) private var theme
+
     private let kind: StatusKind
     private let size: CGFloat
     private let label: String?
@@ -66,7 +68,7 @@ public struct StatusDot: View {
             .onAppear { if pulses { withAnimation(.easeOut(duration: 1.2).repeatForever(autoreverses: false)) { animating = true } } }
 
             if let label {
-                Text(label).textStyle(.labelSm600).foregroundStyle(Theme.shared.text(.textPrimary))
+                Text(label).textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary))
             }
         }
         // Collapse dot + label into one element so the status is always spoken,

--- a/Sources/ThemeKit/Components/Atoms/Swap.swift
+++ b/Sources/ThemeKit/Components/Atoms/Swap.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Atom. Animated toggle between two SF Symbols (e.g. menu↔close, sun↔moon).
 /// (daisyUI "Swap".)
 public struct Swap: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var isOn: Bool
     private let onSystemImage: String
     private let offSystemImage: String
@@ -45,7 +47,7 @@ public struct Swap: View {
     private func glyph(_ name: String, visible: Bool, angle: Double) -> some View {
         Image(systemName: name)
             .font(.system(size: size, weight: .medium))
-            .foregroundStyle(Theme.shared.text(.textPrimary))
+            .foregroundStyle(theme.text(.textPrimary))
             .opacity(visible ? 1 : 0)
             .rotationEffect(.degrees(visible ? 0 : angle))
             .scaleEffect(visible ? 1 : 0.6)

--- a/Sources/ThemeKit/Components/Atoms/TextLink.swift
+++ b/Sources/ThemeKit/Components/Atoms/TextLink.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Atom. A standalone tappable text link. (daisyUI "Link"; for links inside a
 /// paragraph use InlineText, for a button use LinkButton.)
 public struct TextLink: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     private let underline: Bool
     private let action: () -> Void
@@ -24,7 +26,7 @@ public struct TextLink: View {
             Text(title)
                 .textStyle(.linkBase)
                 .underline(underline)
-                .foregroundStyle(Theme.shared.text(.textHero))
+                .foregroundStyle(theme.text(.textHero))
         }
         .buttonStyle(.plain)
     }

--- a/Sources/ThemeKit/Components/Atoms/Title.swift
+++ b/Sources/ThemeKit/Components/Atoms/Title.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Atom. A section title: optional eyebrow, title + optional subtitle, and an
 /// optional trailing action (e.g. "See all").
 public struct Title: View {
+    @Environment(\.theme) private var theme
+
     private let text: String
     private let subtitle: String?
     private let eyebrow: String?
@@ -35,21 +37,21 @@ public struct Title: View {
                 if let eyebrow {
                     Text(eyebrow.uppercased())
                         .textStyle(.overline500)
-                        .foregroundStyle(Theme.shared.text(.textHero))
+                        .foregroundStyle(theme.text(.textHero))
                 }
                 Text(text)
                     .textStyle(.headingBase)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
                 if let subtitle {
                     Text(subtitle)
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                        .foregroundStyle(theme.text(.textSecondary))
                 }
             }
             Spacer(minLength: Theme.SpacingKey.sm.value)
             if let actionTitle, let action {
                 Button(action: action) {
-                    Text(actionTitle).textStyle(.linkBase).foregroundStyle(Theme.shared.text(.textHero))
+                    Text(actionTitle).textStyle(.linkBase).foregroundStyle(theme.text(.textHero))
                 }
                 .buttonStyle(.plain)
             }


### PR DESCRIPTION
## What
Continues the **singleton→environment rollout** (P0) opened by #57. **18 atom `View` structs** now read `\.theme` from the environment instead of `Theme.shared`, so an injected `.theme(_:)` re-skins them per-subtree. Because `\.theme` defaults to `Theme.shared`, **the default render is unchanged**.

## Scope (batch 1 of 3 — Atoms)
- **Migrated (66 reads):** Chip, Rating, Avatar/AvatarGroup, DividerView, Title, ProgressBar/StepIndicator, Kbd, InputLabel, RadialProgress, ScoreBadge, AnimatedImage, InlineText, RemoteImage, SkeletonShimmer, Spinner, StatusDot, Swap, TextLink.
- **Left on `Theme.shared`** (no environment in a static context): `BadgeStyle` color resolvers and other enum / init-time lookups — these need an explicit theme parameter to be subtree-themeable; tracked for a later pass.

## Safety — verified non-breaking
- Every **regenerated screenshot is byte-identical** to the committed baseline (BorderBeam excluded — animated/non-deterministic, source untouched).
- Full suite green (**160 tests**); migration is compiler-guarded (static/init reads can't see `\.theme`, so any wrong migration fails to build — none did).

Part of the `\.theme` rollout item in `docs/AUDIT.md` (P0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)