### PR TITLE
refactor(theme): zero static Theme.shared reads — Hero generic + final sweep (rollout 8)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/BorderBeam.swift
+++ b/Sources/ThemeKit/Components/Atoms/BorderBeam.swift
@@ -141,19 +141,20 @@ private struct BorderBeamModifier: ViewModifier {
 }
 
 #Preview {
+    @Previewable @Environment(\.theme) var theme
     VStack(spacing: 36) {
         Text("Featured")
             .textStyle(.headingSm)
             .padding(40)
-            .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: 20))
+            .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: 20))
             .borderBeam(cornerRadius: 20, lineWidth: 2.5)
 
         Text("Pro")
             .padding(.horizontal, 28).padding(.vertical, 14)
-            .background(Theme.shared.background(.bgElevatorTertiary), in: Capsule())
+            .background(theme.background(.bgElevatorTertiary), in: Capsule())
             .borderBeam(cornerRadius: 100, lineWidth: 2, duration: 3,
                         colors: [SemanticColor.purple.base, SemanticColor.pink.base])
     }
     .padding(48)
-    .background(Theme.shared.background(.bgTertiary))
+    .background(theme.background(.bgTertiary))
 }

--- a/Sources/ThemeKit/Components/Atoms/CountBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/CountBadge.swift
@@ -86,12 +86,13 @@ public struct Ribbon<Content: View>: View {
 }
 
 #Preview {
+    @Previewable @Environment(\.theme) var theme
     HStack(spacing: 32) {
         Image(systemName: "bell.fill").font(.title).countBadge(5)
         Image(systemName: "envelope.fill").font(.title).countBadge(128)
         Image(systemName: "cart.fill").font(.title).dotBadge(color: .success)
         Ribbon("New", color: .error) {
-            RoundedRectangle(cornerRadius: 12).fill(Theme.shared.background(.bgElevatorTertiary)).frame(width: 100, height: 70)
+            RoundedRectangle(cornerRadius: 12).fill(theme.background(.bgElevatorTertiary)).frame(width: 100, height: 70)
         }
     }
     .padding(40)

--- a/Sources/ThemeKit/Components/Atoms/Icon.swift
+++ b/Sources/ThemeKit/Components/Atoms/Icon.swift
@@ -51,9 +51,10 @@ public struct Icon: View {
 }
 
 #Preview {
+    @Previewable @Environment(\.theme) var theme
     HStack(spacing: 12) {
         ForEach(IconSize.allCases, id: \.self) { s in
-            Icon(systemName: "star.fill", size: s, color: Theme.shared.foreground(.fgHero))
+            Icon(systemName: "star.fill", size: s, color: theme.foreground(.fgHero))
         }
     }
     .padding()

--- a/Sources/ThemeKit/Components/Atoms/Indicator.swift
+++ b/Sources/ThemeKit/Components/Atoms/Indicator.swift
@@ -59,10 +59,11 @@ private struct IndicatorDot: View {
 }
 
 #Preview {
+    @Previewable @Environment(\.theme) var theme
     HStack(spacing: 32) {
-        Icon(systemName: "bell", size: .lg, color: Theme.shared.text(.textPrimary))
+        Icon(systemName: "bell", size: .lg, color: theme.text(.textPrimary))
             .indicatorDot()
-        Icon(systemName: "envelope", size: .lg, color: Theme.shared.text(.textPrimary))
+        Icon(systemName: "envelope", size: .lg, color: theme.text(.textPrimary))
             .indicator { Badge("3", style: .error, size: .small) }
     }
     .padding()

--- a/Sources/ThemeKit/Components/Molecules/ThemeController.swift
+++ b/Sources/ThemeKit/Components/Molecules/ThemeController.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 /// Molecule. A packaged theme switcher: selecting an option loads that theme via
-/// `Theme.shared.loadTheme(named:)`. (daisyUI "Theme Controller".)
+/// ``Theme/loadTheme(named:)``. (daisyUI "Theme Controller".)
 public struct ThemeController: View {
     @Environment(\.theme) private var theme
 

--- a/Sources/ThemeKit/Components/Organisms/BlogCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/BlogCard.swift
@@ -86,14 +86,15 @@ public struct BlogCard<Media: View>: View {
 }
 
 #Preview {
+    @Previewable @Environment(\.theme) var theme
     VStack(spacing: 20) {
         BlogCard(title: "Kapadokya'yı Tek Başına Keşfetmeye Ne Dersin?",
                  excerpt: "Kimine göre doğanın bir mucizesi, kimine göre periler diyarı…",
                  onReadMore: {}) {
-            Theme.shared.background(.bgTertiary)
+            theme.background(.bgTertiary)
         }
         BlogCard(title: "Kapadokya'yı Tek Başına Keşfetmeye Ne Dersin?", compact: true, onReadMore: {}) {
-            Theme.shared.background(.bgTertiary)
+            theme.background(.bgTertiary)
         }
     }
     .padding()

--- a/Sources/ThemeKit/Components/Organisms/Card.swift
+++ b/Sources/ThemeKit/Components/Organisms/Card.swift
@@ -126,12 +126,13 @@ struct CardShadow: ViewModifier {
 }
 
 #Preview {
+    @Previewable @Environment(\.theme) var theme
     VStack(spacing: 16) {
         Card {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Card title").textStyle(.headingSm)
                 Text("Supporting body text inside a card surface.").textStyle(.bodyBase400)
-                    .foregroundStyle(Theme.shared.text(.textSecondary))
+                    .foregroundStyle(theme.text(.textSecondary))
             }
         }
         Card(elevation: .elevated) {
@@ -139,5 +140,5 @@ struct CardShadow: ViewModifier {
         }
     }
     .padding()
-    .background(Theme.shared.background(.bgElevatorPrimary))
+    .background(theme.background(.bgElevatorPrimary))
 }

--- a/Sources/ThemeKit/Components/Organisms/DataTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/DataTable.swift
@@ -63,9 +63,7 @@ public struct DataTable<Row: Identifiable>: View {
             value: @escaping (Row) -> String
         ) {
             self.init(title, align: align, sortKey: sortKey) { row in
-                Text(value(row))
-                    .textStyle(.bodyBase400)
-                    .foregroundStyle(Theme.shared.text(.textPrimary))   // nested Column has no environment
+                DefaultTextCell(text: value(row))
             }
         }
     }
@@ -263,6 +261,19 @@ public struct DataTable<Row: Identifiable>: View {
         let clamped = min(max(page, 1), pageCount(rowCount: rowCount, pageSize: size))
         let start = (clamped - 1) * size
         return start..<min(start + size, rowCount)
+    }
+}
+
+// The plain-text column's default cell, as a View so it resolves the injected
+// `\.theme` (the `Column` value type that builds it has no environment).
+private struct DefaultTextCell: View {
+    let text: String
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Text(text)
+            .textStyle(.bodyBase400)
+            .foregroundStyle(theme.text(.textPrimary))
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/Diff.swift
+++ b/Sources/ThemeKit/Components/Organisms/Diff.swift
@@ -58,10 +58,11 @@ public struct Diff<Before: View, After: View>: View {
 }
 
 #Preview {
+    @Previewable @Environment(\.theme) var theme
     Diff {
-        Theme.shared.background(.bgHero).overlay(Text("BEFORE").foregroundStyle(.white).font(.headline))
+        theme.background(.bgHero).overlay(Text("BEFORE").foregroundStyle(.white).font(.headline))
     } after: {
-        Theme.shared.background(.bgTertiary).overlay(Text("AFTER").foregroundStyle(.white).font(.headline))
+        theme.background(.bgTertiary).overlay(Text("AFTER").foregroundStyle(.white).font(.headline))
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/Hero.swift
+++ b/Sources/ThemeKit/Components/Organisms/Hero.swift
@@ -66,10 +66,22 @@ public struct Hero<Background: View>: View {
     private var subtitleColor: Color { dark ? theme.text(.textSecondaryInverse) : theme.text(.textSecondary) }
 }
 
-public extension Hero where Background == Color {
+/// The default `Hero` surface. A `View` (not a bare `Color`) so it can resolve the
+/// injected `\.theme` — that's why the convenience `Hero(title:)` below defaults
+/// `Background` to this type instead of `Color`.
+public struct HeroSurface: View {
+    let dark: Bool
+    @Environment(\.theme) private var theme
+
+    public var body: some View {
+        dark ? theme.background(.bgTertiary) : theme.background(.bgElevatorTertiary)
+    }
+}
+
+public extension Hero where Background == HeroSurface {
     init(title: String, subtitle: String? = nil, ctaTitle: String? = nil, dark: Bool = false, action: (() -> Void)? = nil) {
         self.init(title: title, subtitle: subtitle, ctaTitle: ctaTitle, dark: dark, action: action) {
-            dark ? Theme.shared.background(.bgTertiary) : Theme.shared.background(.bgElevatorTertiary)
+            HeroSurface(dark: dark)
         }
     }
 }


### PR DESCRIPTION
## What
Closes out the `\.theme` rollout: **no component renders a color from the `Theme.shared` singleton anymore** — every read resolves the injected `\.theme`.

- **Hero generic:** the `Background == Color` convenience defaulted the surface to a `Color` **value** resolved at init (no environment). Replaced with a **`HeroSurface`** `View` that reads `\.theme`; the convenience now defaults `Background` to `HeroSurface`. **Source-compatible** — `Hero(title:)` infers the new type (no call site names `Hero<Color>`).
- **DataTable:** the plain-text column's default cell is now a `DefaultTextCell` View instead of an inline closure, so it resolves `\.theme` (the `Column` value type has no environment).
- **Previews:** the 13 demo reads use `@Previewable @Environment(\.theme)` — even preview code is singleton-free.
- **ThemeController doc:** `` `Theme.shared.loadTheme(named:)` `` → DocC symbol link `` ``Theme/loadTheme(named:)`` `` (clickable, no singleton literal).

## Result
`Theme.shared.` color reads in `Components` = **0**. The only remaining `Theme.shared` references are a preview's `.environmentObject(Theme.shared)` (legacy `@EnvironmentObject` injection) and the **core singleton wiring** in `Theme/` (the `\.theme` default, typography resolver, root `ObservedObject`) — all by design.

## Safety
- Screenshots **byte-identical** (BorderBeam excluded — animated).
- Full suite green (**160 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)