### PR TITLE
refactor(button): isEnabled binding → native .disabled() (audit P0/c)

### DIFF
--- a/Demo/Demo/Examples/HotelCheckoutView.swift
+++ b/Demo/Demo/Examples/HotelCheckoutView.swift
@@ -69,7 +69,7 @@ struct HotelCheckoutView: View {
                     Text("Toplam").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
                     Text(total.priceText).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
                 }
-                PrimaryButton("Öde", block: true, isEnabled: $acceptTerms) { showSuccess = true }
+                PrimaryButton("Öde", block: true) { showSuccess = true }.disabled(!acceptTerms)
             }
             .padding(.bottom, 4)
         }

--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -35,19 +35,19 @@ struct ButtonDemo: View {
             Group {
                 if asyncMode {
                     switch style {
-                    case .primary: PrimaryButton(title, size: size, block: fullWidth, helperText: helperText, isEnabled: $enabled, task: work)
-                    case .secondary: SecondaryButton(title, size: size, block: fullWidth, helperText: helperText, isEnabled: $enabled, task: work)
-                    case .outline: OutlineButton(title, size: size, block: fullWidth, helperText: helperText, isEnabled: $enabled, task: work)
-                    case .ghost: GhostButton(title, size: size, block: fullWidth, helperText: helperText, isEnabled: $enabled, task: work)
-                    case .link: LinkButton(title, size: size, isEnabled: $enabled, action: tapped)
+                    case .primary: PrimaryButton(title, size: size, block: fullWidth, helperText: helperText, task: work).disabled(!enabled)
+                    case .secondary: SecondaryButton(title, size: size, block: fullWidth, helperText: helperText, task: work).disabled(!enabled)
+                    case .outline: OutlineButton(title, size: size, block: fullWidth, helperText: helperText, task: work).disabled(!enabled)
+                    case .ghost: GhostButton(title, size: size, block: fullWidth, helperText: helperText, task: work).disabled(!enabled)
+                    case .link: LinkButton(title, size: size, action: tapped).disabled(!enabled)
                     }
                 } else {
                     switch style {
-                    case .primary: PrimaryButton(title, size: size, block: fullWidth, helperText: helperText, isEnabled: $enabled, isLoading: $loading, action: tapped)
-                    case .secondary: SecondaryButton(title, size: size, block: fullWidth, helperText: helperText, isEnabled: $enabled, isLoading: $loading, action: tapped)
-                    case .outline: OutlineButton(title, size: size, block: fullWidth, helperText: helperText, isEnabled: $enabled, isLoading: $loading, action: tapped)
-                    case .ghost: GhostButton(title, size: size, block: fullWidth, helperText: helperText, isEnabled: $enabled, isLoading: $loading, action: tapped)
-                    case .link: LinkButton(title, size: size, isEnabled: $enabled, action: tapped)
+                    case .primary: PrimaryButton(title, size: size, block: fullWidth, helperText: helperText, isLoading: $loading, action: tapped).disabled(!enabled)
+                    case .secondary: SecondaryButton(title, size: size, block: fullWidth, helperText: helperText, isLoading: $loading, action: tapped).disabled(!enabled)
+                    case .outline: OutlineButton(title, size: size, block: fullWidth, helperText: helperText, isLoading: $loading, action: tapped).disabled(!enabled)
+                    case .ghost: GhostButton(title, size: size, block: fullWidth, helperText: helperText, isLoading: $loading, action: tapped).disabled(!enabled)
+                    case .link: LinkButton(title, size: size, action: tapped).disabled(!enabled)
                     }
                 }
             }

--- a/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
@@ -22,6 +22,7 @@ public enum ThemeButtonStyle {
 /// success-confirmation that morphs the label into a checkmark.
 private struct ThemedButton: View {
     @Environment(\.theme) private var theme
+    @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
 
     enum Phase { case idle, running, success }
 
@@ -33,7 +34,6 @@ private struct ThemedButton: View {
     let block: Bool
     let confirmsSuccess: Bool
     let accessibilityID: String?
-    @Binding var isEnabled: Bool
     @Binding var isLoading: Bool
     let run: () async -> Void
 
@@ -146,7 +146,6 @@ public struct PrimaryButton: View {
         textStyle: TextStyle? = nil,
         confirmsSuccess: Bool = false,
         accessibilityID: String? = nil,
-        isEnabled: Binding<Bool> = .constant(true),
         isLoading: Binding<Bool> = .constant(false),
         action: @escaping () -> Void
     ) {
@@ -154,7 +153,7 @@ public struct PrimaryButton: View {
             title: title, helperText: helperText, textStyle: textStyle,
             style: .primary, size: size, block: block,
             confirmsSuccess: confirmsSuccess, accessibilityID: accessibilityID,
-            isEnabled: isEnabled, isLoading: isLoading, run: { action() }
+            isLoading: isLoading, run: { action() }
         )
     }
 
@@ -168,14 +167,13 @@ public struct PrimaryButton: View {
         textStyle: TextStyle? = nil,
         confirmsSuccess: Bool = true,
         accessibilityID: String? = nil,
-        isEnabled: Binding<Bool> = .constant(true),
         task: @escaping () async -> Void
     ) {
         configuration = ButtonConfiguration(
             title: title, helperText: helperText, textStyle: textStyle,
             style: .primary, size: size, block: block,
             confirmsSuccess: confirmsSuccess, accessibilityID: accessibilityID,
-            isEnabled: isEnabled, isLoading: .constant(false), run: task
+            isLoading: .constant(false), run: task
         )
     }
 
@@ -193,7 +191,6 @@ public struct SecondaryButton: View {
         textStyle: TextStyle? = nil,
         confirmsSuccess: Bool = false,
         accessibilityID: String? = nil,
-        isEnabled: Binding<Bool> = .constant(true),
         isLoading: Binding<Bool> = .constant(false),
         action: @escaping () -> Void
     ) {
@@ -201,7 +198,7 @@ public struct SecondaryButton: View {
             title: title, helperText: helperText, textStyle: textStyle,
             style: .secondary, size: size, block: block,
             confirmsSuccess: confirmsSuccess, accessibilityID: accessibilityID,
-            isEnabled: isEnabled, isLoading: isLoading, run: { action() }
+            isLoading: isLoading, run: { action() }
         )
     }
 
@@ -214,14 +211,13 @@ public struct SecondaryButton: View {
         textStyle: TextStyle? = nil,
         confirmsSuccess: Bool = true,
         accessibilityID: String? = nil,
-        isEnabled: Binding<Bool> = .constant(true),
         task: @escaping () async -> Void
     ) {
         configuration = ButtonConfiguration(
             title: title, helperText: helperText, textStyle: textStyle,
             style: .secondary, size: size, block: block,
             confirmsSuccess: confirmsSuccess, accessibilityID: accessibilityID,
-            isEnabled: isEnabled, isLoading: .constant(false), run: task
+            isLoading: .constant(false), run: task
         )
     }
 
@@ -239,7 +235,6 @@ public struct OutlineButton: View {
         textStyle: TextStyle? = nil,
         confirmsSuccess: Bool = false,
         accessibilityID: String? = nil,
-        isEnabled: Binding<Bool> = .constant(true),
         isLoading: Binding<Bool> = .constant(false),
         action: @escaping () -> Void
     ) {
@@ -247,7 +242,7 @@ public struct OutlineButton: View {
             title: title, helperText: helperText, textStyle: textStyle,
             style: .outline, size: size, block: block,
             confirmsSuccess: confirmsSuccess, accessibilityID: accessibilityID,
-            isEnabled: isEnabled, isLoading: isLoading, run: { action() }
+            isLoading: isLoading, run: { action() }
         )
     }
 
@@ -260,14 +255,13 @@ public struct OutlineButton: View {
         textStyle: TextStyle? = nil,
         confirmsSuccess: Bool = true,
         accessibilityID: String? = nil,
-        isEnabled: Binding<Bool> = .constant(true),
         task: @escaping () async -> Void
     ) {
         configuration = ButtonConfiguration(
             title: title, helperText: helperText, textStyle: textStyle,
             style: .outline, size: size, block: block,
             confirmsSuccess: confirmsSuccess, accessibilityID: accessibilityID,
-            isEnabled: isEnabled, isLoading: .constant(false), run: task
+            isLoading: .constant(false), run: task
         )
     }
 
@@ -285,7 +279,6 @@ public struct GhostButton: View {
         textStyle: TextStyle? = nil,
         confirmsSuccess: Bool = false,
         accessibilityID: String? = nil,
-        isEnabled: Binding<Bool> = .constant(true),
         isLoading: Binding<Bool> = .constant(false),
         action: @escaping () -> Void
     ) {
@@ -293,7 +286,7 @@ public struct GhostButton: View {
             title: title, helperText: helperText, textStyle: textStyle,
             style: .ghost, size: size, block: block,
             confirmsSuccess: confirmsSuccess, accessibilityID: accessibilityID,
-            isEnabled: isEnabled, isLoading: isLoading, run: { action() }
+            isLoading: isLoading, run: { action() }
         )
     }
 
@@ -306,14 +299,13 @@ public struct GhostButton: View {
         textStyle: TextStyle? = nil,
         confirmsSuccess: Bool = true,
         accessibilityID: String? = nil,
-        isEnabled: Binding<Bool> = .constant(true),
         task: @escaping () async -> Void
     ) {
         configuration = ButtonConfiguration(
             title: title, helperText: helperText, textStyle: textStyle,
             style: .ghost, size: size, block: block,
             confirmsSuccess: confirmsSuccess, accessibilityID: accessibilityID,
-            isEnabled: isEnabled, isLoading: .constant(false), run: task
+            isLoading: .constant(false), run: task
         )
     }
 
@@ -327,13 +319,12 @@ public struct LinkButton: View {
         _ title: String,
         size: ButtonSize = .medium,
         accessibilityID: String? = nil,
-        isEnabled: Binding<Bool> = .constant(true),
         action: @escaping () -> Void
     ) {
         configuration = ButtonConfiguration(
             title: title, style: .link, size: size, block: false,
             accessibilityID: accessibilityID,
-            isEnabled: isEnabled, isLoading: .constant(false), run: { action() }
+            isLoading: .constant(false), run: { action() }
         )
     }
 
@@ -351,7 +342,6 @@ private struct ButtonConfiguration {
     let block: Bool
     var confirmsSuccess: Bool = false
     let accessibilityID: String?
-    let isEnabled: Binding<Bool>
     let isLoading: Binding<Bool>
     let run: () async -> Void
 
@@ -363,7 +353,7 @@ private struct ButtonConfiguration {
             title: title, helperText: helperText, textStyle: textStyle,
             style: style, size: size, block: block,
             confirmsSuccess: confirmsSuccess, accessibilityID: accessibilityID,
-            isEnabled: isEnabled, isLoading: isLoading, run: run
+            isLoading: isLoading, run: run
         )
     }
 }
@@ -373,7 +363,7 @@ private struct ButtonConfiguration {
         PrimaryButton("Primary") {}
         SecondaryButton("Secondary") {}
         OutlineButton("Outline") {}
-        PrimaryButton("Disabled", isEnabled: .constant(false)) {}
+        PrimaryButton("Disabled") {}.disabled(true)
         PrimaryButton("Loading", isLoading: .constant(true)) {}
         PrimaryButton("Full-width CTA", block: true) {}
     }

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -55,7 +55,7 @@ struct DialogCard: View {
                     PrimaryButton(primaryTitle, isLoading: .constant(isPrimaryLoading), action: onPrimary)
                 }
                 if let secondaryTitle, let onSecondary {
-                    OutlineButton(secondaryTitle, isEnabled: .constant(!isPrimaryLoading), action: onSecondary)
+                    OutlineButton(secondaryTitle, action: onSecondary).disabled(isPrimaryLoading)
                 }
             }
         }

--- a/Sources/ThemeKit/Components/Organisms/Upload.swift
+++ b/Sources/ThemeKit/Components/Organisms/Upload.swift
@@ -62,7 +62,7 @@ public struct Upload: View {
             Text(prompt)
                 .textStyle(.bodySm400)
                 .foregroundStyle(theme.text(.textSecondary))
-            PrimaryButton(buttonTitle, isEnabled: .constant(!atLimit)) { onPick() }
+            PrimaryButton(buttonTitle) { onPick() }.disabled(atLimit)
             if let maxCount {
                 Text("\(files.count)/\(maxCount)")
                     .textStyle(.overline400)


### PR DESCRIPTION
## Why
The button family took `isEnabled: Binding<Bool>` — a **read-only binding reinventing SwiftUI's own disabled mechanism**.

## What
- The shared core now reads **`@Environment(\.isEnabled)`** (set automatically by `.disabled(_:)`, inherited down the tree). Removed `isEnabled` from every button init + the internal config; the disabled **visual** (muted colors) and **behavior** both come from the environment.
- Migrated **all call sites** to native `.disabled(_:)`: `isEnabled: $acceptTerms` → `.disabled(!acceptTerms)`, `isEnabled: .constant(!atLimit)` → `.disabled(atLimit)`. Covers Upload, Dialog, the Hotel checkout CTA, and the gallery ButtonDemo (incl. `LinkButton`).

More idiomatic (matches SwiftUI's controls), one fewer param, and **disable now inherits through containers**.

## Verified
**164 tests** green; **Demo builds**. 0 `isEnabled:` button params left.

Completes the button API cleanup: `isContentWidth`→`block` (#97), label `.lineLimit(1)` (#96), and now `isEnabled`→`.disabled()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)