### PR TITLE
refactor(theme): extension-method statics theme-aware via wrapper Views (rollout 7)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/BorderBeam.swift
+++ b/Sources/ThemeKit/Components/Atoms/BorderBeam.swift
@@ -70,11 +70,12 @@ private struct BorderBeamModifier: ViewModifier {
 
     @State private var start = Date()
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.theme) private var theme
 
     private let segments = 22
 
     private var palette: [Color] {
-        colors ?? [Theme.shared.background(.bgHero), SemanticColor.turquoise.base]
+        colors ?? [theme.background(.bgHero), SemanticColor.turquoise.base]
     }
 
     func body(content: Content) -> some View {

--- a/Sources/ThemeKit/Components/Atoms/CountBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/CountBadge.swift
@@ -14,26 +14,47 @@ public extension View {
     /// Overlays a count bubble in the top-trailing corner (Ant `Badge count`).
     func countBadge(_ count: Int, overflowCount: Int = 99, showZero: Bool = false, color: SemanticColor = .error) -> some View {
         overlay(alignment: .topTrailing) {
-            if count > 0 || showZero {
-                Text(count > overflowCount ? "\(overflowCount)+" : "\(count)")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(color.onSolid)
-                    .padding(.horizontal, 5)
-                    .frame(minWidth: 18, minHeight: 18)
-                    .background(color.solid, in: Capsule())
-                    .overlay(Capsule().strokeBorder(Theme.shared.background(.bgWhite), lineWidth: 1.5))
-                    .offset(x: 9, y: -9)
-            }
+            CountBubble(count: count, overflowCount: overflowCount, showZero: showZero, color: color)
         }
     }
 
     /// Overlays a status dot in the top-trailing corner (Ant `Badge dot`).
     func dotBadge(color: SemanticColor = .error) -> some View {
-        overlay(alignment: .topTrailing) {
-            Circle().fill(color.solid).frame(width: 10, height: 10)
-                .overlay(Circle().strokeBorder(Theme.shared.background(.bgWhite), lineWidth: 1.5))
-                .offset(x: 4, y: -4)
+        overlay(alignment: .topTrailing) { DotBadge(color: color) }
+    }
+}
+
+// Extracted into Views so the white halo stroke resolves the injected `\.theme`
+// (an extension method can't read the environment; a View body can).
+private struct CountBubble: View {
+    let count: Int
+    let overflowCount: Int
+    let showZero: Bool
+    let color: SemanticColor
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        if count > 0 || showZero {
+            Text(count > overflowCount ? "\(overflowCount)+" : "\(count)")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(color.onSolid)
+                .padding(.horizontal, 5)
+                .frame(minWidth: 18, minHeight: 18)
+                .background(color.solid, in: Capsule())
+                .overlay(Capsule().strokeBorder(theme.background(.bgWhite), lineWidth: 1.5))
+                .offset(x: 9, y: -9)
         }
+    }
+}
+
+private struct DotBadge: View {
+    let color: SemanticColor
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Circle().fill(color.solid).frame(width: 10, height: 10)
+            .overlay(Circle().strokeBorder(theme.background(.bgWhite), lineWidth: 1.5))
+            .offset(x: 4, y: -4)
     }
 }
 

--- a/Sources/ThemeKit/Components/Atoms/Indicator.swift
+++ b/Sources/ThemeKit/Components/Atoms/Indicator.swift
@@ -41,12 +41,20 @@ public extension View {
 
     /// Overlays a small status dot at a corner.
     func indicatorDot(_ color: Color? = nil, position: IndicatorPosition = .topTrailing) -> some View {
-        indicator(position) {
-            Circle()
-                .fill(color ?? Theme.shared.foreground(.systemcolorsFgError))
-                .frame(width: 10, height: 10)
-                .overlay(Circle().stroke(Theme.shared.background(.bgWhite), lineWidth: 2))
-        }
+        indicator(position) { IndicatorDot(color: color) }
+    }
+}
+
+// Extracted into a View so the dot + halo resolve the injected `\.theme`.
+private struct IndicatorDot: View {
+    let color: Color?
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Circle()
+            .fill(color ?? theme.foreground(.systemcolorsFgError))
+            .frame(width: 10, height: 10)
+            .overlay(Circle().stroke(theme.background(.bgWhite), lineWidth: 2))
     }
 }
 

--- a/Sources/ThemeKit/Components/Atoms/RollingNumber.swift
+++ b/Sources/ThemeKit/Components/Atoms/RollingNumber.swift
@@ -15,6 +15,8 @@ public struct RollingNumber: View {
     private let weight: Font.Weight
     private let color: Color?
 
+    @Environment(\.theme) private var theme
+
     public init(_ value: Int, size: CGFloat = 28, weight: Font.Weight = .bold, color: Color? = nil) {
         self.value = value
         self.size = size
@@ -26,7 +28,7 @@ public struct RollingNumber: View {
 
     public var body: some View {
         HStack(spacing: 0) {
-            if value < 0 { Text("-").rollingFont(size, weight, color) }
+            if value < 0 { Text("-").rollingFont(size, weight, color ?? theme.text(.textPrimary)) }
             ForEach(Array(digits.enumerated()), id: \.offset) { _, digit in
                 DigitColumn(digit: digit, size: size, weight: weight, color: color)
             }
@@ -42,13 +44,14 @@ private struct DigitColumn: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.microAnimations) private var micro
+    @Environment(\.theme) private var theme
 
     private var rowHeight: CGFloat { size * 1.25 }
 
     var body: some View {
         VStack(spacing: 0) {
             ForEach(0...9, id: \.self) { n in
-                Text("\(n)").rollingFont(size, weight, color).frame(height: rowHeight)
+                Text("\(n)").rollingFont(size, weight, color ?? theme.text(.textPrimary)).frame(height: rowHeight)
             }
         }
         .offset(y: -CGFloat(digit) * rowHeight)
@@ -60,9 +63,9 @@ private struct DigitColumn: View {
 }
 
 private extension Text {
-    func rollingFont(_ size: CGFloat, _ weight: Font.Weight, _ color: Color?) -> some View {
+    func rollingFont(_ size: CGFloat, _ weight: Font.Weight, _ color: Color) -> some View {
         font(.system(size: size, weight: weight, design: .rounded).monospacedDigit())
-            .foregroundStyle(color ?? Theme.shared.text(.textPrimary))
+            .foregroundStyle(color)
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/ButtonDock.swift
+++ b/Sources/ThemeKit/Components/Organisms/ButtonDock.swift
@@ -13,14 +13,24 @@ public extension View {
     /// Pins `content` to the bottom edge as a docked action bar.
     func buttonDock<DockContent: View>(@ViewBuilder content: () -> DockContent) -> some View {
         safeAreaInset(edge: .bottom, spacing: 0) {
-            VStack(spacing: 0) {
-                DividerView(size: .small)
-                content()
-                    .padding(.horizontal, Theme.SpacingKey.md.value)
-                    .padding(.top, Theme.SpacingKey.sm.value)
-            }
-            .background(Theme.shared.background(.bgWhite))
+            ButtonDockBar(content: content())
         }
+    }
+}
+
+// Extracted into a View so the dock surface resolves the injected `\.theme`.
+private struct ButtonDockBar<DockContent: View>: View {
+    let content: DockContent
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            DividerView(size: .small)
+            content
+                .padding(.horizontal, Theme.SpacingKey.md.value)
+                .padding(.top, Theme.SpacingKey.sm.value)
+        }
+        .background(theme.background(.bgWhite))
     }
 }
 


### PR DESCRIPTION
## What
The last reachable static reads were inline content built inside **`View`-extension methods** / a `ViewModifier` computed property. An extension method can't read the environment, but a small extracted `View` body can — so each is pulled into a private View that reads `@Environment(\.theme)`.

## Scope (7 reads)
- CountBadge → `CountBubble` / `DotBadge`
- Indicator → `IndicatorDot`
- ButtonDock → `ButtonDockBar`
- RollingNumber → digit views read `\.theme` and pass the resolved color into the `Text` helper
- BorderBeam → `palette` reads `\.theme`

## Safety
- Regenerated screenshots **byte-identical** (BorderBeam excluded — animated).
- Full suite green (**160 tests**).

## Irreducible floor (17 reads)
`#Preview` demo code (no injected theme — the singleton is correct there), one doc-comment mention, DataTable's nested `Column` (a non-View value type), and Hero's `Background == Color` convenience default (the generic constrains the default to a `Color` **value**, which can't read the environment). Documented in `docs/AUDIT.md`.

This concludes the `\.theme` parameterization: **139 of 156** former static reads are now environment-driven; the rest are demo code or structurally static by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)