### PR TITLE
feat(theme): secondary + accent brand colors (daisyUI parity)

### DIFF
--- a/Demo/Demo/Views/ThemesView.swift
+++ b/Demo/Demo/Views/ThemesView.swift
@@ -62,6 +62,12 @@ struct ThemesView: View {
                 Text("The quick brown fox jumps over the lazy dog.")
                     .textStyle(.bodyBase400)
                     .foregroundStyle(theme.text(.textSecondary))
+                // The three daisyUI brand colors — primary / secondary / accent.
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    ThemeButton("Primary", color: .primary, variant: .solid) {}
+                    ThemeButton("Secondary", color: .secondary, variant: .solid) {}
+                    ThemeButton("Accent", color: .accent, variant: .solid) {}
+                }
                 HStack(spacing: Theme.SpacingKey.sm.value) {
                     PrimaryButton("Continue") {}
                     SecondaryButton("Cancel") {}

--- a/Sources/ThemeKit/Theme/DaisyThemes.swift
+++ b/Sources/ThemeKit/Theme/DaisyThemes.swift
@@ -38,7 +38,8 @@ public struct DaisyTheme: Identifiable, Equatable, Sendable {
     /// The recipe that recreates this theme through `ThemeGenerator` — apply it
     /// with `Theme.shared.apply(_:)`.
     public var config: ThemeConfig {
-        ThemeConfig(primaryHex: primary, baseHex: base, tint: tint, dark: isDark)
+        ThemeConfig(primaryHex: primary, baseHex: base, secondaryHex: secondary,
+                    accentHex: accent, tint: tint, dark: isDark)
     }
 
     /// SwiftUI colors for the four signature swatches (primary, secondary, accent, base).

--- a/Sources/ThemeKit/Theme/SemanticColor.swift
+++ b/Sources/ThemeKit/Theme/SemanticColor.swift
@@ -13,6 +13,9 @@ import SwiftUI
 public enum SemanticColor: String, CaseIterable {
     case primary, neutral, info, success, warning, error
     case turquoise, orange, purple, pink
+    /// daisyUI brand colors — backed by additive `palette.secondary/accent.*`
+    /// ladders; fall back to `primary` when a theme doesn't define them.
+    case secondary, accent
 
     /// Background for the `solid` variant.
     public var solid: Color {
@@ -27,6 +30,7 @@ public enum SemanticColor: String, CaseIterable {
         case .orange: return Theme.shared.background(.bgOrange)
         case .purple: return Theme.shared.text(.textPurple)
         case .pink: return Theme.shared.background(.badgeBgMaximumpinkBase)
+        case .secondary, .accent: return base
         }
     }
 
@@ -51,6 +55,7 @@ public enum SemanticColor: String, CaseIterable {
         case .orange: return Theme.shared.background(.badgeBgOrange)
         case .purple: return Theme.shared.background(.badgeBgPurple)
         case .pink: return Theme.shared.background(.badgeBgMaximumpinkLight)
+        case .secondary, .accent: return bg
         }
     }
 
@@ -67,6 +72,7 @@ public enum SemanticColor: String, CaseIterable {
         case .orange: return Theme.shared.foreground(.badgeFgOrange)
         case .purple: return Theme.shared.text(.textPurple)
         case .pink: return Theme.shared.foreground(.badgeFgMaximumpink)
+        case .secondary, .accent: return strong
         }
     }
 
@@ -83,6 +89,7 @@ public enum SemanticColor: String, CaseIterable {
         case .orange: return Theme.shared.border(.borderOrange)
         case .purple: return Theme.shared.text(.textPurple)
         case .pink: return Theme.shared.foreground(.badgeFgMaximumpink)
+        case .secondary, .accent: return base
         }
     }
 
@@ -96,6 +103,12 @@ public enum SemanticColor: String, CaseIterable {
 
     /// Resolve any ladder step for this color, e.g. `.primary.shade(.s700)`.
     public func shade(_ step: Shade) -> Color {
+        // Brand secondary/accent live in the additive ladder; fall back to primary
+        // when a theme doesn't define them, so they never resolve to `.clear`.
+        if self == .secondary || self == .accent {
+            return Theme.shared.brandShade(rawValue, step.rawValue)
+                ?? (Theme.PaletteColorKey(rawValue: "palette.primary.\(step.rawValue)").map { Theme.shared.palette($0) } ?? .clear)
+        }
         guard let key = Theme.PaletteColorKey(rawValue: "palette.\(rawValue).\(step.rawValue)") else { return .clear }
         return Theme.shared.palette(key)
     }

--- a/Sources/ThemeKit/Theme/Theme.swift
+++ b/Sources/ThemeKit/Theme/Theme.swift
@@ -49,6 +49,10 @@ public final class Theme: @unchecked Sendable {
     private var border: [BorderColorKey: Color] = [:]
     private var text: [TextColorKey: Color] = [:]
     private var palette: [PaletteColorKey: Color] = [:]
+    /// Additive brand-color ladders (daisyUI `secondary` / `accent`) that aren't
+    /// part of the generated Figma `PaletteColorKey` set. Keyed `"<family>.<step>"`
+    /// (e.g. `"accent.500"`). Empty unless a theme/config provides these hexes.
+    private var brandPalette: [String: Color] = [:]
     private var radiusList: [String: CGFloat] = [:]
     private var spacingList: [String: CGFloat] = [:]
     private var typographyList: [String: ResolvedTextStyle] = [:]
@@ -130,7 +134,7 @@ public final class Theme: @unchecked Sendable {
             primaryHex: config.primaryHex, tint: config.tint, dark: config.dark, font: config.font,
             fontScale: config.fontScale, radiusScale: config.radiusScale,
             spacingScale: config.spacingScale, shadowScale: config.shadowScale,
-            baseHex: config.baseHex
+            baseHex: config.baseHex, secondaryHex: config.secondaryHex, accentHex: config.accentHex
         ))
     }
 
@@ -161,7 +165,7 @@ public final class Theme: @unchecked Sendable {
             primaryHex: config.primaryHex, tint: config.tint, dark: config.dark, font: config.font,
             fontScale: config.fontScale, radiusScale: config.radiusScale,
             spacingScale: config.spacingScale, shadowScale: config.shadowScale,
-            baseHex: config.baseHex
+            baseHex: config.baseHex, secondaryHex: config.secondaryHex, accentHex: config.accentHex
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted]
@@ -207,6 +211,9 @@ public final class Theme: @unchecked Sendable {
                 text[key] = value
             } else if let key = PaletteColorKey(rawValue: color.name) {
                 palette[key] = value
+            } else if color.name.hasPrefix("palette.secondary.") || color.name.hasPrefix("palette.accent.") {
+                // Additive brand ladders (not in the generated PaletteColorKey set).
+                brandPalette[String(color.name.dropFirst("palette.".count))] = value
             }
         }
         for r in decoded.radius ?? [] { radiusList[r.name] = r.radius }
@@ -226,7 +233,7 @@ public final class Theme: @unchecked Sendable {
     }
 
     private func resetThemeState() {
-        foreground = [:]; background = [:]; border = [:]; text = [:]; palette = [:]
+        foreground = [:]; background = [:]; border = [:]; text = [:]; palette = [:]; brandPalette = [:]
         radiusList = [:]; spacingList = [:]; typographyList = [:]; shadowList = [:]
     }
 
@@ -239,6 +246,10 @@ public final class Theme: @unchecked Sendable {
 
     /// Primitive 50..900 ladder color (Ant-style). `step 500` is the base.
     public func palette(_ key: PaletteColorKey) -> Color { palette[key] ?? .clear }
+
+    /// An additive brand ladder step (daisyUI `secondary` / `accent`), or `nil`
+    /// when the active theme doesn't define one (callers fall back to primary).
+    public func brandShade(_ family: String, _ step: Int) -> Color? { brandPalette["\(family).\(step)"] }
 
     // MARK: - Metric accessors
 

--- a/Sources/ThemeKit/Theme/ThemeConfig.swift
+++ b/Sources/ThemeKit/Theme/ThemeConfig.swift
@@ -20,6 +20,11 @@ public struct ThemeConfig: Codable, Equatable, Sendable {
     /// When set, the card/page backgrounds derive from it instead of a
     /// primary-tinted grey — so a theme keeps its signature base (cream, slate…).
     public var baseHex: String?
+    /// Optional brand `secondary` / `accent` colors (daisyUI parity) as RRGGBB
+    /// hex. Each gets a full 50..900 ladder, surfaced via `SemanticColor.secondary`
+    /// / `.accent`. `nil` → that role falls back to `primary`.
+    public var secondaryHex: String?
+    public var accentHex: String?
     /// 0…0.25 — how strongly the accent bleeds into neutrals / surfaces.
     public var tint: Double
     /// Dark variant.
@@ -36,6 +41,8 @@ public struct ThemeConfig: Codable, Equatable, Sendable {
     public init(
         primaryHex: String = "056bfd",
         baseHex: String? = nil,
+        secondaryHex: String? = nil,
+        accentHex: String? = nil,
         tint: Double = 0.06,
         dark: Bool = false,
         font: String = "Montserrat",
@@ -46,6 +53,8 @@ public struct ThemeConfig: Codable, Equatable, Sendable {
     ) {
         self.primaryHex = ThemeConfig.normalizeHex(primaryHex)
         self.baseHex = baseHex.map(ThemeConfig.normalizeHex)
+        self.secondaryHex = secondaryHex.map(ThemeConfig.normalizeHex)
+        self.accentHex = accentHex.map(ThemeConfig.normalizeHex)
         self.tint = tint
         self.dark = dark
         self.font = font

--- a/Sources/ThemeKit/Theme/ThemeGenerator.swift
+++ b/Sources/ThemeKit/Theme/ThemeGenerator.swift
@@ -253,7 +253,7 @@ enum ThemeGenerator {
     static func generate(
         primaryHex: String, tint: Double, dark: Bool,
         font: String, fontScale: Double, radiusScale: Double, spacingScale: Double, shadowScale: Double,
-        baseHex: String? = nil
+        baseHex: String? = nil, secondaryHex: String? = nil, accentHex: String? = nil
     ) -> Theme.ThemeData {
         let primary = primaryHex.hasPrefix("#") ? String(primaryHex.dropFirst()) : primaryHex
         let palette = buildPalette(primaryBase: primary, dark: dark, tint: tint)
@@ -287,6 +287,17 @@ enum ThemeGenerator {
         }
         for (key, hex) in palette {
             colors.append(.init(name: "palette." + key.replacingOccurrences(of: "/", with: "."), hex: hex))
+        }
+
+        // Additive brand ladders (daisyUI `secondary` / `accent`) — full 50..900
+        // ramps seeded from the given hexes, emitted alongside the typed palette.
+        for (family, seedHex) in [("secondary", secondaryHex), ("accent", accentHex)] {
+            guard let seedHex else { continue }
+            let seed = seedHex.hasPrefix("#") ? String(seedHex.dropFirst()) : seedHex
+            let shades = dark ? antGenerateDark(seed) : antGenerate(seed)
+            for (step, shadeHex) in zip(steps, shades) {
+                colors.append(.init(name: "palette.\(family).\(step)", hex: shadeHex))
+            }
         }
 
         let radius = radiusBase.map { Theme.AppRadius(name: $0.0, radius: ($0.1 * radiusScale).rounded()) }

--- a/Tests/ThemeKitTests/BrandColorTests.swift
+++ b/Tests/ThemeKitTests/BrandColorTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import SwiftUI
+@testable import ThemeKit
+#if canImport(UIKit)
+import UIKit
+private typealias BrandNativeColor = UIColor
+#elseif canImport(AppKit)
+import AppKit
+private typealias BrandNativeColor = NSColor
+#endif
+
+@MainActor
+final class BrandColorTests: XCTestCase {
+    private func rgb(_ c: Color) -> String {
+        let ui = BrandNativeColor(c)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        ui.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return String(format: "%02x%02x%02x", Int((r * 255).rounded()), Int((g * 255).rounded()), Int((b * 255).rounded()))
+    }
+
+    override func tearDown() {
+        Theme.shared.loadTheme(named: Theme.defaultThemeName)
+        super.tearDown()
+    }
+
+    func testConfigCarriesSecondaryAndAccent() {
+        Theme.shared.apply(ThemeConfig(primaryHex: "056bfd", secondaryHex: "f43098", accentHex: "00d3bb"))
+        // The base (step 500) of each brand ladder is the seed.
+        XCTAssertEqual(rgb(SemanticColor.secondary.base), "f43098")
+        XCTAssertEqual(rgb(SemanticColor.accent.base), "00d3bb")
+        // solid == base for the brand colors.
+        XCTAssertEqual(rgb(SemanticColor.accent.solid), "00d3bb")
+        // A lighter step exists (the full ladder generated).
+        XCTAssertNotEqual(rgb(SemanticColor.accent.shade(.s50)), "00d3bb")
+    }
+
+    func testBrandColorsFallBackToPrimaryWhenUndefined() {
+        // A theme without secondary/accent → those resolve to primary, never clear.
+        Theme.shared.apply(ThemeConfig(primaryHex: "056bfd"))
+        XCTAssertEqual(rgb(SemanticColor.accent.base), rgb(SemanticColor.primary.base))
+        XCTAssertEqual(rgb(SemanticColor.secondary.base), rgb(SemanticColor.primary.base))
+        // Bundled JSON themes have no brand ladders either → still primary, not clear.
+        Theme.shared.loadTheme(named: Theme.defaultThemeName)
+        XCTAssertEqual(rgb(SemanticColor.accent.base), rgb(SemanticColor.primary.base))
+    }
+
+    func testDaisyThemeAppliesSecondaryAndAccent() {
+        // Dracula: secondary bd93f9, accent ffb86c (light-mode ladder seed == hex).
+        DaisyTheme.named("light")!.apply()   // light theme so the dark mix doesn't shift the seed
+        let light = DaisyTheme.named("light")!
+        XCTAssertEqual(rgb(SemanticColor.secondary.base), light.secondary)
+        XCTAssertEqual(rgb(SemanticColor.accent.base), light.accent)
+    }
+
+    func testConfigRoundTripsBrandHexes() throws {
+        let original = ThemeConfig(primaryHex: "056bfd", secondaryHex: "f43098", accentHex: "00d3bb")
+        let restored = try ThemeConfig(jsonData: original.jsonData())
+        XCTAssertEqual(restored, original)
+        XCTAssertEqual(restored.secondaryHex, "f43098")
+        XCTAssertEqual(restored.accentHex, "00d3bb")
+    }
+}


### PR DESCRIPTION
daisyUI themes have three brand colors (**primary / secondary / accent**); ThemeKit was primary-only. Adds the other two as **additive brand ladders** — without touching the generated Figma token set.

- `ThemeGenerator` + `ThemeConfig` gain optional `secondaryHex` / `accentHex`; each gets a full 50..900 ladder (`palette.secondary/accent.*`).
- `Theme` captures them in a separate `brandPalette` (the generated `PaletteColorKey` enum is **left untouched**) + a `brandShade(_:_:)` accessor.
- `SemanticColor` gains `.secondary` / `.accent` across every variant (solid / soft / accent / border / ladder), **falling back to `primary`** when a theme doesn't define them — never `.clear`.

Because the configurable components already take a `SemanticColor`, this auto-enables `ThemeButton(color: .accent)`, `Tag`, `CountBadge`, etc.

- `DaisyTheme` now applies its catalog secondary/accent — the picker swatches finally drive real tokens.
- Demo: the Themes tab preview shows **primary / secondary / accent** buttons recoloring per theme.

Tests: ladders generated from the seeds, fallback-to-primary when absent (incl. bundled themes), daisyUI application, config round-trip. **180 tests pass · Demo BUILD SUCCEEDED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)