### PR TITLE
chore(demo): surface the Themes tab (avoid the iOS "More" overflow)

### DIFF
--- a/Demo/Demo/ContentView.swift
+++ b/Demo/Demo/ContentView.swift
@@ -18,20 +18,20 @@ struct ContentView: View {
                 .tabItem { Label("Components", systemImage: "square.grid.2x2") }
                 .tag(0)
 
+            ThemesView()
+                .tabItem { Label("Themes", systemImage: "swatchpalette") }
+                .tag(1)
+
             ThemeGalleryView()
                 .tabItem { Label("Colors", systemImage: "paintpalette") }
-                .tag(1)
+                .tag(2)
 
             TypographyView()
                 .tabItem { Label("Type", systemImage: "textformat") }
-                .tag(2)
+                .tag(3)
 
             LayoutTokensView()
                 .tabItem { Label("Layout", systemImage: "ruler") }
-                .tag(3)
-
-            ThemesView()
-                .tabItem { Label("Themes", systemImage: "swatchpalette") }
                 .tag(4)
 
             HotelSearchView()


### PR DESCRIPTION
With 6 tabs iOS collapses the last two into a "More" item, burying the new daisyUI **Themes** gallery. Move Themes to the 2nd slot so it's a directly visible tab; the Example (HotelSearch) tab takes the overflow instead.

Demo BUILD SUCCEEDED · runs on simulator with Themes as a top-level tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)