### PR TITLE
refactor(theme): migrate overlay host ViewModifiers to @Environment(\.theme) (rollout 6)

### DIFF
--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -77,6 +77,8 @@ struct DialogCard: View {
 }
 
 private struct DialogModifier: ViewModifier {
+    @Environment(\.theme) private var theme
+
     @Binding var isPresented: Bool
     let title: String
     let message: String?
@@ -98,7 +100,7 @@ private struct DialogModifier: ViewModifier {
         content.overlay {
             if isPresented {
                 ZStack {
-                    Theme.shared.background(.bgTertiary).opacity(0.4)
+                    theme.background(.bgTertiary).opacity(0.4)
                         .ignoresSafeArea()
                         .onTapGesture { if maskClosable, !primaryLoading { isPresented = false } }
                     DialogCard(

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -184,6 +184,8 @@ public final class FeedbackPresenter: ObservableObject {
 // MARK: - Host
 
 private struct FeedbackHostModifier: ViewModifier {
+    @Environment(\.theme) private var theme
+
     @StateObject private var presenter: FeedbackPresenter
     private let toastEdge: Edge
 
@@ -209,13 +211,13 @@ private struct FeedbackHostModifier: ViewModifier {
     private var loadingLayer: some View {
         if let title = presenter.activeLoading {
             ZStack {
-                Theme.shared.background(.bgTertiary).opacity(0.3).ignoresSafeArea()
+                theme.background(.bgTertiary).opacity(0.3).ignoresSafeArea()
                 VStack(spacing: Theme.SpacingKey.sm.value) {
                     Spinner(size: 28, lineWidth: 3)
-                    Text(title).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textPrimary))
+                    Text(title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
                 }
                 .padding(Theme.SpacingKey.lg.value)
-                .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
+                .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
                 .themeShadow(.elevated)
             }
             .transition(.opacity)
@@ -228,19 +230,19 @@ private struct FeedbackHostModifier: ViewModifier {
             HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
                 Icon(systemName: note.kind.systemImage, size: .md, color: note.kind.semanticColor.accent)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(note.title).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textPrimary))
+                    Text(note.title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
                     if let message = note.message {
-                        Text(message).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+                        Text(message).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
                     }
                 }
                 Spacer(minLength: 0)
                 Button { presenter.dismissNotification() } label: {
-                    Icon(systemName: "xmark", size: .xs, color: Theme.shared.text(.textTertiary))
+                    Icon(systemName: "xmark", size: .xs, color: theme.text(.textTertiary))
                 }
                 .buttonStyle(.plain)
             }
             .padding(Theme.SpacingKey.md.value)
-            .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
+            .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
             .themeShadow(.elevated)
             .padding(Theme.SpacingKey.md.value)
             .transition(.move(edge: .top).combined(with: .opacity))
@@ -267,7 +269,7 @@ private struct FeedbackHostModifier: ViewModifier {
     private var confirmLayer: some View {
         if let confirm = presenter.activeConfirm {
             ZStack {
-                Theme.shared.background(.bgTertiary).opacity(0.4)
+                theme.background(.bgTertiary).opacity(0.4)
                     .ignoresSafeArea()
                     .onTapGesture { presenter.dismissConfirm() }
                 DialogCard(

--- a/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
+++ b/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
@@ -13,6 +13,8 @@
 import SwiftUI
 
 private struct PopconfirmModifier: ViewModifier {
+    @Environment(\.theme) private var theme
+
     @Binding var isPresented: Bool
     let title: String
     let message: String?
@@ -44,11 +46,11 @@ private struct PopconfirmModifier: ViewModifier {
     private var card: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
-                Icon(systemName: "exclamationmark.circle.fill", size: .sm, color: Theme.shared.foreground(.systemcolorsFgWarning))
+                Icon(systemName: "exclamationmark.circle.fill", size: .sm, color: theme.foreground(.systemcolorsFgWarning))
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(title).textStyle(.labelBase600).foregroundStyle(Theme.shared.text(.textPrimary))
+                    Text(title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
                     if let message {
-                        Text(message).textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+                        Text(message).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
                     }
                 }
             }
@@ -69,8 +71,8 @@ private struct PopconfirmModifier: ViewModifier {
         }
         .padding(Theme.SpacingKey.md.value)
         .frame(width: 260)
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).stroke(Theme.shared.border(.borderPrimary), lineWidth: 1))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous).stroke(theme.border(.borderPrimary), lineWidth: 1))
         .themeShadow(.elevated)
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/Tour.swift
+++ b/Sources/ThemeKit/Components/Organisms/Tour.swift
@@ -63,6 +63,8 @@ public extension View {
 }
 
 private struct TourHostModifier: ViewModifier {
+    @Environment(\.theme) private var theme
+
     @ObservedObject var controller: TourController
     let steps: [TourStep]
 
@@ -73,7 +75,7 @@ private struct TourHostModifier: ViewModifier {
                     let step = steps[controller.index]
                     let rect = anchors[step.id].map { proxy[$0] }
                     ZStack {
-                        Theme.shared.background(.bgTertiary).opacity(0.6)
+                        theme.background(.bgTertiary).opacity(0.6)
                             .reverseMask {
                                 if let rect {
                                     RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
@@ -86,7 +88,7 @@ private struct TourHostModifier: ViewModifier {
 
                         if let rect {
                             RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-                                .stroke(Theme.shared.background(.bgHero), lineWidth: 2)
+                                .stroke(theme.background(.bgHero), lineWidth: 2)
                                 .frame(width: rect.width + 12, height: rect.height + 12)
                                 .position(x: rect.midX, y: rect.midY)
                         }
@@ -104,11 +106,11 @@ private struct TourHostModifier: ViewModifier {
         let y = rect == nil ? proxy.size.height / 2 : (fitsBelow ? (rect!.maxY + 90) : (rect!.minY - 90))
 
         return VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
-            Text(step.title).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
-            Text(step.message).textStyle(.bodyBase400).foregroundStyle(Theme.shared.text(.textSecondary))
+            Text(step.title).textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
+            Text(step.message).textStyle(.bodyBase400).foregroundStyle(theme.text(.textSecondary))
             HStack {
                 Text("\(controller.index + 1) / \(steps.count)")
-                    .textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textTertiary))
+                    .textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
                 Spacer()
                 if controller.index > 0 {
                     ThemeButton(String(themeKit: "Back"), variant: .outline, size: .small) { controller.prev() }
@@ -120,11 +122,11 @@ private struct TourHostModifier: ViewModifier {
         }
         .padding(Theme.SpacingKey.md.value)
         .frame(width: 280)
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
         .themeShadow(.elevated)
         .overlay(alignment: .topTrailing) {
             Button { controller.stop() } label: {
-                Icon(systemName: "xmark", size: .xs, color: Theme.shared.text(.textTertiary)).padding(Theme.SpacingKey.sm.value)
+                Icon(systemName: "xmark", size: .xs, color: theme.text(.textTertiary)).padding(Theme.SpacingKey.sm.value)
             }
             .buttonStyle(.plain)
         }


### PR DESCRIPTION
## What
The **Feedback / Tour / Popconfirm / Dialog** overlay hosts are `ViewModifier`s whose `body(content:)` is part of the view tree, so they **can** read the environment. They now resolve `\.theme` instead of `Theme.shared`, so a presented overlay honors an injected subtree theme.

## Scope (21 reads)
`FeedbackHostModifier`, `TourHostModifier`, `PopconfirmModifier`, `DialogModifier`.

## Safety
- Regenerated screenshots **byte-identical** (BorderBeam excluded — animated).
- Full suite green (**160 tests**).

## Remaining floor (24 reads — intentional)
`#Preview` demo code (correctly on the singleton — previews have no injected theme), View-extension modifier statics that build inline content with no environment to read, DataTable's nested `Column` (a non-View value type), and one doc-comment mention. Documented in `docs/AUDIT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)