### PR TITLE
refactor(theme): migrate Molecules to @Environment(\.theme) (rollout 2/3)

### DIFF
--- a/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
+++ b/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
@@ -12,6 +12,8 @@ import SwiftUI
 ///     spinner, an empty "no results" state, and in-flight cancellation.
 /// State (the bound text) is owned by the caller.
 public struct Autocomplete: View {
+    @Environment(\.theme) private var theme
+
 
     /// Where suggestions come from.
     private enum Source {
@@ -110,11 +112,11 @@ public struct Autocomplete: View {
             if let label { InputLabel(label) }
 
             HStack(spacing: Theme.SpacingKey.sm.value) {
-                Icon(systemName: "magnifyingglass", size: .sm, color: Theme.shared.text(.textTertiary))
+                Icon(systemName: "magnifyingglass", size: .sm, color: theme.text(.textTertiary))
                 TextField(placeholder, text: $text)
                     .textStyle(.bodyBase400)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
-                    .tint(Theme.shared.foreground(.fgHero))
+                    .foregroundStyle(theme.text(.textPrimary))
+                    .tint(theme.foreground(.fgHero))
                     .focused($isFocused)
                     .disabled(!isEnabled)
                     .a11y(A11yElement.Field.field, in: accessibilityID)
@@ -123,17 +125,17 @@ public struct Autocomplete: View {
                     Spinner(size: IconSize.sm.value, lineWidth: 2)
                 } else if !text.isEmpty {
                     Button { text = "" } label: {
-                        Icon(systemName: "xmark.circle.fill", size: .sm, color: Theme.shared.text(.textTertiary))
+                        Icon(systemName: "xmark.circle.fill", size: .sm, color: theme.text(.textTertiary))
                     }
                     .buttonStyle(.plain)
                 }
             }
             .padding(.horizontal, Theme.SpacingKey.md.value)
             .scaledControlHeight(48)
-            .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+            .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                    .strokeBorder(isFocused ? Theme.shared.border(.borderHero) : Theme.shared.border(.borderPrimary), lineWidth: isFocused ? 1.5 : 1)
+                    .strokeBorder(isFocused ? theme.border(.borderHero) : theme.border(.borderPrimary), lineWidth: isFocused ? 1.5 : 1)
             )
 
             if showsDropdown { dropdown }
@@ -151,11 +153,11 @@ public struct Autocomplete: View {
             if isLoading {
                 row { HStack(spacing: Theme.SpacingKey.sm.value) {
                     Spinner(size: IconSize.sm.value, lineWidth: 2)
-                    Text(String(themeKit: "Searching…")).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary))
+                    Text(String(themeKit: "Searching…")).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
                     Spacer()
                 } }
             } else if results.isEmpty {
-                row { Text(String(themeKit: "No results")).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary)) }
+                row { Text(String(themeKit: "No results")).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary)) }
             } else {
                 ForEach(results, id: \.self) { suggestion in
                     let enabled = suggestionEnabled(suggestion)
@@ -166,7 +168,7 @@ public struct Autocomplete: View {
                         isFocused = false
                     } label: {
                         row { HStack {
-                            Text(suggestion).textStyle(.bodyBase400).foregroundStyle(Theme.shared.text(.textPrimary))
+                            Text(suggestion).textStyle(.bodyBase400).foregroundStyle(theme.text(.textPrimary))
                             Spacer()
                         } }
                     }
@@ -177,10 +179,10 @@ public struct Autocomplete: View {
                 }
             }
         }
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                .strokeBorder(theme.border(.borderPrimary), lineWidth: 1)
         )
         .themeShadow(.soft)
     }

--- a/Sources/ThemeKit/Components/Molecules/Breadcrumbs.swift
+++ b/Sources/ThemeKit/Components/Molecules/Breadcrumbs.swift
@@ -11,6 +11,8 @@ import SwiftUI
 /// When `maxItems` is set and exceeded, the middle crumbs collapse into a "…"
 /// menu that still navigates to any hidden crumb.
 public struct Breadcrumbs: View {
+    @Environment(\.theme) private var theme
+
     public struct Crumb: Identifiable {
         public let id = UUID()
         let title: String
@@ -53,7 +55,7 @@ public struct Breadcrumbs: View {
             Button { crumbs[index].action?() } label: {
                 Text(crumbs[index].title)
                     .textStyle(isLast ? .labelSm700 : .labelSm600)
-                    .foregroundStyle(isLast ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textHero))
+                    .foregroundStyle(isLast ? theme.text(.textPrimary) : theme.text(.textHero))
             }
             .buttonStyle(.plain)
             .disabled(isLast || crumbs[index].action == nil)
@@ -66,7 +68,7 @@ public struct Breadcrumbs: View {
             } label: {
                 Text("…")
                     .textStyle(.labelSm700)
-                    .foregroundStyle(Theme.shared.text(.textHero))
+                    .foregroundStyle(theme.text(.textHero))
                     .frame(minWidth: 20)
             }
             .accessibilityLabel(String(themeKit: "Show hidden breadcrumbs"))
@@ -76,7 +78,7 @@ public struct Breadcrumbs: View {
     private var separator: some View {
         Image(systemName: "chevron.right")
             .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(Theme.shared.text(.textTertiary))
+            .foregroundStyle(theme.text(.textTertiary))
             .mirrorsInRTL()
     }
 

--- a/Sources/ThemeKit/Components/Molecules/CalendarView.swift
+++ b/Sources/ThemeKit/Components/Molecules/CalendarView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Molecule. An inline month calendar with day selection + month navigation.
 /// (daisyUI "Calendar"; complements DateField which presents a popover.)
 public struct CalendarView: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var selection: Date?
     @State private var displayed: Date
 
@@ -26,8 +28,8 @@ public struct CalendarView: View {
             grid
         }
         .padding(Theme.SpacingKey.md.value)
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous).stroke(Theme.shared.border(.borderPrimary), lineWidth: 1))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous).stroke(theme.border(.borderPrimary), lineWidth: 1))
     }
 
     private var header: some View {
@@ -36,7 +38,7 @@ public struct CalendarView: View {
             Spacer()
             Text(displayed.formatted(.dateTime.month(.wide).year()))
                 .textStyle(.labelMd700)
-                .foregroundStyle(Theme.shared.text(.textPrimary))
+                .foregroundStyle(theme.text(.textPrimary))
             Spacer()
             navButton("chevron.right", months: 1)
         }
@@ -48,7 +50,7 @@ public struct CalendarView: View {
                 withAnimation(Motion.fast.animation) { displayed = d }
             }
         } label: {
-            Icon(systemName: name, size: .sm, color: Theme.shared.text(.textPrimary))
+            Icon(systemName: name, size: .sm, color: theme.text(.textPrimary))
                 .frame(width: 32, height: 32)
                 .mirrorsInRTL()
         }
@@ -60,7 +62,7 @@ public struct CalendarView: View {
             ForEach(orderedWeekdaySymbols, id: \.self) { symbol in
                 Text(symbol)
                     .textStyle(.labelSm600)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
                     .frame(maxWidth: .infinity)
             }
         }
@@ -86,10 +88,10 @@ public struct CalendarView: View {
         } label: {
             Text("\(calendar.component(.day, from: date))")
                 .textStyle(.bodyBase400)
-                .foregroundStyle(isSelected ? Theme.shared.foreground(.fgSecondary) : (isToday ? Theme.shared.text(.textHero) : Theme.shared.text(.textPrimary)))
+                .foregroundStyle(isSelected ? theme.foreground(.fgSecondary) : (isToday ? theme.text(.textHero) : theme.text(.textPrimary)))
                 .frame(width: 36, height: 36)
-                .background(isSelected ? Theme.shared.background(.bgHero) : .clear, in: Circle())
-                .overlay { if isToday && !isSelected { Circle().stroke(Theme.shared.border(.borderHero), lineWidth: 1) } }
+                .background(isSelected ? theme.background(.bgHero) : .clear, in: Circle())
+                .overlay { if isToday && !isSelected { Circle().stroke(theme.border(.borderHero), lineWidth: 1) } }
         }
         .buttonStyle(.plain)
     }

--- a/Sources/ThemeKit/Components/Molecules/Checkbox.swift
+++ b/Sources/ThemeKit/Components/Molecules/Checkbox.swift
@@ -32,6 +32,8 @@ public enum CheckboxType: Equatable {
 /// Figma "Control Items" → Checkboxes. Sizes Small (20) / Medium (24);
 /// states checked / disabled / indeterminate. Colors from theme tokens.
 public struct Checkbox: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var isChecked: Bool
     private let label: String?
     private let size: ControlSize
@@ -85,7 +87,7 @@ public struct Checkbox: View {
                     if let label {
                         Text(label)
                             .textStyle(.bodyBase400)
-                            .foregroundStyle(isEnabled ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textDisabled))
+                            .foregroundStyle(isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
                     }
                 }
                 .contentShape(Rectangle())
@@ -125,16 +127,16 @@ public struct Checkbox: View {
             guard selected else { return .clear }
             // `.inner` keeps the outer box transparent; the inset square is the fill.
             if case .inner = type { return .clear }
-            return Theme.shared.background(isEnabled ? .bgHero : .bgSecondary)
+            return theme.background(isEnabled ? .bgHero : .bgSecondary)
         }
     }
 
     private var stroke: Color {
         if case .customInner = type { return .clear }
-        if !isEnabled { return Theme.shared.border(.borderPrimary) }
-        if dominant == .error { return Theme.shared.border(.systemcolorsBorderError) }
-        if dominant == .warning { return Theme.shared.border(.systemcolorsBorderWarning) }
-        return selected ? Theme.shared.border(.borderHero) : Theme.shared.border(.borderPrimary)
+        if !isEnabled { return theme.border(.borderPrimary) }
+        if dominant == .error { return theme.border(.systemcolorsBorderError) }
+        if dominant == .warning { return theme.border(.systemcolorsBorderWarning) }
+        return selected ? theme.border(.borderHero) : theme.border(.borderPrimary)
     }
 
     @ViewBuilder
@@ -142,20 +144,20 @@ public struct Checkbox: View {
         if case .inner = type {
             if selected {
                 RoundedRectangle(cornerRadius: max(radius - 2, 1), style: .continuous)
-                    .fill(Theme.shared.background(isEnabled ? .bgHero : .bgSecondary))
+                    .fill(theme.background(isEnabled ? .bgHero : .bgSecondary))
                     .padding(side * 0.2)
                     .overlay {
                         if isIndeterminate {
                             Image(systemName: "minus")
                                 .font(.system(size: side * 0.34, weight: .bold))
-                                .foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                                .foregroundStyle(theme.foreground(.fgSecondary))
                         }
                     }
             }
         } else if selected {
             Image(systemName: isIndeterminate ? "minus" : "checkmark")
                 .font(.system(size: side * 0.6, weight: .bold))
-                .foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                .foregroundStyle(theme.foreground(.fgSecondary))
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/CheckboxGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/CheckboxGroup.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Molecule. A labelled, multi-select group composed from the Checkbox atom.
 /// Selection state is owned by the caller (single Set binding — no per-row state).
 public struct CheckboxGroup<Option: Hashable>: View {
+    @Environment(\.theme) private var theme
+
     private let title: String?
     private let options: [Option]
     @Binding private var selection: Set<Option>
@@ -43,9 +45,9 @@ public struct CheckboxGroup<Option: Hashable>: View {
 
     private var titleColor: Color {
         switch infoMessages.dominantKind {
-        case .error: return Theme.shared.foreground(.systemcolorsFgError)
-        case .warning: return Theme.shared.foreground(.systemcolorsFgWarning)
-        default: return Theme.shared.text(.textPrimary)
+        case .error: return theme.foreground(.systemcolorsFgError)
+        case .warning: return theme.foreground(.systemcolorsFgWarning)
+        default: return theme.text(.textPrimary)
         }
     }
 
@@ -73,7 +75,7 @@ public struct CheckboxGroup<Option: Hashable>: View {
                         Checkbox(isChecked: .constant(allSelected), isIndeterminate: someSelected)
                         Text(selectAllTitle)
                             .textStyle(.labelBase600)
-                            .foregroundStyle(Theme.shared.text(.textPrimary))
+                            .foregroundStyle(theme.text(.textPrimary))
                         Spacer()
                     }
                     .contentShape(Rectangle())
@@ -95,7 +97,7 @@ public struct CheckboxGroup<Option: Hashable>: View {
                         Checkbox(isChecked: .constant(isOn))
                         Text(label(option))
                             .textStyle(.bodyBase400)
-                            .foregroundStyle(Theme.shared.text(.textPrimary))
+                            .foregroundStyle(theme.text(.textPrimary))
                         Spacer()
                     }
                     .contentShape(Rectangle())

--- a/Sources/ThemeKit/Components/Molecules/Chips.swift
+++ b/Sources/ThemeKit/Components/Molecules/Chips.swift
@@ -26,6 +26,8 @@ public enum ImageChipSize {
 
 /// A selectable remote-image tile with a selection border. (Reference ImageChip.)
 public struct ImageChip: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var isSelected: Bool
     private let url: URL?
     private let size: ImageChipSize
@@ -44,7 +46,7 @@ public struct ImageChip: View {
             .frame(width: s.width, height: s.height)
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                    .strokeBorder(isSelected ? Theme.shared.border(.borderHero) : Theme.shared.border(.borderPrimary),
+                    .strokeBorder(isSelected ? theme.border(.borderHero) : theme.border(.borderPrimary),
                                   lineWidth: isSelected ? 2 : 1)
             )
             .opacity(isEnabled ? 1 : 0.5)
@@ -58,6 +60,8 @@ public struct ImageChip: View {
 /// A selectable card: an optional rating + label row, then an optional logo +
 /// price row. (Reference CompactChip.)
 public struct CompactChip: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var isSelected: Bool
     private let text: String
     private let price: String
@@ -78,27 +82,27 @@ public struct CompactChip: View {
                 if let rating {
                     HStack(spacing: 2) {
                         Image(systemName: "star.fill").font(.system(size: 11))
-                            .foregroundStyle(Theme.shared.foreground(.systemcolorsFgWarning))
+                            .foregroundStyle(theme.foreground(.systemcolorsFgWarning))
                         Text(String(format: "%.1f", rating)).textStyle(.labelSm700)
-                            .foregroundStyle(Theme.shared.text(.textPrimary))
+                            .foregroundStyle(theme.text(.textPrimary))
                     }
                 }
                 Text(text).textStyle(.labelBase600).lineLimit(1)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
             }
             HStack(spacing: Theme.SpacingKey.xs.value) {
                 if let imageURL {
                     RemoteImage(imageURL, contentMode: .fit).frame(height: 16)
                 }
-                Text(price).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
+                Text(price).textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
             }
         }
         .padding(Theme.SpacingKey.md.value)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                .strokeBorder(isSelected ? Theme.shared.border(.borderHero) : Theme.shared.border(.borderPrimary),
+                .strokeBorder(isSelected ? theme.border(.borderHero) : theme.border(.borderPrimary),
                               lineWidth: isSelected ? 2 : 1)
         )
         .contentShape(Rectangle())
@@ -111,6 +115,8 @@ public struct CompactChip: View {
 /// A selectable card: a leading icon, a title with an optional "free" gradient
 /// badge, and a rating + description row. (Reference ChoseChip.)
 public struct ChoseChip: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var isSelected: Bool
     private let title: String
     private let description: String?
@@ -140,36 +146,36 @@ public struct ChoseChip: View {
     public var body: some View {
         HStack(spacing: Theme.SpacingKey.md.value) {
             if let systemImage {
-                Icon(systemName: systemImage, size: .md, color: Theme.shared.foreground(.fgHero))
+                Icon(systemName: systemImage, size: .md, color: theme.foreground(.fgHero))
             }
             VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
                 HStack(spacing: Theme.SpacingKey.xs.value) {
                     Text(title).textStyle(.labelMd600).lineLimit(1)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                     if showFree { freeBadge }
                 }
                 HStack(spacing: Theme.SpacingKey.xs.value) {
                     if let rating {
                         HStack(spacing: 2) {
                             Image(systemName: "star.fill").font(.system(size: 11))
-                                .foregroundStyle(Theme.shared.foreground(.systemcolorsFgWarning))
+                                .foregroundStyle(theme.foreground(.systemcolorsFgWarning))
                             Text(String(format: "%.1f", rating)).textStyle(.labelSm700)
-                                .foregroundStyle(Theme.shared.text(.textPrimary))
+                                .foregroundStyle(theme.text(.textPrimary))
                         }
                     }
                     if let description {
                         Text(description).textStyle(.bodySm400).lineLimit(1)
-                            .foregroundStyle(Theme.shared.text(.textSecondary))
+                            .foregroundStyle(theme.text(.textSecondary))
                     }
                 }
             }
             Spacer(minLength: 0)
         }
         .padding(Theme.SpacingKey.base.value)
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                .strokeBorder(isSelected ? Theme.shared.border(.borderHero) : Theme.shared.border(.borderPrimary),
+                .strokeBorder(isSelected ? theme.border(.borderHero) : theme.border(.borderPrimary),
                               lineWidth: isSelected ? 2 : 1)
         )
         .contentShape(Rectangle())
@@ -179,7 +185,7 @@ public struct ChoseChip: View {
     private var freeBadge: some View {
         Text(freeLabel)
             .textStyle(.overline400)
-            .foregroundStyle(Theme.shared.foreground(.fgSecondary))
+            .foregroundStyle(theme.foreground(.fgSecondary))
             .padding(.vertical, 2).padding(.horizontal, Theme.SpacingKey.xs.value)
             .background(
                 LinearGradient(colors: [SemanticColor.primary.base, SemanticColor.purple.base],
@@ -196,6 +202,8 @@ public enum FilterChipShape { case pill, square }
 /// A dismissible filter chip in a pill (with a soft shadow) or square shape.
 /// (Reference FilterChip.)
 public struct FilterChip: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     private let shape: FilterChipShape
     private let showsClose: Bool
@@ -224,19 +232,19 @@ public struct FilterChip: View {
 
     private var chipBody: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
-            Text(title).textStyle(.labelSm600).foregroundStyle(Theme.shared.text(.textPrimary))
+            Text(title).textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary))
             if showsClose {
                 Button { onDismiss?() } label: {
                     Image(systemName: "xmark").font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                        .foregroundStyle(theme.text(.textTertiary))
                 }
                 .buttonStyle(.plain)
             }
         }
         .padding(.vertical, Theme.SpacingKey.sm.value)
         .padding(.horizontal, Theme.SpacingKey.md.value)
-        .background(Theme.shared.background(.bgWhite), in: clipShape)
-        .overlay(clipShape.stroke(Theme.shared.border(.borderPrimary), lineWidth: 1))
+        .background(theme.background(.bgWhite), in: clipShape)
+        .overlay(clipShape.stroke(theme.border(.borderPrimary), lineWidth: 1))
     }
 }
 
@@ -244,6 +252,8 @@ public struct FilterChip: View {
 
 /// A horizontally-scrolling, multi-select chip group backed by a `Set` binding.
 public struct ChipGroup<Option: Hashable>: View {
+    @Environment(\.theme) private var theme
+
     private let title: String?
     private let options: [Option]
     @Binding private var selection: Set<Option>
@@ -267,7 +277,7 @@ public struct ChipGroup<Option: Hashable>: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             if let title {
-                Text(title).textStyle(.labelMd600).foregroundStyle(Theme.shared.text(.textPrimary))
+                Text(title).textStyle(.labelMd600).foregroundStyle(theme.text(.textPrimary))
             }
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: Theme.SpacingKey.sm.value) {

--- a/Sources/ThemeKit/Components/Molecules/DateField.swift
+++ b/Sources/ThemeKit/Components/Molecules/DateField.swift
@@ -28,6 +28,8 @@ public enum DateFieldComponents {
 /// icon. The displayed value is formatter-driven: pick a `DateFieldStyle` (or a
 /// custom pattern), a `locale`, and which `components` (date / time) to show.
 public struct DateField: View {
+    @Environment(\.theme) private var theme
+
     private let label: String?
     @Binding private var date: Date?
     private let placeholder: String
@@ -130,7 +132,7 @@ public struct DateField: View {
     private var trailing: some View {
         if showsClear {
             Button { date = nil } label: {
-                Icon(systemName: "xmark.circle.fill", size: .sm, color: Theme.shared.text(.textTertiary))
+                Icon(systemName: "xmark.circle.fill", size: .sm, color: theme.text(.textTertiary))
             }
             .buttonStyle(.plain)
             .a11y(A11yElement.Field.clear, in: accessibilityID)
@@ -167,7 +169,7 @@ public struct DateField: View {
             content
                 .datePickerStyle(.graphical)
                 .environment(\.locale, locale)
-                .tint(Theme.shared.foreground(.fgHero))
+                .tint(theme.foreground(.fgHero))
                 .labelsHidden()
             PrimaryButton("Tamam", isContentWidth: true) { showPicker = false }
         }
@@ -179,23 +181,23 @@ public struct DateField: View {
     // MARK: - Colors
 
     private var iconColor: Color {
-        isEnabled ? Theme.shared.text(.textTertiary) : Theme.shared.text(.textDisabled)
+        isEnabled ? theme.text(.textTertiary) : theme.text(.textDisabled)
     }
 
     private var textColor: Color {
-        if !isEnabled { return Theme.shared.text(.textDisabled) }
-        return date == nil ? Theme.shared.text(.textTertiary) : Theme.shared.text(.textPrimary)
+        if !isEnabled { return theme.text(.textDisabled) }
+        return date == nil ? theme.text(.textTertiary) : theme.text(.textPrimary)
     }
 
     private var backgroundColor: Color {
-        Theme.shared.background(isEnabled ? .bgWhite : .bgSecondaryLight)
+        theme.background(isEnabled ? .bgWhite : .bgSecondaryLight)
     }
 
     private var borderColor: Color {
-        if hasError { return Theme.shared.border(.systemcolorsBorderError) }
-        if hasWarning { return Theme.shared.border(.systemcolorsBorderWarning) }
-        if showPicker { return Theme.shared.border(.borderHero) }
-        return Theme.shared.border(.borderPrimary)
+        if hasError { return theme.border(.systemcolorsBorderError) }
+        if hasWarning { return theme.border(.systemcolorsBorderWarning) }
+        if showPicker { return theme.border(.borderHero) }
+        return theme.border(.borderPrimary)
     }
 
     // MARK: - Formatting

--- a/Sources/ThemeKit/Components/Molecules/Fieldset.swift
+++ b/Sources/ThemeKit/Components/Molecules/Fieldset.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Molecule. A bordered form group with a legend + optional helper text.
 /// (daisyUI "Fieldset".)
 public struct Fieldset<Content: View>: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     private let helper: String?
     private let content: () -> Content
@@ -23,18 +25,18 @@ public struct Fieldset<Content: View>: View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             Text(title)
                 .textStyle(.labelBase700)
-                .foregroundStyle(Theme.shared.text(.textPrimary))
+                .foregroundStyle(theme.text(.textPrimary))
             content()
             if let helper {
                 Text(helper)
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
             }
         }
         .padding(Theme.SpacingKey.md.value)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous).stroke(Theme.shared.border(.borderPrimary), lineWidth: 1))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous).stroke(theme.border(.borderPrimary), lineWidth: 1))
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/FileInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/FileInput.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Molecule. A styled file-picker field: a "Choose file" segment + the selected
 /// filename. (daisyUI "File Input"; complements the list-based Upload.)
 public struct FileInput: View {
+    @Environment(\.theme) private var theme
+
     private let label: String?
     private let fileName: String?
     private let buttonTitle: String
@@ -40,9 +42,9 @@ public struct FileInput: View {
 
     private var fieldBorder: Color {
         switch infoMessages.dominantKind {
-        case .error: return Theme.shared.border(.systemcolorsBorderError)
-        case .warning: return Theme.shared.border(.systemcolorsBorderWarning)
-        default: return Theme.shared.border(.borderPrimary)
+        case .error: return theme.border(.systemcolorsBorderError)
+        case .warning: return theme.border(.systemcolorsBorderWarning)
+        default: return theme.border(.borderPrimary)
         }
     }
 
@@ -56,17 +58,17 @@ public struct FileInput: View {
                         Image(systemName: "paperclip").font(.system(size: 13, weight: .semibold))
                         Text(buttonTitle).textStyle(.labelSm700)
                     }
-                    .foregroundStyle(Theme.shared.text(.textHero))
+                    .foregroundStyle(theme.text(.textHero))
                     .padding(.horizontal, Theme.SpacingKey.md.value)
                     .frame(maxHeight: .infinity)
-                    .background(Theme.shared.background(.bgElevatorTertiary))
+                    .background(theme.background(.bgElevatorTertiary))
                 }
                 .buttonStyle(.plain)
                 .disabled(!isEnabled)
 
                 Text(fileName ?? placeholder)
                     .textStyle(.bodyBase400)
-                    .foregroundStyle(fileName != nil ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textTertiary))
+                    .foregroundStyle(fileName != nil ? theme.text(.textPrimary) : theme.text(.textTertiary))
                     .lineLimit(1)
                     .padding(.horizontal, Theme.SpacingKey.md.value)
 
@@ -74,7 +76,7 @@ public struct FileInput: View {
 
                 if fileName != nil, let onClear {
                     Button(action: onClear) {
-                        Icon(systemName: "xmark.circle.fill", size: .sm, color: Theme.shared.text(.textTertiary))
+                        Icon(systemName: "xmark.circle.fill", size: .sm, color: theme.text(.textTertiary))
                     }
                     .buttonStyle(.plain)
                     .padding(.trailing, Theme.SpacingKey.md.value)
@@ -82,7 +84,7 @@ public struct FileInput: View {
                 }
             }
             .frame(height: 48)
-            .background(Theme.shared.background(.bgWhite))
+            .background(theme.background(.bgWhite))
             .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
             .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).stroke(fieldBorder, lineWidth: infoMessages.dominantKind != nil ? 1.5 : 1))
 

--- a/Sources/ThemeKit/Components/Molecules/FilterGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/FilterGroup.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 /// Molecule. A single-select chip filter with a reset control. (daisyUI "Filter".)
 public struct FilterGroup<Option: Hashable>: View {
+    @Environment(\.theme) private var theme
+
     private let title: String?
     private let options: [Option]
     @Binding private var selection: Option?
@@ -23,7 +25,7 @@ public struct FilterGroup<Option: Hashable>: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             if let title {
-                Text(title).textStyle(.labelMd600).foregroundStyle(Theme.shared.text(.textPrimary))
+                Text(title).textStyle(.labelMd600).foregroundStyle(theme.text(.textPrimary))
             }
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
@@ -31,10 +33,10 @@ public struct FilterGroup<Option: Hashable>: View {
                         Button { selection = nil } label: {
                             Image(systemName: "xmark")
                                 .font(.system(size: 12, weight: .semibold))
-                                .foregroundStyle(Theme.shared.text(.textTertiary))
+                                .foregroundStyle(theme.text(.textTertiary))
                                 .frame(width: 32, height: 32)
-                                .background(Theme.shared.background(.bgElevatorPrimary), in: Circle())
-                                .overlay(Circle().strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1))
+                                .background(theme.background(.bgElevatorPrimary), in: Circle())
+                                .overlay(Circle().strokeBorder(theme.border(.borderPrimary), lineWidth: 1))
                         }
                         .buttonStyle(.plain)
                     }

--- a/Sources/ThemeKit/Components/Molecules/InputNumber.swift
+++ b/Sources/ThemeKit/Components/Molecules/InputNumber.swift
@@ -13,6 +13,8 @@ import SwiftUI
 /// directly editable (type a number, clamped to `range` on commit), steppers move
 /// by `step`, and an optional `unit` suffix labels the value (e.g. "kişi", "₺").
 public struct InputNumber: View {
+    @Environment(\.theme) private var theme
+
     private let label: String?
     @Binding private var value: Int
     private let range: ClosedRange<Int>
@@ -69,7 +71,7 @@ public struct InputNumber: View {
                 HStack(spacing: 4) {
                     Text(label).textStyle(.labelSm600).foregroundStyle(labelColor)
                     if hasInfo {
-                        Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(Theme.shared.text(.textTertiary))
+                        Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(theme.text(.textTertiary))
                     }
                 }
             }
@@ -96,7 +98,7 @@ public struct InputNumber: View {
             if let message = errorText ?? hint {
                 Text(message)
                     .textStyle(.bodySm400)
-                    .foregroundStyle(hasError ? Theme.shared.foreground(.systemcolorsFgError) : Theme.shared.text(.textTertiary))
+                    .foregroundStyle(hasError ? theme.foreground(.systemcolorsFgError) : theme.text(.textTertiary))
             }
         }
         .onChange(of: value) { _, newValue in
@@ -134,12 +136,12 @@ public struct InputNumber: View {
             if let unit {
                 Text(unit)
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
             }
         }
         .textStyle(.labelMd600)
         .monospacedDigit()
-        .foregroundStyle(isEnabled ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textDisabled))
+        .foregroundStyle(isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
     }
 
     private func stepper(_ systemName: String, label: String, enabled: Bool, action: @escaping () -> Void) -> some View {
@@ -147,9 +149,9 @@ public struct InputNumber: View {
         return Button(action: action) {
             Image(systemName: systemName)
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(active ? Theme.shared.foreground(.fgSecondary) : Theme.shared.text(.textDisabled))
+                .foregroundStyle(active ? theme.foreground(.fgSecondary) : theme.text(.textDisabled))
                 .frame(width: height - 12, height: height - 12)
-                .background(active ? Theme.shared.background(.bgHero) : Theme.shared.background(.bgSecondaryLight),
+                .background(active ? theme.background(.bgHero) : theme.background(.bgSecondaryLight),
                            in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
         }
         .buttonStyle(.plain)
@@ -170,12 +172,12 @@ public struct InputNumber: View {
     }
 
     private var labelColor: Color {
-        hasError ? Theme.shared.foreground(.systemcolorsFgError) : Theme.shared.text(.textPrimary)
+        hasError ? theme.foreground(.systemcolorsFgError) : theme.text(.textPrimary)
     }
     private var borderColor: Color {
-        if hasError { return Theme.shared.border(.systemcolorsBorderError) }
-        if isFocused { return Theme.shared.border(.borderHero) }
-        return Theme.shared.border(.borderPrimary)
+        if hasError { return theme.border(.systemcolorsBorderError) }
+        if isFocused { return theme.border(.borderHero) }
+        return theme.border(.borderPrimary)
     }
 
     // MARK: - Pure helpers (extracted for testing)

--- a/Sources/ThemeKit/Components/Molecules/MultiLineTextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiLineTextInput.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Improved, token-bound rewrite of the reference MultiLineInput — a bordered
 /// TextEditor with header label, placeholder, character counter and error state.
 public struct MultiLineTextInput: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var text: String
     private let label: String
     private let placeholder: String
@@ -58,8 +60,8 @@ public struct MultiLineTextInput: View {
                 TextEditor(text: editorBinding)
                     .focused($isFocused)
                     .textStyle(.bodyBase400)
-                    .foregroundStyle(isEnabled ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textDisabled))
-                    .tint(Theme.shared.foreground(.fgHero))
+                    .foregroundStyle(isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
+                    .tint(theme.foreground(.fgHero))
                     .scrollContentBackground(.hidden)
                     .padding(8)
                     .disabled(!isEnabled)
@@ -70,14 +72,14 @@ public struct MultiLineTextInput: View {
                 if text.isEmpty {
                     Text(placeholder)
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                        .foregroundStyle(theme.text(.textTertiary))
                         .padding(.horizontal, 13)
                         .padding(.vertical, 16)
                         .allowsHitTesting(false)
                 }
             }
             .frame(minHeight: minHeight)
-            .background(Theme.shared.background(isEnabled ? .bgWhite : .bgSecondaryLight),
+            .background(theme.background(isEnabled ? .bgWhite : .bgSecondaryLight),
                        in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
@@ -91,7 +93,7 @@ public struct MultiLineTextInput: View {
                 if let characterLimit {
                     Text("\(text.count)/\(characterLimit)")
                         .textStyle(.bodySm400)
-                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                        .foregroundStyle(theme.text(.textTertiary))
                 }
             }
         }
@@ -111,17 +113,17 @@ public struct MultiLineTextInput: View {
     }
 
     private var labelColor: Color {
-        if hasError { return Theme.shared.foreground(.systemcolorsFgError) }
-        if hasWarning { return Theme.shared.foreground(.systemcolorsFgWarning) }
-        if isFocused { return Theme.shared.text(.textHero) }
-        return Theme.shared.text(.textTertiary)
+        if hasError { return theme.foreground(.systemcolorsFgError) }
+        if hasWarning { return theme.foreground(.systemcolorsFgWarning) }
+        if isFocused { return theme.text(.textHero) }
+        return theme.text(.textTertiary)
     }
 
     private var borderColor: Color {
-        if hasError { return Theme.shared.border(.systemcolorsBorderError) }
-        if hasWarning { return Theme.shared.border(.systemcolorsBorderWarning) }
-        if isFocused { return Theme.shared.border(.borderHero) }
-        return Theme.shared.border(.borderPrimary)
+        if hasError { return theme.border(.systemcolorsBorderError) }
+        if hasWarning { return theme.border(.systemcolorsBorderWarning) }
+        if isFocused { return theme.border(.borderHero) }
+        return theme.border(.borderPrimary)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
@@ -11,6 +11,8 @@ import SwiftUI
 /// panel with a search field and checkable rows. The single-value `Select`
 /// remains for the simple case.
 public struct MultiSelect<Option: Hashable>: View {
+    @Environment(\.theme) private var theme
+
     private let label: String?
     private let options: [Option]
     @Binding private var selection: Set<Option>
@@ -59,11 +61,11 @@ public struct MultiSelect<Option: Hashable>: View {
     }
 
     private var fieldBorder: Color {
-        if open { return Theme.shared.border(.borderHero) }
+        if open { return theme.border(.borderHero) }
         switch infoMessages.dominantKind {
-        case .error: return Theme.shared.border(.systemcolorsBorderError)
-        case .warning: return Theme.shared.border(.systemcolorsBorderWarning)
-        default: return Theme.shared.border(.borderPrimary)
+        case .error: return theme.border(.systemcolorsBorderError)
+        case .warning: return theme.border(.systemcolorsBorderWarning)
+        default: return theme.border(.borderPrimary)
         }
     }
 
@@ -103,7 +105,7 @@ public struct MultiSelect<Option: Hashable>: View {
                 if selection.isEmpty {
                     Text(placeholder)
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                        .foregroundStyle(theme.text(.textTertiary))
                 } else {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: Theme.SpacingKey.xs.value) {
@@ -119,20 +121,20 @@ public struct MultiSelect<Option: Hashable>: View {
                 Spacer(minLength: 0)
                 if allowClear && !selection.isEmpty && isEnabled && !isLoading {
                     Button { selection.removeAll() } label: {
-                        Icon(systemName: "xmark.circle.fill", size: .sm, color: Theme.shared.text(.textTertiary))
+                        Icon(systemName: "xmark.circle.fill", size: .sm, color: theme.text(.textTertiary))
                     }
                     .buttonStyle(.plain)
                 }
                 if isLoading {
                     Spinner(size: IconSize.sm.value, lineWidth: 2)
                 } else {
-                    Icon(systemName: open ? "chevron.up" : "chevron.down", size: .sm, color: Theme.shared.text(.textTertiary))
+                    Icon(systemName: open ? "chevron.up" : "chevron.down", size: .sm, color: theme.text(.textTertiary))
                 }
             }
             .padding(.horizontal, Theme.SpacingKey.md.value)
             .frame(minHeight: 56)
             .frame(maxWidth: .infinity)
-            .background(Theme.shared.background(isEnabled ? .bgWhite : .bgSecondaryLight),
+            .background(theme.background(isEnabled ? .bgWhite : .bgSecondaryLight),
                        in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
@@ -150,10 +152,10 @@ public struct MultiSelect<Option: Hashable>: View {
         VStack(spacing: 0) {
             if searchable {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
-                    Icon(systemName: "magnifyingglass", size: .sm, color: Theme.shared.text(.textTertiary))
+                    Icon(systemName: "magnifyingglass", size: .sm, color: theme.text(.textTertiary))
                     TextField("Ara", text: $query)
                         .textStyle(.bodyBase400)
-                        .tint(Theme.shared.foreground(.fgHero))
+                        .tint(theme.foreground(.fgHero))
                 }
                 .padding(.horizontal, Theme.SpacingKey.md.value)
                 .scaledControlHeight(44)
@@ -162,14 +164,14 @@ public struct MultiSelect<Option: Hashable>: View {
             if isLoading {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
                     Spinner(size: IconSize.sm.value, lineWidth: 2)
-                    Text(String(themeKit: "Searching…")).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary))
+                    Text(String(themeKit: "Searching…")).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
                     Spacer()
                 }
                 .padding(Theme.SpacingKey.md.value)
             } else if filtered.isEmpty {
                 Text(String(themeKit: "No results"))
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
                     .padding(Theme.SpacingKey.md.value)
             } else {
                 ForEach(filtered, id: \.self) { opt in
@@ -180,7 +182,7 @@ public struct MultiSelect<Option: Hashable>: View {
                                 .allowsHitTesting(false)
                             Text(optionTitle(opt))
                                 .textStyle(.bodyBase400)
-                                .foregroundStyle(Theme.shared.text(.textPrimary))
+                                .foregroundStyle(theme.text(.textPrimary))
                             Spacer()
                         }
                         .padding(.horizontal, Theme.SpacingKey.md.value)
@@ -194,10 +196,10 @@ public struct MultiSelect<Option: Hashable>: View {
                 }
             }
         }
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                .strokeBorder(theme.border(.borderPrimary), lineWidth: 1)
         )
         .themeShadow(.soft)
     }

--- a/Sources/ThemeKit/Components/Molecules/OTPInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/OTPInput.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Improved, token-bound rewrite of the reference OTPInputView. A row of digit
 /// boxes backed by a single hidden field, with focus caret + error state.
 public struct OTPInput: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var code: String
     private let digitCount: Int
     private let messages: [InfoMessage]
@@ -125,7 +127,7 @@ public struct OTPInput: View {
             if secondsLeft > 0 {
                 Text(String(themeKit: "Resend code in \(secondsLeft)s"))
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
             } else {
                 Button {
                     onResend()
@@ -133,7 +135,7 @@ public struct OTPInput: View {
                 } label: {
                     Text(String(themeKit: "Resend code"))
                         .textStyle(.labelSm700)
-                        .foregroundStyle(Theme.shared.text(.textHero))
+                        .foregroundStyle(theme.text(.textHero))
                 }
                 .buttonStyle(.plain)
                 .disabled(!isEnabled)

--- a/Sources/ThemeKit/Components/Molecules/Pagination.swift
+++ b/Sources/ThemeKit/Components/Molecules/Pagination.swift
@@ -13,6 +13,8 @@ import SwiftUI
 /// `siblingCount` pages on each side of the current page; gaps collapse to an
 /// ellipsis. An optional quick-jumper field jumps straight to a page.
 public struct Pagination: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var current: Int   // 1-based
     private let total: Int
     private let simple: Bool
@@ -52,7 +54,7 @@ public struct Pagination: View {
             if let showTotal {
                 Text(showTotal(current, total))
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
                     .padding(.trailing, Theme.SpacingKey.xs.value)
             }
 
@@ -61,12 +63,12 @@ public struct Pagination: View {
             if simple {
                 Text("\(current) / \(total)")
                     .textStyle(.labelBase600)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
                     .frame(minWidth: 48)
             } else {
                 ForEach(Array(pages.enumerated()), id: \.offset) { _, page in
                     if page == -1 {
-                        Text("…").textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textTertiary)).frame(width: 36, height: 36)
+                        Text("…").textStyle(.labelBase600).foregroundStyle(theme.text(.textTertiary)).frame(width: 36, height: 36)
                     } else {
                         pageButton(page)
                     }
@@ -88,17 +90,17 @@ public struct Pagination: View {
 
     private var jumper: some View {
         HStack(spacing: Theme.SpacingKey.xs.value) {
-            Text(jumperTitle).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary))
+            Text(jumperTitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
             TextField("", text: $jumpText)
                 .multilineTextAlignment(.center)
                 .textStyle(.labelBase600)
-                .foregroundStyle(Theme.shared.text(.textPrimary))
+                .foregroundStyle(theme.text(.textPrimary))
                 .frame(width: 44, height: 36)
-                .background(Theme.shared.background(.bgWhite),
+                .background(theme.background(.bgWhite),
                            in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                        .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                        .strokeBorder(theme.border(.borderPrimary), lineWidth: 1)
                 )
                 .jumperKeyboard()
                 .submitLabel(.go)
@@ -120,13 +122,13 @@ public struct Pagination: View {
         return Button { if isEnabled { current = page } } label: {
             Text("\(page)")
                 .textStyle(.labelBase600)
-                .foregroundStyle(isCurrent ? Theme.shared.foreground(.fgSecondary) : Theme.shared.text(.textPrimary))
+                .foregroundStyle(isCurrent ? theme.foreground(.fgSecondary) : theme.text(.textPrimary))
                 .frame(width: 36, height: 36)
-                .background(isCurrent ? Theme.shared.background(.bgHero) : .clear,
+                .background(isCurrent ? theme.background(.bgHero) : .clear,
                            in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                        .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: isCurrent ? 0 : 1)
+                        .strokeBorder(theme.border(.borderPrimary), lineWidth: isCurrent ? 0 : 1)
                 )
         }
         .buttonStyle(.plain)
@@ -137,7 +139,7 @@ public struct Pagination: View {
     private func arrow(systemName: String, enabled: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Icon(systemName: systemName, size: .sm,
-                 color: enabled ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textDisabled))
+                 color: enabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
                 .frame(width: 36, height: 36)
                 .mirrorsInRTL()
         }

--- a/Sources/ThemeKit/Components/Molecules/ProgressIndicator.swift
+++ b/Sources/ThemeKit/Components/Molecules/ProgressIndicator.swift
@@ -29,6 +29,8 @@ public enum ProgressStepText { case none, slash, padded }
 /// continuous bar. Optional "3 / 10" or "01 | 05" step text. Distinct from the
 /// dot-style `StepIndicator` and the value-driven `ProgressBar`.
 public struct ProgressIndicator: View {
+    @Environment(\.theme) private var theme
+
     private let variant: ProgressIndicatorVariant
     private let current: Int   // 1-based active step
     private let total: Int
@@ -60,7 +62,7 @@ public struct ProgressIndicator: View {
             if stepText != .none {
                 Text(stepLabel)
                     .textStyle(.labelSm700)
-                    .foregroundStyle(Theme.shared.text(.textSecondary))
+                    .foregroundStyle(theme.text(.textSecondary))
                     .monospacedDigit()
                     .frame(maxWidth: .infinity, alignment: .trailing)
             }
@@ -91,8 +93,8 @@ public struct ProgressIndicator: View {
     private func segment(fill: Double) -> some View {
         GeometryReader { geo in
             ZStack(alignment: .leading) {
-                shape.fill(Theme.shared.border(.borderPrimary))
-                shape.fill(Theme.shared.background(.bgHero))
+                shape.fill(theme.border(.borderPrimary))
+                shape.fill(theme.background(.bgHero))
                     .frame(width: geo.size.width * fill)
             }
         }

--- a/Sources/ThemeKit/Components/Molecules/QuantityStepper.swift
+++ b/Sources/ThemeKit/Components/Molecules/QuantityStepper.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 /// A token-bound quantity stepper (− value +), bounded by a range.
 public struct QuantityStepper: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var value: Int
     private let range: ClosedRange<Int>
     private let step: Int
@@ -36,7 +38,7 @@ public struct QuantityStepper: View {
 
             Text("\(value)")
                 .textStyle(.labelMd600)
-                .foregroundStyle(Theme.shared.text(.textPrimary))
+                .foregroundStyle(theme.text(.textPrimary))
                 .frame(minWidth: 24)
                 .monospacedDigit()
 
@@ -47,7 +49,7 @@ public struct QuantityStepper: View {
         .padding(.horizontal, Theme.SpacingKey.sm.value)
         .padding(.vertical, Theme.SpacingKey.xs.value)
         .overlay(
-            Capsule().strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1)
+            Capsule().strokeBorder(theme.border(.borderPrimary), lineWidth: 1)
         )
         .a11y(A11yElement.Control.stepper, in: accessibilityID)
         .accessibilityValue("\(value)")
@@ -56,7 +58,7 @@ public struct QuantityStepper: View {
     private func stepButton(systemName: String, enabled: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Icon(systemName: systemName, size: .sm,
-                 color: enabled && isEnabled ? Theme.shared.text(.textHero) : Theme.shared.text(.textDisabled))
+                 color: enabled && isEnabled ? theme.text(.textHero) : theme.text(.textDisabled))
                 .frame(width: 32, height: 32)
         }
         .buttonStyle(.plain)

--- a/Sources/ThemeKit/Components/Molecules/RadioButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioButton.swift
@@ -37,6 +37,8 @@ public enum RadioButtonPadding {
 /// Figma "Control Items" → Radioboxes. Sizes Small (20) / Medium (24);
 /// states selected / disabled. Colors from theme tokens.
 public struct RadioButton: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var isSelected: Bool
     private let label: String?
     private let size: ControlSize
@@ -81,7 +83,7 @@ public struct RadioButton: View {
 
     private var dominant: InfoMessage.Kind? { infoMessages.dominantKind }
     private var filled: Bool { isSelected && type == .check && style == .plain }
-    private var fillColor: Color { backgroundColor ?? Theme.shared.background(isEnabled ? .bgHero : .bgSecondary) }
+    private var fillColor: Color { backgroundColor ?? theme.background(isEnabled ? .bgHero : .bgSecondary) }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
@@ -98,7 +100,7 @@ public struct RadioButton: View {
                     if let label {
                         Text(label)
                             .textStyle(.bodyBase400)
-                            .foregroundStyle(isEnabled ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textDisabled))
+                            .foregroundStyle(isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
                     }
                 }
                 .contentShape(Rectangle())
@@ -117,10 +119,10 @@ public struct RadioButton: View {
     }
 
     private var stroke: Color {
-        if !isEnabled { return Theme.shared.border(.borderPrimary) }
-        if dominant == .error { return Theme.shared.border(.systemcolorsBorderError) }
-        if dominant == .warning { return Theme.shared.border(.systemcolorsBorderWarning) }
-        return (isSelected) ? Theme.shared.border(.borderHero) : Theme.shared.border(.borderPrimary)
+        if !isEnabled { return theme.border(.borderPrimary) }
+        if dominant == .error { return theme.border(.systemcolorsBorderError) }
+        if dominant == .warning { return theme.border(.systemcolorsBorderWarning) }
+        return (isSelected) ? theme.border(.borderHero) : theme.border(.borderPrimary)
     }
 
     @ViewBuilder
@@ -132,10 +134,10 @@ public struct RadioButton: View {
             case (.check, .plain):
                 Image(systemName: "checkmark")
                     .font(.system(size: size.side * 0.55, weight: .bold))
-                    .foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                    .foregroundStyle(theme.foreground(.fgSecondary))
             case (.check, .inner):
                 ZStack {
-                    Circle().fill(Theme.shared.background(.bgWhite))
+                    Circle().fill(theme.background(.bgWhite))
                     Circle().fill(fillColor).padding(size.side * 0.18)
                 }
                 .frame(width: size.side * 0.74, height: size.side * 0.74)

--- a/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Molecule. A labelled, single-select group composed from the RadioButton atom.
 /// Selection state is owned by the caller (single optional binding).
 public struct RadioGroup<Option: Hashable>: View {
+    @Environment(\.theme) private var theme
+
     private let title: String?
     private let options: [Option]
     @Binding private var selection: Option?
@@ -42,9 +44,9 @@ public struct RadioGroup<Option: Hashable>: View {
 
     private var titleColor: Color {
         switch infoMessages.dominantKind {
-        case .error: return Theme.shared.foreground(.systemcolorsFgError)
-        case .warning: return Theme.shared.foreground(.systemcolorsFgWarning)
-        default: return Theme.shared.text(.textPrimary)
+        case .error: return theme.foreground(.systemcolorsFgError)
+        case .warning: return theme.foreground(.systemcolorsFgWarning)
+        default: return theme.text(.textPrimary)
         }
     }
 
@@ -62,7 +64,7 @@ public struct RadioGroup<Option: Hashable>: View {
                         RadioButton(isSelected: .constant(selection == option))
                         Text(label(option))
                             .textStyle(.bodyBase400)
-                            .foregroundStyle(Theme.shared.text(.textPrimary))
+                            .foregroundStyle(theme.text(.textPrimary))
                         Spacer()
                     }
                     .contentShape(Rectangle())
@@ -87,6 +89,8 @@ public enum RadioGroupButtonStyle { case solid, outline }
 /// A connected, segmented button-style single-select radio group — a distinct
 /// API from the stacked `RadioGroup` and the enclosed `SegmentedControl`.
 public struct RadioButtonGroup<Option: Hashable>: View {
+    @Environment(\.theme) private var theme
+
     private let options: [Option]
     @Binding private var selection: Option?
     private let style: RadioGroupButtonStyle
@@ -134,7 +138,7 @@ public struct RadioButtonGroup<Option: Hashable>: View {
                         .background(background(isSelected))
                         .overlay(alignment: .leading) {
                             if index > 0 {
-                                Rectangle().fill(Theme.shared.border(.borderPrimary)).frame(width: 1)
+                                Rectangle().fill(theme.border(.borderPrimary)).frame(width: 1)
                             }
                         }
                         .contentShape(Rectangle())
@@ -150,23 +154,23 @@ public struct RadioButtonGroup<Option: Hashable>: View {
         .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: radius, style: .continuous)
-                .stroke(Theme.shared.border(style == .outline ? .borderHero : .borderPrimary), lineWidth: 1)
+                .stroke(theme.border(style == .outline ? .borderHero : .borderPrimary), lineWidth: 1)
         )
     }
 
     private func foreground(_ isSelected: Bool) -> Color {
-        guard isSelected else { return Theme.shared.text(.textSecondary) }
+        guard isSelected else { return theme.text(.textSecondary) }
         switch style {
-        case .solid: return Theme.shared.foreground(.fgSecondary)
-        case .outline: return Theme.shared.text(.textHero)
+        case .solid: return theme.foreground(.fgSecondary)
+        case .outline: return theme.text(.textHero)
         }
     }
 
     private func background(_ isSelected: Bool) -> Color {
-        guard isSelected else { return Theme.shared.background(.bgWhite) }
+        guard isSelected else { return theme.background(.bgWhite) }
         switch style {
-        case .solid: return Theme.shared.background(.bgHero)
-        case .outline: return Theme.shared.background(.bgHero).opacity(0.1)
+        case .solid: return theme.background(.bgHero)
+        case .outline: return theme.background(.bgHero).opacity(0.1)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
+++ b/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
@@ -13,6 +13,8 @@ import SwiftUI
 /// (labeled ticks), a disabled state, an `onChangeEnd` commit callback (fire the
 /// search on release, not on every drag tick), and VoiceOver-adjustable thumbs.
 public struct RangeSlider: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var lowerValue: Double
     @Binding private var upperValue: Double
     private let bounds: ClosedRange<Double>
@@ -71,7 +73,7 @@ public struct RangeSlider: View {
                     Text(valueLabel(upperValue))
                 }
                 .textStyle(.labelBase600)
-                .foregroundStyle(Theme.shared.text(.textPrimary))
+                .foregroundStyle(theme.text(.textPrimary))
             }
 
             GeometryReader { geo in
@@ -82,10 +84,10 @@ public struct RangeSlider: View {
 
                 ZStack(alignment: .leading) {
                     Capsule()
-                        .fill(Theme.shared.border(.borderPrimary))
+                        .fill(theme.border(.borderPrimary))
                         .frame(height: trackHeight)
                     Capsule()
-                        .fill(Theme.shared.background(isEnabled ? .bgHero : .bgSecondaryLight))
+                        .fill(theme.background(isEnabled ? .bgHero : .bgSecondaryLight))
                         .frame(width: max(upperX - lowerX, 0), height: trackHeight)
                         .offset(x: lowerX + thumbSize / 2)
 
@@ -132,10 +134,10 @@ public struct RangeSlider: View {
                 let ratio = span > 0 ? (mark - bounds.lowerBound) / span : 0
                 let centerX = thumbSize / 2 + CGFloat(ratio) * usable
                 VStack(spacing: 2) {
-                    Capsule().fill(Theme.shared.border(.borderPrimary)).frame(width: 1, height: 5)
+                    Capsule().fill(theme.border(.borderPrimary)).frame(width: 1, height: 5)
                     Text(markLabel(mark))
                         .textStyle(.labelSm600)
-                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                        .foregroundStyle(theme.text(.textTertiary))
                         .fixedSize()
                 }
                 .position(x: centerX, y: 11)
@@ -149,7 +151,7 @@ public struct RangeSlider: View {
         HStack(spacing: Theme.SpacingKey.md.value) {
             field(title: inputTitles.min, text: $lowerText, field: .lower)
             Rectangle()
-                .fill(Theme.shared.border(.borderPrimary))
+                .fill(theme.border(.borderPrimary))
                 .frame(width: 10, height: 1)
                 .padding(.top, Theme.SpacingKey.base.value)
             field(title: inputTitles.max, text: $upperText, field: .upper)
@@ -160,7 +162,7 @@ public struct RangeSlider: View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
             Text(title)
                 .textStyle(.labelSm600)
-                .foregroundStyle(Theme.shared.text(.textSecondary))
+                .foregroundStyle(theme.text(.textSecondary))
             Group {
                 #if os(iOS)
                 TextField("", text: text).keyboardType(.numberPad)
@@ -169,17 +171,17 @@ public struct RangeSlider: View {
                 #endif
             }
                 .textStyle(.bodyBase400)
-                .foregroundStyle(Theme.shared.text(.textPrimary))
+                .foregroundStyle(theme.text(.textPrimary))
                 .focused($focusedField, equals: field)
                 .disabled(!isEnabled)
                 .padding(.horizontal, Theme.SpacingKey.md.value)
                 .frame(height: 44)
-                .background(Theme.shared.background(.bgWhite),
+                .background(theme.background(.bgWhite),
                            in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous)
-                        .strokeBorder(focusedField == field ? Theme.shared.border(.borderHero)
-                                                             : Theme.shared.border(.borderPrimary), lineWidth: 1)
+                        .strokeBorder(focusedField == field ? theme.border(.borderHero)
+                                                             : theme.border(.borderPrimary), lineWidth: 1)
                 )
         }
         .frame(maxWidth: .infinity)
@@ -205,10 +207,10 @@ public struct RangeSlider: View {
 
     private func thumb(value: Double, title: String, isLower: Bool) -> some View {
         Circle()
-            .fill(Theme.shared.background(.bgWhite))
+            .fill(theme.background(.bgWhite))
             .overlay(
-                Circle().strokeBorder(isEnabled ? Theme.shared.border(.borderHero)
-                                                : Theme.shared.border(.borderPrimary), lineWidth: 2)
+                Circle().strokeBorder(isEnabled ? theme.border(.borderHero)
+                                                : theme.border(.borderPrimary), lineWidth: 2)
             )
             .frame(width: thumbSize, height: thumbSize)
             .themeShadow(.soft)

--- a/Sources/ThemeKit/Components/Molecules/SearchBar.swift
+++ b/Sources/ThemeKit/Components/Molecules/SearchBar.swift
@@ -23,6 +23,8 @@ import SwiftUI
 /// SearchBar(text: $query, suggestions: cities, recent: recents, onSubmit: search)
 /// ```
 public struct SearchBar: View {
+    @Environment(\.theme) private var theme
+
 
     /// Where typeahead suggestions come from. `.none` keeps the classic bar
     /// (no dropdown) for callers that don't opt in.
@@ -138,19 +140,19 @@ public struct SearchBar: View {
             HStack(spacing: Theme.SpacingKey.sm.value) {
                 if showBackButton {
                     Button { onBack?() } label: {
-                        Icon(systemName: "chevron.left", size: .md, color: Theme.shared.text(.textPrimary))
+                        Icon(systemName: "chevron.left", size: .md, color: theme.text(.textPrimary))
                             .mirrorsInRTL()
                     }
                     .buttonStyle(.plain)
                 }
 
                 HStack(spacing: Theme.SpacingKey.sm.value) {
-                    Icon(systemName: "magnifyingglass", size: .sm, color: Theme.shared.text(.textTertiary))
+                    Icon(systemName: "magnifyingglass", size: .sm, color: theme.text(.textTertiary))
 
                     TextField(placeholder, text: $text)
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
-                        .tint(Theme.shared.foreground(.fgHero))
+                        .foregroundStyle(theme.text(.textPrimary))
+                        .tint(theme.foreground(.fgHero))
                         .focused($isFocused)
                         .disabled(!isEnabled)
                         .submitLabel(.search)
@@ -162,11 +164,11 @@ public struct SearchBar: View {
                 }
                 .padding(.horizontal, Theme.SpacingKey.md.value)
                 .scaledControlHeight(44)
-                .background(Theme.shared.background(.bgElevatorPrimary),
+                .background(theme.background(.bgElevatorPrimary),
                            in: RoundedRectangle(cornerRadius: Theme.RadiusKey.base.value, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: Theme.RadiusKey.base.value, style: .continuous)
-                        .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                        .strokeBorder(theme.border(.borderPrimary), lineWidth: 1)
                 )
             }
 
@@ -187,12 +189,12 @@ public struct SearchBar: View {
             Spinner(size: IconSize.sm.value, lineWidth: 2)
         } else if !text.isEmpty {
             Button { text = "" } label: {
-                Icon(systemName: "xmark.circle.fill", size: .sm, color: Theme.shared.text(.textTertiary))
+                Icon(systemName: "xmark.circle.fill", size: .sm, color: theme.text(.textTertiary))
             }
             .buttonStyle(.plain)
         } else if let trailingSystemImage {
             Button { onTrailing?() } label: {
-                Icon(systemName: trailingSystemImage, size: .sm, color: Theme.shared.text(.textPrimary))
+                Icon(systemName: trailingSystemImage, size: .sm, color: theme.text(.textPrimary))
             }
             .buttonStyle(.plain)
         }
@@ -257,7 +259,7 @@ public struct SearchBar: View {
                         Spinner(size: IconSize.sm.value, lineWidth: 2)
                         Text(String(themeKit: "Searching…"))
                             .textStyle(.bodySm400)
-                            .foregroundStyle(Theme.shared.text(.textTertiary))
+                            .foregroundStyle(theme.text(.textTertiary))
                         Spacer()
                     }
                 }
@@ -267,7 +269,7 @@ public struct SearchBar: View {
                 row {
                     Text(String(themeKit: "No results"))
                         .textStyle(.bodySm400)
-                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                        .foregroundStyle(theme.text(.textTertiary))
                 }
             }
         case .results(let items):
@@ -280,13 +282,13 @@ public struct SearchBar: View {
         HStack {
             Text(title)
                 .textStyle(.labelSm700)
-                .foregroundStyle(Theme.shared.text(.textTertiary))
+                .foregroundStyle(theme.text(.textTertiary))
             Spacer()
             if showsClear {
                 Button { onClearRecent?() } label: {
                     Text(String(themeKit: "Clear"))
                         .textStyle(.labelSm700)
-                        .foregroundStyle(Theme.shared.foreground(.fgHero))
+                        .foregroundStyle(theme.foreground(.fgHero))
                 }
                 .buttonStyle(.plain)
             }
@@ -302,11 +304,11 @@ public struct SearchBar: View {
                 row {
                     HStack(spacing: Theme.SpacingKey.sm.value) {
                         if let leadingSystemImage {
-                            Icon(systemName: leadingSystemImage, size: .sm, color: Theme.shared.text(.textTertiary))
+                            Icon(systemName: leadingSystemImage, size: .sm, color: theme.text(.textTertiary))
                         }
                         Text(item)
                             .textStyle(.bodyBase400)
-                            .foregroundStyle(Theme.shared.text(.textPrimary))
+                            .foregroundStyle(theme.text(.textPrimary))
                         Spacer()
                     }
                 }
@@ -320,11 +322,11 @@ public struct SearchBar: View {
 
     private func card<V: View>(@ViewBuilder _ content: () -> V) -> some View {
         VStack(spacing: 0) { content() }
-            .background(Theme.shared.background(.bgWhite),
+            .background(theme.background(.bgWhite),
                        in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                    .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                    .strokeBorder(theme.border(.borderPrimary), lineWidth: 1)
             )
             .themeShadow(.soft)
     }

--- a/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
+++ b/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
@@ -31,6 +31,8 @@ public enum SegmentedSize {
 /// Molecule. Enclosed single-select control — the selected segment is a raised
 /// white pill. Options can carry an icon and a disabled state. (Ant Segmented.)
 public struct SegmentedControl: View {
+    @Environment(\.theme) private var theme
+
     private let items: [SegmentItem]
     @Binding private var selection: Int
     private let block: Bool
@@ -91,7 +93,7 @@ public struct SegmentedControl: View {
                     .background {
                         if isActive {
                             RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous)
-                                .fill(Theme.shared.background(.bgWhite))
+                                .fill(theme.background(.bgWhite))
                                 .themeShadow(.soft)
                                 .matchedGeometryEffect(id: "pill", in: pill)
                         }
@@ -103,7 +105,7 @@ public struct SegmentedControl: View {
             }
         }
         .padding(4)
-        .background(Theme.shared.background(.bgElevatorPrimary),
+        .background(theme.background(.bgElevatorPrimary),
                    in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
         .opacity(isEnabled ? 1 : 0.5)
         .a11y(A11yElement.Control.toggle, in: accessibilityID)
@@ -111,8 +113,8 @@ public struct SegmentedControl: View {
     }
 
     private func foreground(isActive: Bool, enabled: Bool) -> Color {
-        guard enabled else { return Theme.shared.text(.textDisabled) }
-        return isActive ? Theme.shared.text(.textHero) : Theme.shared.text(.textSecondary)
+        guard enabled else { return theme.text(.textDisabled) }
+        return isActive ? theme.text(.textHero) : theme.text(.textSecondary)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/Select.swift
+++ b/Sources/ThemeKit/Components/Molecules/Select.swift
@@ -17,6 +17,8 @@ import SwiftUI
 /// Select("City", options: cities, selection: $city, searchable: true) { $0.name }
 /// ```
 public struct Select<Option: Hashable>: View {
+    @Environment(\.theme) private var theme
+
     public struct Section {
         public let title: String?
         public let options: [Option]
@@ -130,12 +132,12 @@ public struct Select<Option: Hashable>: View {
             ZStack(alignment: .leading) {
                 Text(label)
                     .textStyle(hasValue ? .labelSm600 : .bodyBase400)
-                    .foregroundStyle(hasValue ? Theme.shared.text(.textHero) : Theme.shared.text(.textTertiary))
+                    .foregroundStyle(hasValue ? theme.text(.textHero) : theme.text(.textTertiary))
                     .offset(y: hasValue ? -11 : 0)
                 if let selection {
                     Text(optionTitle(selection))
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                         .offset(y: 9)
                 }
             }
@@ -144,7 +146,7 @@ public struct Select<Option: Hashable>: View {
                 Spinner(size: IconSize.sm.value, lineWidth: 2)
             } else {
                 Icon(systemName: open ? "chevron.up" : "chevron.down", size: .sm,
-                     color: showsClear ? .clear : Theme.shared.text(.textTertiary))
+                     color: showsClear ? .clear : theme.text(.textTertiary))
             }
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
@@ -167,7 +169,7 @@ public struct Select<Option: Hashable>: View {
     private var clearButton: some View {
         if showsClear {
             Button { selection = nil } label: {
-                Icon(systemName: "xmark.circle.fill", size: .sm, color: Theme.shared.text(.textTertiary))
+                Icon(systemName: "xmark.circle.fill", size: .sm, color: theme.text(.textTertiary))
             }
             .buttonStyle(.plain)
             .padding(.trailing, Theme.SpacingKey.md.value)
@@ -211,7 +213,7 @@ public struct Select<Option: Hashable>: View {
     private func panelMessage(spinner: Bool, _ text: String) -> some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
             if spinner { Spinner(size: IconSize.sm.value, lineWidth: 2) }
-            Text(text).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary))
+            Text(text).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
             Spacer()
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
@@ -221,8 +223,8 @@ public struct Select<Option: Hashable>: View {
     private var panel: some View {
         VStack(spacing: 0) {
             HStack(spacing: Theme.SpacingKey.sm.value) {
-                Icon(systemName: "magnifyingglass", size: .sm, color: Theme.shared.text(.textTertiary))
-                TextField("Ara", text: $query).textStyle(.bodyBase400).tint(Theme.shared.foreground(.fgHero))
+                Icon(systemName: "magnifyingglass", size: .sm, color: theme.text(.textTertiary))
+                TextField("Ara", text: $query).textStyle(.bodyBase400).tint(theme.foreground(.fgHero))
             }
             .padding(.horizontal, Theme.SpacingKey.md.value)
             .scaledControlHeight(44)
@@ -237,7 +239,7 @@ public struct Select<Option: Hashable>: View {
                     let opts = filtered(section.options)
                     if !opts.isEmpty {
                         if let title = section.title {
-                            Text(title).textStyle(.labelSm600).foregroundStyle(Theme.shared.text(.textTertiary))
+                            Text(title).textStyle(.labelSm600).foregroundStyle(theme.text(.textTertiary))
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.horizontal, Theme.SpacingKey.md.value).padding(.vertical, Theme.SpacingKey.xs.value)
                         }
@@ -245,10 +247,10 @@ public struct Select<Option: Hashable>: View {
                             let enabled = optionEnabled(option)
                             Button { selection = option; open = false; query = "" } label: {
                                 HStack {
-                                    Text(optionTitle(option)).textStyle(.bodyBase400).foregroundStyle(Theme.shared.text(.textPrimary))
+                                    Text(optionTitle(option)).textStyle(.bodyBase400).foregroundStyle(theme.text(.textPrimary))
                                     Spacer()
                                     if selection == option {
-                                        Icon(systemName: "checkmark", size: .sm, color: Theme.shared.foreground(.fgHero))
+                                        Icon(systemName: "checkmark", size: .sm, color: theme.foreground(.fgHero))
                                     }
                                 }
                                 .padding(.horizontal, Theme.SpacingKey.md.value).padding(.vertical, Theme.SpacingKey.sm.value)
@@ -262,10 +264,10 @@ public struct Select<Option: Hashable>: View {
                 }
             }
         }
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                .stroke(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                .stroke(theme.border(.borderPrimary), lineWidth: 1)
         )
         .themeShadow(.soft)
     }

--- a/Sources/ThemeKit/Components/Molecules/SelectBox.swift
+++ b/Sources/ThemeKit/Components/Molecules/SelectBox.swift
@@ -10,6 +10,8 @@ import SwiftUI
 /// default / focused / error / disabled states). Covers Figma SelectBox /
 /// Combobox / DropDown field. Single-select via native Menu.
 public struct SelectBox<Option: Hashable>: View {
+    @Environment(\.theme) private var theme
+
     private let label: String?
     private let options: [Option]
     @Binding private var selection: Option?
@@ -49,7 +51,7 @@ public struct SelectBox<Option: Hashable>: View {
             if let label {
                 HStack(spacing: 4) {
                     Text(label).textStyle(.labelSm600).foregroundStyle(labelColor)
-                    Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(Theme.shared.text(.textTertiary))
+                    Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(theme.text(.textTertiary))
                 }
             }
 
@@ -69,14 +71,14 @@ public struct SelectBox<Option: Hashable>: View {
                 HStack {
                     Text(selection.map(optionTitle) ?? placeholder)
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(selection == nil ? Theme.shared.text(.textTertiary) : Theme.shared.text(.textPrimary))
+                        .foregroundStyle(selection == nil ? theme.text(.textTertiary) : theme.text(.textPrimary))
                     Spacer(minLength: 0)
-                    Icon(systemName: "chevron.down", size: .sm, color: Theme.shared.text(.textTertiary))
+                    Icon(systemName: "chevron.down", size: .sm, color: theme.text(.textTertiary))
                 }
                 .padding(.horizontal, Theme.SpacingKey.md.value)
                 .scaledControlHeight(48)
                 .frame(maxWidth: .infinity)
-                .background(Theme.shared.background(isEnabled ? .bgWhite : .bgSecondaryLight),
+                .background(theme.background(isEnabled ? .bgWhite : .bgSecondaryLight),
                            in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
@@ -91,16 +93,16 @@ public struct SelectBox<Option: Hashable>: View {
             if let message = errorText ?? hint {
                 Text(message)
                     .textStyle(.bodySm400)
-                    .foregroundStyle(hasError ? Theme.shared.foreground(.systemcolorsFgError) : Theme.shared.text(.textTertiary))
+                    .foregroundStyle(hasError ? theme.foreground(.systemcolorsFgError) : theme.text(.textTertiary))
             }
         }
     }
 
     private var labelColor: Color {
-        hasError ? Theme.shared.foreground(.systemcolorsFgError) : Theme.shared.text(.textPrimary)
+        hasError ? theme.foreground(.systemcolorsFgError) : theme.text(.textPrimary)
     }
     private var borderColor: Color {
-        hasError ? Theme.shared.border(.systemcolorsBorderError) : Theme.shared.border(.borderPrimary)
+        hasError ? theme.border(.systemcolorsBorderError) : theme.border(.borderPrimary)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/Slider.swift
+++ b/Sources/ThemeKit/Components/Molecules/Slider.swift
@@ -10,6 +10,8 @@ import SwiftUI
 /// value tooltip and a disabled state. (Ant Slider parity.) Shares the visual
 /// language of RangeSlider (token track / fill / thumb).
 public struct Slider: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var value: Double
     private let bounds: ClosedRange<Double>
     private let step: Double
@@ -75,13 +77,13 @@ public struct Slider: View {
     private var verticalBody: some View {
         VStack(spacing: Theme.SpacingKey.sm.value) {
             if let label {
-                Text(label).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textPrimary))
+                Text(label).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
             }
             GeometryReader { geo in
                 let usable = max(geo.size.height - thumbSize, 1)
                 let y = CGFloat((value - bounds.lowerBound) / span) * usable
                 ZStack(alignment: .bottom) {
-                    Capsule().fill(Theme.shared.border(.borderPrimary)).frame(width: trackHeight)
+                    Capsule().fill(theme.border(.borderPrimary)).frame(width: trackHeight)
                     Capsule().fill(fillColor).frame(width: trackHeight, height: y + thumbSize / 2)
                     thumb
                         .offset(y: -y)
@@ -110,20 +112,20 @@ public struct Slider: View {
             if let label {
                 Text(label)
                     .textStyle(.labelBase600)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
             }
             GeometryReader { geo in
                 let usable = max(geo.size.width - thumbSize, 1)
                 let x = CGFloat((value - bounds.lowerBound) / span) * usable
 
                 ZStack(alignment: .leading) {
-                    Capsule().fill(Theme.shared.border(.borderPrimary)).frame(height: trackHeight)
+                    Capsule().fill(theme.border(.borderPrimary)).frame(height: trackHeight)
                     Capsule().fill(fillColor)
                         .frame(width: x + thumbSize / 2, height: trackHeight)
 
                     ForEach(marks.keys.sorted(), id: \.self) { mark in
                         Circle()
-                            .fill(mark <= value ? Theme.shared.foreground(.fgSecondary) : Theme.shared.border(.borderPrimary))
+                            .fill(mark <= value ? theme.foreground(.fgSecondary) : theme.border(.borderPrimary))
                             .frame(width: 6, height: 6)
                             .offset(x: CGFloat((mark - bounds.lowerBound) / span) * usable + thumbSize / 2 - 3)
                     }
@@ -143,7 +145,7 @@ public struct Slider: View {
                     ForEach(marks.keys.sorted(), id: \.self) { mark in
                         Text(marks[mark] ?? "")
                             .textStyle(.bodySm400)
-                            .foregroundStyle(Theme.shared.text(.textTertiary))
+                            .foregroundStyle(theme.text(.textTertiary))
                             .fixedSize()
                             .position(x: CGFloat((mark - bounds.lowerBound) / span) * usable + thumbSize / 2, y: 8)
                     }
@@ -168,7 +170,7 @@ public struct Slider: View {
     private var thumb: some View {
         Circle()
             .fill(fillColor)
-            .overlay(Circle().strokeBorder(Theme.shared.foreground(.fgSecondary), lineWidth: 2))
+            .overlay(Circle().strokeBorder(theme.foreground(.fgSecondary), lineWidth: 2))
             .frame(width: thumbSize, height: thumbSize)
             .themeShadow(.soft)
     }
@@ -178,16 +180,16 @@ public struct Slider: View {
         if showValueTooltip && dragging {
             Text(valueText(value))
                 .textStyle(.labelSm600)
-                .foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                .foregroundStyle(theme.foreground(.fgSecondary))
                 .padding(.horizontal, Theme.SpacingKey.sm.value)
                 .padding(.vertical, 2)
-                .background(Theme.shared.background(.bgTertiary), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value))
+                .background(theme.background(.bgTertiary), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value))
                 .fixedSize()
         }
     }
 
     private var fillColor: Color {
-        Theme.shared.background(isEnabled ? .bgHero : .bgSecondary)
+        theme.background(isEnabled ? .bgHero : .bgSecondary)
     }
 
     private func drag(usable: CGFloat) -> some Gesture {

--- a/Sources/ThemeKit/Components/Molecules/Stat.swift
+++ b/Sources/ThemeKit/Components/Molecules/Stat.swift
@@ -30,6 +30,8 @@ public enum StatTrend {
 /// Molecule. A single statistic block: title, value, optional description,
 /// figure icon and trend. (daisyUI "Stat".)
 public struct Stat: View {
+    @Environment(\.theme) private var theme
+
     private enum Value { case text(String), number(Int) }
 
     private let title: String
@@ -101,11 +103,11 @@ public struct Stat: View {
     private var valueRow: some View {
         HStack(alignment: .firstTextBaseline, spacing: 2) {
             if let prefix {
-                Text(prefix).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textSecondary))
+                Text(prefix).textStyle(.headingSm).foregroundStyle(theme.text(.textSecondary))
             }
             valueView
             if let suffix {
-                Text(suffix).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textSecondary))
+                Text(suffix).textStyle(.headingSm).foregroundStyle(theme.text(.textSecondary))
             }
         }
     }
@@ -117,11 +119,11 @@ public struct Stat: View {
         } else {
             switch value {
             case .text(let string):
-                Text(string).textStyle(.headingMd).foregroundStyle(Theme.shared.text(.textPrimary))
+                Text(string).textStyle(.headingMd).foregroundStyle(theme.text(.textPrimary))
                     .lineLimit(1)
                     .minimumScaleFactor(0.6)
             case .number(let number):
-                RollingNumber(number, size: 28, weight: .semibold, color: Theme.shared.text(.textPrimary))
+                RollingNumber(number, size: 28, weight: .semibold, color: theme.text(.textPrimary))
             }
         }
     }

--- a/Sources/ThemeKit/Components/Molecules/Steps.swift
+++ b/Sources/ThemeKit/Components/Molecules/Steps.swift
@@ -21,6 +21,8 @@ public enum StepState {
 /// Steps([.init("Cart", state: .done), .init("Pay", state: .active)]) { active = $0 }
 /// ```
 public struct Steps: View {
+    @Environment(\.theme) private var theme
+
     public struct Step: Identifiable {
         public let id = UUID()
         let title: String
@@ -69,7 +71,7 @@ public struct Steps: View {
                             .foregroundStyle(titleColor(step.state))
                             .multilineTextAlignment(.center)
                         if let description = step.description {
-                            Text(description).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary))
+                            Text(description).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
                                 .multilineTextAlignment(.center)
                         }
                     }
@@ -93,7 +95,7 @@ public struct Steps: View {
                                 .textStyle(.labelBase600)
                                 .foregroundStyle(titleColor(step.state))
                             if let description = step.description {
-                                Text(description).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary))
+                                Text(description).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
                             }
                         }
                         .padding(.top, 4)
@@ -116,7 +118,7 @@ public struct Steps: View {
                 glyph(step, number: number)
                 if let percent = step.percent, step.state == .active {
                     Circle().trim(from: 0, to: CGFloat(min(max(percent, 0), 1)))
-                        .stroke(Theme.shared.background(.bgHero), style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+                        .stroke(theme.background(.bgHero), style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
                         .rotationEffect(.degrees(-90))
                         .frame(width: dotSize + 7, height: dotSize + 7)
                 }
@@ -127,9 +129,9 @@ public struct Steps: View {
 
     private func dotFill(_ state: StepState) -> Color {
         switch state {
-        case .done, .active: return Theme.shared.background(.bgHero)
-        case .error: return Theme.shared.background(.systemcolorsBgError)
-        case .todo: return Theme.shared.border(.borderPrimary)
+        case .done, .active: return theme.background(.bgHero)
+        case .error: return theme.background(.systemcolorsBgError)
+        case .todo: return theme.border(.borderPrimary)
         }
     }
 
@@ -138,43 +140,43 @@ public struct Steps: View {
         let iconSize = small ? 10.0 : 12.0
         switch step.state {
         case .done:
-            Image(systemName: step.systemImage ?? "checkmark").font(.system(size: iconSize, weight: .bold)).foregroundStyle(Theme.shared.foreground(.fgSecondary))
+            Image(systemName: step.systemImage ?? "checkmark").font(.system(size: iconSize, weight: .bold)).foregroundStyle(theme.foreground(.fgSecondary))
         case .error:
-            Image(systemName: "xmark").font(.system(size: iconSize, weight: .bold)).foregroundStyle(Theme.shared.foreground(.fgSecondary))
+            Image(systemName: "xmark").font(.system(size: iconSize, weight: .bold)).foregroundStyle(theme.foreground(.fgSecondary))
         case .active:
             if let icon = step.systemImage {
-                Image(systemName: icon).font(.system(size: iconSize, weight: .bold)).foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                Image(systemName: icon).font(.system(size: iconSize, weight: .bold)).foregroundStyle(theme.foreground(.fgSecondary))
             } else {
-                Text("\(number)").textStyle(.labelSm700).foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                Text("\(number)").textStyle(.labelSm700).foregroundStyle(theme.foreground(.fgSecondary))
             }
         case .todo:
-            Text("\(number)").textStyle(.labelSm700).foregroundStyle(Theme.shared.text(.textTertiary))
+            Text("\(number)").textStyle(.labelSm700).foregroundStyle(theme.text(.textTertiary))
         }
     }
 
     private func fill(_ state: StepState) -> Color {
         switch state {
-        case .done, .active: return Theme.shared.background(.bgHero)
-        case .error: return Theme.shared.background(.systemcolorsBgError)
-        case .todo: return Theme.shared.background(.bgWhite)
+        case .done, .active: return theme.background(.bgHero)
+        case .error: return theme.background(.systemcolorsBgError)
+        case .todo: return theme.background(.bgWhite)
         }
     }
     private func stroke(_ state: StepState) -> Color {
         switch state {
-        case .todo: return Theme.shared.border(.borderPrimary)
-        case .error: return Theme.shared.background(.systemcolorsBgError)
-        case .done, .active: return Theme.shared.background(.bgHero)
+        case .todo: return theme.border(.borderPrimary)
+        case .error: return theme.background(.systemcolorsBgError)
+        case .done, .active: return theme.background(.bgHero)
         }
     }
     private func titleColor(_ state: StepState) -> Color {
         switch state {
-        case .todo: return Theme.shared.text(.textTertiary)
-        case .error: return Theme.shared.foreground(.systemcolorsFgError)
-        case .done, .active: return Theme.shared.text(.textPrimary)
+        case .todo: return theme.text(.textTertiary)
+        case .error: return theme.foreground(.systemcolorsFgError)
+        case .done, .active: return theme.text(.textPrimary)
         }
     }
     private func connectorColor(_ index: Int) -> Color {
-        steps[index].state == .done ? Theme.shared.background(.bgHero) : Theme.shared.border(.borderPrimary)
+        steps[index].state == .done ? theme.background(.bgHero) : theme.border(.borderPrimary)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/TextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInput.swift
@@ -126,6 +126,8 @@ public struct TextInputModel {
 /// a `TextInputModel` config struct, a structured `[InfoMessage]` validation
 /// model, and namespaced accessibility identifiers — alongside the flat init.
 public struct TextInput: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var text: String
     private let model: TextInputModel
     /// Optional external focus (e.g. driven by `FormValidator.focusBinding`).
@@ -247,14 +249,14 @@ public struct TextInput: View {
     private func addonSegment(_ text: String) -> some View {
         Text(text)
             .textStyle(.bodyBase400)
-            .foregroundStyle(Theme.shared.text(.textSecondary))
+            .foregroundStyle(theme.text(.textSecondary))
             .padding(.horizontal, Theme.SpacingKey.md.value)
             .frame(maxHeight: .infinity)
-            .background(Theme.shared.background(.bgElevatorTertiary))
+            .background(theme.background(.bgElevatorTertiary))
     }
 
     private var addonSeparator: some View {
-        Rectangle().fill(Theme.shared.border(.borderPrimary)).frame(width: 1)
+        Rectangle().fill(theme.border(.borderPrimary)).frame(width: 1)
     }
 
     @ViewBuilder
@@ -297,7 +299,7 @@ public struct TextInput: View {
                     if model.showCount {
                         Text(Self.counterText(count: text.count, maxLength: model.maxLength, style: model.countStyle))
                             .textStyle(.bodySm400)
-                            .foregroundStyle(isOverLimit ? Theme.shared.foreground(.systemcolorsFgError) : Theme.shared.text(.textTertiary))
+                            .foregroundStyle(isOverLimit ? theme.foreground(.systemcolorsFgError) : theme.text(.textTertiary))
                             .monospacedDigit()
                     }
                 }
@@ -330,8 +332,8 @@ public struct TextInput: View {
         }
         .focused($isFocused)
         .textStyle(.bodyBase400)
-        .foregroundStyle(model.isEnabled ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textDisabled))
-        .tint(Theme.shared.foreground(.fgHero))
+        .foregroundStyle(model.isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
+        .tint(theme.foreground(.fgHero))
         .disabled(!model.isEnabled)
         .submitLabel(model.submitLabel)
         .autocorrectionDisabled(model.autocorrectionDisabled)
@@ -347,14 +349,14 @@ public struct TextInput: View {
     private var trailing: some View {
         if model.isSecure {
             Button { reveal.toggle() } label: {
-                Icon(systemName: reveal ? "eye.slash" : "eye", size: .sm, color: Theme.shared.text(.textTertiary))
+                Icon(systemName: reveal ? "eye.slash" : "eye", size: .sm, color: theme.text(.textTertiary))
             }
             .buttonStyle(.plain)
             .a11y(A11yElement.Field.reveal, in: model.accessibilityID)
             .accessibilityLabel(reveal ? String(themeKit: "Hide password") : String(themeKit: "Show password"))
         } else if showsClear || (!text.isEmpty && isFocused && model.suffixSystemImage == nil) {
             Button { text = "" } label: {
-                Icon(systemName: "xmark.circle.fill", size: .sm, color: Theme.shared.text(.textTertiary))
+                Icon(systemName: "xmark.circle.fill", size: .sm, color: theme.text(.textTertiary))
             }
             .buttonStyle(.plain)
             .a11y(A11yElement.Field.clear, in: model.accessibilityID)
@@ -365,25 +367,25 @@ public struct TextInput: View {
     }
 
     private var labelColor: Color {
-        if hasError { return Theme.shared.foreground(.systemcolorsFgError) }
-        if hasWarning { return Theme.shared.foreground(.systemcolorsFgWarning) }
-        if isFocused { return Theme.shared.text(.textHero) }
-        return Theme.shared.text(.textTertiary)
+        if hasError { return theme.foreground(.systemcolorsFgError) }
+        if hasWarning { return theme.foreground(.systemcolorsFgWarning) }
+        if isFocused { return theme.text(.textHero) }
+        return theme.text(.textTertiary)
     }
 
     private var iconColor: Color {
-        model.isEnabled ? Theme.shared.text(.textTertiary) : Theme.shared.text(.textDisabled)
+        model.isEnabled ? theme.text(.textTertiary) : theme.text(.textDisabled)
     }
 
     private var backgroundColor: Color {
-        Theme.shared.background(model.isEnabled ? .bgWhite : .bgSecondaryLight)
+        theme.background(model.isEnabled ? .bgWhite : .bgSecondaryLight)
     }
 
     private var borderColor: Color {
-        if hasError { return Theme.shared.border(.systemcolorsBorderError) }
-        if hasWarning { return Theme.shared.border(.systemcolorsBorderWarning) }
-        if isFocused { return Theme.shared.border(.borderHero) }
-        return Theme.shared.border(.borderPrimary)
+        if hasError { return theme.border(.systemcolorsBorderError) }
+        if hasWarning { return theme.border(.systemcolorsBorderWarning) }
+        if isFocused { return theme.border(.borderHero) }
+        return theme.border(.borderPrimary)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/ThemeController.swift
+++ b/Sources/ThemeKit/Components/Molecules/ThemeController.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Molecule. A packaged theme switcher: selecting an option loads that theme via
 /// `Theme.shared.loadTheme(named:)`. (daisyUI "Theme Controller".)
 public struct ThemeController: View {
+    @Environment(\.theme) private var theme
+
     public struct Option: Identifiable {
         public let id = UUID()
         let name: String
@@ -29,18 +31,18 @@ public struct ThemeController: View {
             ForEach(options) { option in
                 let isActive = option.name == selectedName
                 Button {
-                    Theme.shared.loadTheme(named: option.name)
+                    theme.loadTheme(named: option.name)
                     withAnimation(Motion.fast.animation) { selectedName = option.name }
                 } label: {
                     Text(option.label)
                         .textStyle(isActive ? .labelBase700 : .labelBase600)
-                        .foregroundStyle(isActive ? Theme.shared.text(.textHero) : Theme.shared.text(.textSecondary))
+                        .foregroundStyle(isActive ? theme.text(.textHero) : theme.text(.textSecondary))
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, Theme.SpacingKey.sm.value)
                         .background {
                             if isActive {
                                 RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous)
-                                    .fill(Theme.shared.background(.bgWhite))
+                                    .fill(theme.background(.bgWhite))
                                     .themeShadow(.soft)
                             }
                         }
@@ -50,7 +52,7 @@ public struct ThemeController: View {
             }
         }
         .padding(4)
-        .background(Theme.shared.background(.bgElevatorPrimary), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+        .background(theme.background(.bgElevatorPrimary), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/ThemeToggle.swift
+++ b/Sources/ThemeKit/Components/Molecules/ThemeToggle.swift
@@ -10,6 +10,8 @@ import SwiftUI
 /// states active / disabled / loading, with optional on/off glyphs in the knob.
 /// (Ant Switch parity.) Colors + motion from theme tokens.
 public struct ThemeToggle: View {
+    @Environment(\.theme) private var theme
+
     @Binding private var isOn: Bool
     private let size: ControlSize
     private let isEnabled: Bool
@@ -68,24 +70,24 @@ public struct ThemeToggle: View {
 
     private var knob: some View {
         Circle()
-            .fill(Theme.shared.foreground(.fgSecondary))
+            .fill(theme.foreground(.fgSecondary))
             .frame(width: knobSize, height: knobSize)
             .overlay {
                 if isLoading {
                     ProgressView()
                         .controlSize(.mini)
-                        .tint(Theme.shared.foreground(.fgHero))
+                        .tint(theme.foreground(.fgHero))
                 } else if let glyph = isOn ? onSystemImage : offSystemImage {
                     Image(systemName: glyph)
                         .font(.system(size: knobSize * 0.55, weight: .bold))
-                        .foregroundStyle(isOn ? Theme.shared.text(.textHero) : Theme.shared.text(.textTertiary))
+                        .foregroundStyle(isOn ? theme.text(.textHero) : theme.text(.textTertiary))
                 }
             }
     }
 
     private var track: Color {
-        guard isEnabled else { return Theme.shared.background(.bgSecondary) }
-        return isOn ? Theme.shared.background(.bgHero) : Theme.shared.background(.bgSecondary)
+        guard isEnabled else { return theme.background(.bgSecondary) }
+        return isOn ? theme.background(.bgHero) : theme.background(.bgSecondary)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/ToggleGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/ToggleGroup.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Molecule. Rows of labelled switches with optional supporting text. Multi-state
 /// owned by the caller (single Set binding).
 public struct ToggleGroup<Option: Hashable>: View {
+    @Environment(\.theme) private var theme
+
     private let title: String?
     private let options: [Option]
     @Binding private var selection: Set<Option>
@@ -35,18 +37,18 @@ public struct ToggleGroup<Option: Hashable>: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
             if let title {
-                Text(title).textStyle(.labelMd600).foregroundStyle(Theme.shared.text(.textPrimary))
+                Text(title).textStyle(.labelMd600).foregroundStyle(theme.text(.textPrimary))
             }
             ForEach(Array(options.enumerated()), id: \.element) { index, option in
                 HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(label(option))
                             .textStyle(.labelBase600)
-                            .foregroundStyle(Theme.shared.text(.textPrimary))
+                            .foregroundStyle(theme.text(.textPrimary))
                         if let description = description(option) {
                             Text(description)
                                 .textStyle(.bodySm400)
-                                .foregroundStyle(Theme.shared.text(.textSecondary))
+                                .foregroundStyle(theme.text(.textSecondary))
                         }
                     }
                     Spacer(minLength: Theme.SpacingKey.sm.value)

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -177,15 +177,17 @@ public extension View {
 
 #Preview {
     struct Demo: View {
+    @Environment(\.theme) private var theme
+
         @State var show = true
         var body: some View {
             VStack(spacing: 64) {
-                Icon(systemName: "info.circle", size: .md, color: Theme.shared.foreground(.fgHero))
+                Icon(systemName: "info.circle", size: .md, color: theme.foreground(.fgHero))
                     .tooltip("Helpful hint", isPresented: $show)
                 HStack(spacing: 56) {
-                    Icon(systemName: "questionmark.circle", size: .md, color: Theme.shared.foreground(.fgHero))
+                    Icon(systemName: "questionmark.circle", size: .md, color: theme.foreground(.fgHero))
                         .tooltip("On the trailing side", edge: .trailing, style: .info)
-                    Icon(systemName: "exclamationmark.triangle", size: .md, color: Theme.shared.foreground(.fgHero))
+                    Icon(systemName: "exclamationmark.triangle", size: .md, color: theme.foreground(.fgHero))
                         .tooltip("A longer hint that wraps onto several lines", edge: .leading, style: .warning, maxWidth: 140)
                 }
             }

--- a/Sources/ThemeKit/Components/Molecules/TreeSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/TreeSelect.swift
@@ -19,6 +19,8 @@ public struct TreeNode: Identifiable {
 /// Hierarchical (nested) select with expand/collapse and multi-selection.
 /// (Ant TreeSelect.) Nodes are a simple value tree; selection is a set of node ids.
 public struct TreeSelect: View {
+    @Environment(\.theme) private var theme
+
     private let label: String?
     private let nodes: [TreeNode]
     @Binding private var selection: Set<String>
@@ -83,8 +85,8 @@ public struct TreeSelect: View {
                     }
                 }
                 .padding(.vertical, Theme.SpacingKey.xs.value)
-                .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
-                .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).stroke(Theme.shared.border(.borderPrimary), lineWidth: 1))
+                .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+                .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).stroke(theme.border(.borderPrimary), lineWidth: 1))
                 .themeShadow(.soft)
             }
         }
@@ -94,13 +96,13 @@ public struct TreeSelect: View {
 
     private var searchField: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
-            Icon(systemName: "magnifyingglass", size: .sm, color: Theme.shared.text(.textTertiary))
+            Icon(systemName: "magnifyingglass", size: .sm, color: theme.text(.textTertiary))
             TextField("Ara", text: $searchText)
                 .textStyle(.bodyBase400)
-                .foregroundStyle(Theme.shared.text(.textPrimary))
+                .foregroundStyle(theme.text(.textPrimary))
             if !searchText.isEmpty {
                 Button { searchText = "" } label: {
-                    Icon(systemName: "xmark.circle.fill", size: .sm, color: Theme.shared.text(.textTertiary))
+                    Icon(systemName: "xmark.circle.fill", size: .sm, color: theme.text(.textTertiary))
                 }
                 .buttonStyle(.plain)
             }
@@ -112,7 +114,7 @@ public struct TreeSelect: View {
     private var loadingRow: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
             Spinner(size: IconSize.sm.value, lineWidth: 2)
-            Text(String(themeKit: "Searching…")).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary))
+            Text(String(themeKit: "Searching…")).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
             Spacer()
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
@@ -122,7 +124,7 @@ public struct TreeSelect: View {
     private var emptyRow: some View {
         Text(String(themeKit: "No results"))
             .textStyle(.bodySm400)
-            .foregroundStyle(Theme.shared.text(.textTertiary))
+            .foregroundStyle(theme.text(.textTertiary))
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, Theme.SpacingKey.md.value)
             .padding(.vertical, Theme.SpacingKey.sm.value)
@@ -133,19 +135,19 @@ public struct TreeSelect: View {
             HStack(spacing: Theme.SpacingKey.sm.value) {
                 Text(summary)
                     .textStyle(.bodyBase400)
-                    .foregroundStyle(selection.isEmpty ? Theme.shared.text(.textTertiary) : Theme.shared.text(.textPrimary))
+                    .foregroundStyle(selection.isEmpty ? theme.text(.textTertiary) : theme.text(.textPrimary))
                     .lineLimit(1)
                 Spacer(minLength: 0)
-                Icon(systemName: open ? "chevron.up" : "chevron.down", size: .sm, color: Theme.shared.text(.textTertiary))
+                Icon(systemName: open ? "chevron.up" : "chevron.down", size: .sm, color: theme.text(.textTertiary))
             }
             .padding(.horizontal, Theme.SpacingKey.md.value)
             .scaledControlHeight(56)
             .frame(maxWidth: .infinity)
-            .background(Theme.shared.background(isEnabled ? .bgWhite : .bgSecondaryLight), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+            .background(theme.background(isEnabled ? .bgWhite : .bgSecondaryLight), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
                     .strokeBorder(
-                        open ? Theme.shared.border(.borderHero) : Theme.shared.border(.borderPrimary),
+                        open ? theme.border(.borderHero) : theme.border(.borderPrimary),
                         lineWidth: open ? 1.5 : 1
                     )
             )
@@ -166,7 +168,7 @@ public struct TreeSelect: View {
                 Color.clear.frame(width: 16, height: 16)
             } else {
                 Button { toggleExpand(node.id) } label: {
-                    Icon(systemName: expanded.contains(node.id) ? "chevron.down" : "chevron.right", size: .xs, color: Theme.shared.text(.textTertiary))
+                    Icon(systemName: expanded.contains(node.id) ? "chevron.down" : "chevron.right", size: .xs, color: theme.text(.textTertiary))
                         .frame(width: 16, height: 16)
                         .mirrorsInRTL()
                 }
@@ -178,9 +180,9 @@ public struct TreeSelect: View {
                     Checkbox(isChecked: .constant(state == .on), size: .small, isIndeterminate: state == .partial)
                         .allowsHitTesting(false)
                     if let icon = node.systemImage {
-                        Icon(systemName: icon, size: .sm, color: Theme.shared.text(.textTertiary))
+                        Icon(systemName: icon, size: .sm, color: theme.text(.textTertiary))
                     }
-                    Text(node.title).textStyle(.bodyBase400).foregroundStyle(Theme.shared.text(.textPrimary))
+                    Text(node.title).textStyle(.bodyBase400).foregroundStyle(theme.text(.textPrimary))
                     Spacer(minLength: 0)
                 }
                 .contentShape(Rectangle())


### PR DESCRIPTION
## What
Second rollout batch (after Atoms #66). **33 molecule `View` structs** now read `\.theme` from the environment instead of `Theme.shared`, so an injected `.theme(_:)` re-skins them per-subtree. `\.theme` defaults to `Theme.shared`, so **the default render is unchanged**.

## Scope (batch 2 of 3 — Molecules, 333 reads)
Form / input / navigation molecules: TextInput, Select, MultiSelect, SelectBox, Autocomplete, SearchBar, InputNumber, MultiLineTextInput, Checkbox(+Group), RadioButton/RadioGroup, Slider, RangeSlider, QuantityStepper, Steps, Pagination, Breadcrumbs, SegmentedControl, the Chips family, CalendarView, DateField, FileInput, OTPInput, TreeSelect, Fieldset, Filter/ToggleGroup, ProgressIndicator, Stat, Theme controls, Tooltip.

Reads in static color resolvers / enum cases / init defaults stay on `Theme.shared` (no environment there) — tracked for a later parameterization pass.

## Safety — verified non-breaking
- Every **regenerated screenshot is byte-identical** to baseline (BorderBeam excluded — animated, source untouched).
- Full suite green (**160 tests**); migration is compiler-guarded and built clean on the first pass.

Part of the `\.theme` rollout item in `docs/AUDIT.md` (P0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)