### PR TITLE
refactor(theme): parameterize enum color resolvers with Theme (rollout 5)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/Avatar.swift
+++ b/Sources/ThemeKit/Components/Atoms/Avatar.swift
@@ -20,18 +20,18 @@ public enum AvatarShape { case circle, square }
 public enum AvatarBackground {
     case blue, white, dark
 
-    var fill: Color {
+    func fill(_ theme: Theme) -> Color {
         switch self {
-        case .blue: return Theme.shared.background(.bgElevatorTertiary)
-        case .white: return Theme.shared.background(.bgWhite)
-        case .dark: return Theme.shared.background(.bgTertiary)
+        case .blue: return theme.background(.bgElevatorTertiary)
+        case .white: return theme.background(.bgWhite)
+        case .dark: return theme.background(.bgTertiary)
         }
     }
-    var foreground: Color {
+    func foreground(_ theme: Theme) -> Color {
         switch self {
-        case .blue: return Theme.shared.text(.textHero)
-        case .white: return Theme.shared.text(.textPrimary)
-        case .dark: return Theme.shared.foreground(.fgSecondary)
+        case .blue: return theme.text(.textHero)
+        case .white: return theme.text(.textPrimary)
+        case .dark: return theme.foreground(.fgSecondary)
         }
     }
     var hasBorder: Bool { self == .white }
@@ -103,7 +103,7 @@ public struct Avatar: View {
 
     public var body: some View {
         ZStack {
-            clip.fill(background.fill)
+            clip.fill(background.fill(theme))
             if background.hasBorder {
                 clip.stroke(theme.border(.borderPrimary), lineWidth: 2)
             }
@@ -137,11 +137,11 @@ public struct Avatar: View {
         case .icon(let name):
             Image(systemName: name)
                 .font(.system(size: dim * 0.5))
-                .foregroundStyle(background.foreground)
+                .foregroundStyle(background.foreground(theme))
         case .initials(let text):
             Text(text.prefix(2).uppercased())
                 .font(.system(size: dim * 0.38, weight: .semibold))
-                .foregroundStyle(background.foreground)
+                .foregroundStyle(background.foreground(theme))
         case .image(let image):
             image.resizable().scaledToFill()
         }

--- a/Sources/ThemeKit/Components/Atoms/Badge.swift
+++ b/Sources/ThemeKit/Components/Atoms/Badge.swift
@@ -10,41 +10,41 @@ public enum BadgeStyle: String, CaseIterable {
     case neutral, info, success, warning, error
     case pink, orange, turquoise, purple
 
-    var background: Color {
+    func background(_ theme: Theme) -> Color {
         switch self {
-        case .neutral: return Theme.shared.background(.bgSecondaryLight)
-        case .info: return Theme.shared.background(.systemcolorsBgInfoLight)
-        case .success: return Theme.shared.background(.systemcolorsBgSuccessLight)
-        case .warning: return Theme.shared.background(.systemcolorsBgWarningLight)
-        case .error: return Theme.shared.background(.systemcolorsBgErrorLight)
-        case .pink: return Theme.shared.background(.badgeBgMaximumpinkLight)
-        case .orange: return Theme.shared.background(.badgeBgOrange)
-        case .turquoise: return Theme.shared.background(.badgeBgTurquoiseLight)
-        case .purple: return Theme.shared.background(.badgeBgPurple)
+        case .neutral: return theme.background(.bgSecondaryLight)
+        case .info: return theme.background(.systemcolorsBgInfoLight)
+        case .success: return theme.background(.systemcolorsBgSuccessLight)
+        case .warning: return theme.background(.systemcolorsBgWarningLight)
+        case .error: return theme.background(.systemcolorsBgErrorLight)
+        case .pink: return theme.background(.badgeBgMaximumpinkLight)
+        case .orange: return theme.background(.badgeBgOrange)
+        case .turquoise: return theme.background(.badgeBgTurquoiseLight)
+        case .purple: return theme.background(.badgeBgPurple)
         }
     }
 
-    var foreground: Color {
+    func foreground(_ theme: Theme) -> Color {
         switch self {
-        case .neutral: return Theme.shared.text(.textSecondary)
-        case .info: return Theme.shared.foreground(.systemcolorsFgInfo)
-        case .success: return Theme.shared.foreground(.systemcolorsFgSuccess)
-        case .warning: return Theme.shared.foreground(.systemcolorsFgWarning)
-        case .error: return Theme.shared.foreground(.systemcolorsFgError)
-        case .pink: return Theme.shared.foreground(.badgeFgMaximumpink)
-        case .orange: return Theme.shared.foreground(.badgeFgOrange)
-        case .turquoise: return Theme.shared.foreground(.badgeFgTurquoise)
-        case .purple: return Theme.shared.text(.textPurple)
+        case .neutral: return theme.text(.textSecondary)
+        case .info: return theme.foreground(.systemcolorsFgInfo)
+        case .success: return theme.foreground(.systemcolorsFgSuccess)
+        case .warning: return theme.foreground(.systemcolorsFgWarning)
+        case .error: return theme.foreground(.systemcolorsFgError)
+        case .pink: return theme.foreground(.badgeFgMaximumpink)
+        case .orange: return theme.foreground(.badgeFgOrange)
+        case .turquoise: return theme.foreground(.badgeFgTurquoise)
+        case .purple: return theme.text(.textPurple)
         }
     }
 
-    var border: Color {
+    func border(_ theme: Theme) -> Color {
         switch self {
-        case .neutral: return Theme.shared.border(.borderPrimary)
-        case .info: return Theme.shared.border(.systemcolorsBorderInfoLight)
-        case .success: return Theme.shared.border(.systemcolorsBorderSuccessLight)
-        case .warning: return Theme.shared.border(.systemcolorsBorderWarningLight)
-        case .error: return Theme.shared.border(.systemcolorsBorderErrorLight)
+        case .neutral: return theme.border(.borderPrimary)
+        case .info: return theme.border(.systemcolorsBorderInfoLight)
+        case .success: return theme.border(.systemcolorsBorderSuccessLight)
+        case .warning: return theme.border(.systemcolorsBorderWarningLight)
+        case .error: return theme.border(.systemcolorsBorderErrorLight)
         case .pink, .orange, .turquoise, .purple: return .clear
         }
     }
@@ -107,6 +107,8 @@ public enum BadgeShape {
 /// by a semantic `BadgeStyle` (system + brand variants) instead of
 /// component-specific color lookups, and icons use SF Symbols.
 public struct Badge: View {
+    @Environment(\.theme) private var theme
+
     private let text: String
     private let style: BadgeStyle
     private let variant: FillVariant
@@ -174,7 +176,7 @@ public struct Badge: View {
     private var foreground: Color {
         if let textColor { return textColor }
         switch variant {
-        case .soft: return style.foreground
+        case .soft: return style.foreground(theme)
         case .solid: return style.semantic.onSolid
         case .outline, .ghost: return style.semantic.accent
         }
@@ -182,14 +184,14 @@ public struct Badge: View {
     private var backgroundStyle: AnyShapeStyle {
         if let gradient { return AnyShapeStyle(LinearGradient(colors: gradient, startPoint: .leading, endPoint: .trailing)) }
         switch variant {
-        case .soft: return AnyShapeStyle(style.background)
+        case .soft: return AnyShapeStyle(style.background(theme))
         case .solid: return AnyShapeStyle(style.semantic.solid)
         case .outline, .ghost: return AnyShapeStyle(Color.clear)
         }
     }
     private var border: Color {
         switch variant {
-        case .soft: return style.border
+        case .soft: return style.border(theme)
         case .solid: return .clear
         case .outline: return style.semantic.border
         case .ghost: return .clear

--- a/Sources/ThemeKit/Components/Atoms/StatusDot.swift
+++ b/Sources/ThemeKit/Components/Atoms/StatusDot.swift
@@ -9,13 +9,13 @@ import SwiftUI
 public enum StatusKind {
     case online, offline, busy, away, neutral
 
-    var color: Color {
+    func color(_ theme: Theme) -> Color {
         switch self {
-        case .online: return Theme.shared.foreground(.systemcolorsFgSuccess)
-        case .offline: return Theme.shared.text(.textTertiary)
-        case .busy: return Theme.shared.foreground(.systemcolorsFgError)
-        case .away: return Theme.shared.foreground(.systemcolorsFgWarning)
-        case .neutral: return Theme.shared.foreground(.fgHero)
+        case .online: return theme.foreground(.systemcolorsFgSuccess)
+        case .offline: return theme.text(.textTertiary)
+        case .busy: return theme.foreground(.systemcolorsFgError)
+        case .away: return theme.foreground(.systemcolorsFgWarning)
+        case .neutral: return theme.foreground(.fgHero)
         }
     }
 
@@ -59,11 +59,11 @@ public struct StatusDot: View {
         HStack(spacing: Theme.SpacingKey.xs.value) {
             ZStack {
                 if pulses {
-                    Circle().fill(kind.color).opacity(animating ? 0 : 0.5)
+                    Circle().fill(kind.color(theme)).opacity(animating ? 0 : 0.5)
                         .scaleEffect(animating ? 2.2 : 1)
                         .frame(width: size, height: size)
                 }
-                Circle().fill(kind.color).frame(width: size, height: size)
+                Circle().fill(kind.color(theme)).frame(width: size, height: size)
             }
             .onAppear { if pulses { withAnimation(.easeOut(duration: 1.2).repeatForever(autoreverses: false)) { animating = true } } }
 

--- a/Sources/ThemeKit/Components/Atoms/Tag.swift
+++ b/Sources/ThemeKit/Components/Atoms/Tag.swift
@@ -58,7 +58,7 @@ public struct Tag: View {
     private var foreground: Color {
         guard let style else { return theme.text(.textHero) }
         switch variant {
-        case .soft: return style.foreground
+        case .soft: return style.foreground(theme)
         case .solid: return style.semantic.onSolid
         case .outline, .ghost: return style.semantic.accent
         }
@@ -67,7 +67,7 @@ public struct Tag: View {
     private var background: Color {
         guard let style else { return theme.background(.bgElevatorTertiary) }
         switch variant {
-        case .soft: return style.background
+        case .soft: return style.background(theme)
         case .solid: return style.semantic.solid
         case .outline, .ghost: return .clear
         }

--- a/Sources/ThemeKit/Components/Molecules/Stat.swift
+++ b/Sources/ThemeKit/Components/Molecules/Stat.swift
@@ -18,10 +18,10 @@ public enum StatTrend {
         case .down(let t): return String(themeKit: "down \(t)")
         }
     }
-    var color: Color {
+    func color(_ theme: Theme) -> Color {
         switch self {
-        case .up: return Theme.shared.foreground(.systemcolorsFgSuccess)
-        case .down: return Theme.shared.foreground(.systemcolorsFgError)
+        case .up: return theme.foreground(.systemcolorsFgSuccess)
+        case .down: return theme.foreground(.systemcolorsFgError)
         }
     }
     var systemImage: String { switch self { case .up: return "arrow.up.right"; case .down: return "arrow.down.right" } }
@@ -97,7 +97,7 @@ public struct Stat: View {
             Image(systemName: trend.systemImage).font(.system(size: 11, weight: .bold))
             Text(trend.text).textStyle(.labelSm600)
         }
-        .foregroundStyle(trend.color)
+        .foregroundStyle(trend.color(theme))
     }
 
     private var valueRow: some View {

--- a/Sources/ThemeKit/Components/Organisms/AlertToast.swift
+++ b/Sources/ThemeKit/Components/Organisms/AlertToast.swift
@@ -9,20 +9,20 @@ import SwiftUI
 public enum AlertToastType {
     case success, warning, danger, info
 
-    var background: Color {
+    func background(_ theme: Theme) -> Color {
         switch self {
-        case .success: return Theme.shared.background(.systemcolorsBgSuccess)
-        case .warning: return Theme.shared.background(.systemcolorsBgWarning)
-        case .danger: return Theme.shared.background(.systemcolorsBgError)
-        case .info: return Theme.shared.background(.systemcolorsBgInfo)
+        case .success: return theme.background(.systemcolorsBgSuccess)
+        case .warning: return theme.background(.systemcolorsBgWarning)
+        case .danger: return theme.background(.systemcolorsBgError)
+        case .info: return theme.background(.systemcolorsBgInfo)
         }
     }
 
     /// Warning uses dark text for contrast on the bright amber fill.
-    var foreground: Color {
+    func foreground(_ theme: Theme) -> Color {
         switch self {
-        case .warning: return Theme.shared.text(.textPrimary)
-        case .success, .danger, .info: return Theme.shared.foreground(.fgSecondary)
+        case .warning: return theme.text(.textPrimary)
+        case .success, .danger, .info: return theme.foreground(.fgSecondary)
         }
     }
 
@@ -51,6 +51,8 @@ public struct ToastAction {
 /// Improved, token-bound rewrite of the reference AlertView — a solid-fill
 /// status banner (complements the light-surface InfoBanner).
 public struct AlertToast: View {
+    @Environment(\.theme) private var theme
+
     private let title: String
     private let message: String?
     private let type: AlertToastType
@@ -82,9 +84,9 @@ public struct AlertToast: View {
             // Leading accessory: an activity spinner while loading, otherwise the
             // status icon (a caller override falls back to the type's default).
             if isLoading {
-                Spinner(size: IconSize.sm.value, lineWidth: 2, color: type.foreground)
+                Spinner(size: IconSize.sm.value, lineWidth: 2, color: type.foreground(theme))
             } else {
-                Icon(systemName: systemImage ?? type.systemImage, size: .sm, color: type.foreground)
+                Icon(systemName: systemImage ?? type.systemImage, size: .sm, color: type.foreground(theme))
             }
 
             VStack(alignment: .leading, spacing: 2) {
@@ -104,15 +106,15 @@ public struct AlertToast: View {
 
             if let onClose {
                 Button(action: onClose) {
-                    Icon(systemName: "xmark", size: .xs, color: type.foreground)
+                    Icon(systemName: "xmark", size: .xs, color: type.foreground(theme))
                 }
                 .buttonStyle(.plain)
             }
         }
-        .foregroundStyle(type.foreground)
+        .foregroundStyle(type.foreground(theme))
         .padding(.vertical, 12)
         .padding(.horizontal, Theme.SpacingKey.md.value)
-        .background(type.background, in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+        .background(type.background(theme), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/Callout.swift
+++ b/Sources/ThemeKit/Components/Organisms/Callout.swift
@@ -9,22 +9,22 @@ import SwiftUI
 public enum CalloutType {
     case neutral, info, success, warning, error
 
-    var accent: Color {
+    func accent(_ theme: Theme) -> Color {
         switch self {
-        case .neutral: return Theme.shared.text(.textSecondary)
-        case .info: return Theme.shared.foreground(.systemcolorsFgInfo)
-        case .success: return Theme.shared.foreground(.systemcolorsFgSuccess)
-        case .warning: return Theme.shared.foreground(.systemcolorsFgWarning)
-        case .error: return Theme.shared.foreground(.systemcolorsFgError)
+        case .neutral: return theme.text(.textSecondary)
+        case .info: return theme.foreground(.systemcolorsFgInfo)
+        case .success: return theme.foreground(.systemcolorsFgSuccess)
+        case .warning: return theme.foreground(.systemcolorsFgWarning)
+        case .error: return theme.foreground(.systemcolorsFgError)
         }
     }
-    var soft: Color {
+    func soft(_ theme: Theme) -> Color {
         switch self {
-        case .neutral: return Theme.shared.background(.bgElevatorPrimary)
-        case .info: return Theme.shared.background(.systemcolorsBgInfoLight)
-        case .success: return Theme.shared.background(.systemcolorsBgSuccessLight)
-        case .warning: return Theme.shared.background(.systemcolorsBgWarningLight)
-        case .error: return Theme.shared.background(.systemcolorsBgErrorLight)
+        case .neutral: return theme.background(.bgElevatorPrimary)
+        case .info: return theme.background(.systemcolorsBgInfoLight)
+        case .success: return theme.background(.systemcolorsBgSuccessLight)
+        case .warning: return theme.background(.systemcolorsBgWarningLight)
+        case .error: return theme.background(.systemcolorsBgErrorLight)
         }
     }
     var systemImage: String {
@@ -46,6 +46,8 @@ public enum CalloutStyle {
 /// InfoBanner — used to highlight a single line of information.
 /// Figma: success / error / info / warning / neutral; plain or soft style.
 public struct Callout: View {
+    @Environment(\.theme) private var theme
+
     private let text: String
     private let type: CalloutType
     private let style: CalloutStyle
@@ -100,12 +102,12 @@ public struct Callout: View {
                 }
             }
         }
-        .foregroundStyle(type.accent)
+        .foregroundStyle(type.accent(theme))
         .padding(.horizontal, style == .soft ? Theme.SpacingKey.sm.value : 0)
         .padding(.vertical, style == .soft ? Theme.SpacingKey.xs.value : 0)
         .background {
             if style == .soft {
-                RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous).fill(type.soft)
+                RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous).fill(type.soft(theme))
             }
         }
     }

--- a/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
@@ -9,33 +9,33 @@ import SwiftUI
 public enum InfoBannerType {
     case neutral, info, success, warning, error
 
-    var background: Color {
+    func background(_ theme: Theme) -> Color {
         switch self {
-        case .neutral: return Theme.shared.background(.bgElevatorPrimary)
-        case .info: return Theme.shared.background(.systemcolorsBgInfoLight)
-        case .success: return Theme.shared.background(.systemcolorsBgSuccessLight)
-        case .warning: return Theme.shared.background(.systemcolorsBgWarningLight)
-        case .error: return Theme.shared.background(.systemcolorsBgErrorLight)
+        case .neutral: return theme.background(.bgElevatorPrimary)
+        case .info: return theme.background(.systemcolorsBgInfoLight)
+        case .success: return theme.background(.systemcolorsBgSuccessLight)
+        case .warning: return theme.background(.systemcolorsBgWarningLight)
+        case .error: return theme.background(.systemcolorsBgErrorLight)
         }
     }
 
-    var accent: Color {
+    func accent(_ theme: Theme) -> Color {
         switch self {
-        case .neutral: return Theme.shared.text(.textSecondary)
-        case .info: return Theme.shared.foreground(.systemcolorsFgInfo)
-        case .success: return Theme.shared.foreground(.systemcolorsFgSuccess)
-        case .warning: return Theme.shared.foreground(.systemcolorsFgWarning)
-        case .error: return Theme.shared.foreground(.systemcolorsFgError)
+        case .neutral: return theme.text(.textSecondary)
+        case .info: return theme.foreground(.systemcolorsFgInfo)
+        case .success: return theme.foreground(.systemcolorsFgSuccess)
+        case .warning: return theme.foreground(.systemcolorsFgWarning)
+        case .error: return theme.foreground(.systemcolorsFgError)
         }
     }
 
-    var border: Color {
+    func border(_ theme: Theme) -> Color {
         switch self {
-        case .neutral: return Theme.shared.border(.borderPrimary)
-        case .info: return Theme.shared.border(.systemcolorsBorderInfoLight)
-        case .success: return Theme.shared.border(.systemcolorsBorderSuccessLight)
-        case .warning: return Theme.shared.border(.systemcolorsBorderWarningLight)
-        case .error: return Theme.shared.border(.systemcolorsBorderErrorLight)
+        case .neutral: return theme.border(.borderPrimary)
+        case .info: return theme.border(.systemcolorsBorderInfoLight)
+        case .success: return theme.border(.systemcolorsBorderSuccessLight)
+        case .warning: return theme.border(.systemcolorsBorderWarningLight)
+        case .error: return theme.border(.systemcolorsBorderErrorLight)
         }
     }
 
@@ -92,7 +92,7 @@ public struct InfoBanner: View {
     public var body: some View {
         HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
             if showIcon {
-                Icon(systemName: type.systemImage, size: .sm, color: type.accent)
+                Icon(systemName: type.systemImage, size: .sm, color: type.accent(theme))
             }
 
             VStack(alignment: .leading, spacing: 2) {
@@ -113,7 +113,7 @@ public struct InfoBanner: View {
 
             if let actionTitle, let onAction {
                 Button(action: onAction) {
-                    Text(actionTitle).textStyle(.labelSm600).foregroundStyle(type.accent)
+                    Text(actionTitle).textStyle(.labelSm600).foregroundStyle(type.accent(theme))
                 }
                 .buttonStyle(.plain)
             }
@@ -127,10 +127,10 @@ public struct InfoBanner: View {
         }
         .padding(Theme.SpacingKey.md.value)
         .frame(maxWidth: banner ? .infinity : nil, alignment: .leading)
-        .background(type.background, in: RoundedRectangle(cornerRadius: radius, style: .continuous))
+        .background(type.background(theme), in: RoundedRectangle(cornerRadius: radius, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: radius, style: .continuous)
-                .stroke(type.border, lineWidth: banner ? 0 : 1)
+                .stroke(type.border(theme), lineWidth: banner ? 0 : 1)
         )
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/KeyValueTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/KeyValueTable.swift
@@ -9,12 +9,12 @@ import SwiftUI
 public enum TableValueStyle {
     case plain, success, error, muted, strikethrough
 
-    var color: Color {
+    func color(_ theme: Theme) -> Color {
         switch self {
-        case .plain: return Theme.shared.text(.textPrimary)
-        case .success: return Theme.shared.foreground(.systemcolorsFgSuccess)
-        case .error: return Theme.shared.foreground(.systemcolorsFgError)
-        case .muted, .strikethrough: return Theme.shared.text(.textTertiary)
+        case .plain: return theme.text(.textPrimary)
+        case .success: return theme.foreground(.systemcolorsFgSuccess)
+        case .error: return theme.foreground(.systemcolorsFgError)
+        case .muted, .strikethrough: return theme.text(.textTertiary)
         }
     }
 }
@@ -77,7 +77,7 @@ public struct KeyValueTable: View {
                     Spacer(minLength: Theme.SpacingKey.md.value)
                     Text(row.value)
                         .textStyle(.labelBase600)
-                        .foregroundStyle(row.style.color)
+                        .foregroundStyle(row.style.color(theme))
                         .strikethrough(row.style == .strikethrough)
                         .multilineTextAlignment(.trailing)
                 }

--- a/Sources/ThemeKit/Components/Organisms/PromoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/PromoBanner.swift
@@ -9,23 +9,23 @@ import SwiftUI
 public enum PromoBannerTint {
     case blue, dark, turquoise
 
-    var background: Color {
+    func background(_ theme: Theme) -> Color {
         switch self {
-        case .blue: return Theme.shared.background(.bgElevatorTertiary)
-        case .dark: return Theme.shared.background(.bgTertiary)
-        case .turquoise: return Theme.shared.background(.bgTurquoiseLight)
+        case .blue: return theme.background(.bgElevatorTertiary)
+        case .dark: return theme.background(.bgTertiary)
+        case .turquoise: return theme.background(.bgTurquoiseLight)
         }
     }
-    var foreground: Color {
+    func foreground(_ theme: Theme) -> Color {
         switch self {
-        case .blue, .turquoise: return Theme.shared.text(.textPrimary)
-        case .dark: return Theme.shared.foreground(.fgSecondary)
+        case .blue, .turquoise: return theme.text(.textPrimary)
+        case .dark: return theme.foreground(.fgSecondary)
         }
     }
-    var secondaryForeground: Color {
+    func secondaryForeground(_ theme: Theme) -> Color {
         switch self {
-        case .blue, .turquoise: return Theme.shared.text(.textSecondary)
-        case .dark: return Theme.shared.text(.textSecondaryInverse)
+        case .blue, .turquoise: return theme.text(.textSecondary)
+        case .dark: return theme.text(.textSecondaryInverse)
         }
     }
 }
@@ -63,16 +63,16 @@ public struct PromoBanner: View {
             if let systemImage {
                 Image(systemName: systemImage)
                     .font(.system(size: 28))
-                    .foregroundStyle(tint.foreground)
+                    .foregroundStyle(tint.foreground(theme))
             }
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .textStyle(.labelMd700)
-                    .foregroundStyle(tint.foreground)
+                    .foregroundStyle(tint.foreground(theme))
                 if let subtitle {
                     Text(subtitle)
                         .textStyle(.bodySm400)
-                        .foregroundStyle(tint.secondaryForeground)
+                        .foregroundStyle(tint.secondaryForeground(theme))
                 }
             }
             Spacer(minLength: Theme.SpacingKey.sm.value)
@@ -90,7 +90,7 @@ public struct PromoBanner: View {
         }
         .padding(Theme.SpacingKey.md.value)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(tint.background, in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
+        .background(tint.background(theme), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
     }
 }
 


### PR DESCRIPTION
## What
The semantic-color **enums** resolved against `Theme.shared` in computed vars, so a component styled by one (Badge / InfoBanner / Callout / …) **ignored an injected subtree theme**. Each resolver var is now a **`func(_ theme: Theme) -> Color`**, and the owning `View` passes its `@Environment(\.theme)` — so these components honor `.theme(_:)` too.

## Scope (78 reads, 9 enums)
`BadgeStyle` (also consumed by Tag), `InfoBannerType`, Callout's type, PromoBanner's tint, `AvatarBackground`, AlertToast's type, StatusDot's kind, KeyValueTable's style, `StatTrend`.

- Added `@Environment(\.theme)` to the **3 Views** that previously *only* used an enum resolver and so were never migrated (Badge, AlertToast, Callout). Note: `theme` has to be a **stored property** there to shadow the `View.theme(_:)` modifier of the same name.
- Resolvers are **internal** members → **no public API change**.

## Safety
- Every **regenerated screenshot byte-identical** (BorderBeam excluded — animated).
- Full suite green (**160 tests**); compiler-guided call-site fixups.

Remaining `Theme.shared` reads: **45** (down from 156) — `ButtonStyle.makeBody` statics, `ObservableObject` presenters, a few enum/init defaults. Final sweep follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)