### PR TITLE
refactor(theme): migrate private/subdir Views to @Environment(\.theme) (rollout 4)

### DIFF
--- a/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
@@ -21,6 +21,8 @@ public enum ThemeButtonStyle {
 /// haptics, an async `run` with an automatic loading spinner, and an optional
 /// success-confirmation that morphs the label into a checkmark.
 private struct ThemedButton: View {
+    @Environment(\.theme) private var theme
+
     enum Phase { case idle, running, success }
 
     let title: String
@@ -45,7 +47,7 @@ private struct ThemedButton: View {
             if let helperText {
                 Text(helperText)
                     .textStyle(.bodySm400)
-                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .foregroundStyle(theme.text(.textTertiary))
                     .multilineTextAlignment(.center)
             }
         }
@@ -100,19 +102,19 @@ private struct ThemedButton: View {
     }
 
     private var foreground: Color {
-        guard isEnabled else { return Theme.shared.text(.textDisabled) }
+        guard isEnabled else { return theme.text(.textDisabled) }
         switch style {
-        case .primary: return Theme.shared.foreground(.fgSecondary)   // white
-        case .secondary, .outline, .ghost, .link: return Theme.shared.text(.textHero)
+        case .primary: return theme.foreground(.fgSecondary)   // white
+        case .secondary, .outline, .ghost, .link: return theme.text(.textHero)
         }
     }
 
     private var background: Color {
         switch style {
         case .primary:
-            return Theme.shared.background(isEnabled ? .bgHero : .bgSecondary)
+            return theme.background(isEnabled ? .bgHero : .bgSecondary)
         case .secondary:
-            return Theme.shared.background(.bgWhite)
+            return theme.background(.bgWhite)
         case .outline, .ghost, .link:
             return .clear
         }
@@ -125,7 +127,7 @@ private struct ThemedButton: View {
             EmptyView()
         case .secondary, .outline:
             RoundedRectangle(cornerRadius: Theme.RadiusKey.base.value, style: .continuous)
-                .stroke(Theme.shared.border(isEnabled ? .borderHero : .borderPrimary), lineWidth: 1)
+                .stroke(theme.border(isEnabled ? .borderHero : .borderPrimary), lineWidth: 1)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
@@ -21,6 +21,8 @@ public enum ButtonShape: String, CaseIterable {
 public enum ButtonIconPosition { case leading, trailing }
 
 public struct ThemeButton: View {
+    @Environment(\.theme) private var theme
+
     private let title: String?
     private let systemImage: String?
     private let iconPosition: ButtonIconPosition
@@ -94,7 +96,7 @@ public struct ThemeButton: View {
             shape: shapeStyle,
             resting: background,
             pressed: pressedBackground,
-            stroke: variant == .outline ? (isEnabled ? color.border : Theme.shared.border(.borderPrimary)) : nil
+            stroke: variant == .outline ? (isEnabled ? color.border : theme.border(.borderPrimary)) : nil
         ))
         .disabled(!isEnabled)
         .a11y(A11yElement.Action.button, in: accessibilityID)
@@ -122,7 +124,7 @@ public struct ThemeButton: View {
     }
 
     private var foreground: Color {
-        guard isEnabled else { return Theme.shared.text(.textDisabled) }
+        guard isEnabled else { return theme.text(.textDisabled) }
         switch variant {
         case .solid: return color.onSolid
         case .soft, .outline, .ghost, .link: return color.accent
@@ -130,7 +132,7 @@ public struct ThemeButton: View {
     }
 
     private var background: Color {
-        guard isEnabled else { return variant == .solid ? Theme.shared.background(.bgSecondary) : .clear }
+        guard isEnabled else { return variant == .solid ? theme.background(.bgSecondary) : .clear }
         switch variant {
         case .solid: return color.solid
         case .soft: return color.soft
@@ -196,6 +198,8 @@ public struct RowPressStyle: ButtonStyle {
 }
 
 private struct RowPressBody: View {
+    @Environment(\.theme) private var theme
+
     let configuration: ButtonStyleConfiguration
     let cornerRadius: CGFloat
     @Environment(\.microAnimations) private var micro
@@ -205,7 +209,7 @@ private struct RowPressBody: View {
     var body: some View {
         configuration.label
             .background(
-                configuration.isPressed ? Theme.shared.background(.bgElevatorTertiary) : .clear,
+                configuration.isPressed ? theme.background(.bgElevatorTertiary) : .clear,
                 in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
             )
             .animation(on ? Motion.instant.animation : nil, value: configuration.isPressed)

--- a/Sources/ThemeKit/Components/Molecules/OTPInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/OTPInput.swift
@@ -170,6 +170,8 @@ private extension View {
 }
 
 private struct OTPDigitBox: View {
+    @Environment(\.theme) private var theme
+
     let digit: String
     let isActive: Bool
     let isFilled: Bool
@@ -183,7 +185,7 @@ private struct OTPDigitBox: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                .fill(Theme.shared.background(isEnabled ? .bgWhite : .bgSecondaryLight))
+                .fill(theme.background(isEnabled ? .bgWhite : .bgSecondaryLight))
                 .overlay(
                     RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
                         .strokeBorder(borderColor, lineWidth: isActive || hasError ? 1.5 : 1)
@@ -195,7 +197,7 @@ private struct OTPDigitBox: View {
             if digit.isEmpty {
                 if isActive {
                     Rectangle()
-                        .fill(Theme.shared.foreground(.fgHero))
+                        .fill(theme.foreground(.fgHero))
                         .frame(width: 2, height: 24)
                         .opacity(reduceMotion ? 1 : (caretOn ? 1 : 0))
                         .onAppear {
@@ -214,15 +216,15 @@ private struct OTPDigitBox: View {
     }
 
     private var borderColor: Color {
-        if hasError { return Theme.shared.border(.systemcolorsBorderError) }
-        if isActive || isFilled { return Theme.shared.border(.borderHero) }
-        return Theme.shared.border(.borderPrimary)
+        if hasError { return theme.border(.systemcolorsBorderError) }
+        if isActive || isFilled { return theme.border(.borderHero) }
+        return theme.border(.borderPrimary)
     }
 
     private var textColor: Color {
-        if !isEnabled { return Theme.shared.text(.textDisabled) }
-        if hasError { return Theme.shared.foreground(.systemcolorsFgError) }
-        return Theme.shared.text(.textPrimary)
+        if !isEnabled { return theme.text(.textDisabled) }
+        if hasError { return theme.foreground(.systemcolorsFgError) }
+        return theme.text(.textPrimary)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -60,13 +60,15 @@ private struct TooltipArrow: Shape {
 }
 
 private struct TooltipBubble: View {
+    @Environment(\.theme) private var theme
+
     let text: String
     let edge: TooltipEdge
     let style: BadgeStyle?
     let maxWidth: CGFloat?
 
-    private var bubbleColor: Color { style?.semantic.solid ?? Theme.shared.background(.bgTertiary) }
-    private var textColor: Color { style?.semantic.onSolid ?? Theme.shared.foreground(.fgSecondary) }
+    private var bubbleColor: Color { style?.semantic.solid ?? theme.background(.bgTertiary) }
+    private var textColor: Color { style?.semantic.onSolid ?? theme.foreground(.fgSecondary) }
 
     var body: some View {
         let bubble = Text(text)

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -158,6 +158,8 @@ public extension View {
 // MARK: - Custom content + footer slot (Ant Modal footer / scroll / afterClose)
 
 private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModifier {
+    @Environment(\.theme) private var theme
+
     @Binding var isPresented: Bool
     let title: String?
     let closable: Bool
@@ -181,7 +183,7 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
         content.overlay {
             if isPresented {
                 ZStack {
-                    Theme.shared.background(.bgTertiary).opacity(0.4)
+                    theme.background(.bgTertiary).opacity(0.4)
                         .ignoresSafeArea()
                         .onTapGesture { if maskClosable { close() } }
 
@@ -189,12 +191,12 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
                         if title != nil || closable {
                             HStack {
                                 if let title {
-                                    Text(title).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
+                                    Text(title).textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
                                 }
                                 Spacer(minLength: Theme.SpacingKey.sm.value)
                                 if closable {
                                     Button(action: close) {
-                                        Icon(systemName: "xmark", size: .sm, color: Theme.shared.text(.textTertiary))
+                                        Icon(systemName: "xmark", size: .sm, color: theme.text(.textTertiary))
                                     }
                                     .buttonStyle(.plain)
                                 }
@@ -216,7 +218,7 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
                             .padding(Theme.SpacingKey.lg.value)
                     }
                     .frame(maxWidth: width ?? 360)
-                    .background(Theme.shared.background(.bgWhite),
+                    .background(theme.background(.bgWhite),
                                 in: RoundedRectangle(cornerRadius: Theme.RadiusKey.lg.value, style: .continuous))
                     .themeShadow(.elevated)
                     .padding(Theme.SpacingKey.lg.value)

--- a/Sources/ThemeKit/Components/Organisms/Drawer.swift
+++ b/Sources/ThemeKit/Components/Organisms/Drawer.swift
@@ -16,6 +16,8 @@ import SwiftUI
 /// Shared scrim + sliding panel with drag-to-dismiss; the scrim fades as the
 /// panel is dragged away. Used by both the declarative modifier and the host.
 private struct DrawerContainer<DrawerContent: View>: View {
+    @Environment(\.theme) private var theme
+
     let edge: HorizontalEdge
     let width: CGFloat
     let dismissOnScrimTap: Bool
@@ -29,14 +31,14 @@ private struct DrawerContainer<DrawerContent: View>: View {
 
     var body: some View {
         ZStack(alignment: edge == .leading ? .leading : .trailing) {
-            Theme.shared.background(.bgTertiary).opacity(0.4 * scrimFactor)
+            theme.background(.bgTertiary).opacity(0.4 * scrimFactor)
                 .ignoresSafeArea()
                 .onTapGesture { if dismissOnScrimTap { onDismiss() } }
 
             content()
                 .frame(maxWidth: width, maxHeight: .infinity, alignment: .topLeading)
                 .frame(maxHeight: .infinity)
-                .background(Theme.shared.background(.bgWhite))
+                .background(theme.background(.bgWhite))
                 .ignoresSafeArea()
                 .offset(x: dragX)
                 .gesture(dragGesture)

--- a/Sources/ThemeKit/Components/Organisms/SelectionCards.swift
+++ b/Sources/ThemeKit/Components/Organisms/SelectionCards.swift
@@ -7,6 +7,8 @@
 import SwiftUI
 
 private struct SelectionCard<Control: View>: View {
+    @Environment(\.theme) private var theme
+
     let title: String
     let description: String?
     let isSelected: Bool
@@ -21,22 +23,22 @@ private struct SelectionCard<Control: View>: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
                         .textStyle(.labelBase600)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                     if let description {
                         Text(description)
                             .textStyle(.bodySm400)
-                            .foregroundStyle(Theme.shared.text(.textSecondary))
+                            .foregroundStyle(theme.text(.textSecondary))
                     }
                 }
                 Spacer(minLength: 0)
             }
             .padding(Theme.SpacingKey.md.value)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isSelected ? Theme.shared.background(.bgElevatorTertiary) : Theme.shared.background(.bgWhite),
+            .background(isSelected ? theme.background(.bgElevatorTertiary) : theme.background(.bgWhite),
                        in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous)
-                    .strokeBorder(isSelected ? Theme.shared.border(.borderHero) : Theme.shared.border(.borderPrimary),
+                    .strokeBorder(isSelected ? theme.border(.borderHero) : theme.border(.borderPrimary),
                                   lineWidth: isSelected ? 1.5 : 1)
             )
             .contentShape(Rectangle())


### PR DESCRIPTION
## What
Follow-up to the #66–#68 rollout. The first sweep's struct matcher only recognized `public`/`final` View structs, so **`private`/`fileprivate` Views** — and the **`Buttons/` subdirectory** (missed by the file glob) — kept reading `Theme.shared`. These are genuine `View`s / `ViewModifier`s, so they can read the environment and migrate the same safe, no-op way.

## Scope (33 reads)
`OTPDigitBox`, `TooltipBubble`, `ThemedButton`, `ThemeButton` + `RowPressBody`, `CustomDialogModifier` (a `ViewModifier`), `DrawerContainer`, `SelectionCard`.

`DataTable`'s nested `Column` stays on `Theme.shared` (a non-View value type — no environment; unchanged from #68).

## Safety
- Every **regenerated screenshot byte-identical** (BorderBeam excluded — animated).
- Full suite green (**160 tests**); compiler-guarded.

Continues the `\.theme` rollout in `docs/AUDIT.md`. Remaining reads are now only true static contexts (enum resolvers, `ButtonStyle.makeBody`, presenters) — the enum pass follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)