### PR TITLE
test(a11y): performAccessibilityAudit XCUITest + setup docs (audit P1 #4)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -38,7 +38,7 @@
 | `#Preview` / slot | **Solid** | 102 `@ViewBuilder` slot, 114 `#Preview` |
 | Dokümantasyon | **Solid** | DocC katalog + 6 article (Sources/ThemeKit/Documentation.docc), 86 struct'ta `///` |
 | CI / tooling | **Solid** | ci.yml + docs.yml, .swiftlint.yml + .swiftformat, api-breakage gate PR'da (ci.yml:57) |
-| Erişilebilirlik | **Partial** | VoiceOver/RTL var, Reduce Motion **118** kullanım — ama `performAccessibilityAudit` = **0** (otomatik a11y denetimi yok) |
+| Erişilebilirlik | **Solid → kod hazır** | VoiceOver/RTL/Reduce Motion (**118**) + unit a11y testleri; `performAccessibilityAudit` XCUITest **yazıldı** (Demo/DemoUITests/AccessibilityAuditTests.swift) — UI-test target bağlama tek manuel Xcode adımı (docs/ACCESSIBILITY-AUDIT.md) |
 | Test çerçevesi | **Partial → improving** | Swift Testing **piloted** (SwiftTestingPilot.swift — parameterized `@Test`/`#expect`, XCTest'le yan yana çalışır); kalan 34 `XCTestCase` fırsatçı taşınır. Theming-injection regresyon testi eklendi. Snapshot 4 suite hâlâ ince |
 | **Concurrency (frontier)** | **Solid** ✅ | ~~tools 6.2 ama v5~~ → **Swift 6 dil modu** + 2 upcoming flag (NonisolatedNonsendingByDefault, InferIsolatedConformances); 0 hata / 0 warning, 163 test + Demo yeşil (Package.swift) |
 | **Observation (frontier)** | **Solid** ✅ | **8/8** `@Observable` — 5 presenter + FormValidator + **Theme** (core engine dahil). `@Published`/`@ObservedObject`/`@EnvironmentObject` 0; `.id(theme.revision)` repaint korundu (revision tracked), runtime tema-switch simulator'da doğrulandı (Ocean render) |
@@ -69,8 +69,9 @@
 - **Yapıldı:** 5 presenter (Drawer/Tour/BottomSheet/Upload/Feedback) + FormValidator `@Observable`'a taşındı; `@Published` 0, `@StateObject`→`@State`, presenter enjeksiyonu `.environmentObject`→`.environment` + okuma `@Environment(_.self)`. 163 test + Demo (gerçek tüketici, güncellendi) yeşil.
 - **Theme de tamamlandı (ayrı PR):** `@Observable public final class Theme: @unchecked Sendable`; `objectWillChange.send()` kaldırıldı (revision bump @Observable tracking'i tetikler), root `@ObservedObject`→plain `let` + `.environmentObject`→`.environment`, tek `@EnvironmentObject Theme` consumer'ı `@Environment(Theme.self)`'e. `.id(theme.revision)` full-rebuild repaint'i korundu. Doğrulama: 163 test + revision-bump testi + Demo Ocean global temada render (teal accent).
 
-**4. Otomatik a11y denetimi (`performAccessibilityAudit`)** — ⏳ ORTAM-BAĞIMLI
-- **Durum:** `performAccessibilityAudit()` yalnız `XCUIApplication` üzerinde çalışır → Demo.xcodeproj'a bir **UI-test target'ı** (pbxproj target + scheme) eklenmesi gerekir. Bu, script ile güvenle yapılamaz (projeyi bozma riski); Xcode'da tek seferlik manuel kurulum gerektirir. Test kodu hazır yazılabilir, target bağlama kullanıcıya kalır.
+**4. Otomatik a11y denetimi (`performAccessibilityAudit`)** — ✅ KOD TESLİM (target bağlama manuel)
+- **Yapıldı:** `Demo/DemoUITests/AccessibilityAuditTests.swift` — galeri + Theme Injection + Form/Select/DataTable/Steps sayfalarını `-openDemo` deep-link ile gezip `performAccessibilityAudit()` çalıştırır. Kurulum dokümanı: `docs/ACCESSIBILITY-AUDIT.md`.
+- **Kalan tek adım (kullanıcı):** Xcode'da bir UI-test target eklemek (pbxproj script ile güvenle yapılamaz). Doküman birebir adımları içerir; target bağlanınca `⌘U` / `xcodebuild test`.
 
 **5. Snapshot kapsamını genişlet**
 - **Ne:** 4 suite → component grubu başına referans; `ScreenshotGenerator` zaten hepsini render ediyor, golden referansa bağla.

--- a/Demo/DemoUITests/AccessibilityAuditTests.swift
+++ b/Demo/DemoUITests/AccessibilityAuditTests.swift
@@ -1,0 +1,52 @@
+//
+//  AccessibilityAuditTests.swift
+//  DemoUITests
+//
+//  Automated accessibility auditing via `XCUIApplication.performAccessibilityAudit()`
+//  (iOS 17+) — catches contrast, dynamic-type clipping, element description, hit-region
+//  and trait issues that the unit-level a11y tests can't. Drives the gallery and
+//  representative component pages through the Demo app's `-openDemo` deep-link.
+//
+//  SETUP: this file needs a UI-testing target in Demo.xcodeproj (one-time, see
+//  docs/ACCESSIBILITY-AUDIT.md). Once wired, run with ⌘U or:
+//    xcodebuild test -project Demo/Demo.xcodeproj -scheme DemoUITests \
+//      -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+//
+
+import XCTest
+
+final class AccessibilityAuditTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = true   // report every screen's issues, don't stop at the first
+    }
+
+    /// Launches the Demo, optionally deep-linked to a gallery page, and audits it.
+    @MainActor
+    private func audit(openDemo page: String? = nil, file: StaticString = #filePath, line: UInt = #line) throws {
+        let app = XCUIApplication()
+        if let page { app.launchArguments += ["-openDemo", page] }
+        app.launch()
+
+        // Audit every category. Add an issue handler here to triage known,
+        // intentional exceptions (return `true` to ignore) once a baseline is set.
+        try app.performAccessibilityAudit()
+    }
+
+    @MainActor
+    func testComponentGalleryIsAccessible() throws {
+        try audit()
+    }
+
+    @MainActor
+    func testThemeInjectionPageIsAccessible() throws {
+        try audit(openDemo: "Theme Injection")
+    }
+
+    // Representative, interaction-heavy components across the three layers.
+    @MainActor func testTextInputFormIsAccessible() throws { try audit(openDemo: "Form") }
+    @MainActor func testSelectIsAccessible() throws { try audit(openDemo: "Select") }
+    @MainActor func testDataTableIsAccessible() throws { try audit(openDemo: "DataTable") }
+    @MainActor func testStepsIsAccessible() throws { try audit(openDemo: "Steps") }
+}

--- a/docs/ACCESSIBILITY-AUDIT.md
+++ b/docs/ACCESSIBILITY-AUDIT.md
@@ -1,0 +1,44 @@
+# Automated accessibility audit
+
+`Tests/.../AccessibilitySemanticsTests.swift` cover a11y *semantics* (labels, traits,
+values) at the unit level. This adds **runtime** auditing —
+`XCUIApplication.performAccessibilityAudit()` (iOS 17+) — which catches contrast,
+dynamic-type clipping, hit-region size, and element-description issues that only show
+up on a rendered screen.
+
+The test code lives in `Demo/DemoUITests/AccessibilityAuditTests.swift`. It drives the
+gallery and representative component pages through the Demo's `-openDemo` deep-link.
+
+## One-time target setup (Xcode)
+
+A UI-testing target can't be added safely by editing `project.pbxproj` by hand, so this
+is a manual step:
+
+1. **File ▸ New ▸ Target… ▸ UI Testing Bundle.** Name it `DemoUITests`, Target to Test = `Demo`.
+2. Delete the auto-generated `DemoUITests.swift` and, in the new target's folder, **add the existing** `Demo/DemoUITests/AccessibilityAuditTests.swift` (Target Membership = `DemoUITests`).
+3. The `Demo` scheme's **Test** action picks up `DemoUITests` automatically. (Optional: share the scheme so CI can run it.)
+
+## Running
+
+```bash
+xcodebuild test -project Demo/Demo.xcodeproj -scheme Demo \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:DemoUITests
+```
+
+or **⌘U** in Xcode.
+
+## Triaging findings
+
+`performAccessibilityAudit()` fails on any issue. To accept a known, intentional
+exception, pass an audit-type set and/or an issue handler:
+
+```swift
+try app.performAccessibilityAudit(for: [.contrast, .dynamicType, .hitRegion]) { issue in
+    // return true to IGNORE this issue (e.g. a decorative element)
+    issue.element?.label == "decorative-spacer"
+}
+```
+
+Start strict (audit everything), record the real findings, fix them in the components,
+and only then add narrowly-scoped ignores for anything genuinely intentional.


### PR DESCRIPTION
## What
Adds **runtime** accessibility auditing to complement the unit-level a11y semantics tests — `XCUIApplication.performAccessibilityAudit()` (iOS 17+) catches contrast / dynamic-type / hit-region / description issues that only surface on a rendered screen.

- **`Demo/DemoUITests/AccessibilityAuditTests.swift`**: audits the gallery + Theme Injection + Form/Select/DataTable/Steps pages, driven by the existing `-openDemo` deep-link.
- **`docs/ACCESSIBILITY-AUDIT.md`**: the one-time Xcode UI-test-target setup (a UI-testing target can't be added safely by hand-editing `project.pbxproj`) + run + triage instructions.

The test code is **ready**; wiring the UI-test target is the single manual Xcode step (documented). Closes audit **P1 #4** to the extent that's safely scriptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)