### PR TITLE
test(swift-testing): pilot @Test/#expect alongside XCTest (audit P2)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -31,7 +31,7 @@
 | Dokümantasyon | **Solid** | DocC katalog + 6 article (Sources/ThemeKit/Documentation.docc), 86 struct'ta `///` |
 | CI / tooling | **Solid** | ci.yml + docs.yml, .swiftlint.yml + .swiftformat, api-breakage gate PR'da (ci.yml:57) |
 | Erişilebilirlik | **Partial** | VoiceOver/RTL var, Reduce Motion **118** kullanım — ama `performAccessibilityAudit` = **0** (otomatik a11y denetimi yok) |
-| Test çerçevesi | **Partial** | 34 `XCTestCase`, Swift Testing (`@Test`/`#expect`) = **0**; snapshot 4 suite (~108 component'e karşı, opt-in/iOS-only) |
+| Test çerçevesi | **Partial → improving** | Swift Testing **piloted** (SwiftTestingPilot.swift — parameterized `@Test`/`#expect`, XCTest'le yan yana çalışır); kalan 34 `XCTestCase` fırsatçı taşınır. Theming-injection regresyon testi eklendi. Snapshot 4 suite hâlâ ince |
 | **Concurrency (frontier)** | **Solid** ✅ | ~~tools 6.2 ama v5~~ → **Swift 6 dil modu** + 2 upcoming flag (NonisolatedNonsendingByDefault, InferIsolatedConformances); 0 hata / 0 warning, 163 test + Demo yeşil (Package.swift) |
 | **Observation (frontier)** | **Solid** ✅ | 6/8 `@Observable`'a taşındı (5 presenter + FormValidator); `@Published` 0, `@StateObject`→`@State`, presenter env'i `@Environment(_.self)`. Yalnız `Theme` (`@unchecked Sendable` singleton + revision-repaint) bilinçli ertelendi |
 | **Liquid Glass (frontier)** | **Solid** ✅ | `.glassChrome()` modifier (Extensions/GlassChrome.swift): `.glassEffect` on OS 26+, `Material` fallback 17–25, opaque fill under Reduce Transparency; adopted in Dialog + Drawer chrome. Gated & additive (iOS 17 min korunur) |

--- a/Sources/ThemeKit/Components/Molecules/DateField.swift
+++ b/Sources/ThemeKit/Components/Molecules/DateField.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 /// How the chosen date renders inside the field.
-public enum DateFieldStyle: Equatable {
+public enum DateFieldStyle: Equatable, Sendable {
     case numeric        // 1/5/2026
     case abbreviated    // Jan 5, 2026   (default)
     case long           // January 5, 2026

--- a/Tests/ThemeKitTests/SwiftTestingPilot.swift
+++ b/Tests/ThemeKitTests/SwiftTestingPilot.swift
@@ -1,0 +1,41 @@
+//
+//  SwiftTestingPilot.swift
+//  ThemeKit
+//
+//  Pilot for the modern Swift Testing framework (`@Test` / `#expect` / parameterized
+//  `arguments:`) alongside the existing XCTest suites. Targets pure, deterministic
+//  logic so it runs anywhere `swift test` does. New tests can follow this style;
+//  the XCTest suites migrate opportunistically.
+//
+
+import Testing
+import Foundation
+@testable import ThemeKit
+
+@Suite("DateField formatting")
+struct DateFieldFormattingTests {
+    /// 2026-01-05 at noon UTC — a Monday; noon keeps the day stable across realistic
+    /// timezones so date-only assertions don't flake.
+    private var jan5: Date {
+        var c = DateComponents()
+        c.year = 2026; c.month = 1; c.day = 5; c.hour = 12
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+    private let enUS = Locale(identifier: "en_US")
+
+    @Test("en-US date styles render the expected string", arguments: [
+        (DateFieldStyle.abbreviated, "Jan 5, 2026"),
+        (DateFieldStyle.numeric, "1/5/2026"),
+        (DateFieldStyle.long, "January 5, 2026"),
+    ])
+    func formats(_ style: DateFieldStyle, _ expected: String) {
+        #expect(DateField.text(for: jan5, style: style, locale: enUS, components: .date) == expected)
+    }
+
+    @Test("a custom pattern is honoured verbatim")
+    func customPattern() {
+        let out = DateField.text(for: jan5, style: .custom("yyyy-MM-dd"), locale: enUS, components: .date)
+        #expect(out == "2026-01-05")
+    }
+}


### PR DESCRIPTION
## What
Introduces **Swift Testing** (`@Test` / `#expect`, bundled with swift-tools 6.2) as a pilot, running **side-by-side with the existing XCTest** suites.

- `SwiftTestingPilot.swift`: a **parameterized** `@Test(arguments:)` over `DateField`'s formatting + a custom-pattern case (pure, deterministic). `✔ Test run with 2 tests in 1 suite passed`.
- The pilot surfaced that the public **`DateFieldStyle` wasn't `Sendable`** — added the conformance (a value enum; a correct Swift 6 improvement for consumers).

New tests can follow this style; XCTest suites migrate opportunistically.

## Safety
Full run green (**163 XCTest + the Swift Testing suite**, exit 0).

Advances audit **P2 / test framework** (`AUDIT.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)