### PR TITLE
feat(theme): semantic radius roles (daisyUI box/field/selector)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/Badge.swift
+++ b/Sources/ThemeKit/Components/Atoms/Badge.swift
@@ -193,7 +193,7 @@ public struct Badge: View {
     private var shapeStyle: AnyShape {
         switch shape {
         case .pill: return AnyShape(Capsule())
-        case .rounded: return AnyShape(RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
+        case .rounded: return AnyShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Checkbox.swift
+++ b/Sources/ThemeKit/Components/Molecules/Checkbox.swift
@@ -98,7 +98,7 @@ public struct Checkbox: View {
         }
     }
 
-    private var radius: CGFloat { Theme.RadiusKey.xs.value }
+    private var radius: CGFloat { Theme.RadiusRole.selector.value }
 
     private var box: some View {
         RoundedRectangle(cornerRadius: radius, style: .continuous)

--- a/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
+++ b/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
@@ -100,7 +100,7 @@ public struct SegmentedControl: View {
         }
         .padding(4)
         .background(theme.background(.bgElevatorPrimary),
-                   in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+                   in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
         .opacity(isEnabled ? 1 : 0.5)
         .a11y(A11yElement.Control.toggle, in: accessibilityID)
         .accessibilityValue(items.indices.contains(selection) ? items[selection].title : "")

--- a/Sources/ThemeKit/Components/Molecules/TextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInput.swift
@@ -271,10 +271,10 @@ public struct TextInput: View {
             }
         }
         .frame(height: model.size.height)
-        .background(backgroundColor, in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
-        .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
+        .background(backgroundColor, in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
+            RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
                 .strokeBorder(borderColor, lineWidth: isFocused || hasError || hasWarning ? 1.5 : 1)
         )
         .contentShape(Rectangle())

--- a/Sources/ThemeKit/Components/Organisms/CardStyle.swift
+++ b/Sources/ThemeKit/Components/Organisms/CardStyle.swift
@@ -48,9 +48,9 @@ private struct DefaultCardSurface: View {
     var body: some View {
         configuration.content
             .background(theme.background(.bgWhite),
-                        in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
             .overlay(
-                RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous)
+                RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
                     .strokeBorder(theme.border(.borderPrimary), lineWidth: configuration.elevation == .none ? 1 : 0)
             )
             .modifier(CardShadow(elevation: configuration.elevation))
@@ -73,7 +73,7 @@ private struct OutlinedCardSurface: View {
     var body: some View {
         configuration.content
             .overlay(
-                RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous)
+                RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
                     .strokeBorder(theme.border(.borderPrimary), lineWidth: 1.5)
             )
     }

--- a/Sources/ThemeKit/Theme/Theme.swift
+++ b/Sources/ThemeKit/Theme/Theme.swift
@@ -243,6 +243,13 @@ public final class Theme: @unchecked Sendable {
     // MARK: - Metric accessors
 
     public func radius(_ key: RadiusKey) -> CGFloat { radiusList[key.rawValue] ?? 0 }
+
+    /// Resolved radius for a semantic *role* (box / field / selector). Reads the
+    /// theme's role token if present, otherwise the role's fallback size key — so
+    /// themes without role tokens (bundled JSON) keep their existing corners.
+    public func radius(_ role: RadiusRole) -> CGFloat {
+        radiusList[role.rawValue] ?? radius(role.fallback)
+    }
     public func spacing(_ key: SpacingKey) -> CGFloat { spacingList[key.rawValue] ?? 0 }
 
     // MARK: - Typography accessor

--- a/Sources/ThemeKit/Theme/ThemeGenerator.swift
+++ b/Sources/ThemeKit/Theme/ThemeGenerator.swift
@@ -210,6 +210,8 @@ enum ThemeGenerator {
 
     private static let radiusBase: [(String, CGFloat)] = [
         ("radius-none", 0), ("rd-xs", 6), ("rd-sm", 8), ("rd-md", 16), ("rd-base", 24), ("rd-lg", 32), ("rd-xl", 40), ("rd-4xl", 64),
+        // Semantic radius roles (daisyUI parity) — box / field / selector.
+        ("radius-box", 16), ("radius-field", 8), ("radius-selector", 6),
     ]
     private static let spacingBase: [(String, CGFloat)] = [
         ("spacing-none", 0), ("sp-xs", 4), ("sp-sm", 8), ("sp-md", 16), ("sp-base", 24), ("sp-lg", 32), ("sp-xl", 40), ("sp-4xl", 64),

--- a/Sources/ThemeKit/Theme/ThemeModel.swift
+++ b/Sources/ThemeKit/Theme/ThemeModel.swift
@@ -78,6 +78,32 @@ extension Theme {
         public var value: CGFloat { Theme.shared.radius(self) }
     }
 
+    /// Semantic radius *roles* (daisyUI parity: `--radius-box / -field / -selector`).
+    /// Name a corner by the component's *role* instead of a fixed size, so a theme
+    /// can re-round a whole category at once — every box, every field, every
+    /// selector — from one token. A theme that omits the role token falls back to
+    /// the matching size key (so existing/bundled themes are unaffected).
+    public enum RadiusRole: String, CaseIterable {
+        /// Cards, modals, sheets, alerts — the large container corner.
+        case box = "radius-box"
+        /// Buttons, inputs, selects, tabs — the medium control corner.
+        case field = "radius-field"
+        /// Checkboxes, toggles, badges, small chips — the tight corner.
+        case selector = "radius-selector"
+
+        /// Size key used when a theme doesn't define this role token.
+        public var fallback: RadiusKey {
+            switch self {
+            case .box: return .md          // 16
+            case .field: return .sm        // 8
+            case .selector: return .xs     // 6
+            }
+        }
+
+        /// Resolved radius from the active theme (role token, else the fallback size).
+        public var value: CGFloat { Theme.shared.radius(self) }
+    }
+
     // MARK: - Spacing scale
 
     public enum SpacingKey: String, CaseIterable {

--- a/Tests/ThemeKitTests/RadiusRoleTests.swift
+++ b/Tests/ThemeKitTests/RadiusRoleTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import ThemeKit
+
+@MainActor
+final class RadiusRoleTests: XCTestCase {
+
+    override func tearDown() {
+        Theme.shared.loadTheme(named: Theme.defaultThemeName)
+        super.tearDown()
+    }
+
+    func testGeneratedThemeCarriesRoleTokens() {
+        Theme.shared.applyGenerated(primaryHex: "056bfd")
+        XCTAssertEqual(Theme.RadiusRole.box.value, 16)
+        XCTAssertEqual(Theme.RadiusRole.field.value, 8)
+        XCTAssertEqual(Theme.RadiusRole.selector.value, 6)
+    }
+
+    func testRadiusScaleScalesRoles() {
+        Theme.shared.applyGenerated(primaryHex: "056bfd", radiusScale: 2)
+        XCTAssertEqual(Theme.RadiusRole.box.value, 32)
+        XCTAssertEqual(Theme.RadiusRole.field.value, 16)
+        XCTAssertEqual(Theme.RadiusRole.selector.value, 12)
+        // A "sharp" theme zeroes every role at once.
+        Theme.shared.applyGenerated(primaryHex: "056bfd", radiusScale: 0)
+        XCTAssertEqual(Theme.RadiusRole.box.value, 0)
+        XCTAssertEqual(Theme.RadiusRole.field.value, 0)
+    }
+
+    func testBundledThemeFallsBackToSizeKeys() {
+        // Bundled JSON themes don't define role tokens — the role must fall back to
+        // its size key, so existing themes keep their corners (visual-neutral).
+        Theme.shared.loadTheme(named: Theme.defaultThemeName)
+        XCTAssertEqual(Theme.RadiusRole.box.value, Theme.RadiusKey.md.value)
+        XCTAssertEqual(Theme.RadiusRole.field.value, Theme.RadiusKey.sm.value)
+        XCTAssertEqual(Theme.RadiusRole.selector.value, Theme.RadiusKey.xs.value)
+    }
+
+    func testRoleFallbackMapping() {
+        XCTAssertEqual(Theme.RadiusRole.box.fallback, .md)
+        XCTAssertEqual(Theme.RadiusRole.field.fallback, .sm)
+        XCTAssertEqual(Theme.RadiusRole.selector.fallback, .xs)
+        XCTAssertEqual(Set(Theme.RadiusRole.allCases.map(\.rawValue)).count, 3)
+    }
+}


### PR DESCRIPTION
Adapts daisyUI's [radius utilities](https://daisyui.com/docs/utilities/) (`--radius-box / -field / -selector`): name a corner by the component's **role** instead of a fixed size, so a theme re-rounds a whole category at once.

- **`Theme.RadiusRole`** { `box`, `field`, `selector` } with `.value` and a size-key `fallback` (box→md, field→sm, selector→xs).
- **`Theme.radius(_ role:)`** reads the role token, else the fallback size — so bundled JSON themes (no role tokens) keep their exact corners.
- `ThemeGenerator` emits `radius-box/field/selector` (16/8/6), scaled by `radiusScale` — **one knob rounds/sharpens every box, field and selector**.

Wired into representative components per role (**visual-neutral** — role defaults equal the current values):

| role | components | was |
|---|---|---|
| box | CardStyle | md / 16 |
| field | TextInput, SegmentedControl | sm / 8 |
| selector | Checkbox, Badge.rounded | xs / 6 |

Other components can adopt `.radius(role:)` incrementally.

Tests: tokens generated + `radiusScale`-scaled, bundled-theme fallback to size keys (visual-neutral), fallback mapping. **176 tests pass · Demo BUILD SUCCEEDED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)