### PR TITLE
refactor(theme): migrate Organisms to @Environment(\.theme) (rollout 3/3)

### DIFF
--- a/Sources/ThemeKit/Components/Organisms/Accordion.swift
+++ b/Sources/ThemeKit/Components/Organisms/Accordion.swift
@@ -39,6 +39,8 @@ public enum AccordionPaddingSize {
 /// Improved, token-bound rewrite of the reference AccordionView — a single
 /// expandable row with a @ViewBuilder body instead of type-erased AnyView models.
 public struct Accordion<Content: View>: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     private let subtitle: String?
     private let number: Int?
@@ -103,7 +105,7 @@ public struct Accordion<Content: View>: View {
                         if let subtitle {
                             Text(subtitle)
                                 .textStyle(.bodySm400)
-                                .foregroundStyle(Theme.shared.text(.textSecondary))
+                                .foregroundStyle(theme.text(.textSecondary))
                                 .lineLimit(truncateSubtitle && !expanded ? 1 : nil)
                         }
                     }
@@ -118,7 +120,7 @@ public struct Accordion<Content: View>: View {
             if expanded {
                 content()
                     .textStyle(.bodyBase400)
-                    .foregroundStyle(Theme.shared.text(.textSecondary))
+                    .foregroundStyle(theme.text(.textSecondary))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .transition(.opacity.combined(with: .move(edge: .top)))
             }
@@ -130,19 +132,19 @@ public struct Accordion<Content: View>: View {
     }
 
     private var titleColor: Color {
-        expanded ? Theme.shared.text(.textHero) : Theme.shared.text(.textPrimary)
+        expanded ? theme.text(.textHero) : theme.text(.textPrimary)
     }
 
     @ViewBuilder
     private var indicatorIcon: some View {
         switch indicator {
         case .chevron:
-            Icon(systemName: "chevron.down", size: .sm, color: Theme.shared.text(.textTertiary))
+            Icon(systemName: "chevron.down", size: .sm, color: theme.text(.textTertiary))
                 .rotationEffect(.degrees(expanded ? 180 : 0))
         case .plusMinus:
-            Icon(systemName: expanded ? "minus" : "plus", size: .sm, color: Theme.shared.text(.textTertiary))
+            Icon(systemName: expanded ? "minus" : "plus", size: .sm, color: theme.text(.textTertiary))
         case .custom(let expand, let collapse):
-            Icon(systemName: expanded ? collapse : expand, size: .sm, color: Theme.shared.text(.textTertiary))
+            Icon(systemName: expanded ? collapse : expand, size: .sm, color: theme.text(.textTertiary))
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/AccordionGroup.swift
+++ b/Sources/ThemeKit/Components/Organisms/AccordionGroup.swift
@@ -12,6 +12,8 @@ public enum AccordionExpandMode { case single, multiple }
 /// reference `AccordionView` tracks a `Set` of open ids). Single mode collapses
 /// the others when one opens.
 public struct AccordionGroup<Item: Identifiable, Content: View>: View {
+    @Environment(\.theme) private var theme
+
     private let items: [Item]
     private let mode: AccordionExpandMode
     private let title: (Item) -> String
@@ -42,9 +44,9 @@ public struct AccordionGroup<Item: Identifiable, Content: View>: View {
                 let isOpen = expanded.contains(item.id)
                 Button { toggle(item.id) } label: {
                     HStack {
-                        Text(title(item)).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textPrimary))
+                        Text(title(item)).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
                         Spacer()
-                        Icon(systemName: "chevron.down", size: .sm, color: Theme.shared.text(.textTertiary))
+                        Icon(systemName: "chevron.down", size: .sm, color: theme.text(.textTertiary))
                             .rotationEffect(.degrees(isOpen ? 180 : 0))
                     }
                     .padding(Theme.SpacingKey.md.value)
@@ -63,8 +65,8 @@ public struct AccordionGroup<Item: Identifiable, Content: View>: View {
                 if index < items.count - 1 { DividerView(size: .small) }
             }
         }
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous).stroke(Theme.shared.border(.borderPrimary), lineWidth: 1))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous).stroke(theme.border(.borderPrimary), lineWidth: 1))
         .animation(motion, value: expanded)
     }
 

--- a/Sources/ThemeKit/Components/Organisms/BlogCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/BlogCard.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Organism. An article card: media + title + excerpt + read-more link, with a
 /// compact (media-left) variant. Media supplied via a ViewBuilder.
 public struct BlogCard<Media: View>: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     private let excerpt: String?
     private let readMoreTitle: String
@@ -55,7 +57,7 @@ public struct BlogCard<Media: View>: View {
                 if let excerpt {
                     Text(excerpt)
                         .textStyle(.bodySm400)
-                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                        .foregroundStyle(theme.text(.textSecondary))
                         .lineLimit(3)
                 }
                 readMore
@@ -66,7 +68,7 @@ public struct BlogCard<Media: View>: View {
     private var titleText: some View {
         Text(title)
             .textStyle(.labelMd700)
-            .foregroundStyle(Theme.shared.text(.textPrimary))
+            .foregroundStyle(theme.text(.textPrimary))
             .lineLimit(2)
     }
 
@@ -77,7 +79,7 @@ public struct BlogCard<Media: View>: View {
                 Image(systemName: "arrow.right").font(.system(size: 11, weight: .semibold))
                     .mirrorsInRTL()
             }
-            .foregroundStyle(Theme.shared.text(.textHero))
+            .foregroundStyle(theme.text(.textHero))
         }
         .buttonStyle(.plain)
     }

--- a/Sources/ThemeKit/Components/Organisms/Carousel.swift
+++ b/Sources/ThemeKit/Components/Organisms/Carousel.swift
@@ -11,6 +11,8 @@ import SwiftUI
 /// two-way `currentIndex` binding, and an active-gating content variant so video
 /// pages can play only while visible. (Ant Carousel parity.)
 public struct Carousel<Item: Identifiable, Content: View>: View {
+    @Environment(\.theme) private var theme
+
     private let items: [Item]
     private let autoplay: TimeInterval?
     private let showsArrows: Bool
@@ -189,10 +191,10 @@ public struct Carousel<Item: Identifiable, Content: View>: View {
 
     private func arrow(_ systemName: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            Icon(systemName: systemName, size: .sm, color: Theme.shared.foreground(.fgSecondary))
+            Icon(systemName: systemName, size: .sm, color: theme.foreground(.fgSecondary))
                 .frame(width: 32, height: 32)
                 .mirrorsInRTL()
-                .background(Theme.shared.background(.bgTertiary).opacity(0.5), in: Circle())
+                .background(theme.background(.bgTertiary).opacity(0.5), in: Circle())
         }
         .buttonStyle(.plain)
     }

--- a/Sources/ThemeKit/Components/Organisms/ChatBubble.swift
+++ b/Sources/ThemeKit/Components/Organisms/ChatBubble.swift
@@ -13,6 +13,8 @@ public enum ChatSide {
 /// Organism. A chat message bubble (incoming / outgoing) with optional avatar,
 /// author and timestamp. (daisyUI "Chat bubble".)
 public struct ChatBubble: View {
+    @Environment(\.theme) private var theme
+
     private let text: String
     private let side: ChatSide
     private let author: String?
@@ -35,16 +37,16 @@ public struct ChatBubble: View {
             VStack(alignment: side == .incoming ? .leading : .trailing, spacing: 2) {
                 if author != nil || time != nil {
                     HStack(spacing: 4) {
-                        if let author { Text(author).textStyle(.labelSm600).foregroundStyle(Theme.shared.text(.textPrimary)) }
-                        if let time { Text(time).textStyle(.overline400).foregroundStyle(Theme.shared.text(.textTertiary)) }
+                        if let author { Text(author).textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary)) }
+                        if let time { Text(time).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary)) }
                     }
                 }
                 Text(text)
                     .textStyle(.bodyBase400)
-                    .foregroundStyle(side == .incoming ? Theme.shared.text(.textPrimary) : Theme.shared.foreground(.fgSecondary))
+                    .foregroundStyle(side == .incoming ? theme.text(.textPrimary) : theme.foreground(.fgSecondary))
                     .padding(.horizontal, Theme.SpacingKey.md.value)
                     .padding(.vertical, Theme.SpacingKey.sm.value)
-                    .background(side == .incoming ? Theme.shared.background(.bgElevatorTertiary) : Theme.shared.background(.bgHero),
+                    .background(side == .incoming ? theme.background(.bgElevatorTertiary) : theme.background(.bgHero),
                                in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
             }
 

--- a/Sources/ThemeKit/Components/Organisms/Counter.swift
+++ b/Sources/ThemeKit/Components/Organisms/Counter.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Organism. Displays numeric values in labelled boxes — e.g. a countdown
 /// (Gün / Saat / Dakika).
 public struct Counter: View {
+    @Environment(\.theme) private var theme
+
     public struct Segment: Identifiable {
         public let id = UUID()
         let value: Int
@@ -41,14 +43,14 @@ public struct Counter: View {
                     Text(String(format: "%02d", segment.value))
                         .textStyle(.labelMd700)
                         .monospacedDigit()
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                     Text(segment.label)
                         .textStyle(.overline400)
-                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                        .foregroundStyle(theme.text(.textTertiary))
                 }
                 .frame(minWidth: 44)
                 .padding(.vertical, Theme.SpacingKey.xs.value)
-                .background(Theme.shared.background(.bgElevatorTertiary),
+                .background(theme.background(.bgElevatorTertiary),
                            in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
             }
         }

--- a/Sources/ThemeKit/Components/Organisms/Coupon.swift
+++ b/Sources/ThemeKit/Components/Organisms/Coupon.swift
@@ -13,6 +13,8 @@ public enum CouponStyle {
 /// Organism. Displays a promo code with a copy action. Styles: filled / outlined
 /// (dashed) / plain.
 public struct Coupon: View {
+    @Environment(\.theme) private var theme
+
     private let code: String
     private let label: String
     private let style: CouponStyle
@@ -44,14 +46,14 @@ public struct Coupon: View {
     }
 
     private var foreground: Color {
-        style == .filled ? Theme.shared.foreground(.fgSecondary) : Theme.shared.text(.textHero)
+        style == .filled ? theme.foreground(.fgSecondary) : theme.text(.textHero)
     }
 
     private var background: Color {
         switch style {
-        case .filled: return Theme.shared.background(.bgHero)
-        case .plain: return Theme.shared.background(.bgElevatorTertiary)
-        case .outlined: return Theme.shared.background(.bgWhite)
+        case .filled: return theme.background(.bgHero)
+        case .plain: return theme.background(.bgElevatorTertiary)
+        case .outlined: return theme.background(.bgWhite)
         }
     }
 
@@ -61,7 +63,7 @@ public struct Coupon: View {
 
     private var dashedBorder: some View {
         shape.strokeBorder(
-            Theme.shared.border(.borderHero),
+            theme.border(.borderHero),
             style: StrokeStyle(lineWidth: 1, dash: [4, 3])
         )
     }

--- a/Sources/ThemeKit/Components/Organisms/DataTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/DataTable.swift
@@ -34,6 +34,8 @@ public enum TableSortKey: Comparable {
 /// Supports tap-to-sort columns, row selection, and fully custom cell views.
 /// (daisyUI "Table"; complements the label/value KeyValueTable.)
 public struct DataTable<Row: Identifiable>: View {
+    @Environment(\.theme) private var theme
+
     public struct Column {
         let title: String
         let align: ColumnAlign
@@ -63,7 +65,7 @@ public struct DataTable<Row: Identifiable>: View {
             self.init(title, align: align, sortKey: sortKey) { row in
                 Text(value(row))
                     .textStyle(.bodyBase400)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(Theme.shared.text(.textPrimary))   // nested Column has no environment
             }
         }
     }
@@ -146,7 +148,7 @@ public struct DataTable<Row: Identifiable>: View {
         .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                .stroke(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                .stroke(theme.border(.borderPrimary), lineWidth: 1)
         )
     }
 
@@ -160,7 +162,7 @@ public struct DataTable<Row: Identifiable>: View {
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
         .padding(.vertical, Theme.SpacingKey.sm.value)
-        .background(Theme.shared.background(.bgElevatorPrimary))
+        .background(theme.background(.bgElevatorPrimary))
     }
 
     @ViewBuilder
@@ -168,11 +170,11 @@ public struct DataTable<Row: Identifiable>: View {
         let title = HStack(spacing: 4) {
             Text(column.title)
                 .textStyle(.labelSm700)
-                .foregroundStyle(Theme.shared.text(.textSecondary))
+                .foregroundStyle(theme.text(.textSecondary))
             if column.sortKey != nil {
                 Icon(systemName: sortColumn == index ? (sortAscending ? "chevron.up" : "chevron.down") : "chevron.up.chevron.down",
                      size: .xs,
-                     color: sortColumn == index ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textTertiary))
+                     color: sortColumn == index ? theme.text(.textPrimary) : theme.text(.textTertiary))
             }
         }
         .frame(maxWidth: .infinity, alignment: column.align.alignment)
@@ -213,9 +215,9 @@ public struct DataTable<Row: Identifiable>: View {
     }
 
     private func rowBackground(index: Int, isSelected: Bool) -> Color {
-        if isSelected { return Theme.shared.background(.systemcolorsBgInfoLight) }
-        if striped && index % 2 == 1 { return Theme.shared.background(.bgElevatorPrimary).opacity(0.5) }
-        return Theme.shared.background(.bgWhite)
+        if isSelected { return theme.background(.systemcolorsBgInfoLight) }
+        if striped && index % 2 == 1 { return theme.background(.bgElevatorPrimary).opacity(0.5) }
+        return theme.background(.bgWhite)
     }
 
     private func handleTap(_ row: Row) {
@@ -229,10 +231,10 @@ public struct DataTable<Row: Identifiable>: View {
     private var emptyRow: some View {
         Text(String(themeKit: "No data"))
             .textStyle(.bodyBase400)
-            .foregroundStyle(Theme.shared.text(.textTertiary))
+            .foregroundStyle(theme.text(.textTertiary))
             .frame(maxWidth: .infinity)
             .padding(.vertical, Theme.SpacingKey.lg.value)
-            .background(Theme.shared.background(.bgWhite))
+            .background(theme.background(.bgWhite))
     }
 
     private var loadingRow: some View {
@@ -240,11 +242,11 @@ public struct DataTable<Row: Identifiable>: View {
             Spinner(size: IconSize.sm.value, lineWidth: 2)
             Text(String(themeKit: "Loading…"))
                 .textStyle(.bodyBase400)
-                .foregroundStyle(Theme.shared.text(.textTertiary))
+                .foregroundStyle(theme.text(.textTertiary))
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, Theme.SpacingKey.lg.value)
-        .background(Theme.shared.background(.bgWhite))
+        .background(theme.background(.bgWhite))
     }
 
     // MARK: - Pure paging (extracted for testing)

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -10,6 +10,8 @@
 import SwiftUI
 
 struct DialogCard: View {
+    @Environment(\.theme) private var theme
+
     let title: String
     let message: String?
     let primaryTitle: String
@@ -36,12 +38,12 @@ struct DialogCard: View {
             VStack(spacing: Theme.SpacingKey.sm.value) {
                 Text(title)
                     .textStyle(.headingSm)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
                     .multilineTextAlignment(.center)
                 if let message {
                     Text(message)
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                        .foregroundStyle(theme.text(.textSecondary))
                         .multilineTextAlignment(.center)
                 }
             }
@@ -59,12 +61,12 @@ struct DialogCard: View {
         }
         .padding(Theme.SpacingKey.lg.value)
         .frame(maxWidth: width ?? 320)
-        .background(Theme.shared.background(.bgWhite),
+        .background(theme.background(.bgWhite),
                    in: RoundedRectangle(cornerRadius: Theme.RadiusKey.lg.value, style: .continuous))
         .overlay(alignment: .topTrailing) {
             if let onClose {
                 Button(action: onClose) {
-                    Icon(systemName: "xmark", size: .sm, color: Theme.shared.text(.textTertiary))
+                    Icon(systemName: "xmark", size: .sm, color: theme.text(.textTertiary))
                         .padding(Theme.SpacingKey.md.value)
                 }
                 .buttonStyle(.plain)

--- a/Sources/ThemeKit/Components/Organisms/Diff.swift
+++ b/Sources/ThemeKit/Components/Organisms/Diff.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Organism. Before / after comparison with a draggable divider that reveals the
 /// two layers. (daisyUI "Diff".)
 public struct Diff<Before: View, After: View>: View {
+    @Environment(\.theme) private var theme
+
     private let aspectRatio: CGFloat
     private let before: () -> Before
     private let after: () -> After
@@ -34,14 +36,14 @@ public struct Diff<Before: View, After: View>: View {
                     .mask(alignment: .leading) { Rectangle().frame(width: max(0, w * fraction)) }
 
                 Rectangle()
-                    .fill(Theme.shared.background(.bgWhite))
+                    .fill(theme.background(.bgWhite))
                     .frame(width: 2)
                     .offset(x: w * fraction - 1)
 
                 Circle()
-                    .fill(Theme.shared.background(.bgWhite))
+                    .fill(theme.background(.bgWhite))
                     .frame(width: 36, height: 36)
-                    .overlay(Image(systemName: "arrow.left.and.right").font(.system(size: 14, weight: .bold)).foregroundStyle(Theme.shared.text(.textPrimary)))
+                    .overlay(Image(systemName: "arrow.left.and.right").font(.system(size: 14, weight: .bold)).foregroundStyle(theme.text(.textPrimary)))
                     .themeShadow(.soft)
                     .offset(x: w * fraction - 18)
             }

--- a/Sources/ThemeKit/Components/Organisms/EmptyState.swift
+++ b/Sources/ThemeKit/Components/Organisms/EmptyState.swift
@@ -10,6 +10,8 @@ import SwiftUI
 /// a faded circle, title, message and an optional primary action. (Lottie /
 /// AppIcon dependencies dropped.)
 public struct EmptyState: View {
+    @Environment(\.theme) private var theme
+
     private let systemImage: String
     private let image: Image?
     private let animatedURL: URL?
@@ -118,11 +120,11 @@ public struct EmptyState: View {
             } else {
                 ZStack {
                     Circle()
-                        .fill(iconBackground ?? Theme.shared.background(.bgElevatorTertiary))
+                        .fill(iconBackground ?? theme.background(.bgElevatorTertiary))
                         .frame(width: iconCircleSize, height: iconCircleSize)
                     Image(systemName: systemImage)
                         .font(.system(size: iconCircleSize * 0.36))
-                        .foregroundStyle(iconForeground ?? Theme.shared.foreground(.fgHero))
+                        .foregroundStyle(iconForeground ?? theme.foreground(.fgHero))
                 }
             }
 
@@ -130,13 +132,13 @@ public struct EmptyState: View {
                 if let title {
                     Text(title)
                         .textStyle(.headingBase)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                         .multilineTextAlignment(.center)
                 }
                 if let message {
                     Text(message)
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                        .foregroundStyle(theme.text(.textSecondary))
                         .multilineTextAlignment(.center)
                 }
             }

--- a/Sources/ThemeKit/Components/Organisms/FloatingActionButton.swift
+++ b/Sources/ThemeKit/Components/Organisms/FloatingActionButton.swift
@@ -23,6 +23,8 @@ public enum FABShape { case circle, square }
 /// Organism. A floating action button with an optional speed-dial of sub-actions.
 /// (daisyUI "FAB / Speed Dial".)
 public struct FloatingActionButton: View {
+    @Environment(\.theme) private var theme
+
     private let systemImage: String
     private let actions: [FABAction]
     private let shape: FABShape
@@ -63,10 +65,10 @@ public struct FloatingActionButton: View {
                         if let label = item.label {
                             Text(label)
                                 .textStyle(.labelSm600)
-                                .foregroundStyle(Theme.shared.text(.textPrimary))
+                                .foregroundStyle(theme.text(.textPrimary))
                                 .padding(.horizontal, Theme.SpacingKey.sm.value)
                                 .frame(height: 28)
-                                .background(Theme.shared.background(.bgWhite), in: Capsule())
+                                .background(theme.background(.bgWhite), in: Capsule())
                                 .themeShadow(.soft)
                         }
                         miniButton(item.systemImage) { item.action(); expanded = false }
@@ -95,9 +97,9 @@ public struct FloatingActionButton: View {
         Button(action: action) {
             Image(systemName: name)
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(Theme.shared.text(.textHero))
+                .foregroundStyle(theme.text(.textHero))
                 .frame(width: 44, height: 44)
-                .background(Theme.shared.background(.bgWhite), in: Circle())
+                .background(theme.background(.bgWhite), in: Circle())
                 .themeShadow(.soft)
         }
         .buttonStyle(.plain)

--- a/Sources/ThemeKit/Components/Organisms/Footer.swift
+++ b/Sources/ThemeKit/Components/Organisms/Footer.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Organism. A page footer: columns of titled links + an optional bottom note.
 /// (daisyUI "Footer".)
 public struct Footer: View {
+    @Environment(\.theme) private var theme
+
     public struct Item: Identifiable {
         public let id = UUID()
         let title: String
@@ -37,7 +39,7 @@ public struct Footer: View {
                     VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
                         Text(column.title.uppercased())
                             .textStyle(.overline500)
-                            .foregroundStyle(Theme.shared.text(.textTertiary))
+                            .foregroundStyle(theme.text(.textTertiary))
                         ForEach(column.items) { item in
                             TextLink(item.title, underline: false, action: item.action)
                         }
@@ -49,12 +51,12 @@ public struct Footer: View {
                 DividerView(size: .small)
                 Text(note)
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
             }
         }
         .padding(Theme.SpacingKey.md.value)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Theme.shared.background(.bgElevatorPrimary))
+        .background(theme.background(.bgElevatorPrimary))
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/Hero.swift
+++ b/Sources/ThemeKit/Components/Organisms/Hero.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Organism. A prominent hero section: centered title + subtitle + optional CTA
 /// over a color or custom background. (daisyUI "Hero".)
 public struct Hero<Background: View>: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     private let subtitle: String?
     private let ctaTitle: String?
@@ -36,7 +38,7 @@ public struct Hero<Background: View>: View {
         ZStack {
             background()
             if dark {
-                Theme.shared.background(.bgTertiary).opacity(0.45)
+                theme.background(.bgTertiary).opacity(0.45)
             }
             VStack(spacing: Theme.SpacingKey.md.value) {
                 Text(title)
@@ -60,8 +62,8 @@ public struct Hero<Background: View>: View {
         .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusKey.lg.value, style: .continuous))
     }
 
-    private var titleColor: Color { dark ? Theme.shared.foreground(.fgSecondary) : Theme.shared.text(.textPrimary) }
-    private var subtitleColor: Color { dark ? Theme.shared.text(.textSecondaryInverse) : Theme.shared.text(.textSecondary) }
+    private var titleColor: Color { dark ? theme.foreground(.fgSecondary) : theme.text(.textPrimary) }
+    private var subtitleColor: Color { dark ? theme.text(.textSecondaryInverse) : theme.text(.textSecondary) }
 }
 
 public extension Hero where Background == Color {

--- a/Sources/ThemeKit/Components/Organisms/ImageCollage.swift
+++ b/Sources/ThemeKit/Components/Organisms/ImageCollage.swift
@@ -10,6 +10,8 @@ import SwiftUI
 /// and a "+N" overlay on the last visible tile. Brand-neutral, token-bound; uses
 /// `RemoteImage` (native AsyncImage), no asset/Kingfisher dependency.
 public struct ImageCollage: View {
+    @Environment(\.theme) private var theme
+
     private let urls: [URL]
     private let height: CGFloat
     private let spacing: CGFloat
@@ -72,8 +74,8 @@ public struct ImageCollage: View {
 
     private var placeholder: some View {
         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-            .fill(Theme.shared.background(.bgSecondaryLight))
-            .overlay(Icon(systemName: "photo.on.rectangle", size: .lg, color: Theme.shared.text(.textTertiary)))
+            .fill(theme.background(.bgSecondaryLight))
+            .overlay(Icon(systemName: "photo.on.rectangle", size: .lg, color: theme.text(.textTertiary)))
             .frame(maxWidth: .infinity)
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
@@ -53,6 +53,8 @@ public enum InfoBannerType {
 /// drive a light-surface banner with a colored icon, optional title and an
 /// optional dismiss action.
 public struct InfoBanner: View {
+    @Environment(\.theme) private var theme
+
     private let type: InfoBannerType
     private let title: String?
     private let message: String
@@ -97,14 +99,14 @@ public struct InfoBanner: View {
                 if let title {
                     Text(title)
                         .textStyle(.labelBase600)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                 }
                 if links.isEmpty {
                     Text(message)
                         .textStyle(.bodySm400)
-                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                        .foregroundStyle(theme.text(.textSecondary))
                 } else {
-                    InlineText(message, links: links, baseColor: Theme.shared.text(.textSecondary))
+                    InlineText(message, links: links, baseColor: theme.text(.textSecondary))
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -118,7 +120,7 @@ public struct InfoBanner: View {
 
             if let onDismiss {
                 Button(action: onDismiss) {
-                    Icon(systemName: "xmark", size: .xs, color: Theme.shared.text(.textTertiary))
+                    Icon(systemName: "xmark", size: .xs, color: theme.text(.textTertiary))
                 }
                 .buttonStyle(.plain)
             }

--- a/Sources/ThemeKit/Components/Organisms/KeyValueTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/KeyValueTable.swift
@@ -22,6 +22,8 @@ public enum TableValueStyle {
 /// Organism. A label/value table (Figma "Table"). Values can carry a status
 /// style (plain / success / error / muted / strikethrough).
 public struct KeyValueTable: View {
+    @Environment(\.theme) private var theme
+
     public struct Row: Identifiable {
         public let id = UUID()
         let label: String
@@ -49,15 +51,15 @@ public struct KeyValueTable: View {
             if let title {
                 Text(title)
                     .textStyle(.labelLg600)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
             }
             if bordered {
                 table
-                    .background(Theme.shared.background(.bgWhite),
+                    .background(theme.background(.bgWhite),
                                 in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
                     .overlay(
                         RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                            .strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                            .strokeBorder(theme.border(.borderPrimary), lineWidth: 1)
                     )
             } else {
                 table
@@ -71,7 +73,7 @@ public struct KeyValueTable: View {
                 HStack {
                     Text(row.label)
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                        .foregroundStyle(theme.text(.textSecondary))
                     Spacer(minLength: Theme.SpacingKey.md.value)
                     Text(row.value)
                         .textStyle(.labelBase600)

--- a/Sources/ThemeKit/Components/Organisms/ListRow.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListRow.swift
@@ -79,6 +79,8 @@ public struct ListRowInfo: Identifiable {
 /// inline button / price block / status text. Plus a per-row meta line (rating,
 /// sentiment, comment count), an active-selected background and an info button.
 public struct ListRow: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     private let subtitle: String?
     private let number: Int?
@@ -142,7 +144,7 @@ public struct ListRow: View {
                 Spacer(minLength: Theme.SpacingKey.sm.value)
                 if let infoAction {
                     Button(action: infoAction) {
-                        Icon(systemName: "info.circle", size: .sm, color: Theme.shared.text(.textTertiary))
+                        Icon(systemName: "info.circle", size: .sm, color: theme.text(.textTertiary))
                     }
                     .buttonStyle(.plain)
                 }
@@ -152,7 +154,7 @@ public struct ListRow: View {
             .padding(.horizontal, isSelected ? Theme.SpacingKey.md.value : 0)
             .background(
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous)
-                    .fill(isSelected ? Theme.shared.background(.bgHero).opacity(0.08) : .clear)
+                    .fill(isSelected ? theme.background(.bgHero).opacity(0.08) : .clear)
             )
             .contentShape(Rectangle())
         }
@@ -179,21 +181,21 @@ public struct ListRow: View {
         } else if let number {
             Text(String(format: "%02d", number))
                 .textStyle(.labelMd700)
-                .foregroundStyle(isSelected ? Theme.shared.text(.textHero) : Theme.shared.text(.textPrimary))
+                .foregroundStyle(isSelected ? theme.text(.textHero) : theme.text(.textPrimary))
                 .monospacedDigit()
                 .frame(width: 32, alignment: .leading)
         } else if let leadingSystemImage {
             ZStack {
-                Circle().fill(Theme.shared.background(.bgElevatorTertiary)).frame(width: 40, height: 40)
-                Icon(systemName: leadingSystemImage, size: .sm, color: Theme.shared.foreground(.fgHero))
+                Circle().fill(theme.background(.bgElevatorTertiary)).frame(width: 40, height: 40)
+                Icon(systemName: leadingSystemImage, size: .sm, color: theme.foreground(.fgHero))
             }
             .overlay(alignment: .topTrailing) {
                 if let alertCount, alertCount > 0 {
                     Text(alertCount > 99 ? "99+" : "\(alertCount)")
                         .textStyle(.overline400)
-                        .foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                        .foregroundStyle(theme.foreground(.fgSecondary))
                         .padding(.horizontal, 5).padding(.vertical, 1)
-                        .background(Theme.shared.background(.systemcolorsBgError), in: Capsule())
+                        .background(theme.background(.systemcolorsBgError), in: Capsule())
                         .offset(x: 6, y: -4)
                 }
             }
@@ -207,7 +209,7 @@ public struct ListRow: View {
             HStack(spacing: Theme.SpacingKey.xs.value) {
                 Text(title)
                     .textStyle(size.titleStyle)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
                     .lineLimit(multilineTitle ? nil : 1)
                 if let badge {
                     Badge(badge, style: .info, variant: .soft, size: .small)
@@ -216,7 +218,7 @@ public struct ListRow: View {
             if let subtitle {
                 Text(subtitle)
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textSecondary))
+                    .foregroundStyle(theme.text(.textSecondary))
                     .lineLimit(multilineTitle ? nil : 2)
             }
             if let meta { metaLine(meta) }
@@ -226,11 +228,11 @@ public struct ListRow: View {
                         HStack(alignment: .top, spacing: Theme.SpacingKey.xs.value) {
                             Image(systemName: info.systemImage ?? "circle.fill")
                                 .font(.system(size: info.systemImage == nil ? 5 : 11))
-                                .foregroundStyle(Theme.shared.text(.textTertiary))
+                                .foregroundStyle(theme.text(.textTertiary))
                                 .padding(.top, info.systemImage == nil ? 6 : 2)
                             Text(info.text)
                                 .textStyle(.bodySm400)
-                                .foregroundStyle(Theme.shared.text(.textSecondary))
+                                .foregroundStyle(theme.text(.textSecondary))
                         }
                     }
                 }
@@ -246,23 +248,23 @@ public struct ListRow: View {
                 HStack(spacing: 2) {
                     Text(meta.ratingLabel ?? String(format: "%.1f", rating))
                         .textStyle(.labelSm700)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                     Image(systemName: "star.fill")
                         .font(.system(size: 11))
-                        .foregroundStyle(Theme.shared.foreground(.systemcolorsFgWarning))
+                        .foregroundStyle(theme.foreground(.systemcolorsFgWarning))
                 }
                 .fixedSize()
             }
             if let sentiment = meta.sentiment {
                 Text(sentiment)
                     .textStyle(.labelSm600)
-                    .foregroundStyle(Theme.shared.foreground(.systemcolorsFgSuccess))
+                    .foregroundStyle(theme.foreground(.systemcolorsFgSuccess))
                     .fixedSize()
             }
             if let commentLabel = meta.commentLabel {
                 Text(commentLabel)
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -278,17 +280,17 @@ public struct ListRow: View {
         case .none:
             EmptyView()
         case .chevron:
-            Icon(systemName: "chevron.right", size: .sm, color: Theme.shared.text(.textTertiary))
+            Icon(systemName: "chevron.right", size: .sm, color: theme.text(.textTertiary))
                 .mirrorsInRTL()
         case .value(let text):
             Text(text)
                 .textStyle(.bodyBase400)
-                .foregroundStyle(Theme.shared.text(.textSecondary))
+                .foregroundStyle(theme.text(.textSecondary))
         case .toggle(let binding):
             ThemeToggle(isOn: binding)
         case .checkmark(let on):
             if on {
-                Icon(systemName: "checkmark", size: .sm, color: Theme.shared.foreground(.fgHero))
+                Icon(systemName: "checkmark", size: .sm, color: theme.foreground(.fgHero))
             }
         case .checkbox(let binding):
             Checkbox(isChecked: binding)
@@ -301,11 +303,11 @@ public struct ListRow: View {
                 if let systemImage {
                     Image(systemName: systemImage)
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(Theme.shared.foreground(.systemcolorsFgSuccess))
+                        .foregroundStyle(theme.foreground(.systemcolorsFgSuccess))
                 }
                 Text(text)
                     .textStyle(.labelSm600)
-                    .foregroundStyle(Theme.shared.foreground(.systemcolorsFgSuccess))
+                    .foregroundStyle(theme.foreground(.systemcolorsFgSuccess))
             }
         }
     }
@@ -316,18 +318,18 @@ public struct ListRow: View {
                 HStack(spacing: 0) {
                     Text(each)
                         .textStyle(.labelBase700)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                     Text(" \(price.unit)")
                         .textStyle(.bodySm400)
-                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                        .foregroundStyle(theme.text(.textTertiary))
                 }
                 Text("Toplam: \(price.total)")
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
             } else {
                 Text(price.total)
                     .textStyle(.labelBase700)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
             }
         }
     }
@@ -335,13 +337,15 @@ public struct ListRow: View {
 
 /// A non-interactive section-header row inside a list (Reference menu `.secondary`).
 public struct ListSectionHeader: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     public init(_ title: String) { self.title = title }
 
     public var body: some View {
         Text(title.uppercased())
             .textStyle(.labelSm700)
-            .foregroundStyle(Theme.shared.text(.textTertiary))
+            .foregroundStyle(theme.text(.textTertiary))
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, Theme.SpacingKey.sm.value)
     }

--- a/Sources/ThemeKit/Components/Organisms/ListView.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 /// dividers (split), and a loading (skeleton) state. Generic over the item +
 /// row content; pairs naturally with `ListRow`.
 public struct ListView<Item: Identifiable, Row: View>: View {
+    @Environment(\.theme) private var theme
+
     private let items: [Item]
     private let header: String?
     private let footer: String?
@@ -44,7 +46,7 @@ public struct ListView<Item: Identifiable, Row: View>: View {
             if let header {
                 Text(header)
                     .textStyle(.labelBase600)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, Theme.SpacingKey.md.value)
                     .padding(.vertical, Theme.SpacingKey.sm.value)
@@ -77,18 +79,18 @@ public struct ListView<Item: Identifiable, Row: View>: View {
                 if split { DividerView(size: .small) }
                 Text(footer)
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, Theme.SpacingKey.md.value)
                     .padding(.vertical, Theme.SpacingKey.sm.value)
             }
         }
-        .background(bordered ? Theme.shared.background(.bgWhite) : .clear,
+        .background(bordered ? theme.background(.bgWhite) : .clear,
                    in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
         .overlay {
             if bordered {
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous)
-                    .stroke(Theme.shared.border(.borderPrimary), lineWidth: 1)
+                    .stroke(theme.border(.borderPrimary), lineWidth: 1)
             }
         }
     }
@@ -96,7 +98,7 @@ public struct ListView<Item: Identifiable, Row: View>: View {
     private var emptyRow: some View {
         Text(emptyText ?? String(themeKit: "No data"))
             .textStyle(.bodySm400)
-            .foregroundStyle(Theme.shared.text(.textTertiary))
+            .foregroundStyle(theme.text(.textTertiary))
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.horizontal, Theme.SpacingKey.md.value)
             .padding(.vertical, Theme.SpacingKey.lg.value)
@@ -104,10 +106,10 @@ public struct ListView<Item: Identifiable, Row: View>: View {
 
     private var skeletonRow: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
-            Circle().fill(Theme.shared.background(.bgSecondaryLight)).frame(width: 36, height: 36)
+            Circle().fill(theme.background(.bgSecondaryLight)).frame(width: 36, height: 36)
             VStack(alignment: .leading, spacing: 6) {
-                RoundedRectangle(cornerRadius: 4).fill(Theme.shared.background(.bgSecondaryLight)).frame(width: 140, height: 12)
-                RoundedRectangle(cornerRadius: 4).fill(Theme.shared.background(.bgSecondaryLight)).frame(width: 90, height: 10)
+                RoundedRectangle(cornerRadius: 4).fill(theme.background(.bgSecondaryLight)).frame(width: 140, height: 12)
+                RoundedRectangle(cornerRadius: 4).fill(theme.background(.bgSecondaryLight)).frame(width: 90, height: 10)
             }
             Spacer()
         }

--- a/Sources/ThemeKit/Components/Organisms/NavigationBar.swift
+++ b/Sources/ThemeKit/Components/Organisms/NavigationBar.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Organism. Floating bottom tab bar. Active item uses a filled glyph + hero
 /// underline. Selection owned by the caller.
 public struct NavigationBar: View {
+    @Environment(\.theme) private var theme
+
     public struct Item: Identifiable {
         public let id = UUID()
         let systemImage: String
@@ -37,9 +39,9 @@ public struct NavigationBar: View {
                     VStack(spacing: 6) {
                         Image(systemName: isActive ? (item.activeSystemImage ?? item.systemImage + ".fill") : item.systemImage)
                             .font(.system(size: 20))
-                            .foregroundStyle(isActive ? Theme.shared.foreground(.fgHero) : Theme.shared.text(.textTertiary))
+                            .foregroundStyle(isActive ? theme.foreground(.fgHero) : theme.text(.textTertiary))
                         Capsule()
-                            .fill(isActive ? Theme.shared.background(.bgHero) : .clear)
+                            .fill(isActive ? theme.background(.bgHero) : .clear)
                             .frame(width: 20, height: 3)
                     }
                     .frame(maxWidth: .infinity)
@@ -50,7 +52,7 @@ public struct NavigationBar: View {
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
         .padding(.vertical, Theme.SpacingKey.sm.value)
-        .background(Theme.shared.background(.bgWhite), in: Capsule())
+        .background(theme.background(.bgWhite), in: Capsule())
         .themeShadow(.tabBar)
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Organism. A notification surface: bell icon, optional unread dot + timestamp,
 /// title, message and optional actions.
 public struct NotificationCard<Actions: View>: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     private let message: String?
     private let date: String?
@@ -36,7 +38,7 @@ public struct NotificationCard<Actions: View>: View {
     }
 
     private var iconName: String { type?.systemImage ?? "bell" }
-    private var iconColor: Color { type?.semanticColor.accent ?? Theme.shared.foreground(.fgHero) }
+    private var iconColor: Color { type?.semanticColor.accent ?? theme.foreground(.fgHero) }
 
     public var body: some View {
         Card {
@@ -47,18 +49,18 @@ public struct NotificationCard<Actions: View>: View {
                     if let date {
                         HStack(spacing: Theme.SpacingKey.xs.value) {
                             if isUnread {
-                                Circle().fill(Theme.shared.foreground(.systemcolorsFgError)).frame(width: 6, height: 6)
+                                Circle().fill(theme.foreground(.systemcolorsFgError)).frame(width: 6, height: 6)
                             }
-                            Text(date).textStyle(.overline400).foregroundStyle(Theme.shared.text(.textTertiary))
+                            Text(date).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
                         }
                     }
                     Text(title)
                         .textStyle(.labelBase600)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                     if let message {
                         Text(message)
                             .textStyle(.bodySm400)
-                            .foregroundStyle(Theme.shared.text(.textSecondary))
+                            .foregroundStyle(theme.text(.textSecondary))
                     }
                     if let actions {
                         actions.padding(.top, Theme.SpacingKey.xs.value)
@@ -67,7 +69,7 @@ public struct NotificationCard<Actions: View>: View {
                 Spacer(minLength: 0)
                 if let onClose {
                     Button(action: onClose) {
-                        Icon(systemName: "xmark", size: .xs, color: Theme.shared.text(.textTertiary))
+                        Icon(systemName: "xmark", size: .xs, color: theme.text(.textTertiary))
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(String(themeKit: "Dismiss"))

--- a/Sources/ThemeKit/Components/Organisms/PageHeader.swift
+++ b/Sources/ThemeKit/Components/Organisms/PageHeader.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Organism. Screen header: optional back button, title + subtitle, trailing
 /// icon actions.
 public struct PageHeader: View {
+    @Environment(\.theme) private var theme
+
     public struct Action: Identifiable {
         public let id = UUID()
         let systemImage: String
@@ -54,7 +56,7 @@ public struct PageHeader: View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
             if let onBack {
                 Button(action: onBack) {
-                    Icon(systemName: "chevron.left", size: .md, color: Theme.shared.text(.textPrimary))
+                    Icon(systemName: "chevron.left", size: .md, color: theme.text(.textPrimary))
                         .mirrorsInRTL()
                 }
                 .buttonStyle(.plain)
@@ -64,7 +66,7 @@ public struct PageHeader: View {
                 HStack(spacing: Theme.SpacingKey.xs.value) {
                     Text(title)
                         .textStyle(.headingSm)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                     ForEach(tags) { tag in
                         ThemeKit.Tag(tag.text, style: tag.style)
                     }
@@ -72,7 +74,7 @@ public struct PageHeader: View {
                 if let subtitle {
                     Text(subtitle)
                         .textStyle(.bodySm400)
-                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                        .foregroundStyle(theme.text(.textSecondary))
                 }
             }
 
@@ -80,7 +82,7 @@ public struct PageHeader: View {
 
             ForEach(actions) { action in
                 Button(action: action.handler) {
-                    Icon(systemName: action.systemImage, size: .md, color: Theme.shared.text(.textPrimary))
+                    Icon(systemName: action.systemImage, size: .md, color: theme.text(.textPrimary))
                 }
                 .buttonStyle(.plain)
             }

--- a/Sources/ThemeKit/Components/Organisms/PromoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/PromoBanner.swift
@@ -33,6 +33,8 @@ public enum PromoBannerTint {
 /// Organism. A promotional banner (campaign / offer). Distinct from InfoBanner
 /// (status). Leading visual + title + subtitle + optional CTA, on a tinted card.
 public struct PromoBanner: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     private let subtitle: String?
     private let systemImage: String?
@@ -78,10 +80,10 @@ public struct PromoBanner: View {
                 Button(action: action) {
                     Text(ctaTitle)
                         .textStyle(.labelSm700)
-                        .foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                        .foregroundStyle(theme.foreground(.fgSecondary))
                         .padding(.horizontal, Theme.SpacingKey.md.value)
                         .frame(height: 36)
-                        .background(Theme.shared.background(.bgHero), in: Capsule())
+                        .background(theme.background(.bgHero), in: Capsule())
                 }
                 .buttonStyle(.plain)
             }

--- a/Sources/ThemeKit/Components/Organisms/RatingSummary.swift
+++ b/Sources/ThemeKit/Components/Organisms/RatingSummary.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// Organism. A review summary row: score badge + qualitative label + review
 /// count link. (Star display lives in the Rating atom.)
 public struct RatingSummary: View {
+    @Environment(\.theme) private var theme
+
     private let score: Double
     private let label: String?
     private let reviewCount: Int?
@@ -27,7 +29,7 @@ public struct RatingSummary: View {
             if let label {
                 Text(label)
                     .textStyle(.labelBase600)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
             }
             Spacer(minLength: Theme.SpacingKey.sm.value)
             if let reviewCount {
@@ -37,7 +39,7 @@ public struct RatingSummary: View {
                         Image(systemName: "chevron.right").font(.system(size: 10, weight: .semibold))
                             .mirrorsInRTL()
                     }
-                    .foregroundStyle(Theme.shared.text(.textHero))
+                    .foregroundStyle(theme.text(.textHero))
                 }
                 .buttonStyle(.plain)
                 .disabled(onReviews == nil)

--- a/Sources/ThemeKit/Components/Organisms/ResultView.swift
+++ b/Sources/ThemeKit/Components/Organisms/ResultView.swift
@@ -51,6 +51,8 @@ public enum ResultStatus: String, CaseIterable {
 /// (404 / 403 / 500), with up to two actions. Generalizes `EmptyState`.
 /// See docs/result-templates.md.
 public struct ResultView: View {
+    @Environment(\.theme) private var theme
+
     private let status: ResultStatus
     private let title: String
     private let message: String?
@@ -84,12 +86,12 @@ public struct ResultView: View {
             VStack(spacing: Theme.SpacingKey.sm.value) {
                 Text(title)
                     .textStyle(.headingBase)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                    .foregroundStyle(theme.text(.textPrimary))
                     .multilineTextAlignment(.center)
                 if let message {
                     Text(message)
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                        .foregroundStyle(theme.text(.textSecondary))
                         .multilineTextAlignment(.center)
                 }
             }
@@ -119,7 +121,7 @@ public struct ResultView: View {
                 .overlay(alignment: .bottomTrailing) {
                     Icon(systemName: status.systemImage, size: .md, color: status.color.base)
                         .padding(6)
-                        .background(Theme.shared.background(.bgWhite), in: Circle())
+                        .background(theme.background(.bgWhite), in: Circle())
                         .offset(x: 10, y: 4)
                 }
         } else {

--- a/Sources/ThemeKit/Components/Organisms/SegmentedTabBar.swift
+++ b/Sources/ThemeKit/Components/Organisms/SegmentedTabBar.swift
@@ -26,6 +26,8 @@ public enum SegmentedTabBarStyle { case underline, card }
 /// Tab bar with a selection binding and an animated underline. Tabs can carry an
 /// icon, a count badge and a disabled state. (Ant Tabs parity.)
 public struct SegmentedTabBar: View {
+    @Environment(\.theme) private var theme
+
     private let items: [TabItem]
     @Binding private var selection: Int
     private let scrollable: Bool
@@ -89,10 +91,10 @@ public struct SegmentedTabBar: View {
                 Button(action: onAdd) {
                     Image(systemName: "plus")
                         .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                        .foregroundStyle(theme.text(.textSecondary))
                         .frame(width: 36, height: 36)
-                        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
-                        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1))
+                        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+                        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).strokeBorder(theme.border(.borderPrimary), lineWidth: 1))
                 }
                 .buttonStyle(.plain)
             }
@@ -113,9 +115,9 @@ public struct SegmentedTabBar: View {
                     }
                     Text(item.title).textStyle(isActive ? .labelBase700 : .labelBase600)
                     if let badge = item.badge {
-                        Text(badge).textStyle(.overline400).foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                        Text(badge).textStyle(.overline400).foregroundStyle(theme.foreground(.fgSecondary))
                             .padding(.horizontal, 5).padding(.vertical, 1)
-                            .background(Theme.shared.background(.systemcolorsBgError), in: Capsule())
+                            .background(theme.background(.systemcolorsBgError), in: Capsule())
                     }
                 }
                 .foregroundStyle(foreground(isActive: isActive, enabled: item.isEnabled))
@@ -125,7 +127,7 @@ public struct SegmentedTabBar: View {
             if let onClose {
                 Button { onClose(index) } label: {
                     Image(systemName: "xmark").font(.system(size: 10, weight: .bold))
-                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                        .foregroundStyle(theme.text(.textTertiary))
                 }
                 .buttonStyle(.plain)
             }
@@ -133,12 +135,12 @@ public struct SegmentedTabBar: View {
         .padding(.horizontal, Theme.SpacingKey.md.value)
         .padding(.vertical, Theme.SpacingKey.sm.value)
         .background(
-            (isActive ? Theme.shared.background(.bgWhite) : Theme.shared.background(.bgElevatorTertiary)),
+            (isActive ? theme.background(.bgWhite) : theme.background(.bgElevatorTertiary)),
             in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
         )
         .overlay(
             RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                .strokeBorder(isActive ? Theme.shared.border(.borderHero) : Theme.shared.border(.borderPrimary), lineWidth: isActive ? 1.5 : 1)
+                .strokeBorder(isActive ? theme.border(.borderHero) : theme.border(.borderPrimary), lineWidth: isActive ? 1.5 : 1)
         )
         .disabled(!item.isEnabled)
     }
@@ -161,13 +163,13 @@ public struct SegmentedTabBar: View {
                         if let badge = item.badge {
                             Text(badge)
                                 .textStyle(.overline400)
-                                .foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                                .foregroundStyle(theme.foreground(.fgSecondary))
                                 .padding(.horizontal, 5).padding(.vertical, 1)
-                                .background(Theme.shared.background(.systemcolorsBgError), in: Capsule())
+                                .background(theme.background(.systemcolorsBgError), in: Capsule())
                         }
                     }
                     if let caption = item.caption {
-                        Text(caption).textStyle(.overline400).foregroundStyle(Theme.shared.text(.textTertiary))
+                        Text(caption).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
                     }
                 }
                 .foregroundStyle(foreground(isActive: isActive, enabled: item.isEnabled))
@@ -176,7 +178,7 @@ public struct SegmentedTabBar: View {
                     Capsule().fill(Color.clear).frame(height: 2)
                     if isActive {
                         Capsule()
-                            .fill(Theme.shared.border(.borderHero))
+                            .fill(theme.border(.borderHero))
                             .frame(height: 2)
                             .matchedGeometryEffect(id: "underline", in: underline)
                     }
@@ -189,8 +191,8 @@ public struct SegmentedTabBar: View {
     }
 
     private func foreground(isActive: Bool, enabled: Bool) -> Color {
-        guard enabled else { return Theme.shared.text(.textDisabled) }
-        return isActive ? Theme.shared.text(.textPrimary) : Theme.shared.text(.textSecondary)
+        guard enabled else { return theme.text(.textDisabled) }
+        return isActive ? theme.text(.textPrimary) : theme.text(.textSecondary)
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/Timeline.swift
+++ b/Sources/ThemeKit/Components/Organisms/Timeline.swift
@@ -21,6 +21,8 @@ public enum TimelineMode: Sendable {
 /// trailing "pending" (loading) node. `mode` places the content left, right or
 /// alternating around the rail; `reverse` flips the order. (Ant Timeline parity.)
 public struct Timeline: View {
+    @Environment(\.theme) private var theme
+
     public struct Item: Identifiable {
         public let id = UUID()
         let title: String
@@ -76,13 +78,13 @@ public struct Timeline: View {
                         marker(item)
                     }
                     if let time = item.time {
-                        Text(time).textStyle(.overline400).foregroundStyle(Theme.shared.text(.textTertiary))
+                        Text(time).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
                     }
                     Text(item.title).textStyle(.labelSm600)
-                        .foregroundStyle(item.state == .todo ? Theme.shared.text(.textTertiary) : Theme.shared.text(.textPrimary))
+                        .foregroundStyle(item.state == .todo ? theme.text(.textTertiary) : theme.text(.textPrimary))
                         .multilineTextAlignment(.center)
                     if let description = item.description {
-                        Text(description).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+                        Text(description).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
                             .multilineTextAlignment(.center)
                     }
                 }
@@ -159,53 +161,53 @@ public struct Timeline: View {
     @ViewBuilder
     private func itemMain(_ item: Item, showTime: Bool) -> some View {
         if showTime, let time = item.time {
-            Text(time).textStyle(.overline400).foregroundStyle(Theme.shared.text(.textTertiary))
+            Text(time).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
         }
-        Text(item.title).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textPrimary))
+        Text(item.title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
         if let description = item.description {
-            Text(description).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+            Text(description).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
         }
     }
 
     @ViewBuilder
     private func oppositeContent(_ item: Item) -> some View {
         if let time = item.time {
-            Text(time).textStyle(.overline400).foregroundStyle(Theme.shared.text(.textTertiary))
+            Text(time).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
         }
     }
 
     private func pendingMain(_ text: String) -> some View {
-        Text(text).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textTertiary))
+        Text(text).textStyle(.labelBase600).foregroundStyle(theme.text(.textTertiary))
     }
 
     private func railColor(_ item: Item) -> Color {
-        item.state == .done ? (item.color?.solid ?? Theme.shared.background(.bgHero)) : Theme.shared.border(.borderPrimary)
+        item.state == .done ? (item.color?.solid ?? theme.background(.bgHero)) : theme.border(.borderPrimary)
     }
 
     @ViewBuilder
     private func marker(_ item: Item) -> some View {
         let dotColor = item.state == .error
-            ? Theme.shared.background(.systemcolorsBgError)
-            : (item.color?.solid ?? Theme.shared.background(.bgHero))
+            ? theme.background(.systemcolorsBgError)
+            : (item.color?.solid ?? theme.background(.bgHero))
         ZStack {
-            Circle().fill(item.state == .todo ? Theme.shared.background(.bgWhite) : dotColor).frame(width: 28, height: 28)
-            Circle().strokeBorder(item.state == .todo ? Theme.shared.border(.borderPrimary) : dotColor, lineWidth: 1.5).frame(width: 28, height: 28)
+            Circle().fill(item.state == .todo ? theme.background(.bgWhite) : dotColor).frame(width: 28, height: 28)
+            Circle().strokeBorder(item.state == .todo ? theme.border(.borderPrimary) : dotColor, lineWidth: 1.5).frame(width: 28, height: 28)
             if item.state == .error {
-                Image(systemName: "xmark").font(.system(size: 11, weight: .bold)).foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                Image(systemName: "xmark").font(.system(size: 11, weight: .bold)).foregroundStyle(theme.foreground(.fgSecondary))
             } else if let systemImage = item.systemImage {
                 Image(systemName: systemImage).font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(item.state == .todo ? Theme.shared.text(.textTertiary) : Theme.shared.foreground(.fgSecondary))
+                    .foregroundStyle(item.state == .todo ? theme.text(.textTertiary) : theme.foreground(.fgSecondary))
             } else if item.state == .done {
-                Image(systemName: "checkmark").font(.system(size: 11, weight: .bold)).foregroundStyle(Theme.shared.foreground(.fgSecondary))
+                Image(systemName: "checkmark").font(.system(size: 11, weight: .bold)).foregroundStyle(theme.foreground(.fgSecondary))
             }
         }
     }
 
     private var pendingMarker: some View {
         ZStack {
-            Circle().fill(Theme.shared.background(.bgWhite)).frame(width: 28, height: 28)
-            Circle().strokeBorder(Theme.shared.border(.borderPrimary), lineWidth: 1.5).frame(width: 28, height: 28)
-            ProgressView().controlSize(.mini).tint(Theme.shared.foreground(.fgHero))
+            Circle().fill(theme.background(.bgWhite)).frame(width: 28, height: 28)
+            Circle().strokeBorder(theme.border(.borderPrimary), lineWidth: 1.5).frame(width: 28, height: 28)
+            ProgressView().controlSize(.mini).tint(theme.foreground(.fgHero))
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/Upload.swift
+++ b/Sources/ThemeKit/Components/Organisms/Upload.swift
@@ -26,6 +26,8 @@ public struct UploadFile: Identifiable, Equatable {
 /// Organism. A file-upload prompt plus a list of files with per-item status
 /// (uploading / done / failed). State owned by the caller.
 public struct Upload: View {
+    @Environment(\.theme) private var theme
+
     private let prompt: String
     private let buttonTitle: String
     private let files: [UploadFile]
@@ -59,12 +61,12 @@ public struct Upload: View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             Text(prompt)
                 .textStyle(.bodySm400)
-                .foregroundStyle(Theme.shared.text(.textSecondary))
+                .foregroundStyle(theme.text(.textSecondary))
             PrimaryButton(buttonTitle, isContentWidth: true, isEnabled: .constant(!atLimit)) { onPick() }
             if let maxCount {
                 Text("\(files.count)/\(maxCount)")
                     .textStyle(.overline400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
             }
 
             if !files.isEmpty {
@@ -81,9 +83,9 @@ public struct Upload: View {
     private func row(for file: UploadFile) -> some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
             RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous)
-                .fill(Theme.shared.background(.bgElevatorTertiary))
+                .fill(theme.background(.bgElevatorTertiary))
                 .frame(width: 36, height: 36)
-                .overlay(Icon(systemName: "photo", size: .sm, color: Theme.shared.foreground(.fgHero)))
+                .overlay(Icon(systemName: "photo", size: .sm, color: theme.foreground(.fgHero)))
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(file.name)
@@ -96,14 +98,14 @@ public struct Upload: View {
 
             if let onRetry, case .failed = file.status {
                 Button { onRetry(file) } label: {
-                    Icon(systemName: "arrow.clockwise", size: .sm, color: Theme.shared.foreground(.fgHero))
+                    Icon(systemName: "arrow.clockwise", size: .sm, color: theme.foreground(.fgHero))
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(String(themeKit: "Retry"))
             }
 
             Button { onRemove(file) } label: {
-                Icon(systemName: "trash", size: .sm, color: Theme.shared.text(.textTertiary))
+                Icon(systemName: "trash", size: .sm, color: theme.text(.textTertiary))
             }
             .buttonStyle(.plain)
         }
@@ -123,8 +125,8 @@ public struct Upload: View {
     }
 
     private func nameColor(for status: UploadStatus) -> Color {
-        if case .failed = status { return Theme.shared.foreground(.systemcolorsFgError) }
-        return Theme.shared.text(.textPrimary)
+        if case .failed = status { return theme.foreground(.systemcolorsFgError) }
+        return theme.text(.textPrimary)
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/VideoPlayerView.swift
+++ b/Sources/ThemeKit/Components/Organisms/VideoPlayerView.swift
@@ -13,6 +13,8 @@ import AVKit
 /// that toggles play/pause, and a mute toggle button. Controls hidden by default.
 /// iOS uses AVPlayerViewController; macOS falls back to the SwiftUI `VideoPlayer`.
 public struct VideoPlayerView: View {
+    @Environment(\.theme) private var theme
+
     private let url: URL?
     private let autoplay: Bool
     private let loop: Bool
@@ -54,8 +56,8 @@ public struct VideoPlayerView: View {
                 player(url)
             } else {
                 ZStack {
-                    Theme.shared.background(.bgTertiary)
-                    Icon(systemName: "play.rectangle", size: .xl, color: Theme.shared.foreground(.fgSecondary))
+                    theme.background(.bgTertiary)
+                    Icon(systemName: "play.rectangle", size: .xl, color: theme.foreground(.fgSecondary))
                 }
             }
         }


### PR DESCRIPTION
## What
Final rollout batch (after Atoms #66, Molecules #67). **29 organism `View` structs** now read `\.theme` from the environment instead of `Theme.shared`, so an injected `.theme(_:)` re-skins them per-subtree. `\.theme` defaults to `Theme.shared`, so **the default render is unchanged**.

## Scope (batch 3 of 3 — Organisms, 181 reads)
DataTable, ListView / ListRow / ListSectionHeader, Timeline, SegmentedTabBar, Accordion(+Group), Upload, Hero, ChatBubble, Coupon, NotificationCard, InfoBanner, EmptyState, ResultView, NavigationBar, PageHeader, Footer, BlogCard, PromoBanner, Counter, Diff, KeyValueTable, RatingSummary, FloatingActionButton, Carousel, ImageCollage, VideoPlayerView, DialogCard.

- **One compiler-caught leak reverted:** DataTable's nested `Column` (a non-View value type) has no environment, so its default text cell stays on `Theme.shared`.

## Rollout status
This completes the bulk **view-body** migration across all three layers (66 + 333 + 181 = **580 reads** now environment-driven). The **~156 reads left** are static color resolvers / enum cases / init defaults / `ObservableObject` presenters that need a *theme parameter* (not environment) to be subtree-themeable — tracked in `docs/AUDIT.md`.

## Safety — verified non-breaking
- Every **regenerated screenshot byte-identical** to baseline (BorderBeam excluded — animated, source untouched).
- Full suite green (**160 tests**); compiler-guarded migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)