### PR TITLE
feat(mcp): ThemeKit MCP server (Node/TypeScript)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # `make ci` is the same set of checks GitHub runs; see docs/CI.md.
 
 .DEFAULT_GOAL := help
-.PHONY: help ci ci-fast build test lint format hooks screenshots skill clean
+.PHONY: help ci ci-fast build test lint format hooks screenshots skill mcp clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
@@ -35,8 +35,11 @@ screenshots: ## Render component screenshots + rebuild the README gallery
 record-gif: ## Record a Demo-app interaction → GIF (NAME=SelectBox [SECS=7]); tap the component during recording
 	@bash scripts/record-gif.sh "$(NAME)" "$(SECS)"
 
-skill: ## Regenerate the Claude Code skill reference from source (skills/themekit/references/)
+skill: ## Regenerate the skill / llms.txt / MCP data from source (skills/, llms.txt, mcp/themekit.json)
 	@python3 tools/gen_skill.py
+
+mcp: skill ## Build the ThemeKit MCP server (mcp/dist)
+	@cd mcp && npm install --silent && npm run build
 
 clean: ## Remove build artifacts
 	rm -rf .build .ci-test.log

--- a/README.md
+++ b/README.md
@@ -542,13 +542,15 @@ component + modifier and resolves colors from tokens, never hardcoded values.
 
 | Tool | What it does | How to use it |
 |---|---|---|
-| **Agent skill** | A Claude Code skill (`skills/themekit/`): idioms + patterns, every component's init & modifiers, and the 32 daisyUI themes — the agent generates correct ThemeKit code. | `/plugin marketplace add isamercan/ThemeKit` → `/plugin install themekit@themekit`, **or** copy `skills/themekit/` into your repo's `.claude/skills/` (zero-install). |
+| **MCP server** ([`mcp/`](mcp/)) | Components, modifiers, tokens and the 32 daisyUI themes as **on-demand tools** (`get_component`, `search_components`, `list_themes`…) — the agent pulls focused context while it codes. | `claude mcp add themekit -- npx -y @isamercan/themekit-mcp` (or from the repo: `cd mcp && npm i && npm run build`). Works in any MCP editor — Cursor, Windsurf, Claude Code. |
+| **Agent skill** ([`skills/themekit/`](skills/themekit/)) | A Claude Code skill: idioms + patterns, every component's init & modifiers, the daisyUI themes — generates correct ThemeKit code. | `/plugin marketplace add isamercan/ThemeKit` → `/plugin install themekit@themekit`, **or** copy `skills/themekit/` into `.claude/skills/` (zero-install). |
 | **`llms.txt`** | Structured LLM context about every component, modifier and theme — the [llms.txt](https://llmstxt.org) standard, at the repo root. | Point any `llms.txt`-aware editor (Cursor, Windsurf, Copilot…) at [`llms.txt`](llms.txt). |
 
 Then just ask: *"Build a sign-up screen. Use the ThemeKit skill."*
 
-Both artifacts are generated from source by `make skill`, so they can't drift
-from the code. An **MCP server** is on the roadmap.
+All three are generated from one source by `make skill`, so they can't drift
+from the code. Works with **Claude Code, Cursor, Windsurf, GitHub Copilot**, and
+any tool that supports MCP or `llms.txt`.
 
 ## Demo
 

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,64 @@
+# @isamercan/themekit-mcp
+
+An [MCP](https://modelcontextprotocol.io) server for the **ThemeKit** SwiftUI
+design system. It exposes ThemeKit's components, modifiers, tokens and the 32
+daisyUI themes as **on-demand tools**, so an MCP-compatible editor (Claude Code,
+Cursor, Windsurf, …) can pull accurate, focused context while generating code —
+instead of loading everything up front.
+
+The data lives in `themekit.json`, generated from the Swift source by
+`tools/gen_skill.py` (`make skill`), so it never drifts from the library.
+
+## Tools
+
+| Tool | What it returns |
+|---|---|
+| `usage_guide` | The golden rules for writing ThemeKit code |
+| `list_components(category?)` | Components by Atom / Molecule / Organism |
+| `get_component(name)` | A component's init signature + chainable modifiers |
+| `search_components(query)` | Components matching a keyword (e.g. "date", "progress") |
+| `list_themes` | The bundled daisyUI theme ids |
+| `theme_snippet(id?)` | Swift code to apply a theme / show `ThemePicker` |
+| `token_reference(kind?)` | Design tokens (colors, radius roles, spacing, semantic colors) |
+
+## Install
+
+### Published (recommended, once on npm)
+
+```sh
+# Claude Code
+claude mcp add themekit -- npx -y @isamercan/themekit-mcp
+```
+
+### From this repo (no publish needed)
+
+```sh
+cd mcp && npm install && npm run build
+claude mcp add themekit -- node "$(pwd)/dist/index.js"
+```
+
+### Any MCP editor — `.mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "themekit": {
+      "command": "npx",
+      "args": ["-y", "@isamercan/themekit-mcp"]
+    }
+  }
+}
+```
+
+Then ask your agent: *"Use the themekit MCP — build a sign-up screen."*
+
+## Develop
+
+```sh
+npm install
+npm run build      # tsc -> dist/
+npm start          # run the stdio server
+```
+
+Re-run `make skill` from the repo root after changing components/themes to
+refresh `themekit.json`.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1213 @@
+{
+  "name": "@isamercan/themekit-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@isamercan/themekit-mcp",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "themekit-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@isamercan/themekit-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for the ThemeKit SwiftUI design system — components, modifiers, tokens and daisyUI themes on demand.",
+  "type": "module",
+  "bin": {
+    "themekit-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "themekit.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": ["mcp", "themekit", "swiftui", "design-system", "daisyui"],
+  "author": "isamercan",
+  "license": "MIT",
+  "homepage": "https://github.com/isamercan/ThemeKit",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * ThemeKit MCP server — exposes the ThemeKit SwiftUI design system (components,
+ * modifiers, tokens, daisyUI themes) as on-demand tools for MCP-compatible
+ * editors (Claude Code, Cursor, Windsurf…).
+ *
+ * Data comes from themekit.json, generated from the Swift source by
+ * `tools/gen_skill.py` (`make skill`), so it never drifts from the library.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+interface Component {
+  name: string;
+  category: string;
+  init: string;
+  modifiers: string[];
+}
+interface ThemeKitData {
+  summary: string;
+  rules: string[];
+  tokens: Record<string, string[]>;
+  components: Component[];
+  modifiers: string[];
+  themes: { id: string; name: string }[];
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const data: ThemeKitData = JSON.parse(readFileSync(join(here, "..", "themekit.json"), "utf8"));
+
+const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] });
+
+const server = new McpServer({ name: "themekit", version: "1.0.0" });
+
+server.registerTool(
+  "usage_guide",
+  {
+    title: "ThemeKit usage guide",
+    description: "The golden rules for writing correct ThemeKit code. Read this first.",
+    inputSchema: {},
+  },
+  async () => text([data.summary, "", "Rules:", ...data.rules.map((r) => `- ${r}`)].join("\n"))
+);
+
+server.registerTool(
+  "list_components",
+  {
+    title: "List components",
+    description: "List ThemeKit components, optionally filtered by category (Atoms / Molecules / Organisms).",
+    inputSchema: { category: z.enum(["Atoms", "Molecules", "Organisms"]).optional() },
+  },
+  async ({ category }) => {
+    const items = data.components.filter((c) => !category || c.category === category);
+    const byCat: Record<string, string[]> = {};
+    for (const c of items) (byCat[c.category] ??= []).push(c.name);
+    return text(
+      Object.entries(byCat)
+        .map(([cat, names]) => `## ${cat} (${names.length})\n${names.join(", ")}`)
+        .join("\n\n")
+    );
+  }
+);
+
+server.registerTool(
+  "get_component",
+  {
+    title: "Get component API",
+    description: "Get one component's init signature + its chainable modifiers.",
+    inputSchema: { name: z.string().describe("Component name, e.g. Badge, TextInput, Carousel") },
+  },
+  async ({ name }) => {
+    const c = data.components.find((x) => x.name.toLowerCase() === name.toLowerCase());
+    if (!c) return text(`No component named "${name}". Try list_components or search_components.`);
+    const mods = c.modifiers.length ? `\nModifiers: ${c.modifiers.join(" ")}` : "";
+    return text(`${c.category} · ${c.init}${mods}\n\nSet styling/variants/flags with the modifiers; sizes use .controlSize(_:), disabled uses .disabled(_:).`);
+  }
+);
+
+server.registerTool(
+  "search_components",
+  {
+    title: "Search components",
+    description: "Find components by a keyword in the name or init (e.g. 'date', 'select', 'progress').",
+    inputSchema: { query: z.string() },
+  },
+  async ({ query }) => {
+    const q = query.toLowerCase();
+    const hits = data.components.filter(
+      (c) => c.name.toLowerCase().includes(q) || c.init.toLowerCase().includes(q)
+    );
+    if (!hits.length) return text(`No matches for "${query}".`);
+    return text(hits.map((c) => `- ${c.name} (${c.category}) — ${c.init}`).join("\n"));
+  }
+);
+
+server.registerTool(
+  "list_themes",
+  {
+    title: "List daisyUI themes",
+    description: "List the bundled daisyUI theme ids.",
+    inputSchema: {},
+  },
+  async () => text(data.themes.map((t) => `${t.id} (${t.name})`).join("\n"))
+);
+
+server.registerTool(
+  "theme_snippet",
+  {
+    title: "Theme apply snippet",
+    description: "Swift code to apply a daisyUI theme (or show the ThemePicker).",
+    inputSchema: { id: z.string().describe('Theme id, e.g. "dracula"').optional() },
+  },
+  async ({ id }) => {
+    const found = id ? data.themes.find((t) => t.id === id) : undefined;
+    if (id && !found) return text(`No theme "${id}". Use list_themes.`);
+    const tid = found?.id ?? "dracula";
+    return text(
+      [
+        `// Apply ${found?.name ?? "a"} theme live`,
+        `DaisyTheme.named("${tid}")?.apply()`,
+        ``,
+        `// Or a tappable grid of all themes:`,
+        `@State private var active: String? = "${tid}"`,
+        `ThemePicker(selection: $active)`,
+      ].join("\n")
+    );
+  }
+);
+
+server.registerTool(
+  "token_reference",
+  {
+    title: "Token reference",
+    description: "List ThemeKit design tokens (colors, radius roles, spacing, semantic colors). Pass a kind to filter.",
+    inputSchema: { kind: z.string().optional().describe("e.g. text, background, semanticColor, radiusRole, spacing") },
+  },
+  async ({ kind }) => {
+    const entries = Object.entries(data.tokens).filter(([k]) => !kind || k.toLowerCase() === kind.toLowerCase());
+    if (!entries.length) return text(`No token kind "${kind}". Kinds: ${Object.keys(data.tokens).join(", ")}`);
+    return text(entries.map(([k, v]) => `${k}: ${v.join(", ")}`).join("\n"));
+  }
+);
+
+await server.connect(new StdioServerTransport());

--- a/mcp/themekit.json
+++ b/mcp/themekit.json
@@ -1,0 +1,1069 @@
+{
+  "name": "themekit",
+  "summary": "A token-driven, brand-neutral SwiftUI design system. Every color / radius / spacing / type style is a token resolved at runtime from the active Theme; components never hardcode a color.",
+  "rules": [
+    "Read the theme via `@Environment(\\.theme) private var theme`; inject `.environment(Theme.shared)` once at the root.",
+    "Never hardcode a color \u2014 use `theme.text(.textPrimary)`, `theme.background(.bgWhite)`, or a `SemanticColor`.",
+    "Put required content/bindings/actions in `init`; set variants, sizes, flags, colors and callbacks with chainable modifiers.",
+    "Sizes use `.controlSize(_:)`; disabled state uses `.disabled(_:)`; accessibility id uses `.a11yID(_:)`.",
+    "Recolor everything with `Theme.shared.applyGenerated(primaryHex:)` or a daisyUI theme: `DaisyTheme.named(\"dracula\")?.apply()`."
+  ],
+  "tokens": {
+    "text": [
+      "textPrimary",
+      "textSecondary",
+      "textTertiary",
+      "textDisabled",
+      "textHero"
+    ],
+    "background": [
+      "bgWhite",
+      "bgElevatorPrimary",
+      "bgSecondary",
+      "bgSecondaryLight",
+      "bgHero",
+      "bgTertiary"
+    ],
+    "border": [
+      "borderPrimary",
+      "borderHero"
+    ],
+    "foreground": [
+      "fgHero",
+      "fgSecondary"
+    ],
+    "semanticColor": [
+      "primary",
+      "secondary",
+      "accent",
+      "neutral",
+      "info",
+      "success",
+      "warning",
+      "error"
+    ],
+    "fillVariant": [
+      "solid",
+      "soft",
+      "outline",
+      "ghost"
+    ],
+    "radiusRole": [
+      "box",
+      "field",
+      "selector"
+    ],
+    "spacing": [
+      "xs",
+      "sm",
+      "md",
+      "base",
+      "lg",
+      "xl"
+    ]
+  },
+  "components": [
+    {
+      "name": "AnimatedImage",
+      "category": "Atoms",
+      "init": "AnimatedImage(url, contentMode:, cornerRadius:)",
+      "modifiers": []
+    },
+    {
+      "name": "Avatar",
+      "category": "Atoms",
+      "init": "Avatar(content, size:, background:, shape:, presence:, presencePulse:)",
+      "modifiers": []
+    },
+    {
+      "name": "AvatarGroup",
+      "category": "Atoms",
+      "init": "AvatarGroup",
+      "modifiers": []
+    },
+    {
+      "name": "Badge",
+      "category": "Atoms",
+      "init": "Badge(text, style:, variant:, size:, leadingSystemImage:, action:)",
+      "modifiers": [
+        ".badgeColor()",
+        ".badgeShape()",
+        ".gradient()",
+        ".highlighted()",
+        ".trailingIcon()"
+      ]
+    },
+    {
+      "name": "Chip",
+      "category": "Atoms",
+      "init": "Chip(title, isSelected:, size:, selectionStyle:)",
+      "modifiers": [
+        ".exists()",
+        ".expands()",
+        ".icon()",
+        ".interactive()",
+        ".rating()"
+      ]
+    },
+    {
+      "name": "Ribbon",
+      "category": "Atoms",
+      "init": "Ribbon(text, color:, @ViewBuilder:)",
+      "modifiers": []
+    },
+    {
+      "name": "DividerView",
+      "category": "Atoms",
+      "init": "DividerView(size:, axis:, dashed:, title:, titleAlign:)",
+      "modifiers": []
+    },
+    {
+      "name": "GaugeView",
+      "category": "Atoms",
+      "init": "GaugeView(value:, in:, label:, style:, showsValue:)",
+      "modifiers": []
+    },
+    {
+      "name": "Icon",
+      "category": "Atoms",
+      "init": "Icon(systemName:, size:, color:)",
+      "modifiers": []
+    },
+    {
+      "name": "InlineText",
+      "category": "Atoms",
+      "init": "InlineText(text, links:)",
+      "modifiers": []
+    },
+    {
+      "name": "InputLabel",
+      "category": "Atoms",
+      "init": "InputLabel(text, isRequired:, hasInfo:, hasError:)",
+      "modifiers": []
+    },
+    {
+      "name": "Join",
+      "category": "Atoms",
+      "init": "Join(axis, @ViewBuilder:)",
+      "modifiers": []
+    },
+    {
+      "name": "Kbd",
+      "category": "Atoms",
+      "init": "Kbd(text)",
+      "modifiers": []
+    },
+    {
+      "name": "ProgressBar",
+      "category": "Atoms",
+      "init": "ProgressBar(value:, showPercentage:, status:)",
+      "modifiers": [
+        ".barHeight()",
+        ".colors()",
+        ".gradient()",
+        ".progressLabel()",
+        ".steps()",
+        ".successSegment()",
+        ".valueFormat()"
+      ]
+    },
+    {
+      "name": "StepIndicator",
+      "category": "Atoms",
+      "init": "StepIndicator",
+      "modifiers": []
+    },
+    {
+      "name": "RadialProgress",
+      "category": "Atoms",
+      "init": "RadialProgress(value:, size:, lineWidth:, showLabel:, status:, dashboard: \u2026)",
+      "modifiers": []
+    },
+    {
+      "name": "Rating",
+      "category": "Atoms",
+      "init": "Rating(value:, layout:, countLabel:)",
+      "modifiers": [
+        ".allowHalf()",
+        ".maxValue()",
+        ".onRate()",
+        ".onReviewTap()",
+        ".sentiment()",
+        ".starSize()",
+        ".symbol()"
+      ]
+    },
+    {
+      "name": "RemoteImage",
+      "category": "Atoms",
+      "init": "RemoteImage(url, aspectRatio:, contentMode:, cornerRadius:, circle:)",
+      "modifiers": []
+    },
+    {
+      "name": "RollingNumber",
+      "category": "Atoms",
+      "init": "RollingNumber(value, size:, weight:, color:)",
+      "modifiers": []
+    },
+    {
+      "name": "ScoreBadge",
+      "category": "Atoms",
+      "init": "ScoreBadge(score, large:)",
+      "modifiers": []
+    },
+    {
+      "name": "ShareButton",
+      "category": "Atoms",
+      "init": "ShareButton(title, item:)",
+      "modifiers": []
+    },
+    {
+      "name": "Skeleton",
+      "category": "Atoms",
+      "init": "Skeleton(shape, width:, height:)",
+      "modifiers": []
+    },
+    {
+      "name": "Spinner",
+      "category": "Atoms",
+      "init": "Spinner(size:, lineWidth:, color:)",
+      "modifiers": []
+    },
+    {
+      "name": "StatusDot",
+      "category": "Atoms",
+      "init": "StatusDot(kind, size:, label:, pulse:)",
+      "modifiers": []
+    },
+    {
+      "name": "Swap",
+      "category": "Atoms",
+      "init": "Swap(isOn:, on:, off:, size:, rotate:)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "Tag",
+      "category": "Atoms",
+      "init": "Tag(text, leadingSystemImage:, style:, variant:, onRemove:)",
+      "modifiers": []
+    },
+    {
+      "name": "TextLink",
+      "category": "Atoms",
+      "init": "TextLink(title, underline:, action:)",
+      "modifiers": []
+    },
+    {
+      "name": "TextRotate",
+      "category": "Atoms",
+      "init": "TextRotate(words, interval:)",
+      "modifiers": []
+    },
+    {
+      "name": "Title",
+      "category": "Atoms",
+      "init": "Title(text, subtitle:, eyebrow:, actionTitle:, action:)",
+      "modifiers": []
+    },
+    {
+      "name": "Autocomplete",
+      "category": "Molecules",
+      "init": "Autocomplete(label:, text:, suggestions:, placeholder:, onSelect:)",
+      "modifiers": [
+        ".a11yID()",
+        ".debounce()",
+        ".maxResults()",
+        ".onSearch()",
+        ".suggestionEnabled()"
+      ]
+    },
+    {
+      "name": "Breadcrumbs",
+      "category": "Molecules",
+      "init": "Breadcrumbs(title, action:)",
+      "modifiers": []
+    },
+    {
+      "name": "ButtonGroup",
+      "category": "Molecules",
+      "init": "ButtonGroup(axis, @ViewBuilder:)",
+      "modifiers": []
+    },
+    {
+      "name": "PrimaryButton",
+      "category": "Molecules",
+      "init": "PrimaryButton(title, size:, block:, helperText:, textStyle:, confirmsSuccess: \u2026)",
+      "modifiers": []
+    },
+    {
+      "name": "SecondaryButton",
+      "category": "Molecules",
+      "init": "SecondaryButton",
+      "modifiers": []
+    },
+    {
+      "name": "OutlineButton",
+      "category": "Molecules",
+      "init": "OutlineButton",
+      "modifiers": []
+    },
+    {
+      "name": "GhostButton",
+      "category": "Molecules",
+      "init": "GhostButton",
+      "modifiers": []
+    },
+    {
+      "name": "LinkButton",
+      "category": "Molecules",
+      "init": "LinkButton",
+      "modifiers": []
+    },
+    {
+      "name": "ThemeButton",
+      "category": "Molecules",
+      "init": "ThemeButton(title, systemImage:, iconPosition:, color:, variant:, size: \u2026)",
+      "modifiers": []
+    },
+    {
+      "name": "CalendarView",
+      "category": "Molecules",
+      "init": "CalendarView(selection:)",
+      "modifiers": []
+    },
+    {
+      "name": "Checkbox",
+      "category": "Molecules",
+      "init": "Checkbox(label, isChecked:, customSize:, type:, isIndeterminate:, alignment: \u2026)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "CheckboxGroup",
+      "category": "Molecules",
+      "init": "CheckboxGroup(title:, options:, selection:, infoMessages:, selectAllTitle:, isOptionEnabled:)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "ImageChip",
+      "category": "Molecules",
+      "init": "ImageChip(isSelected:, url:, size:, isEnabled:)",
+      "modifiers": []
+    },
+    {
+      "name": "CompactChip",
+      "category": "Molecules",
+      "init": "CompactChip",
+      "modifiers": []
+    },
+    {
+      "name": "ChoseChip",
+      "category": "Molecules",
+      "init": "ChoseChip",
+      "modifiers": []
+    },
+    {
+      "name": "FilterChip",
+      "category": "Molecules",
+      "init": "FilterChip",
+      "modifiers": []
+    },
+    {
+      "name": "ChipGroup",
+      "category": "Molecules",
+      "init": "ChipGroup",
+      "modifiers": []
+    },
+    {
+      "name": "ColorField",
+      "category": "Molecules",
+      "init": "ColorField(label, selection:, supportsOpacity:)",
+      "modifiers": []
+    },
+    {
+      "name": "DateField",
+      "category": "Molecules",
+      "init": "DateField(label:, date:, placeholder:, range:, style:, locale: \u2026)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "Fieldset",
+      "category": "Molecules",
+      "init": "Fieldset(title, helper:, @ViewBuilder:)",
+      "modifiers": []
+    },
+    {
+      "name": "FileInput",
+      "category": "Molecules",
+      "init": "FileInput(label:, fileName:, buttonTitle:, placeholder:, infoMessages:, onPick:)",
+      "modifiers": []
+    },
+    {
+      "name": "FilterGroup",
+      "category": "Molecules",
+      "init": "FilterGroup(title:, options:, selection:, label:)",
+      "modifiers": []
+    },
+    {
+      "name": "InputNumber",
+      "category": "Molecules",
+      "init": "InputNumber(label:, value:, range:, step:, unit:, hint: \u2026)",
+      "modifiers": [
+        ".a11yID()",
+        ".editable()",
+        ".hasInfo()",
+        ".onValueChange()"
+      ]
+    },
+    {
+      "name": "MultiLineTextInput",
+      "category": "Molecules",
+      "init": "MultiLineTextInput(label, text:, placeholder:, characterLimit:, errorText:, infoMessages: \u2026)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "MultiSelect",
+      "category": "Molecules",
+      "init": "MultiSelect(label:, options:, selection:, placeholder:, infoMessages:, isOptionEnabled:)",
+      "modifiers": [
+        ".a11yID()",
+        ".clearable()",
+        ".loading()",
+        ".maxTags()",
+        ".searchable()"
+      ]
+    },
+    {
+      "name": "OTPInput",
+      "category": "Molecules",
+      "init": "OTPInput(code:, digitCount:, isSecure:, errorText:, infoMessages:, onComplete:)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "Pagination",
+      "category": "Molecules",
+      "init": "Pagination(current:, total:)",
+      "modifiers": [
+        ".jumper()",
+        ".showTotal()",
+        ".simple()",
+        ".window()"
+      ]
+    },
+    {
+      "name": "ProgressIndicator",
+      "category": "Molecules",
+      "init": "ProgressIndicator(variant:, current:, total:, size:, videoProgress:, stepText: \u2026)",
+      "modifiers": []
+    },
+    {
+      "name": "QuantityStepper",
+      "category": "Molecules",
+      "init": "QuantityStepper(value:, range:, step:)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "RadioButton",
+      "category": "Molecules",
+      "init": "RadioButton(label, isSelected:, type:, style:, padding:, backgroundColor: \u2026)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "RadioGroup",
+      "category": "Molecules",
+      "init": "RadioGroup(title:, options:, selection:, infoMessages:, isOptionEnabled:)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "RadioButtonGroup",
+      "category": "Molecules",
+      "init": "RadioButtonGroup",
+      "modifiers": []
+    },
+    {
+      "name": "RangeSlider",
+      "category": "Molecules",
+      "init": "RangeSlider(lowerValue:, upperValue:, in:, step:)",
+      "modifiers": [
+        ".a11yID()",
+        ".inputs()",
+        ".marks()",
+        ".onChangeEnd()",
+        ".valueLabel()"
+      ]
+    },
+    {
+      "name": "SearchBar",
+      "category": "Molecules",
+      "init": "SearchBar(text:, placeholder:, suggestions:, recent:, onSearch:)",
+      "modifiers": [
+        ".a11yID()",
+        ".backButton()",
+        ".debounce()",
+        ".maxResults()",
+        ".trailingIcon()"
+      ]
+    },
+    {
+      "name": "SegmentedControl",
+      "category": "Molecules",
+      "init": "SegmentedControl(title, systemImage:, isEnabled:)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "Select",
+      "category": "Molecules",
+      "init": "Select(title, options)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "SelectBox",
+      "category": "Molecules",
+      "init": "SelectBox(label:, options:, selection:, placeholder:, hint:, errorText: \u2026)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "Slider",
+      "category": "Molecules",
+      "init": "Slider(value:, in:, step:, label:)",
+      "modifiers": [
+        ".a11yID()",
+        ".axis()",
+        ".marks()",
+        ".onChangeEnd()",
+        ".showsValueTooltip()"
+      ]
+    },
+    {
+      "name": "Stat",
+      "category": "Molecules",
+      "init": "Stat(title:, value:, prefix:, suffix:, isLoading:, description: \u2026)",
+      "modifiers": []
+    },
+    {
+      "name": "Steps",
+      "category": "Molecules",
+      "init": "Steps(title, description:, systemImage:, state:, percent:)",
+      "modifiers": []
+    },
+    {
+      "name": "TextInput",
+      "category": "Molecules",
+      "init": "TextInput(label:, placeholder:, leadingSystemImage:, suffixSystemImage:, addonBefore:, addonAfter: \u2026)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "ThemeController",
+      "category": "Molecules",
+      "init": "ThemeController(name:, label:)",
+      "modifiers": []
+    },
+    {
+      "name": "ThemeToggle",
+      "category": "Molecules",
+      "init": "ThemeToggle(isOn:, isLoading:, onSystemImage:, offSystemImage:)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "ToggleGroup",
+      "category": "Molecules",
+      "init": "ToggleGroup(title:, options:, selection:, label:)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "TreeSelect",
+      "category": "Molecules",
+      "init": "TreeSelect(id:, title, systemImage:, children:)",
+      "modifiers": []
+    },
+    {
+      "name": "Accordion",
+      "category": "Organisms",
+      "init": "Accordion(title, leadingSystemImage:, initiallyExpanded:, @ViewBuilder:)",
+      "modifiers": [
+        ".density()",
+        ".divider()",
+        ".indicator()",
+        ".number()",
+        ".subtitle()",
+        ".titleSize()",
+        ".truncateSubtitle()"
+      ]
+    },
+    {
+      "name": "AccordionGroup",
+      "category": "Organisms",
+      "init": "AccordionGroup(items, mode:, initiallyExpanded:, title:)",
+      "modifiers": []
+    },
+    {
+      "name": "AlertToast",
+      "category": "Organisms",
+      "init": "AlertToast(title, handler:)",
+      "modifiers": []
+    },
+    {
+      "name": "BlogCard",
+      "category": "Organisms",
+      "init": "BlogCard(title:, excerpt:, readMoreTitle:, compact:, onReadMore:)",
+      "modifiers": []
+    },
+    {
+      "name": "Callout",
+      "category": "Organisms",
+      "init": "Callout(text, type:, style:, showIcon:, actionTitle:, onAction:)",
+      "modifiers": []
+    },
+    {
+      "name": "Card",
+      "category": "Organisms",
+      "init": "Card(elevation:, padding:, title:, subtitle:, extraTitle:, onExtra:)",
+      "modifiers": []
+    },
+    {
+      "name": "CardStack",
+      "category": "Organisms",
+      "init": "CardStack(items, @ViewBuilder:)",
+      "modifiers": []
+    },
+    {
+      "name": "Carousel",
+      "category": "Organisms",
+      "init": "Carousel(items, loop:, currentIndex:, @ViewBuilder:)",
+      "modifiers": [
+        ".arrows()",
+        ".autoplay()",
+        ".dots()",
+        ".fade()"
+      ]
+    },
+    {
+      "name": "ChatBubble",
+      "category": "Organisms",
+      "init": "ChatBubble(text, side:, author:, time:, avatarSystemImage:)",
+      "modifiers": []
+    },
+    {
+      "name": "Counter",
+      "category": "Organisms",
+      "init": "Counter(value:, label:)",
+      "modifiers": []
+    },
+    {
+      "name": "Coupon",
+      "category": "Organisms",
+      "init": "Coupon(code:, label:, style:, onCopy:)",
+      "modifiers": []
+    },
+    {
+      "name": "DataTable",
+      "category": "Organisms",
+      "init": "DataTable(title, align:, sortKey:)",
+      "modifiers": []
+    },
+    {
+      "name": "Diff",
+      "category": "Organisms",
+      "init": "Diff(aspectRatio:, @ViewBuilder:)",
+      "modifiers": []
+    },
+    {
+      "name": "EmptyState",
+      "category": "Organisms",
+      "init": "EmptyState(systemImage:, iconForeground:, iconBackground:, iconCircleSize:, title:, message: \u2026)",
+      "modifiers": []
+    },
+    {
+      "name": "FloatingActionButton",
+      "category": "Organisms",
+      "init": "FloatingActionButton(systemImage:, label:, action:)",
+      "modifiers": []
+    },
+    {
+      "name": "Footer",
+      "category": "Organisms",
+      "init": "Footer(title, action:)",
+      "modifiers": []
+    },
+    {
+      "name": "Gallery",
+      "category": "Organisms",
+      "init": "Gallery(items, columns:, aspect:, @ViewBuilder:)",
+      "modifiers": []
+    },
+    {
+      "name": "Hero",
+      "category": "Organisms",
+      "init": "Hero(title:, subtitle:, ctaTitle:, dark:, action:)",
+      "modifiers": []
+    },
+    {
+      "name": "HeroSurface",
+      "category": "Organisms",
+      "init": "HeroSurface",
+      "modifiers": []
+    },
+    {
+      "name": "ImageCollage",
+      "category": "Organisms",
+      "init": "ImageCollage(urls, height:, spacing:, cornerRadius:, onTap:)",
+      "modifiers": []
+    },
+    {
+      "name": "InfoBanner",
+      "category": "Organisms",
+      "init": "InfoBanner(message, type:, title:, links:)",
+      "modifiers": []
+    },
+    {
+      "name": "KeyValueTable",
+      "category": "Organisms",
+      "init": "KeyValueTable(label, value:, style:)",
+      "modifiers": []
+    },
+    {
+      "name": "ListRow",
+      "category": "Organisms",
+      "init": "ListRow(total:, each:, unit:)",
+      "modifiers": []
+    },
+    {
+      "name": "ListSectionHeader",
+      "category": "Organisms",
+      "init": "ListSectionHeader",
+      "modifiers": []
+    },
+    {
+      "name": "ListView",
+      "category": "Organisms",
+      "init": "ListView(items, header:, footer:, bordered:, loading:, split: \u2026)",
+      "modifiers": []
+    },
+    {
+      "name": "MenuCard",
+      "category": "Organisms",
+      "init": "MenuCard(title:, subtitle:, systemImage:, action:)",
+      "modifiers": []
+    },
+    {
+      "name": "NavigationBar",
+      "category": "Organisms",
+      "init": "NavigationBar(systemImage:, activeSystemImage:)",
+      "modifiers": []
+    },
+    {
+      "name": "NotificationCard",
+      "category": "Organisms",
+      "init": "NotificationCard(title:, message:, date:, isUnread:, type:, onClose:)",
+      "modifiers": []
+    },
+    {
+      "name": "PageHeader",
+      "category": "Organisms",
+      "init": "PageHeader(systemImage:, handler:)",
+      "modifiers": []
+    },
+    {
+      "name": "PagingCarousel",
+      "category": "Organisms",
+      "init": "PagingCarousel(items, peek:, spacing:, autoplay:, @ViewBuilder:)",
+      "modifiers": []
+    },
+    {
+      "name": "PromoBanner",
+      "category": "Organisms",
+      "init": "PromoBanner(title:, subtitle:, systemImage:, ctaTitle:, tint:, action:)",
+      "modifiers": []
+    },
+    {
+      "name": "RatingSummary",
+      "category": "Organisms",
+      "init": "RatingSummary(score:, label:, reviewCount:, onReviews:)",
+      "modifiers": []
+    },
+    {
+      "name": "ResultView",
+      "category": "Organisms",
+      "init": "ResultView(status, title:, message:, primaryTitle:, onPrimary:)",
+      "modifiers": []
+    },
+    {
+      "name": "SegmentedTabBar",
+      "category": "Organisms",
+      "init": "SegmentedTabBar(title, caption:, systemImage:, trailingSystemImage:, badge:, isEnabled:)",
+      "modifiers": [
+        ".a11yID()"
+      ]
+    },
+    {
+      "name": "RadioCard",
+      "category": "Organisms",
+      "init": "RadioCard(title, description:, isSelected:, isEnabled:, action:)",
+      "modifiers": []
+    },
+    {
+      "name": "CheckboxCard",
+      "category": "Organisms",
+      "init": "CheckboxCard",
+      "modifiers": []
+    },
+    {
+      "name": "ThemePicker",
+      "category": "Organisms",
+      "init": "ThemePicker(selection:, themes:, onSelect:)",
+      "modifiers": []
+    },
+    {
+      "name": "Timeline",
+      "category": "Organisms",
+      "init": "Timeline(title:, time:, description:, systemImage:, state:, color:)",
+      "modifiers": []
+    },
+    {
+      "name": "Upload",
+      "category": "Organisms",
+      "init": "Upload(id:, name:, status:)",
+      "modifiers": []
+    },
+    {
+      "name": "UploadList",
+      "category": "Organisms",
+      "init": "UploadList",
+      "modifiers": []
+    },
+    {
+      "name": "VideoPlayerView",
+      "category": "Organisms",
+      "init": "VideoPlayerView(url, progress:, isMuted:, onTap:)",
+      "modifiers": [
+        ".autoplay()",
+        ".loop()",
+        ".muteToggle()",
+        ".muted()",
+        ".tapToToggle()"
+      ]
+    }
+  ],
+  "modifiers": [
+    ".a11yID()",
+    ".allowHalf()",
+    ".arrows()",
+    ".autoplay()",
+    ".axis()",
+    ".backButton()",
+    ".badgeColor()",
+    ".badgeShape()",
+    ".barHeight()",
+    ".clearable()",
+    ".colors()",
+    ".debounce()",
+    ".density()",
+    ".divider()",
+    ".dots()",
+    ".editable()",
+    ".exists()",
+    ".expands()",
+    ".fade()",
+    ".gradient()",
+    ".hasInfo()",
+    ".highlighted()",
+    ".icon()",
+    ".indicator()",
+    ".inputs()",
+    ".interactive()",
+    ".jumper()",
+    ".loading()",
+    ".loop()",
+    ".marks()",
+    ".maxResults()",
+    ".maxTags()",
+    ".maxValue()",
+    ".muteToggle()",
+    ".muted()",
+    ".number()",
+    ".onChangeEnd()",
+    ".onRate()",
+    ".onReviewTap()",
+    ".onSearch()",
+    ".onValueChange()",
+    ".progressLabel()",
+    ".rating()",
+    ".searchable()",
+    ".sentiment()",
+    ".showTotal()",
+    ".showsValueTooltip()",
+    ".simple()",
+    ".starSize()",
+    ".steps()",
+    ".subtitle()",
+    ".successSegment()",
+    ".suggestionEnabled()",
+    ".symbol()",
+    ".tapToToggle()",
+    ".titleSize()",
+    ".trailingIcon()",
+    ".truncateSubtitle()",
+    ".valueFormat()",
+    ".valueLabel()",
+    ".window()"
+  ],
+  "themes": [
+    {
+      "id": "light",
+      "name": "Light"
+    },
+    {
+      "id": "dark",
+      "name": "Dark"
+    },
+    {
+      "id": "cupcake",
+      "name": "Cupcake"
+    },
+    {
+      "id": "bumblebee",
+      "name": "Bumblebee"
+    },
+    {
+      "id": "emerald",
+      "name": "Emerald"
+    },
+    {
+      "id": "corporate",
+      "name": "Corporate"
+    },
+    {
+      "id": "synthwave",
+      "name": "Synthwave"
+    },
+    {
+      "id": "retro",
+      "name": "Retro"
+    },
+    {
+      "id": "cyberpunk",
+      "name": "Cyberpunk"
+    },
+    {
+      "id": "valentine",
+      "name": "Valentine"
+    },
+    {
+      "id": "halloween",
+      "name": "Halloween"
+    },
+    {
+      "id": "garden",
+      "name": "Garden"
+    },
+    {
+      "id": "forest",
+      "name": "Forest"
+    },
+    {
+      "id": "aqua",
+      "name": "Aqua"
+    },
+    {
+      "id": "lofi",
+      "name": "Lo-Fi"
+    },
+    {
+      "id": "pastel",
+      "name": "Pastel"
+    },
+    {
+      "id": "fantasy",
+      "name": "Fantasy"
+    },
+    {
+      "id": "wireframe",
+      "name": "Wireframe"
+    },
+    {
+      "id": "black",
+      "name": "Black"
+    },
+    {
+      "id": "luxury",
+      "name": "Luxury"
+    },
+    {
+      "id": "dracula",
+      "name": "Dracula"
+    },
+    {
+      "id": "cmyk",
+      "name": "CMYK"
+    },
+    {
+      "id": "autumn",
+      "name": "Autumn"
+    },
+    {
+      "id": "business",
+      "name": "Business"
+    },
+    {
+      "id": "acid",
+      "name": "Acid"
+    },
+    {
+      "id": "lemonade",
+      "name": "Lemonade"
+    },
+    {
+      "id": "night",
+      "name": "Night"
+    },
+    {
+      "id": "coffee",
+      "name": "Coffee"
+    },
+    {
+      "id": "winter",
+      "name": "Winter"
+    },
+    {
+      "id": "dim",
+      "name": "Dim"
+    },
+    {
+      "id": "nord",
+      "name": "Nord"
+    },
+    {
+      "id": "sunset",
+      "name": "Sunset"
+    }
+  ]
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src"]
+}

--- a/tools/gen_skill.py
+++ b/tools/gen_skill.py
@@ -8,6 +8,7 @@ Re-run with `make skill` (or `python3 tools/gen_skill.py`) so the reference can
 never drift from the code.
 """
 import re
+import json
 import pathlib
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -16,7 +17,27 @@ OUT = ROOT / "skills/themekit/references/components.md"
 THEMES_SRC = ROOT / "Sources/ThemeKit/Theme/DaisyThemes.swift"
 THEMES_OUT = ROOT / "skills/themekit/references/themes.md"
 LLMS_OUT = ROOT / "llms.txt"
+JSON_OUT = ROOT / "mcp/themekit.json"
 THEME_RE = re.compile(r'\.init\(\s*"(\w+)",\s*"([^"]+)"')
+
+RULES = [
+    "Read the theme via `@Environment(\\.theme) private var theme`; inject `.environment(Theme.shared)` once at the root.",
+    "Never hardcode a color — use `theme.text(.textPrimary)`, `theme.background(.bgWhite)`, or a `SemanticColor`.",
+    "Put required content/bindings/actions in `init`; set variants, sizes, flags, colors and callbacks with chainable modifiers.",
+    "Sizes use `.controlSize(_:)`; disabled state uses `.disabled(_:)`; accessibility id uses `.a11yID(_:)`.",
+    "Recolor everything with `Theme.shared.applyGenerated(primaryHex:)` or a daisyUI theme: `DaisyTheme.named(\"dracula\")?.apply()`.",
+]
+
+TOKENS = {
+    "text": ["textPrimary", "textSecondary", "textTertiary", "textDisabled", "textHero"],
+    "background": ["bgWhite", "bgElevatorPrimary", "bgSecondary", "bgSecondaryLight", "bgHero", "bgTertiary"],
+    "border": ["borderPrimary", "borderHero"],
+    "foreground": ["fgHero", "fgSecondary"],
+    "semanticColor": ["primary", "secondary", "accent", "neutral", "info", "success", "warning", "error"],
+    "fillVariant": ["solid", "soft", "outline", "ghost"],
+    "radiusRole": ["box", "field", "selector"],
+    "spacing": ["xs", "sm", "md", "base", "lg", "xl"],
+}
 
 CATEGORIES = [("Atoms", "Atoms"), ("Molecules", "Molecules"), ("Organisms", "Organisms")]
 
@@ -187,6 +208,29 @@ def render_llms(cats, modifiers, themes):
     return "\n".join(lines)
 
 
+def render_json(cats, modifiers, themes):
+    components = []
+    for label, _ in CATEGORIES:
+        for name, params, mods in cats[label]:
+            components.append({
+                "name": name,
+                "category": label,
+                "init": f"{name}({params})" if params else name,
+                "modifiers": [f".{m}()" for m in mods],
+            })
+    return json.dumps({
+        "name": "themekit",
+        "summary": "A token-driven, brand-neutral SwiftUI design system. Every color / "
+                   "radius / spacing / type style is a token resolved at runtime from the "
+                   "active Theme; components never hardcode a color.",
+        "rules": RULES,
+        "tokens": TOKENS,
+        "components": components,
+        "modifiers": [f".{m}()" for m in modifiers],
+        "themes": [{"id": t[0], "name": t[1]} for t in themes],
+    }, indent=2)
+
+
 def main():
     cats, modifiers = collect()
     themes = THEME_RE.findall(THEMES_SRC.read_text(encoding="utf-8"))
@@ -195,10 +239,14 @@ def main():
     themes_md, n_themes = render_themes(themes)
     THEMES_OUT.write_text(themes_md, encoding="utf-8")
     LLMS_OUT.write_text(render_llms(cats, modifiers, themes), encoding="utf-8")
+    if JSON_OUT.parent.exists():
+        JSON_OUT.write_text(render_json(cats, modifiers, themes), encoding="utf-8")
     total = sum(len(v) for v in cats.values())
     print(f"Wrote {OUT.relative_to(ROOT)} — {total} components, {len(modifiers)} modifiers")
     print(f"Wrote {THEMES_OUT.relative_to(ROOT)} — {n_themes} daisyUI themes")
     print(f"Wrote {LLMS_OUT.relative_to(ROOT)} — llms.txt index")
+    if JSON_OUT.parent.exists():
+        print(f"Wrote {JSON_OUT.relative_to(ROOT)} — MCP data")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
An **MCP server** so MCP-compatible editors (Claude Code, Cursor, Windsurf…) pull *focused* ThemeKit context **on demand** while coding — instead of loading everything up front.

### What's in it
- **`mcp/`** — a TypeScript stdio server (`@modelcontextprotocol/sdk`) exposing **7 tools**:
  `usage_guide`, `list_components`, `get_component`, `search_components`, `list_themes`, `theme_snippet`, `token_reference`.
- Data is **`mcp/themekit.json`**, emitted by `tools/gen_skill.py` alongside the skill + `llms.txt` (one source — `make skill` keeps all in sync; `make mcp` also builds the server).

### Verified
- `npm install` + `npm run build` (tsc) — clean.
- stdio smoke test: `tools/list` → all 7 tools; `tools/call get_component(Badge)` → correct init + modifiers.

### Install
```sh
claude mcp add themekit -- npx -y @isamercan/themekit-mcp   # once published
# or from the repo:
cd mcp && npm install && npm run build
claude mcp add themekit -- node "$(pwd)/dist/index.js"
```

The README's "AI-assisted development" table now lists **MCP + skill + llms.txt** — works with Claude Code, Cursor, Windsurf, Copilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)