### PR TITLE
refactor(concurrency): Swift 6 language mode + upcoming features (audit P0)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -32,7 +32,7 @@
 | CI / tooling | **Solid** | ci.yml + docs.yml, .swiftlint.yml + .swiftformat, api-breakage gate PR'da (ci.yml:57) |
 | Erişilebilirlik | **Partial** | VoiceOver/RTL var, Reduce Motion **118** kullanım — ama `performAccessibilityAudit` = **0** (otomatik a11y denetimi yok) |
 | Test çerçevesi | **Partial** | 34 `XCTestCase`, Swift Testing (`@Test`/`#expect`) = **0**; snapshot 4 suite (~108 component'e karşı, opt-in/iOS-only) |
-| **Concurrency (frontier)** | **Anti-pattern** | tools 6.2 ama `swiftLanguageModes: [.v5]`; swiftSettings 0 upcoming flag; `@concurrent` = 0 (@MainActor 15, Sendable 14) |
+| **Concurrency (frontier)** | **Solid** ✅ | ~~tools 6.2 ama v5~~ → **Swift 6 dil modu** + 2 upcoming flag (NonisolatedNonsendingByDefault, InferIsolatedConformances); 0 hata / 0 warning, 163 test + Demo yeşil (Package.swift) |
 | **Observation (frontier)** | **Partial** | `@Observable` = **0**, `ObservableObject` = **8** (Theme + 5 presenter); hâlâ `@Published` (11) |
 | **Liquid Glass (frontier)** | **Missing** | `.glassEffect` = 0, `GlassEffectContainer` = 0, `reduceTransparency` = 0 |
 | Magic-number spacing | **Partial** | 34 literal `.padding(n)` (token yerine); örn. Molecules/Tooltip.swift:196 `.padding(80)` |
@@ -40,7 +40,9 @@
 
 ## Aksiyon planı
 
-### P0 — önce yapılacak
+### P0 — önce yapılacak ✅ TAMAMLANDI (PR'da)
+
+> Swift 6 dil moduna geçildi (`swiftLanguageModes: [.v6]`) + 2 upcoming flag. 46 strict-concurrency hatası idiomatik fix'lerle çözüldü: 3 style erasure init'inde `sending` parametre, `ThemeContext` `@EnvironmentObject`→`@Environment(\.theme)`, `DateField.text` `nonisolated`, `FormValidator` `@MainActor`. 0 hata / 0 warning, 163 test + Demo yeşil.
 
 **1. Swift 6 dil moduna geç**
 - **Ne:** `swiftLanguageModes: [.v6]` + `ThemeKit` target'ına `swiftSettings: [.swiftLanguageMode(.v6)]` ekleyip çıkan strict-concurrency hatalarını gider.

--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,13 @@ let package = Package(
             name: "ThemeKit",
             resources: [
                 .process("Resources"),
+            ],
+            swiftSettings: [
+                // Swift 6.2 upcoming behaviours, adopted early:
+                // nonisolated async stays on the caller's actor (no hidden hops),
+                // and a @MainActor type's protocol conformances infer @MainActor.
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+                .enableUpcomingFeature("InferIsolatedConformances"),
             ]
         ),
         // Lottie add-on: depends on the core + Lottie. Keeps Lottie out of the core
@@ -63,5 +70,5 @@ let package = Package(
             ]
         ),
     ],
-    swiftLanguageModes: [.v5]
+    swiftLanguageModes: [.v6]
 )

--- a/Sources/ThemeKit/Components/Molecules/DateField.swift
+++ b/Sources/ThemeKit/Components/Molecules/DateField.swift
@@ -202,8 +202,9 @@ public struct DateField: View {
 
     // MARK: - Formatting
 
-    /// Renders `date` per `style` / `locale` / `components`. Pure (extracted for testing).
-    static func text(for date: Date, style: DateFieldStyle, locale: Locale, components: DateFieldComponents) -> String {
+    /// Renders `date` per `style` / `locale` / `components`. Pure (extracted for
+    /// testing) and `nonisolated` — a string formatter, callable off the main actor.
+    nonisolated static func text(for date: Date, style: DateFieldStyle, locale: Locale, components: DateFieldComponents) -> String {
         switch style {
         case .relative:
             return date.formatted(.relative(presentation: .named).locale(locale))

--- a/Sources/ThemeKit/Components/Molecules/SelectStyle.swift
+++ b/Sources/ThemeKit/Components/Molecules/SelectStyle.swift
@@ -107,7 +107,7 @@ public extension SelectStyle where Self == FilledSelectStyle {
 
 struct AnySelectStyle: SelectStyle {
     private let _makeBody: @MainActor (SelectStyleConfiguration) -> AnyView
-    init<S: SelectStyle>(_ style: S) {
+    init<S: SelectStyle>(_ style: sending S) {
         _makeBody = { AnyView(style.makeBody(configuration: $0)) }
     }
     func makeBody(configuration: SelectStyleConfiguration) -> AnyView { _makeBody(configuration) }
@@ -126,7 +126,7 @@ extension EnvironmentValues {
 
 public extension View {
     /// Set the ``SelectStyle`` for `Select`s in this view and its descendants.
-    func selectStyle<S: SelectStyle>(_ style: S) -> some View {
+    func selectStyle<S: SelectStyle>(_ style: sending S) -> some View {
         environment(\.selectStyle, AnySelectStyle(style))
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/StatStyle.swift
+++ b/Sources/ThemeKit/Components/Molecules/StatStyle.swift
@@ -117,7 +117,7 @@ public extension StatStyle where Self == CenteredStatStyle {
 
 struct AnyStatStyle: StatStyle {
     private let _makeBody: @MainActor (StatStyleConfiguration) -> AnyView
-    init<S: StatStyle>(_ style: S) {
+    init<S: StatStyle>(_ style: sending S) {
         _makeBody = { AnyView(style.makeBody(configuration: $0)) }
     }
     func makeBody(configuration: StatStyleConfiguration) -> AnyView { _makeBody(configuration) }
@@ -136,7 +136,7 @@ extension EnvironmentValues {
 
 public extension View {
     /// Set the ``StatStyle`` for `Stat`s in this view and its descendants.
-    func statStyle<S: StatStyle>(_ style: S) -> some View {
+    func statStyle<S: StatStyle>(_ style: sending S) -> some View {
         environment(\.statStyle, AnyStatStyle(style))
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/CardStyle.swift
+++ b/Sources/ThemeKit/Components/Organisms/CardStyle.swift
@@ -93,7 +93,7 @@ public extension CardStyle where Self == OutlinedCardStyle {
 
 struct AnyCardStyle: CardStyle {
     private let _makeBody: @MainActor (CardStyleConfiguration) -> AnyView
-    init<S: CardStyle>(_ style: S) {
+    init<S: CardStyle>(_ style: sending S) {
         _makeBody = { AnyView(style.makeBody(configuration: $0)) }
     }
     func makeBody(configuration: CardStyleConfiguration) -> AnyView { _makeBody(configuration) }
@@ -112,7 +112,7 @@ extension EnvironmentValues {
 
 public extension View {
     /// Set the ``CardStyle`` for `Card`s in this view and its descendants.
-    func cardStyle<S: CardStyle>(_ style: S) -> some View {
+    func cardStyle<S: CardStyle>(_ style: sending S) -> some View {
         environment(\.cardStyle, AnyCardStyle(style))
     }
 }

--- a/Sources/ThemeKit/Theme/ThemeContext.swift
+++ b/Sources/ThemeKit/Theme/ThemeContext.swift
@@ -21,7 +21,7 @@ import SwiftUI
 /// ```
 @propertyWrapper
 public struct ThemeContext: DynamicProperty {
-    @EnvironmentObject private var theme: Theme
+    @Environment(\.theme) private var theme
 
     public init() {}
 

--- a/Sources/ThemeKit/Validation/FormValidator.swift
+++ b/Sources/ThemeKit/Validation/FormValidator.swift
@@ -19,6 +19,7 @@
 
 import SwiftUI
 
+@MainActor
 public final class FormValidator<Field: Hashable>: ObservableObject {
     @Published public private(set) var messages: [Field: [InfoMessage]] = [:]
     /// The field that should currently hold focus (set to the first invalid on submit).
@@ -69,13 +70,8 @@ public final class FormValidator<Field: Hashable>: ObservableObject {
     }
 
     /// A bool focus binding for a field — true while it's the focused field.
-    /// Hand this to `TextInput(externalFocus:)`.
-    ///
-    /// Note: under `-strict-concurrency=complete` this emits Sendable-capture
-    /// warnings (SwiftUI's `Binding` get/set are `@Sendable`, and `self`/`Field`
-    /// are not). Clearing them would require a `Field: Sendable` constraint, which
-    /// is a source-breaking API change — so we keep the binding always evaluated
-    /// on the main thread instead. Harmless in the default `.v5` language mode.
+    /// Hand this to `TextInput(externalFocus:)`. The validator is `@MainActor`, so
+    /// the binding's get/set are main-actor isolated — clean under Swift 6.
     public func focusBinding(_ field: Field) -> Binding<Bool> {
         Binding(
             get: { [weak self] in self?.focusedField == field },

--- a/Tests/ThemeKitTests/ValidationTests.swift
+++ b/Tests/ThemeKitTests/ValidationTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import ThemeKit
 
+@MainActor
 final class ValidationTests: XCTestCase {
 
     func testRequiredAndEmail() {


### PR DESCRIPTION
## What
The package declared `swift-tools-version: 6.2` but built in **`swiftLanguageModes: [.v5]`** — strict concurrency was never enforced, a data-race-warning risk for consumers compiling under Swift 6. This switches to **`.v6`** and enables two upcoming features: `NonisolatedNonsendingByDefault`, `InferIsolatedConformances`.

## Fixes (46 diagnostics → 0, idiomatic — no `@unchecked`, no suppression)
- **Style erasure** (`AnyCardStyle`/`AnyStatStyle`/`AnySelectStyle` + the `.cardStyle`/`.statStyle`/`.selectStyle` modifiers): `sending` parameter so a non-Sendable style transfers cleanly into the `@MainActor` closure.
- **`ThemeContext`**: `@EnvironmentObject` → `@Environment(\.theme)` — fixes the wrapper's Swift 6 init, and is crash-proof + consistent with the rollout.
- **`DateField.text`**: `nonisolated` (a pure string formatter — now callable off-main).
- **`FormValidator`**: `@MainActor` (UI form state) — clears the documented Sendable-capture warnings without the source-breaking `Field: Sendable` constraint.

## Safety
- **0 errors / 0 warnings.** Full suite green (**163 tests**).
- **Demo app builds** against the Swift 6 library — source-compatible for consumers (`sending` is caller-transparent; `@MainActor` form state is already used on the main actor).

Closes audit **P0** (`AUDIT.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)