### PR TITLE
feat(demo): -injectTheme launch arg for ThemeInjectionDemo

### DIFF
--- a/Demo/Demo/Gallery/Demos/ThemeInjectionDemo.swift
+++ b/Demo/Demo/Gallery/Demos/ThemeInjectionDemo.swift
@@ -27,8 +27,14 @@ struct ThemeInjectionDemo: View {
         ]
     }()
 
-    @State private var selected = "Default"
+    @State private var selected = ThemeInjectionDemo.initialSelection
     private var active: Theme { Self.options.first { $0.name == selected }?.theme ?? Theme.shared }
+
+    /// Deep-link the starting theme for screenshots: launch with `-injectTheme <name>`.
+    private static var initialSelection: String {
+        let arg = UserDefaults.standard.string(forKey: "injectTheme") ?? "Default"
+        return options.contains { $0.name == arg } ? arg : "Default"
+    }
 
     var body: some View {
         ComponentStage(


### PR DESCRIPTION
Opens the Theme Injection page pre-set to a theme (`-injectTheme Grape`), matching the existing `-openDemo` deep-link — handy for screenshots / verifying the live subtree re-skin without tapping. Verified live on iPhone 17 Pro: launching with `-openDemo "Theme Injection" -injectTheme Grape` opens the page already re-skinned to the purple theme. 🤖 Generated with [Claude Code](https://claude.com/claude-code)