### PR TITLE
feat(mcp): richer data + lint/scaffold/theme/migrate tools, resources, prompts

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@isamercan/themekit-mcp",
-  "version": "1.0.0",
-  "description": "MCP server for the ThemeKit SwiftUI design system — components, modifiers, tokens and daisyUI themes on demand.",
+  "version": "1.1.0",
+  "description": "MCP server for the ThemeKit SwiftUI design system \u2014 components, modifiers, tokens and daisyUI themes on demand.",
   "type": "module",
   "bin": {
     "themekit-mcp": "dist/index.js"
@@ -15,7 +15,13 @@
     "start": "node dist/index.js",
     "prepublishOnly": "npm run build"
   },
-  "keywords": ["mcp", "themekit", "swiftui", "design-system", "daisyui"],
+  "keywords": [
+    "mcp",
+    "themekit",
+    "swiftui",
+    "design-system",
+    "daisyui"
+  ],
   "author": "isamercan",
   "license": "MIT",
   "homepage": "https://github.com/isamercan/ThemeKit",

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,148 +1,282 @@
 #!/usr/bin/env node
 /**
  * ThemeKit MCP server — exposes the ThemeKit SwiftUI design system (components,
- * modifiers, tokens, daisyUI themes) as on-demand tools for MCP-compatible
- * editors (Claude Code, Cursor, Windsurf…).
+ * modifiers, tokens, theme presets) as on-demand tools, resources and prompts
+ * for MCP-compatible editors (Claude Code, Cursor, Windsurf…).
  *
  * Data comes from themekit.json, generated from the Swift source by
  * `tools/gen_skill.py` (`make skill`), so it never drifts from the library.
  */
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-interface Component {
-  name: string;
-  category: string;
-  init: string;
-  modifiers: string[];
-}
-interface ThemeKitData {
-  summary: string;
-  rules: string[];
-  tokens: Record<string, string[]>;
-  components: Component[];
-  modifiers: string[];
-  themes: { id: string; name: string }[];
+interface Modifier { name: string; signature: string; doc: string; }
+interface Component { name: string; category: string; doc: string; init: string; modifiers: Modifier[]; }
+interface ThemePreset { id: string; name: string; primary: string; secondary: string; accent: string; base: string; }
+interface Data {
+  summary: string; rules: string[]; tokens: Record<string, string[]>;
+  components: Component[]; modifiers: string[]; themes: ThemePreset[];
 }
 
 const here = dirname(fileURLToPath(import.meta.url));
-const data: ThemeKitData = JSON.parse(readFileSync(join(here, "..", "themekit.json"), "utf8"));
-
+const data: Data = JSON.parse(readFileSync(join(here, "..", "themekit.json"), "utf8"));
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] });
+const findComponent = (name: string) =>
+  data.components.find((c) => c.name.toLowerCase() === name.toLowerCase());
 
 const server = new McpServer({ name: "themekit", version: "1.0.0" });
 
-server.registerTool(
-  "usage_guide",
-  {
-    title: "ThemeKit usage guide",
-    description: "The golden rules for writing correct ThemeKit code. Read this first.",
-    inputSchema: {},
-  },
-  async () => text([data.summary, "", "Rules:", ...data.rules.map((r) => `- ${r}`)].join("\n"))
-);
+// ── Reference tools ────────────────────────────────────────────────────────
 
-server.registerTool(
-  "list_components",
-  {
-    title: "List components",
-    description: "List ThemeKit components, optionally filtered by category (Atoms / Molecules / Organisms).",
-    inputSchema: { category: z.enum(["Atoms", "Molecules", "Organisms"]).optional() },
-  },
-  async ({ category }) => {
-    const items = data.components.filter((c) => !category || c.category === category);
-    const byCat: Record<string, string[]> = {};
-    for (const c of items) (byCat[c.category] ??= []).push(c.name);
-    return text(
-      Object.entries(byCat)
-        .map(([cat, names]) => `## ${cat} (${names.length})\n${names.join(", ")}`)
-        .join("\n\n")
-    );
+server.registerTool("usage_guide", {
+  title: "ThemeKit usage guide",
+  description: "The golden rules for writing correct ThemeKit code. Read this first.",
+  inputSchema: {},
+}, async () => text([data.summary, "", "Rules:", ...data.rules.map((r) => `- ${r}`)].join("\n")));
+
+server.registerTool("list_components", {
+  title: "List components",
+  description: "List ThemeKit components, optionally filtered by category.",
+  inputSchema: { category: z.enum(["Atoms", "Molecules", "Organisms"]).optional() },
+}, async ({ category }) => {
+  const items = data.components.filter((c) => !category || c.category === category);
+  const byCat: Record<string, string[]> = {};
+  for (const c of items) (byCat[c.category] ??= []).push(c.name);
+  return text(Object.entries(byCat).map(([c, n]) => `## ${c} (${n.length})\n${n.join(", ")}`).join("\n\n"));
+});
+
+server.registerTool("get_component", {
+  title: "Get component API",
+  description: "A component's summary, init signature and chainable modifiers (with signatures + docs).",
+  inputSchema: { name: z.string().describe("Component name, e.g. Badge, TextInput, Carousel") },
+}, async ({ name }) => {
+  const c = findComponent(name);
+  if (!c) return text(`No component "${name}". Try list_components or search_components.`);
+  const out = [`# ${c.name} (${c.category})`, c.doc, "", `**Init:** \`${c.init}\``];
+  if (c.modifiers.length) {
+    out.push("", "**Modifiers:**");
+    for (const m of c.modifiers) out.push(`- \`.${m.signature}\`${m.doc ? ` — ${m.doc}` : ""}`);
   }
-);
+  out.push("", "Sizes use `.controlSize(_:)`; disabled uses `.disabled(_:)`; never hardcode a color.");
+  return text(out.join("\n"));
+});
 
-server.registerTool(
-  "get_component",
-  {
-    title: "Get component API",
-    description: "Get one component's init signature + its chainable modifiers.",
-    inputSchema: { name: z.string().describe("Component name, e.g. Badge, TextInput, Carousel") },
-  },
-  async ({ name }) => {
-    const c = data.components.find((x) => x.name.toLowerCase() === name.toLowerCase());
-    if (!c) return text(`No component named "${name}". Try list_components or search_components.`);
-    const mods = c.modifiers.length ? `\nModifiers: ${c.modifiers.join(" ")}` : "";
-    return text(`${c.category} · ${c.init}${mods}\n\nSet styling/variants/flags with the modifiers; sizes use .controlSize(_:), disabled uses .disabled(_:).`);
-  }
-);
+server.registerTool("search_components", {
+  title: "Search components",
+  description: "Find components by a keyword in the name, init or summary (e.g. 'date', 'progress').",
+  inputSchema: { query: z.string() },
+}, async ({ query }) => {
+  const q = query.toLowerCase();
+  const hits = data.components.filter(
+    (c) => c.name.toLowerCase().includes(q) || c.init.toLowerCase().includes(q) || c.doc.toLowerCase().includes(q)
+  );
+  if (!hits.length) return text(`No matches for "${query}".`);
+  return text(hits.map((c) => `- ${c.name} (${c.category}) — ${c.init}`).join("\n"));
+});
 
-server.registerTool(
-  "search_components",
-  {
-    title: "Search components",
-    description: "Find components by a keyword in the name or init (e.g. 'date', 'select', 'progress').",
-    inputSchema: { query: z.string() },
-  },
-  async ({ query }) => {
-    const q = query.toLowerCase();
-    const hits = data.components.filter(
-      (c) => c.name.toLowerCase().includes(q) || c.init.toLowerCase().includes(q)
-    );
-    if (!hits.length) return text(`No matches for "${query}".`);
-    return text(hits.map((c) => `- ${c.name} (${c.category}) — ${c.init}`).join("\n"));
-  }
-);
+server.registerTool("token_reference", {
+  title: "Token reference",
+  description: "ThemeKit design tokens (colors, radius roles, spacing, semantic colors). Pass a kind to filter.",
+  inputSchema: { kind: z.string().optional().describe("e.g. text, background, semanticColor, radiusRole, spacing") },
+}, async ({ kind }) => {
+  const entries = Object.entries(data.tokens).filter(([k]) => !kind || k.toLowerCase() === kind.toLowerCase());
+  if (!entries.length) return text(`No token kind "${kind}". Kinds: ${Object.keys(data.tokens).join(", ")}`);
+  return text(entries.map(([k, v]) => `${k}: ${v.join(", ")}`).join("\n"));
+});
 
-server.registerTool(
-  "list_themes",
-  {
-    title: "List daisyUI themes",
-    description: "List the bundled daisyUI theme ids.",
-    inputSchema: {},
-  },
-  async () => text(data.themes.map((t) => `${t.id} (${t.name})`).join("\n"))
-);
+// ── Theme tools ────────────────────────────────────────────────────────────
 
-server.registerTool(
-  "theme_snippet",
-  {
-    title: "Theme apply snippet",
-    description: "Swift code to apply a daisyUI theme (or show the ThemePicker).",
-    inputSchema: { id: z.string().describe('Theme id, e.g. "dracula"').optional() },
-  },
-  async ({ id }) => {
-    const found = id ? data.themes.find((t) => t.id === id) : undefined;
-    if (id && !found) return text(`No theme "${id}". Use list_themes.`);
-    const tid = found?.id ?? "dracula";
-    return text(
-      [
-        `// Apply ${found?.name ?? "a"} theme live`,
-        `DaisyTheme.named("${tid}")?.apply()`,
-        ``,
-        `// Or a tappable grid of all themes:`,
-        `@State private var active: String? = "${tid}"`,
-        `ThemePicker(selection: $active)`,
-      ].join("\n")
-    );
-  }
-);
+server.registerTool("list_themes", {
+  title: "List theme presets",
+  description: "List the bundled theme-preset ids.",
+  inputSchema: {},
+}, async () => text(data.themes.map((t) => `${t.id} (${t.name})`).join("\n")));
 
-server.registerTool(
-  "token_reference",
-  {
-    title: "Token reference",
-    description: "List ThemeKit design tokens (colors, radius roles, spacing, semantic colors). Pass a kind to filter.",
-    inputSchema: { kind: z.string().optional().describe("e.g. text, background, semanticColor, radiusRole, spacing") },
+server.registerTool("theme_colors", {
+  title: "Theme preset colors",
+  description: "The primary / secondary / accent / base hexes of a theme preset.",
+  inputSchema: { id: z.string().describe('Preset id, e.g. "dracula"') },
+}, async ({ id }) => {
+  const t = data.themes.find((x) => x.id === id);
+  if (!t) return text(`No preset "${id}". Use list_themes.`);
+  return text(`${t.name}\nprimary #${t.primary}\nsecondary #${t.secondary}\naccent #${t.accent}\nbase #${t.base}`);
+});
+
+server.registerTool("generate_theme", {
+  title: "Generate a theme",
+  description: "Swift code applying a custom theme from an accent (+ optional base / secondary / accent / dark).",
+  inputSchema: {
+    primaryHex: z.string().describe("RRGGBB, no #"),
+    baseHex: z.string().optional(), secondaryHex: z.string().optional(),
+    accentHex: z.string().optional(), dark: z.boolean().optional(),
   },
-  async ({ kind }) => {
-    const entries = Object.entries(data.tokens).filter(([k]) => !kind || k.toLowerCase() === kind.toLowerCase());
-    if (!entries.length) return text(`No token kind "${kind}". Kinds: ${Object.keys(data.tokens).join(", ")}`);
-    return text(entries.map(([k, v]) => `${k}: ${v.join(", ")}`).join("\n"));
-  }
-);
+}, async ({ primaryHex, baseHex, secondaryHex, accentHex, dark }) => {
+  const args = [`primaryHex: "${primaryHex}"`];
+  if (baseHex) args.push(`baseHex: "${baseHex}"`);
+  if (secondaryHex) args.push(`secondaryHex: "${secondaryHex}"`);
+  if (accentHex) args.push(`accentHex: "${accentHex}"`);
+  if (dark) args.push(`dark: true`);
+  return text(`Theme.shared.apply(ThemeConfig(${args.join(", ")}))\n\n// Every component recolors from these tokens — don't restyle them by hand.`);
+});
+
+server.registerTool("theme_snippet", {
+  title: "Theme apply snippet",
+  description: "Swift code to apply a theme preset live, or show the theme picker.",
+  inputSchema: { id: z.string().optional().describe('Preset id, e.g. "dracula"') },
+}, async ({ id }) => {
+  const found = id ? data.themes.find((t) => t.id === id) : undefined;
+  if (id && !found) return text(`No preset "${id}". Use list_themes.`);
+  const tid = found?.id ?? data.themes[0].id;
+  return text([
+    `DaisyTheme.named("${tid}")?.apply()          // recolor live`,
+    ``,
+    `@State private var active: String? = "${tid}"`,
+    `ThemePicker(selection: $active)              // a grid of all presets`,
+  ].join("\n"));
+});
+
+// ── Actionable tools ───────────────────────────────────────────────────────
+
+const LINT_RULES: { re: RegExp; msg: string }[] = [
+  { re: /Color\((?:hex:|red:|\.s)/, msg: "Hardcoded color — use a theme token (theme.text/.background/.foreground) or a SemanticColor." },
+  { re: /\.(?:foregroundStyle|foregroundColor|fill|background|tint)\(\s*\.(?:blue|red|green|orange|yellow|purple|pink|gray|grey|black|white|indigo|teal|mint|cyan|brown)\b/,
+    msg: "Hardcoded system color — use a theme token / SemanticColor." },
+  { re: /\bisEnabled:\s*/, msg: "`isEnabled:` is not an init arg — use the native `.disabled(_:)` modifier." },
+  { re: /\.cornerRadius\(\s*\d/, msg: "Hardcoded corner radius — use Theme.RadiusRole.box/field/selector.value." },
+  { re: /cornerRadius:\s*\d/, msg: "Hardcoded corner radius literal — use a RadiusRole/RadiusKey token." },
+  { re: /\.font\(\.system\(/, msg: "Raw system font — use `.textStyle(.bodyBase400 | .headingSm | …)`." },
+  { re: /\.padding\(\s*\d/, msg: "Hardcoded padding — use Theme.SpacingKey.sm/md/lg.value." },
+];
+
+server.registerTool("lint_snippet", {
+  title: "Lint ThemeKit code",
+  description: "Scan a SwiftUI snippet for ThemeKit anti-patterns (hardcoded colors / radius / fonts, isEnabled: arg) and report fixes.",
+  inputSchema: { swift: z.string() },
+}, async ({ swift }) => {
+  const lines = swift.split("\n");
+  const findings: string[] = [];
+  lines.forEach((line, i) => {
+    for (const rule of LINT_RULES) {
+      if (rule.re.test(line)) findings.push(`L${i + 1}: ${rule.msg}\n    ${line.trim()}`);
+    }
+  });
+  return text(findings.length ? `${findings.length} issue(s):\n\n${findings.join("\n\n")}` : "✓ No ThemeKit anti-patterns found.");
+});
+
+const SCAFFOLDS: Record<string, string> = {
+  form: `@Environment(\\.theme) private var theme
+@State private var email = ""; @State private var pw = ""; @State private var agree = false
+var body: some View {
+    Card(title: "Sign up") {
+        VStack(spacing: Theme.SpacingKey.md.value) {
+            TextInput("Email", text: $email, leadingSystemImage: "envelope").a11yID("email")
+            TextInput("Password", text: $pw, isSecure: true).a11yID("pw")
+            Checkbox("Accept terms", isChecked: $agree)
+            PrimaryButton("Create account", block: true) { submit() }.disabled(!agree)
+        }
+    }
+}`,
+  list: `@Environment(\\.theme) private var theme
+var body: some View {
+    ScrollView {
+        VStack(spacing: Theme.SpacingKey.sm.value) {
+            ForEach(items) { item in
+                Card { ListRow(title: item.title, subtitle: item.subtitle) }
+            }
+        }
+        .padding(Theme.SpacingKey.md.value)
+    }
+    .background(theme.background(.bgElevatorPrimary))
+}`,
+  detail: `@Environment(\\.theme) private var theme
+var body: some View {
+    ScrollView {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+            Title("Detail")
+            HStack { Badge("Info", style: .info); Rating(value: 4.5) }
+            Text(body).textStyle(.bodyBase400).foregroundStyle(theme.text(.textSecondary))
+            PrimaryButton("Continue", block: true) {}
+        }
+        .padding(Theme.SpacingKey.lg.value)
+    }
+}`,
+  settings: `@Environment(\\.theme) private var theme
+@State private var notify = true; @State private var active: String? = "light"
+var body: some View {
+    ScrollView {
+        VStack(spacing: Theme.SpacingKey.md.value) {
+            Card(title: "Preferences") {
+                ToggleGroup { ThemeToggle(isOn: $notify) }
+            }
+            Card(title: "Theme") { ThemePicker(selection: $active) }
+        }.padding(Theme.SpacingKey.md.value)
+    }
+}`,
+};
+
+server.registerTool("scaffold_screen", {
+  title: "Scaffold a screen",
+  description: "A starter SwiftUI screen built from ThemeKit components.",
+  inputSchema: { kind: z.enum(["form", "list", "detail", "settings"]) },
+}, async ({ kind }) => text("```swift\n" + SCAFFOLDS[kind] + "\n```"));
+
+server.registerTool("migrate_snippet", {
+  title: "Migrate SwiftUI → ThemeKit",
+  description: "Rewrite a plain-SwiftUI snippet toward ThemeKit (tokens + components), with notes.",
+  inputSchema: { swift: z.string() },
+}, async ({ swift }) => {
+  let out = swift;
+  const notes: string[] = [];
+  const sub = (re: RegExp, to: string, note: string) => {
+    if (re.test(out)) { out = out.replace(re, to); notes.push(note); }
+  };
+  sub(/\.foregroundColor\(\.(?:blue|accentColor)\)/g, ".foregroundStyle(theme.text(.textHero))", "system accent → theme.text(.textHero)");
+  sub(/Color\.blue/g, "theme.foreground(.fgHero)", "Color.blue → theme.foreground(.fgHero)");
+  sub(/\.cornerRadius\(\s*\d+\s*\)/g, ".cornerRadius(Theme.RadiusRole.box.value)", "hardcoded radius → RadiusRole.box");
+  sub(/\bToggle\(("[^"]*",\s*)?isOn:\s*(\$\w+)\)/g, "ThemeToggle(isOn: $2)", "Toggle → ThemeToggle");
+  return text(`Suggested:\n\n\`\`\`swift\n${out}\n\`\`\`\n\nNotes:\n${notes.length ? notes.map((n) => `- ${n}`).join("\n") : "- (no automatic rewrites; check lint_snippet)"}\n\nReplace plain Button/TextField with PrimaryButton/TextInput, and any remaining hardcoded colors with theme tokens.`);
+});
+
+// ── Resources (attachable context) ─────────────────────────────────────────
+
+server.registerResource("guide", "themekit://guide",
+  { title: "ThemeKit guide", description: "Summary + golden rules", mimeType: "text/markdown" },
+  async (uri) => ({ contents: [{ uri: uri.href, text: [data.summary, "", ...data.rules.map((r) => `- ${r}`)].join("\n") }] }));
+
+server.registerResource("components", "themekit://components",
+  { title: "ThemeKit components", description: "All components by category", mimeType: "text/markdown" },
+  async (uri) => ({ contents: [{ uri: uri.href, text: data.components.map((c) => `- ${c.name} (${c.category}) — ${c.init}`).join("\n") }] }));
+
+server.registerResource("component", new ResourceTemplate("themekit://component/{name}", { list: undefined }),
+  { title: "ThemeKit component", description: "One component's API" },
+  async (uri, { name }) => {
+    const c = findComponent(String(name));
+    const body = c ? [`# ${c.name}`, c.doc, `Init: ${c.init}`, ...c.modifiers.map((m) => `.${m.signature} — ${m.doc}`)].join("\n") : `Unknown: ${name}`;
+    return { contents: [{ uri: uri.href, text: body }] };
+  });
+
+// ── Prompts (slash-command templates) ──────────────────────────────────────
+
+server.registerPrompt("themekit-screen",
+  { title: "Build a ThemeKit screen", description: "Generate a screen with ThemeKit components",
+    argsSchema: { description: z.string().describe("What the screen should do") } },
+  ({ description }) => ({ messages: [{ role: "user", content: { type: "text", text:
+    `Build a SwiftUI screen with ThemeKit for: ${description}\n\nUse ThemeKit components + modifiers, resolve every color from theme tokens (never hardcode), inject \`.environment(Theme.shared)\`. Call get_component for any API you're unsure of, and lint_snippet on the result.` } }] }));
+
+server.registerPrompt("themekit-theme",
+  { title: "Theme a ThemeKit app", description: "Apply or generate a theme",
+    argsSchema: { idOrColor: z.string().describe("A preset id (e.g. dracula) or an accent hex") } },
+  ({ idOrColor }) => ({ messages: [{ role: "user", content: { type: "text", text:
+    `Apply a ThemeKit theme: "${idOrColor}". If it's a preset id use DaisyTheme.named(...)?.apply(); if it's a hex use Theme.shared.applyGenerated(primaryHex:). Confirm with theme_colors / list_themes.` } }] }));
+
+server.registerPrompt("migrate-to-themekit",
+  { title: "Migrate to ThemeKit", description: "Rewrite plain SwiftUI with ThemeKit",
+    argsSchema: { code: z.string().describe("The SwiftUI code to migrate") } },
+  ({ code }) => ({ messages: [{ role: "user", content: { type: "text", text:
+    `Migrate this SwiftUI to ThemeKit — tokens instead of hardcoded colors, ThemeKit components instead of raw ones. Run migrate_snippet then lint_snippet.\n\n\`\`\`swift\n${code}\n\`\`\`` } }] }));
 
 await server.connect(new StdioServerTransport());

--- a/mcp/themekit.json
+++ b/mcp/themekit.json
@@ -66,810 +66,1281 @@
     {
       "name": "AnimatedImage",
       "category": "Atoms",
+      "doc": "Animated GIF / APNG playback with NO third-party dependency \u2014 frames and per-frame delays are decoded natively via ImageIO (`CGImageSource`) and driven by a `TimelineView(.animation)`.",
       "init": "AnimatedImage(url, contentMode:, cornerRadius:)",
       "modifiers": []
     },
     {
       "name": "Avatar",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "Avatar(content, size:, background:, shape:, presence:, presencePulse:)",
       "modifiers": []
     },
     {
       "name": "AvatarGroup",
       "category": "Atoms",
+      "doc": "Overlapping stack of avatars with a \"+N\" overflow bubble.",
       "init": "AvatarGroup",
       "modifiers": []
     },
     {
       "name": "Badge",
       "category": "Atoms",
+      "doc": "Improved, token-bound rewrite of the reference BadgeView.",
       "init": "Badge(text, style:, variant:, size:, leadingSystemImage:, action:)",
       "modifiers": [
-        ".badgeColor()",
-        ".badgeShape()",
-        ".gradient()",
-        ".highlighted()",
-        ".trailingIcon()"
+        {
+          "name": "badgeShape",
+          "signature": "badgeShape(_ shape: BadgeShape)",
+          "doc": "Pill (default) or rounded-rectangle outline."
+        },
+        {
+          "name": "trailingIcon",
+          "signature": "trailingIcon(_ systemName: String?)",
+          "doc": "A trailing SF Symbol after the text (e.g."
+        },
+        {
+          "name": "badgeColor",
+          "signature": "badgeColor(_ color: Color?)",
+          "doc": "Overrides the text/foreground color (otherwise derived from style + variant)."
+        },
+        {
+          "name": "gradient",
+          "signature": "gradient(_ colors: [Color]?)",
+          "doc": "Fills the badge with a horizontal gradient instead of the style background."
+        },
+        {
+          "name": "highlighted",
+          "signature": "highlighted(_ on: Bool = true)",
+          "doc": "Lifts the badge off the surface with a subtle drop shadow."
+        }
       ]
     },
     {
       "name": "Chip",
       "category": "Atoms",
+      "doc": "Improved, token-bound rewrite of the reference BasicChip \u2014 a single clear selection API (tonal / solid) instead of the reference's nested status \u00d7 mode \u00d7 fullSelect \u00d7 isExist matrix.",
       "init": "Chip(title, isSelected:, size:, selectionStyle:)",
       "modifiers": [
-        ".exists()",
-        ".expands()",
-        ".icon()",
-        ".interactive()",
-        ".rating()"
+        {
+          "name": "icon",
+          "signature": "icon(_ systemName: String?)",
+          "doc": "A leading SF Symbol before the title."
+        },
+        {
+          "name": "rating",
+          "signature": "rating(_ value: Double?)",
+          "doc": "A leading star + numeric rating before the title."
+        },
+        {
+          "name": "exists",
+          "signature": "exists(_ on: Bool = true)",
+          "doc": "Whether the represented item still exists; `false` strikes through and dims the chip (e.g."
+        },
+        {
+          "name": "interactive",
+          "signature": "interactive(_ on: Bool = true)",
+          "doc": "Whether the chip responds to taps (a read-only display chip passes `false`)."
+        },
+        {
+          "name": "expands",
+          "signature": "expands(_ on: Bool = true)",
+          "doc": "Stretches the chip to fill the available width (e.g."
+        }
       ]
     },
     {
       "name": "Ribbon",
       "category": "Atoms",
+      "doc": "A corner ribbon wrapping any content (Ant `Badge.Ribbon`).",
       "init": "Ribbon(text, color:, @ViewBuilder:)",
       "modifiers": []
     },
     {
       "name": "DividerView",
       "category": "Atoms",
+      "doc": "A theme-driven divider: horizontal / vertical, solid / dashed, with an optional inline text label (left / center / right).",
       "init": "DividerView(size:, axis:, dashed:, title:, titleAlign:)",
       "modifiers": []
     },
     {
       "name": "GaugeView",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "GaugeView(value:, in:, label:, style:, showsValue:)",
       "modifiers": []
     },
     {
       "name": "Icon",
       "category": "Atoms",
+      "doc": "Icon system.",
       "init": "Icon(systemName:, size:, color:)",
       "modifiers": []
     },
     {
       "name": "InlineText",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "InlineText(text, links:)",
       "modifiers": []
     },
     {
       "name": "InputLabel",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "InputLabel(text, isRequired:, hasInfo:, hasError:)",
       "modifiers": []
     },
     {
       "name": "Join",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "Join(axis, @ViewBuilder:)",
       "modifiers": []
     },
     {
       "name": "Kbd",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "Kbd(text)",
       "modifiers": []
     },
     {
       "name": "ProgressBar",
       "category": "Atoms",
+      "doc": "Linear determinate progress with status colors, an optional ladder gradient, a segmented (steps) variant and a custom format label.",
       "init": "ProgressBar(value:, showPercentage:, status:)",
       "modifiers": [
-        ".barHeight()",
-        ".colors()",
-        ".gradient()",
-        ".progressLabel()",
-        ".steps()",
-        ".successSegment()",
-        ".valueFormat()"
+        {
+          "name": "barHeight",
+          "signature": "barHeight(_ points: CGFloat)",
+          "doc": "Bar thickness in points (default 8)."
+        },
+        {
+          "name": "gradient",
+          "signature": "gradient(_ on: Bool = true)",
+          "doc": "Fill with a status gradient instead of a solid color."
+        },
+        {
+          "name": "steps",
+          "signature": "steps(_ count: Int?)",
+          "doc": "Render as a segmented (stepped) bar with this many segments."
+        },
+        {
+          "name": "colors",
+          "signature": "colors(fill: Color? = nil, track: Color? = nil)",
+          "doc": "Overrides the fill color and/or the track color (otherwise status-derived)."
+        },
+        {
+          "name": "successSegment",
+          "signature": "successSegment(_ portion: Double?)",
+          "doc": "A 0...1 portion drawn in the success color on top of the fill (Ant `success.percent`)."
+        },
+        {
+          "name": "valueFormat",
+          "signature": "valueFormat(_ format: ((Double) -> String)?)",
+          "doc": "Custom formatter for the percentage label (receives the 0...1 value)."
+        },
+        {
+          "name": "progressLabel",
+          "signature": "progressLabel(_ label: String?)",
+          "doc": "VoiceOver name for the bar (e.g."
+        }
       ]
     },
     {
       "name": "StepIndicator",
       "category": "Atoms",
+      "doc": "Segmented step indicator (e.g.",
       "init": "StepIndicator",
       "modifiers": []
     },
     {
       "name": "RadialProgress",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "RadialProgress(value:, size:, lineWidth:, showLabel:, status:, dashboard: \u2026)",
       "modifiers": []
     },
     {
       "name": "Rating",
       "category": "Atoms",
+      "doc": "Star rating with two layouts (stars / numeric-leading), continuous fractional fill (display) or half-step interaction, a tappable review count, a custom character and a disabled state.",
       "init": "Rating(value:, layout:, countLabel:)",
       "modifiers": [
-        ".allowHalf()",
-        ".maxValue()",
-        ".onRate()",
-        ".onReviewTap()",
-        ".sentiment()",
-        ".starSize()",
-        ".symbol()"
+        {
+          "name": "maxValue",
+          "signature": "maxValue(_ max: Int)",
+          "doc": "Number of glyphs / the score denominator (default 5)."
+        },
+        {
+          "name": "starSize",
+          "signature": "starSize(_ points: CGFloat)",
+          "doc": "Glyph point size (default 16)."
+        },
+        {
+          "name": "allowHalf",
+          "signature": "allowHalf(_ on: Bool = true)",
+          "doc": "Enables half-step interaction (and half-star tap targets)."
+        },
+        {
+          "name": "symbol",
+          "signature": "symbol(_ systemImage: String)",
+          "doc": "Overrides the SF Symbol used for the glyph (default \"star\")."
+        },
+        {
+          "name": "sentiment",
+          "signature": "sentiment(_ text: String?)",
+          "doc": "Sentiment word for the `.rateNumberText` layout (otherwise score-derived)."
+        },
+        {
+          "name": "onRate",
+          "signature": "onRate(_ action: ((Double) -> Void)?)",
+          "doc": "Makes the rating interactive: the closure receives the newly tapped value."
+        },
+        {
+          "name": "onReviewTap",
+          "signature": "onReviewTap(_ action: (() -> Void)?)",
+          "doc": "Makes the review count label a tappable link."
+        }
       ]
     },
     {
       "name": "RemoteImage",
       "category": "Atoms",
+      "doc": "Async remote image on native `AsyncImage` (no Kingfisher dependency): URL + aspect ratio (number or \"16:9\" string) + shimmer placeholder + failure state.",
       "init": "RemoteImage(url, aspectRatio:, contentMode:, cornerRadius:, circle:)",
       "modifiers": []
     },
     {
       "name": "RollingNumber",
       "category": "Atoms",
+      "doc": "Odometer / slot-machine number \u2014 each digit column rolls vertically to its new value when `value` changes (reference `RollingText`).",
       "init": "RollingNumber(value, size:, weight:, color:)",
       "modifiers": []
     },
     {
       "name": "ScoreBadge",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "ScoreBadge(score, large:)",
       "modifiers": []
     },
     {
       "name": "ShareButton",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "ShareButton(title, item:)",
       "modifiers": []
     },
     {
       "name": "Skeleton",
       "category": "Atoms",
+      "doc": "A standalone skeleton block of an arbitrary shape and size.",
       "init": "Skeleton(shape, width:, height:)",
       "modifiers": []
     },
     {
       "name": "Spinner",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "Spinner(size:, lineWidth:, color:)",
       "modifiers": []
     },
     {
       "name": "StatusDot",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "StatusDot(kind, size:, label:, pulse:)",
       "modifiers": []
     },
     {
       "name": "Swap",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "Swap(isOn:, on:, off:, size:, rotate:)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "Tag",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "Tag(text, leadingSystemImage:, style:, variant:, onRemove:)",
       "modifiers": []
     },
     {
       "name": "TextLink",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "TextLink(title, underline:, action:)",
       "modifiers": []
     },
     {
       "name": "TextRotate",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "TextRotate(words, interval:)",
       "modifiers": []
     },
     {
       "name": "Title",
       "category": "Atoms",
+      "doc": "Atom.",
       "init": "Title(text, subtitle:, eyebrow:, actionTitle:, action:)",
       "modifiers": []
     },
     {
       "name": "Autocomplete",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "Autocomplete(label:, text:, suggestions:, placeholder:, onSelect:)",
       "modifiers": [
-        ".a11yID()",
-        ".debounce()",
-        ".maxResults()",
-        ".onSearch()",
-        ".suggestionEnabled()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        },
+        {
+          "name": "maxResults",
+          "signature": "maxResults(_ count: Int)",
+          "doc": "Caps the number of suggestion rows (default 5)."
+        },
+        {
+          "name": "debounce",
+          "signature": "debounce(_ interval: TimeInterval)",
+          "doc": "Debounce interval for typeahead (async init defaults to 0.3s)."
+        },
+        {
+          "name": "suggestionEnabled",
+          "signature": "suggestionEnabled(_ predicate: ((String) -> Bool)?)",
+          "doc": "Per-suggestion enable predicate; disabled rows are shown greyed and unselectable."
+        },
+        {
+          "name": "onSearch",
+          "signature": "onSearch(_ action: ((String) -> Void)?)",
+          "doc": "Fires with the query text on each (debounced) change."
+        }
       ]
     },
     {
       "name": "Breadcrumbs",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "Breadcrumbs(title, action:)",
       "modifiers": []
     },
     {
       "name": "ButtonGroup",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "ButtonGroup(axis, @ViewBuilder:)",
       "modifiers": []
     },
     {
       "name": "PrimaryButton",
       "category": "Molecules",
+      "doc": "",
       "init": "PrimaryButton(title, size:, block:, helperText:, textStyle:, confirmsSuccess: \u2026)",
       "modifiers": []
     },
     {
       "name": "SecondaryButton",
       "category": "Molecules",
+      "doc": "",
       "init": "SecondaryButton",
       "modifiers": []
     },
     {
       "name": "OutlineButton",
       "category": "Molecules",
+      "doc": "",
       "init": "OutlineButton",
       "modifiers": []
     },
     {
       "name": "GhostButton",
       "category": "Molecules",
+      "doc": "",
       "init": "GhostButton",
       "modifiers": []
     },
     {
       "name": "LinkButton",
       "category": "Molecules",
+      "doc": "",
       "init": "LinkButton",
       "modifiers": []
     },
     {
       "name": "ThemeButton",
       "category": "Molecules",
+      "doc": "",
       "init": "ThemeButton(title, systemImage:, iconPosition:, color:, variant:, size: \u2026)",
       "modifiers": []
     },
     {
       "name": "CalendarView",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "CalendarView(selection:)",
       "modifiers": []
     },
     {
       "name": "Checkbox",
       "category": "Molecules",
+      "doc": "Figma \"Control Items\" \u2192 Checkboxes.",
       "init": "Checkbox(label, isChecked:, customSize:, type:, isIndeterminate:, alignment: \u2026)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "CheckboxGroup",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "CheckboxGroup(title:, options:, selection:, infoMessages:, selectAllTitle:, isOptionEnabled:)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "ImageChip",
       "category": "Molecules",
+      "doc": "A selectable remote-image tile with a selection border.",
       "init": "ImageChip(isSelected:, url:, size:, isEnabled:)",
       "modifiers": []
     },
     {
       "name": "CompactChip",
       "category": "Molecules",
+      "doc": "A selectable card: an optional rating + label row, then an optional logo + price row.",
       "init": "CompactChip",
       "modifiers": []
     },
     {
       "name": "ChoseChip",
       "category": "Molecules",
+      "doc": "A selectable card: a leading icon, a title with an optional \"free\" gradient badge, and a rating + description row.",
       "init": "ChoseChip",
       "modifiers": []
     },
     {
       "name": "FilterChip",
       "category": "Molecules",
+      "doc": "A dismissible filter chip in a pill (with a soft shadow) or square shape.",
       "init": "FilterChip",
       "modifiers": []
     },
     {
       "name": "ChipGroup",
       "category": "Molecules",
+      "doc": "A horizontally-scrolling, multi-select chip group backed by a `Set` binding.",
       "init": "ChipGroup",
       "modifiers": []
     },
     {
       "name": "ColorField",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "ColorField(label, selection:, supportsOpacity:)",
       "modifiers": []
     },
     {
       "name": "DateField",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "DateField(label:, date:, placeholder:, range:, style:, locale: \u2026)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "Fieldset",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "Fieldset(title, helper:, @ViewBuilder:)",
       "modifiers": []
     },
     {
       "name": "FileInput",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "FileInput(label:, fileName:, buttonTitle:, placeholder:, infoMessages:, onPick:)",
       "modifiers": []
     },
     {
       "name": "FilterGroup",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "FilterGroup(title:, options:, selection:, label:)",
       "modifiers": []
     },
     {
       "name": "InputNumber",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "InputNumber(label:, value:, range:, step:, unit:, hint: \u2026)",
       "modifiers": [
-        ".a11yID()",
-        ".editable()",
-        ".hasInfo()",
-        ".onValueChange()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        },
+        {
+          "name": "editable",
+          "signature": "editable(_ on: Bool = true)",
+          "doc": "Whether the value can be typed (default true); `false` shows it read-only with steppers still active."
+        },
+        {
+          "name": "hasInfo",
+          "signature": "hasInfo(_ on: Bool = true)",
+          "doc": "Shows an info-circle glyph next to the label."
+        },
+        {
+          "name": "onValueChange",
+          "signature": "onValueChange(_ action: ((Int) -> Void)?)",
+          "doc": "Fires with the clamped value whenever it changes (stepper / type / commit)."
+        }
       ]
     },
     {
       "name": "MultiLineTextInput",
       "category": "Molecules",
+      "doc": "Improved, token-bound rewrite of the reference MultiLineInput \u2014 a bordered TextEditor with header label, placeholder, character counter and error state.",
       "init": "MultiLineTextInput(label, text:, placeholder:, characterLimit:, errorText:, infoMessages: \u2026)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "MultiSelect",
       "category": "Molecules",
+      "doc": "Multiple / tags select with optional search (Ant Select mode=\"multiple\").",
       "init": "MultiSelect(label:, options:, selection:, placeholder:, infoMessages:, isOptionEnabled:)",
       "modifiers": [
-        ".a11yID()",
-        ".clearable()",
-        ".loading()",
-        ".maxTags()",
-        ".searchable()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        },
+        {
+          "name": "searchable",
+          "signature": "searchable(_ on: Bool = true)",
+          "doc": "Whether the dropdown shows a search field (default true)."
+        },
+        {
+          "name": "clearable",
+          "signature": "clearable(_ on: Bool = true)",
+          "doc": "Whether a clear-all button is offered (default true)."
+        },
+        {
+          "name": "maxTags",
+          "signature": "maxTags(_ count: Int?)",
+          "doc": "Caps the visible selected-tag chips, collapsing the rest into a \"+N\" tag."
+        },
+        {
+          "name": "loading",
+          "signature": "loading(_ on: Bool = true)",
+          "doc": "Shows a loading spinner in place of the chevron (async option fetch)."
+        }
       ]
     },
     {
       "name": "OTPInput",
       "category": "Molecules",
+      "doc": "Improved, token-bound rewrite of the reference OTPInputView.",
       "init": "OTPInput(code:, digitCount:, isSecure:, errorText:, infoMessages:, onComplete:)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "Pagination",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "Pagination(current:, total:)",
       "modifiers": [
-        ".jumper()",
-        ".showTotal()",
-        ".simple()",
-        ".window()"
+        {
+          "name": "simple",
+          "signature": "simple(_ on: Bool = true)",
+          "doc": "Compact \"current / total\" mode instead of the numbered page buttons."
+        },
+        {
+          "name": "window",
+          "signature": "window(sibling: Int = 1, boundary: Int = 1)",
+          "doc": "Window size: `sibling` pages each side of the current page, `boundary` pages pinned at each end (gaps collapse to an ellipsis)."
+        },
+        {
+          "name": "jumper",
+          "signature": "jumper(_ on: Bool = true, title: String = String(themeKit: \"Go to\"))",
+          "doc": "Shows a quick-jumper field that jumps straight to a typed page number."
+        },
+        {
+          "name": "showTotal",
+          "signature": "showTotal(_ format: ((Int, Int) -> String)?)",
+          "doc": "A leading summary label built from `(current, total)` \u2014 e.g."
+        }
       ]
     },
     {
       "name": "ProgressIndicator",
       "category": "Molecules",
+      "doc": "Segmented position/progress indicator (Reference ProgressIndicator parity).",
       "init": "ProgressIndicator(variant:, current:, total:, size:, videoProgress:, stepText: \u2026)",
       "modifiers": []
     },
     {
       "name": "QuantityStepper",
       "category": "Molecules",
+      "doc": "A token-bound quantity stepper (\u2212 value +), bounded by a range.",
       "init": "QuantityStepper(value:, range:, step:)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "RadioButton",
       "category": "Molecules",
+      "doc": "Figma \"Control Items\" \u2192 Radioboxes.",
       "init": "RadioButton(label, isSelected:, type:, style:, padding:, backgroundColor: \u2026)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "RadioGroup",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "RadioGroup(title:, options:, selection:, infoMessages:, isOptionEnabled:)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "RadioButtonGroup",
       "category": "Molecules",
+      "doc": "A connected, segmented button-style single-select radio group \u2014 a distinct API from the stacked `RadioGroup` and the enclosed `SegmentedControl`.",
       "init": "RadioButtonGroup",
       "modifiers": []
     },
     {
       "name": "RangeSlider",
       "category": "Molecules",
+      "doc": "Improved, token-bound rewrite of the reference RangeSliderView \u2014 a self-contained dual-thumb slider over a numeric range (decoupled from the reference's text-field wiring).",
       "init": "RangeSlider(lowerValue:, upperValue:, in:, step:)",
       "modifiers": [
-        ".a11yID()",
-        ".inputs()",
-        ".marks()",
-        ".onChangeEnd()",
-        ".valueLabel()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        },
+        {
+          "name": "marks",
+          "signature": "marks(_ marks: [Double])",
+          "doc": "Labeled tick marks at the given values."
+        },
+        {
+          "name": "inputs",
+          "signature": "inputs(_ on: Bool = true, titles: (min: String, max: String) = (String(themeKit: \"Min\"), String(themeKit: \"Max\")))",
+          "doc": "Shows linked numeric min/max input fields above the track."
+        },
+        {
+          "name": "onChangeEnd",
+          "signature": "onChangeEnd(_ action: ((Double, Double) -> Void)?)",
+          "doc": "Fires with the snapped (lower, upper) pair when a drag ends."
+        },
+        {
+          "name": "valueLabel",
+          "signature": "valueLabel(_ format: ((Double) -> String)?)",
+          "doc": "Formats the value readout shown above each thumb (e.g."
+        }
       ]
     },
     {
       "name": "SearchBar",
       "category": "Molecules",
+      "doc": "A search field with optional typeahead suggestions, a recent-searches list and submit/clear callbacks.",
       "init": "SearchBar(text:, placeholder:, suggestions:, recent:, onSearch:)",
       "modifiers": [
-        ".a11yID()",
-        ".backButton()",
-        ".debounce()",
-        ".maxResults()",
-        ".trailingIcon()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        },
+        {
+          "name": "backButton",
+          "signature": "backButton(_ on: Bool = true, action: (() -> Void)? = nil)",
+          "doc": "Shows a leading back chevron; the optional action fires on tap."
+        },
+        {
+          "name": "trailingIcon",
+          "signature": "trailingIcon(_ systemName: String?, action: (() -> Void)? = nil)",
+          "doc": "A trailing SF Symbol button (shown when the field is empty); the optional action fires on tap (e.g."
+        },
+        {
+          "name": "debounce",
+          "signature": "debounce(_ interval: TimeInterval)",
+          "doc": "Debounce interval for typeahead / `onSearch` (async init defaults to 0.3s)."
+        },
+        {
+          "name": "maxResults",
+          "signature": "maxResults(_ count: Int)",
+          "doc": "Caps the number of suggestion rows (default 6)."
+        }
       ]
     },
     {
       "name": "SegmentedControl",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "SegmentedControl(title, systemImage:, isEnabled:)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "Select",
       "category": "Molecules",
+      "doc": "A single-select dropdown \u2014 a native `Menu` by default, or a searchable inline panel with section headers when `searchable` is on.",
       "init": "Select(title, options)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "SelectBox",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "SelectBox(label:, options:, selection:, placeholder:, hint:, errorText: \u2026)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "Slider",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "Slider(value:, in:, step:, label:)",
       "modifiers": [
-        ".a11yID()",
-        ".axis()",
-        ".marks()",
-        ".onChangeEnd()",
-        ".showsValueTooltip()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        },
+        {
+          "name": "marks",
+          "signature": "marks(_ marks: [Double: String])",
+          "doc": "Labeled tick marks at the given values (e.g."
+        },
+        {
+          "name": "axis",
+          "signature": "axis(_ axis: Axis, height: CGFloat = 160)",
+          "doc": "Lays the slider out vertically with the given track height (default 160)."
+        },
+        {
+          "name": "showsValueTooltip",
+          "signature": "showsValueTooltip(_ on: Bool = true)",
+          "doc": "Shows a value tooltip above the thumb while dragging."
+        },
+        {
+          "name": "onChangeEnd",
+          "signature": "onChangeEnd(_ action: ((Double) -> Void)?)",
+          "doc": "Fires with the snapped value when a drag ends (not on every step)."
+        }
       ]
     },
     {
       "name": "Stat",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "Stat(title:, value:, prefix:, suffix:, isLoading:, description: \u2026)",
       "modifiers": []
     },
     {
       "name": "Steps",
       "category": "Molecules",
+      "doc": "A horizontal or vertical step / progress indicator with done / active / todo / error states, an optional progress dot, and tap-to-navigate.",
       "init": "Steps(title, description:, systemImage:, state:, percent:)",
       "modifiers": []
     },
     {
       "name": "TextInput",
       "category": "Molecules",
+      "doc": "Single floating-label text field.",
       "init": "TextInput(label:, placeholder:, leadingSystemImage:, suffixSystemImage:, addonBefore:, addonAfter: \u2026)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this field (its sub-elements \u2014 label, field, clear, reveal, messages \u2014 get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "ThemeController",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "ThemeController(name:, label:)",
       "modifiers": []
     },
     {
       "name": "ThemeToggle",
       "category": "Molecules",
+      "doc": "Figma \"Control Items\" \u2192 Switch Toggles.",
       "init": "ThemeToggle(isOn:, isLoading:, onSystemImage:, offSystemImage:)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "ToggleGroup",
       "category": "Molecules",
+      "doc": "Molecule.",
       "init": "ToggleGroup(title:, options:, selection:, label:)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "TreeSelect",
       "category": "Molecules",
+      "doc": "Hierarchical (nested) select with expand/collapse and multi-selection.",
       "init": "TreeSelect(id:, title, systemImage:, children:)",
       "modifiers": []
     },
     {
       "name": "Accordion",
       "category": "Organisms",
+      "doc": "Improved, token-bound rewrite of the reference AccordionView \u2014 a single expandable row with a @ViewBuilder body instead of type-erased AnyView models.",
       "init": "Accordion(title, leadingSystemImage:, initiallyExpanded:, @ViewBuilder:)",
       "modifiers": [
-        ".density()",
-        ".divider()",
-        ".indicator()",
-        ".number()",
-        ".subtitle()",
-        ".titleSize()",
-        ".truncateSubtitle()"
+        {
+          "name": "subtitle",
+          "signature": "subtitle(_ text: String?)",
+          "doc": "A secondary line under the title."
+        },
+        {
+          "name": "number",
+          "signature": "number(_ value: Int?)",
+          "doc": "A leading two-digit number badge (e.g."
+        },
+        {
+          "name": "indicator",
+          "signature": "indicator(_ indicator: AccordionIndicator)",
+          "doc": "Expand/collapse indicator glyph (chevron / plus-minus / custom)."
+        },
+        {
+          "name": "titleSize",
+          "signature": "titleSize(_ size: AccordionTitleSize)",
+          "doc": "Title text size."
+        },
+        {
+          "name": "density",
+          "signature": "density(_ size: AccordionPaddingSize)",
+          "doc": "Header row vertical padding (default / small / large)."
+        },
+        {
+          "name": "truncateSubtitle",
+          "signature": "truncateSubtitle(_ on: Bool = true)",
+          "doc": "Clamps the subtitle to one line while collapsed."
+        },
+        {
+          "name": "divider",
+          "signature": "divider(_ on: Bool)",
+          "doc": "Whether to draw the bottom divider (default true)."
+        }
       ]
     },
     {
       "name": "AccordionGroup",
       "category": "Organisms",
+      "doc": "A group of accordion rows with single- or multiple-open behavior (the reference `AccordionView` tracks a `Set` of open ids).",
       "init": "AccordionGroup(items, mode:, initiallyExpanded:, title:)",
       "modifiers": []
     },
     {
       "name": "AlertToast",
       "category": "Organisms",
+      "doc": "Improved, token-bound rewrite of the reference AlertView \u2014 a solid-fill status banner (complements the light-surface InfoBanner).",
       "init": "AlertToast(title, handler:)",
       "modifiers": []
     },
     {
       "name": "BlogCard",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "BlogCard(title:, excerpt:, readMoreTitle:, compact:, onReadMore:)",
       "modifiers": []
     },
     {
       "name": "Callout",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "Callout(text, type:, style:, showIcon:, actionTitle:, onAction:)",
       "modifiers": []
     },
     {
       "name": "Card",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "Card(elevation:, padding:, title:, subtitle:, extraTitle:, onExtra:)",
       "modifiers": []
     },
     {
       "name": "CardStack",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "CardStack(items, @ViewBuilder:)",
       "modifiers": []
     },
     {
       "name": "Carousel",
       "category": "Organisms",
+      "doc": "A generic paging carousel with dot indicators, optional autoplay and optional prev/next arrows.",
       "init": "Carousel(items, loop:, currentIndex:, @ViewBuilder:)",
       "modifiers": [
-        ".arrows()",
-        ".autoplay()",
-        ".dots()",
-        ".fade()"
+        {
+          "name": "autoplay",
+          "signature": "autoplay(_ interval: TimeInterval?)",
+          "doc": "Advances pages automatically every `interval` seconds."
+        },
+        {
+          "name": "arrows",
+          "signature": "arrows(_ on: Bool = true)",
+          "doc": "Shows prev / next arrow buttons."
+        },
+        {
+          "name": "dots",
+          "signature": "dots(_ on: Bool = true, position: Edge = .bottom)",
+          "doc": "Shows the page-dot indicators (default true) and where they sit."
+        },
+        {
+          "name": "fade",
+          "signature": "fade(_ on: Bool = true)",
+          "doc": "Cross-fades between pages instead of sliding."
+        }
       ]
     },
     {
       "name": "ChatBubble",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "ChatBubble(text, side:, author:, time:, avatarSystemImage:)",
       "modifiers": []
     },
     {
       "name": "Counter",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "Counter(value:, label:)",
       "modifiers": []
     },
     {
       "name": "Coupon",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "Coupon(code:, label:, style:, onCopy:)",
       "modifiers": []
     },
     {
       "name": "DataTable",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "DataTable(title, align:, sortKey:)",
       "modifiers": []
     },
     {
       "name": "Diff",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "Diff(aspectRatio:, @ViewBuilder:)",
       "modifiers": []
     },
     {
       "name": "EmptyState",
       "category": "Organisms",
+      "doc": "Improved, token-bound rewrite of the reference EmptyCardView.",
       "init": "EmptyState(systemImage:, iconForeground:, iconBackground:, iconCircleSize:, title:, message: \u2026)",
       "modifiers": []
     },
     {
       "name": "FloatingActionButton",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "FloatingActionButton(systemImage:, label:, action:)",
       "modifiers": []
     },
     {
       "name": "Footer",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "Footer(title, action:)",
       "modifiers": []
     },
     {
       "name": "Gallery",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "Gallery(items, columns:, aspect:, @ViewBuilder:)",
       "modifiers": []
     },
     {
       "name": "Hero",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "Hero(title:, subtitle:, ctaTitle:, dark:, action:)",
       "modifiers": []
     },
     {
       "name": "HeroSurface",
       "category": "Organisms",
+      "doc": "The default `Hero` surface.",
       "init": "HeroSurface",
       "modifiers": []
     },
     {
       "name": "ImageCollage",
       "category": "Organisms",
+      "doc": "A gallery collage of remote images with count-aware layouts (1 / 2 / 3 / 4+) and a \"+N\" overlay on the last visible tile.",
       "init": "ImageCollage(urls, height:, spacing:, cornerRadius:, onTap:)",
       "modifiers": []
     },
     {
       "name": "InfoBanner",
       "category": "Organisms",
+      "doc": "Improved, token-bound rewrite of the reference InfoMessage.",
       "init": "InfoBanner(message, type:, title:, links:)",
       "modifiers": []
     },
     {
       "name": "KeyValueTable",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "KeyValueTable(label, value:, style:)",
       "modifiers": []
     },
     {
       "name": "ListRow",
       "category": "Organisms",
+      "doc": "A flexible list row that consolidates the reference ListItem family (Default / Chevron / Checkbox / Radio / Menu / Quick-action) into one token-bound view.",
       "init": "ListRow(total:, each:, unit:)",
       "modifiers": []
     },
     {
       "name": "ListSectionHeader",
       "category": "Organisms",
+      "doc": "A non-interactive section-header row inside a list (Reference menu `.secondary`).",
       "init": "ListSectionHeader",
       "modifiers": []
     },
     {
       "name": "ListView",
       "category": "Organisms",
+      "doc": "Ant-style List container: optional header/footer, bordered surface, row dividers (split), and a loading (skeleton) state.",
       "init": "ListView(items, header:, footer:, bordered:, loading:, split: \u2026)",
       "modifiers": []
     },
     {
       "name": "MenuCard",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "MenuCard(title:, subtitle:, systemImage:, action:)",
       "modifiers": []
     },
     {
       "name": "NavigationBar",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "NavigationBar(systemImage:, activeSystemImage:)",
       "modifiers": []
     },
     {
       "name": "NotificationCard",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "NotificationCard(title:, message:, date:, isUnread:, type:, onClose:)",
       "modifiers": []
     },
     {
       "name": "PageHeader",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "PageHeader(systemImage:, handler:)",
       "modifiers": []
     },
     {
       "name": "PagingCarousel",
       "category": "Organisms",
+      "doc": "Custom drag-paging carousel with PEEKING neighbors + threshold snap (the reference `PagingScrollView`).",
       "init": "PagingCarousel(items, peek:, spacing:, autoplay:, @ViewBuilder:)",
       "modifiers": []
     },
     {
       "name": "PromoBanner",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "PromoBanner(title:, subtitle:, systemImage:, ctaTitle:, tint:, action:)",
       "modifiers": []
     },
     {
       "name": "RatingSummary",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "RatingSummary(score:, label:, reviewCount:, onReviews:)",
       "modifiers": []
     },
     {
       "name": "ResultView",
       "category": "Organisms",
+      "doc": "Ant-style \"Result\" template: a full-page status view for the outcome of an operation (success / info / warning / error) or an exception page (404 / 403 / 500), with up to two actions.",
       "init": "ResultView(status, title:, message:, primaryTitle:, onPrimary:)",
       "modifiers": []
     },
     {
       "name": "SegmentedTabBar",
       "category": "Organisms",
+      "doc": "Tab bar with a selection binding and an animated underline.",
       "init": "SegmentedTabBar(title, caption:, systemImage:, trailingSystemImage:, badge:, isEnabled:)",
       "modifiers": [
-        ".a11yID()"
+        {
+          "name": "a11yID",
+          "signature": "a11yID(_ id: String?)",
+          "doc": "Sets the accessibility-identifier namespace for this component (its sub-elements get `\"<id>.<element>\"`)."
+        }
       ]
     },
     {
       "name": "RadioCard",
       "category": "Organisms",
+      "doc": "Organisms.",
       "init": "RadioCard(title, description:, isSelected:, isEnabled:, action:)",
       "modifiers": []
     },
     {
       "name": "CheckboxCard",
       "category": "Organisms",
+      "doc": "",
       "init": "CheckboxCard",
       "modifiers": []
     },
     {
       "name": "ThemePicker",
       "category": "Organisms",
+      "doc": "A grid of `DaisyTheme` preview cards.",
       "init": "ThemePicker(selection:, themes:, onSelect:)",
       "modifiers": []
     },
     {
       "name": "Timeline",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "Timeline(title:, time:, description:, systemImage:, state:, color:)",
       "modifiers": []
     },
     {
       "name": "Upload",
       "category": "Organisms",
+      "doc": "Organism.",
       "init": "Upload(id:, name:, status:)",
       "modifiers": []
     },
     {
       "name": "UploadList",
       "category": "Organisms",
+      "doc": "`Upload` wired to an `UploadController` \u2014 renders its files with remove + retry.",
       "init": "UploadList",
       "modifiers": []
     },
     {
       "name": "VideoPlayerView",
       "category": "Organisms",
+      "doc": "Inline video on AVKit (reference `InlineVideoPlayerView`): autoplay, loop, mute, aspect-fill, and active-gating (only the visible item plays).",
       "init": "VideoPlayerView(url, progress:, isMuted:, onTap:)",
       "modifiers": [
-        ".autoplay()",
-        ".loop()",
-        ".muteToggle()",
-        ".muted()",
-        ".tapToToggle()"
+        {
+          "name": "autoplay",
+          "signature": "autoplay(_ on: Bool = true)",
+          "doc": "Whether the video starts playing on appear (default true)."
+        },
+        {
+          "name": "loop",
+          "signature": "loop(_ on: Bool = true)",
+          "doc": "Whether playback loops back to the start (default true)."
+        },
+        {
+          "name": "muted",
+          "signature": "muted(_ on: Bool = true)",
+          "doc": "Whether the audio starts muted (default true \u2014 required for iOS inline autoplay)."
+        },
+        {
+          "name": "muteToggle",
+          "signature": "muteToggle(_ on: Bool = true)",
+          "doc": "Shows a mute/unmute toggle button overlay."
+        },
+        {
+          "name": "tapToToggle",
+          "signature": "tapToToggle(_ on: Bool = true)",
+          "doc": "Whether tapping the video toggles play/pause."
+        }
       ]
     }
   ],
@@ -939,131 +1410,259 @@
   "themes": [
     {
       "id": "light",
-      "name": "Light"
+      "name": "Light",
+      "primary": "422ad5",
+      "secondary": "009689",
+      "accent": "00d3bb",
+      "base": "ffffff"
     },
     {
       "id": "dark",
-      "name": "Dark"
+      "name": "Dark",
+      "primary": "605dff",
+      "secondary": "f43098",
+      "accent": "00d3bb",
+      "base": "1d232a"
     },
     {
       "id": "cupcake",
-      "name": "Cupcake"
+      "name": "Cupcake",
+      "primary": "65c3c8",
+      "secondary": "ef9fbc",
+      "accent": "eeaf3a",
+      "base": "faf7f5"
     },
     {
       "id": "bumblebee",
-      "name": "Bumblebee"
+      "name": "Bumblebee",
+      "primary": "e0a82e",
+      "secondary": "f9d72f",
+      "accent": "181830",
+      "base": "fffbeb"
     },
     {
       "id": "emerald",
-      "name": "Emerald"
+      "name": "Emerald",
+      "primary": "66cc8a",
+      "secondary": "377cfb",
+      "accent": "ea5234",
+      "base": "ffffff"
     },
     {
       "id": "corporate",
-      "name": "Corporate"
+      "name": "Corporate",
+      "primary": "4b6bfb",
+      "secondary": "7b92b2",
+      "accent": "67cba0",
+      "base": "ffffff"
     },
     {
       "id": "synthwave",
-      "name": "Synthwave"
+      "name": "Synthwave",
+      "primary": "e779c1",
+      "secondary": "58c7f3",
+      "accent": "f3cc30",
+      "base": "1a103c"
     },
     {
       "id": "retro",
-      "name": "Retro"
+      "name": "Retro",
+      "primary": "ef9995",
+      "secondary": "a4cbb4",
+      "accent": "dc8850",
+      "base": "ece3ca"
     },
     {
       "id": "cyberpunk",
-      "name": "Cyberpunk"
+      "name": "Cyberpunk",
+      "primary": "ff7598",
+      "secondary": "75d1f0",
+      "accent": "c07eec",
+      "base": "fff248"
     },
     {
       "id": "valentine",
-      "name": "Valentine"
+      "name": "Valentine",
+      "primary": "e96d7b",
+      "secondary": "a991f7",
+      "accent": "88dbdd",
+      "base": "fae7f4"
     },
     {
       "id": "halloween",
-      "name": "Halloween"
+      "name": "Halloween",
+      "primary": "f28c18",
+      "secondary": "6d3a9c",
+      "accent": "51a800",
+      "base": "212121"
     },
     {
       "id": "garden",
-      "name": "Garden"
+      "name": "Garden",
+      "primary": "5c7f67",
+      "secondary": "5a5b9f",
+      "accent": "ef9fbc",
+      "base": "e9e7e7"
     },
     {
       "id": "forest",
-      "name": "Forest"
+      "name": "Forest",
+      "primary": "1eb854",
+      "secondary": "1db990",
+      "accent": "1db98a",
+      "base": "171212"
     },
     {
       "id": "aqua",
-      "name": "Aqua"
+      "name": "Aqua",
+      "primary": "09ecf3",
+      "secondary": "966fb3",
+      "accent": "ffe999",
+      "base": "345da7"
     },
     {
       "id": "lofi",
-      "name": "Lo-Fi"
+      "name": "Lo-Fi",
+      "primary": "0d0d0d",
+      "secondary": "1a1919",
+      "accent": "262626",
+      "base": "ffffff"
     },
     {
       "id": "pastel",
-      "name": "Pastel"
+      "name": "Pastel",
+      "primary": "d1c1d7",
+      "secondary": "f6cbd1",
+      "accent": "b4e9d6",
+      "base": "ffffff"
     },
     {
       "id": "fantasy",
-      "name": "Fantasy"
+      "name": "Fantasy",
+      "primary": "6e0b75",
+      "secondary": "0075be",
+      "accent": "ff8d05",
+      "base": "ffffff"
     },
     {
       "id": "wireframe",
-      "name": "Wireframe"
+      "name": "Wireframe",
+      "primary": "b8b8b8",
+      "secondary": "b8b8b8",
+      "accent": "b8b8b8",
+      "base": "ffffff"
     },
     {
       "id": "black",
-      "name": "Black"
+      "name": "Black",
+      "primary": "373737",
+      "secondary": "373737",
+      "accent": "373737",
+      "base": "000000"
     },
     {
       "id": "luxury",
-      "name": "Luxury"
+      "name": "Luxury",
+      "primary": "d4af37",
+      "secondary": "152747",
+      "accent": "513448",
+      "base": "09090b"
     },
     {
       "id": "dracula",
-      "name": "Dracula"
+      "name": "Dracula",
+      "primary": "ff79c6",
+      "secondary": "bd93f9",
+      "accent": "ffb86c",
+      "base": "282a36"
     },
     {
       "id": "cmyk",
-      "name": "CMYK"
+      "name": "CMYK",
+      "primary": "45aeee",
+      "secondary": "e8488a",
+      "accent": "fff232",
+      "base": "ffffff"
     },
     {
       "id": "autumn",
-      "name": "Autumn"
+      "name": "Autumn",
+      "primary": "8c0327",
+      "secondary": "d85251",
+      "accent": "d59b6a",
+      "base": "f1f1f1"
     },
     {
       "id": "business",
-      "name": "Business"
+      "name": "Business",
+      "primary": "1c4e80",
+      "secondary": "7c909a",
+      "accent": "ea6947",
+      "base": "202020"
     },
     {
       "id": "acid",
-      "name": "Acid"
+      "name": "Acid",
+      "primary": "ff00f4",
+      "secondary": "ff7400",
+      "accent": "cbfd03",
+      "base": "fafafa"
     },
     {
       "id": "lemonade",
-      "name": "Lemonade"
+      "name": "Lemonade",
+      "primary": "519903",
+      "secondary": "e9e92f",
+      "accent": "f7fd03",
+      "base": "ffffff"
     },
     {
       "id": "night",
-      "name": "Night"
+      "name": "Night",
+      "primary": "38bdf8",
+      "secondary": "818cf8",
+      "accent": "f471b5",
+      "base": "0f172a"
     },
     {
       "id": "coffee",
-      "name": "Coffee"
+      "name": "Coffee",
+      "primary": "db924b",
+      "secondary": "6f4e37",
+      "accent": "10576d",
+      "base": "20161f"
     },
     {
       "id": "winter",
-      "name": "Winter"
+      "name": "Winter",
+      "primary": "047aff",
+      "secondary": "463aa2",
+      "accent": "c148ac",
+      "base": "ffffff"
     },
     {
       "id": "dim",
-      "name": "Dim"
+      "name": "Dim",
+      "primary": "9fe88d",
+      "secondary": "ff7d5c",
+      "accent": "c792e9",
+      "base": "2a303c"
     },
     {
       "id": "nord",
-      "name": "Nord"
+      "name": "Nord",
+      "primary": "5e81ac",
+      "secondary": "81a1c1",
+      "accent": "88c0d0",
+      "base": "eceff4"
     },
     {
       "id": "sunset",
-      "name": "Sunset"
+      "name": "Sunset",
+      "primary": "ff865b",
+      "secondary": "fd6f9c",
+      "accent": "b387fa",
+      "base": "1a1626"
     }
   ]
 }

--- a/skills/themekit/references/components.md
+++ b/skills/themekit/references/components.md
@@ -5,127 +5,127 @@
 
 ## Atoms (29)
 
-- `AnimatedImage(url, contentMode:, cornerRadius:)`
-- `Avatar(content, size:, background:, shape:, presence:, presencePulse:)`
-- `AvatarGroup`
-- `Badge(text, style:, variant:, size:, leadingSystemImage:, action:)` — modifiers: `.badgeColor()`, `.badgeShape()`, `.gradient()`, `.highlighted()`, `.trailingIcon()`
-- `Chip(title, isSelected:, size:, selectionStyle:)` — modifiers: `.exists()`, `.expands()`, `.icon()`, `.interactive()`, `.rating()`
-- `Ribbon(text, color:, @ViewBuilder:)`
-- `DividerView(size:, axis:, dashed:, title:, titleAlign:)`
-- `GaugeView(value:, in:, label:, style:, showsValue:)`
-- `Icon(systemName:, size:, color:)`
-- `InlineText(text, links:)`
-- `InputLabel(text, isRequired:, hasInfo:, hasError:)`
-- `Join(axis, @ViewBuilder:)`
-- `Kbd(text)`
-- `ProgressBar(value:, showPercentage:, status:)` — modifiers: `.barHeight()`, `.colors()`, `.gradient()`, `.progressLabel()`, `.steps()`, `.successSegment()`, `.valueFormat()`
-- `StepIndicator`
-- `RadialProgress(value:, size:, lineWidth:, showLabel:, status:, dashboard: …)`
-- `Rating(value:, layout:, countLabel:)` — modifiers: `.allowHalf()`, `.maxValue()`, `.onRate()`, `.onReviewTap()`, `.sentiment()`, `.starSize()`, `.symbol()`
-- `RemoteImage(url, aspectRatio:, contentMode:, cornerRadius:, circle:)`
-- `RollingNumber(value, size:, weight:, color:)`
-- `ScoreBadge(score, large:)`
-- `ShareButton(title, item:)`
-- `Skeleton(shape, width:, height:)`
-- `Spinner(size:, lineWidth:, color:)`
-- `StatusDot(kind, size:, label:, pulse:)`
-- `Swap(isOn:, on:, off:, size:, rotate:)` — modifiers: `.a11yID()`
-- `Tag(text, leadingSystemImage:, style:, variant:, onRemove:)`
-- `TextLink(title, underline:, action:)`
-- `TextRotate(words, interval:)`
-- `Title(text, subtitle:, eyebrow:, actionTitle:, action:)`
+- `AnimatedImage(url, contentMode:, cornerRadius:)` — Animated GIF / APNG playback with NO third-party dependency — frames and per-frame delays are decoded natively via ImageIO (`CGImageSource`) and driven by a `TimelineView(.animation)`.
+- `Avatar(content, size:, background:, shape:, presence:, presencePulse:)` — Atom.
+- `AvatarGroup` — Overlapping stack of avatars with a "+N" overflow bubble.
+- `Badge(text, style:, variant:, size:, leadingSystemImage:, action:)` — Improved, token-bound rewrite of the reference BadgeView. · modifiers: `.badgeShape()`, `.trailingIcon()`, `.badgeColor()`, `.gradient()`, `.highlighted()`
+- `Chip(title, isSelected:, size:, selectionStyle:)` — Improved, token-bound rewrite of the reference BasicChip — a single clear selection API (tonal / solid) instead of the reference's nested status × mode × fullSelect × isExist matrix. · modifiers: `.icon()`, `.rating()`, `.exists()`, `.interactive()`, `.expands()`
+- `Ribbon(text, color:, @ViewBuilder:)` — A corner ribbon wrapping any content (Ant `Badge.Ribbon`).
+- `DividerView(size:, axis:, dashed:, title:, titleAlign:)` — A theme-driven divider: horizontal / vertical, solid / dashed, with an optional inline text label (left / center / right).
+- `GaugeView(value:, in:, label:, style:, showsValue:)` — Atom.
+- `Icon(systemName:, size:, color:)` — Icon system.
+- `InlineText(text, links:)` — Atom.
+- `InputLabel(text, isRequired:, hasInfo:, hasError:)` — Atom.
+- `Join(axis, @ViewBuilder:)` — Atom.
+- `Kbd(text)` — Atom.
+- `ProgressBar(value:, showPercentage:, status:)` — Linear determinate progress with status colors, an optional ladder gradient, a segmented (steps) variant and a custom format label. · modifiers: `.barHeight()`, `.gradient()`, `.steps()`, `.colors()`, `.successSegment()`, `.valueFormat()`, `.progressLabel()`
+- `StepIndicator` — Segmented step indicator (e.g.
+- `RadialProgress(value:, size:, lineWidth:, showLabel:, status:, dashboard: …)` — Atom.
+- `Rating(value:, layout:, countLabel:)` — Star rating with two layouts (stars / numeric-leading), continuous fractional fill (display) or half-step interaction, a tappable review count, a custom character and a disabled state. · modifiers: `.maxValue()`, `.starSize()`, `.allowHalf()`, `.symbol()`, `.sentiment()`, `.onRate()`, `.onReviewTap()`
+- `RemoteImage(url, aspectRatio:, contentMode:, cornerRadius:, circle:)` — Async remote image on native `AsyncImage` (no Kingfisher dependency): URL + aspect ratio (number or "16:9" string) + shimmer placeholder + failure state.
+- `RollingNumber(value, size:, weight:, color:)` — Odometer / slot-machine number — each digit column rolls vertically to its new value when `value` changes (reference `RollingText`).
+- `ScoreBadge(score, large:)` — Atom.
+- `ShareButton(title, item:)` — Atom.
+- `Skeleton(shape, width:, height:)` — A standalone skeleton block of an arbitrary shape and size.
+- `Spinner(size:, lineWidth:, color:)` — Atom.
+- `StatusDot(kind, size:, label:, pulse:)` — Atom.
+- `Swap(isOn:, on:, off:, size:, rotate:)` — Atom. · modifiers: `.a11yID()`
+- `Tag(text, leadingSystemImage:, style:, variant:, onRemove:)` — Atom.
+- `TextLink(title, underline:, action:)` — Atom.
+- `TextRotate(words, interval:)` — Atom.
+- `Title(text, subtitle:, eyebrow:, actionTitle:, action:)` — Atom.
 
 ## Molecules (45)
 
-- `Autocomplete(label:, text:, suggestions:, placeholder:, onSelect:)` — modifiers: `.a11yID()`, `.debounce()`, `.maxResults()`, `.onSearch()`, `.suggestionEnabled()`
-- `Breadcrumbs(title, action:)`
-- `ButtonGroup(axis, @ViewBuilder:)`
+- `Autocomplete(label:, text:, suggestions:, placeholder:, onSelect:)` — Molecule. · modifiers: `.a11yID()`, `.maxResults()`, `.debounce()`, `.suggestionEnabled()`, `.onSearch()`
+- `Breadcrumbs(title, action:)` — Molecule.
+- `ButtonGroup(axis, @ViewBuilder:)` — Molecule.
 - `PrimaryButton(title, size:, block:, helperText:, textStyle:, confirmsSuccess: …)`
 - `SecondaryButton`
 - `OutlineButton`
 - `GhostButton`
 - `LinkButton`
 - `ThemeButton(title, systemImage:, iconPosition:, color:, variant:, size: …)`
-- `CalendarView(selection:)`
-- `Checkbox(label, isChecked:, customSize:, type:, isIndeterminate:, alignment: …)` — modifiers: `.a11yID()`
-- `CheckboxGroup(title:, options:, selection:, infoMessages:, selectAllTitle:, isOptionEnabled:)` — modifiers: `.a11yID()`
-- `ImageChip(isSelected:, url:, size:, isEnabled:)`
-- `CompactChip`
-- `ChoseChip`
-- `FilterChip`
-- `ChipGroup`
-- `ColorField(label, selection:, supportsOpacity:)`
-- `DateField(label:, date:, placeholder:, range:, style:, locale: …)` — modifiers: `.a11yID()`
-- `Fieldset(title, helper:, @ViewBuilder:)`
-- `FileInput(label:, fileName:, buttonTitle:, placeholder:, infoMessages:, onPick:)`
-- `FilterGroup(title:, options:, selection:, label:)`
-- `InputNumber(label:, value:, range:, step:, unit:, hint: …)` — modifiers: `.a11yID()`, `.editable()`, `.hasInfo()`, `.onValueChange()`
-- `MultiLineTextInput(label, text:, placeholder:, characterLimit:, errorText:, infoMessages: …)` — modifiers: `.a11yID()`
-- `MultiSelect(label:, options:, selection:, placeholder:, infoMessages:, isOptionEnabled:)` — modifiers: `.a11yID()`, `.clearable()`, `.loading()`, `.maxTags()`, `.searchable()`
-- `OTPInput(code:, digitCount:, isSecure:, errorText:, infoMessages:, onComplete:)` — modifiers: `.a11yID()`
-- `Pagination(current:, total:)` — modifiers: `.jumper()`, `.showTotal()`, `.simple()`, `.window()`
-- `ProgressIndicator(variant:, current:, total:, size:, videoProgress:, stepText: …)`
-- `QuantityStepper(value:, range:, step:)` — modifiers: `.a11yID()`
-- `RadioButton(label, isSelected:, type:, style:, padding:, backgroundColor: …)` — modifiers: `.a11yID()`
-- `RadioGroup(title:, options:, selection:, infoMessages:, isOptionEnabled:)` — modifiers: `.a11yID()`
-- `RadioButtonGroup`
-- `RangeSlider(lowerValue:, upperValue:, in:, step:)` — modifiers: `.a11yID()`, `.inputs()`, `.marks()`, `.onChangeEnd()`, `.valueLabel()`
-- `SearchBar(text:, placeholder:, suggestions:, recent:, onSearch:)` — modifiers: `.a11yID()`, `.backButton()`, `.debounce()`, `.maxResults()`, `.trailingIcon()`
-- `SegmentedControl(title, systemImage:, isEnabled:)` — modifiers: `.a11yID()`
-- `Select(title, options)` — modifiers: `.a11yID()`
-- `SelectBox(label:, options:, selection:, placeholder:, hint:, errorText: …)` — modifiers: `.a11yID()`
-- `Slider(value:, in:, step:, label:)` — modifiers: `.a11yID()`, `.axis()`, `.marks()`, `.onChangeEnd()`, `.showsValueTooltip()`
-- `Stat(title:, value:, prefix:, suffix:, isLoading:, description: …)`
-- `Steps(title, description:, systemImage:, state:, percent:)`
-- `TextInput(label:, placeholder:, leadingSystemImage:, suffixSystemImage:, addonBefore:, addonAfter: …)` — modifiers: `.a11yID()`
-- `ThemeController(name:, label:)`
-- `ThemeToggle(isOn:, isLoading:, onSystemImage:, offSystemImage:)` — modifiers: `.a11yID()`
-- `ToggleGroup(title:, options:, selection:, label:)` — modifiers: `.a11yID()`
-- `TreeSelect(id:, title, systemImage:, children:)`
+- `CalendarView(selection:)` — Molecule.
+- `Checkbox(label, isChecked:, customSize:, type:, isIndeterminate:, alignment: …)` — Figma "Control Items" → Checkboxes. · modifiers: `.a11yID()`
+- `CheckboxGroup(title:, options:, selection:, infoMessages:, selectAllTitle:, isOptionEnabled:)` — Molecule. · modifiers: `.a11yID()`
+- `ImageChip(isSelected:, url:, size:, isEnabled:)` — A selectable remote-image tile with a selection border.
+- `CompactChip` — A selectable card: an optional rating + label row, then an optional logo + price row.
+- `ChoseChip` — A selectable card: a leading icon, a title with an optional "free" gradient badge, and a rating + description row.
+- `FilterChip` — A dismissible filter chip in a pill (with a soft shadow) or square shape.
+- `ChipGroup` — A horizontally-scrolling, multi-select chip group backed by a `Set` binding.
+- `ColorField(label, selection:, supportsOpacity:)` — Molecule.
+- `DateField(label:, date:, placeholder:, range:, style:, locale: …)` — Molecule. · modifiers: `.a11yID()`
+- `Fieldset(title, helper:, @ViewBuilder:)` — Molecule.
+- `FileInput(label:, fileName:, buttonTitle:, placeholder:, infoMessages:, onPick:)` — Molecule.
+- `FilterGroup(title:, options:, selection:, label:)` — Molecule.
+- `InputNumber(label:, value:, range:, step:, unit:, hint: …)` — Molecule. · modifiers: `.a11yID()`, `.editable()`, `.hasInfo()`, `.onValueChange()`
+- `MultiLineTextInput(label, text:, placeholder:, characterLimit:, errorText:, infoMessages: …)` — Improved, token-bound rewrite of the reference MultiLineInput — a bordered TextEditor with header label, placeholder, character counter and error state. · modifiers: `.a11yID()`
+- `MultiSelect(label:, options:, selection:, placeholder:, infoMessages:, isOptionEnabled:)` — Multiple / tags select with optional search (Ant Select mode="multiple"). · modifiers: `.a11yID()`, `.searchable()`, `.clearable()`, `.maxTags()`, `.loading()`
+- `OTPInput(code:, digitCount:, isSecure:, errorText:, infoMessages:, onComplete:)` — Improved, token-bound rewrite of the reference OTPInputView. · modifiers: `.a11yID()`
+- `Pagination(current:, total:)` — Molecule. · modifiers: `.simple()`, `.window()`, `.jumper()`, `.showTotal()`
+- `ProgressIndicator(variant:, current:, total:, size:, videoProgress:, stepText: …)` — Segmented position/progress indicator (Reference ProgressIndicator parity).
+- `QuantityStepper(value:, range:, step:)` — A token-bound quantity stepper (− value +), bounded by a range. · modifiers: `.a11yID()`
+- `RadioButton(label, isSelected:, type:, style:, padding:, backgroundColor: …)` — Figma "Control Items" → Radioboxes. · modifiers: `.a11yID()`
+- `RadioGroup(title:, options:, selection:, infoMessages:, isOptionEnabled:)` — Molecule. · modifiers: `.a11yID()`
+- `RadioButtonGroup` — A connected, segmented button-style single-select radio group — a distinct API from the stacked `RadioGroup` and the enclosed `SegmentedControl`.
+- `RangeSlider(lowerValue:, upperValue:, in:, step:)` — Improved, token-bound rewrite of the reference RangeSliderView — a self-contained dual-thumb slider over a numeric range (decoupled from the reference's text-field wiring). · modifiers: `.a11yID()`, `.marks()`, `.inputs()`, `.onChangeEnd()`, `.valueLabel()`
+- `SearchBar(text:, placeholder:, suggestions:, recent:, onSearch:)` — A search field with optional typeahead suggestions, a recent-searches list and submit/clear callbacks. · modifiers: `.a11yID()`, `.backButton()`, `.trailingIcon()`, `.debounce()`, `.maxResults()`
+- `SegmentedControl(title, systemImage:, isEnabled:)` — Molecule. · modifiers: `.a11yID()`
+- `Select(title, options)` — A single-select dropdown — a native `Menu` by default, or a searchable inline panel with section headers when `searchable` is on. · modifiers: `.a11yID()`
+- `SelectBox(label:, options:, selection:, placeholder:, hint:, errorText: …)` — Molecule. · modifiers: `.a11yID()`
+- `Slider(value:, in:, step:, label:)` — Molecule. · modifiers: `.a11yID()`, `.marks()`, `.axis()`, `.showsValueTooltip()`, `.onChangeEnd()`
+- `Stat(title:, value:, prefix:, suffix:, isLoading:, description: …)` — Molecule.
+- `Steps(title, description:, systemImage:, state:, percent:)` — A horizontal or vertical step / progress indicator with done / active / todo / error states, an optional progress dot, and tap-to-navigate.
+- `TextInput(label:, placeholder:, leadingSystemImage:, suffixSystemImage:, addonBefore:, addonAfter: …)` — Single floating-label text field. · modifiers: `.a11yID()`
+- `ThemeController(name:, label:)` — Molecule.
+- `ThemeToggle(isOn:, isLoading:, onSystemImage:, offSystemImage:)` — Figma "Control Items" → Switch Toggles. · modifiers: `.a11yID()`
+- `ToggleGroup(title:, options:, selection:, label:)` — Molecule. · modifiers: `.a11yID()`
+- `TreeSelect(id:, title, systemImage:, children:)` — Hierarchical (nested) select with expand/collapse and multi-selection.
 
 ## Organisms (41)
 
-- `Accordion(title, leadingSystemImage:, initiallyExpanded:, @ViewBuilder:)` — modifiers: `.density()`, `.divider()`, `.indicator()`, `.number()`, `.subtitle()`, `.titleSize()`, `.truncateSubtitle()`
-- `AccordionGroup(items, mode:, initiallyExpanded:, title:)`
-- `AlertToast(title, handler:)`
-- `BlogCard(title:, excerpt:, readMoreTitle:, compact:, onReadMore:)`
-- `Callout(text, type:, style:, showIcon:, actionTitle:, onAction:)`
-- `Card(elevation:, padding:, title:, subtitle:, extraTitle:, onExtra:)`
-- `CardStack(items, @ViewBuilder:)`
-- `Carousel(items, loop:, currentIndex:, @ViewBuilder:)` — modifiers: `.arrows()`, `.autoplay()`, `.dots()`, `.fade()`
-- `ChatBubble(text, side:, author:, time:, avatarSystemImage:)`
-- `Counter(value:, label:)`
-- `Coupon(code:, label:, style:, onCopy:)`
-- `DataTable(title, align:, sortKey:)`
-- `Diff(aspectRatio:, @ViewBuilder:)`
-- `EmptyState(systemImage:, iconForeground:, iconBackground:, iconCircleSize:, title:, message: …)`
-- `FloatingActionButton(systemImage:, label:, action:)`
-- `Footer(title, action:)`
-- `Gallery(items, columns:, aspect:, @ViewBuilder:)`
-- `Hero(title:, subtitle:, ctaTitle:, dark:, action:)`
-- `HeroSurface`
-- `ImageCollage(urls, height:, spacing:, cornerRadius:, onTap:)`
-- `InfoBanner(message, type:, title:, links:)`
-- `KeyValueTable(label, value:, style:)`
-- `ListRow(total:, each:, unit:)`
-- `ListSectionHeader`
-- `ListView(items, header:, footer:, bordered:, loading:, split: …)`
-- `MenuCard(title:, subtitle:, systemImage:, action:)`
-- `NavigationBar(systemImage:, activeSystemImage:)`
-- `NotificationCard(title:, message:, date:, isUnread:, type:, onClose:)`
-- `PageHeader(systemImage:, handler:)`
-- `PagingCarousel(items, peek:, spacing:, autoplay:, @ViewBuilder:)`
-- `PromoBanner(title:, subtitle:, systemImage:, ctaTitle:, tint:, action:)`
-- `RatingSummary(score:, label:, reviewCount:, onReviews:)`
-- `ResultView(status, title:, message:, primaryTitle:, onPrimary:)`
-- `SegmentedTabBar(title, caption:, systemImage:, trailingSystemImage:, badge:, isEnabled:)` — modifiers: `.a11yID()`
-- `RadioCard(title, description:, isSelected:, isEnabled:, action:)`
+- `Accordion(title, leadingSystemImage:, initiallyExpanded:, @ViewBuilder:)` — Improved, token-bound rewrite of the reference AccordionView — a single expandable row with a @ViewBuilder body instead of type-erased AnyView models. · modifiers: `.subtitle()`, `.number()`, `.indicator()`, `.titleSize()`, `.density()`, `.truncateSubtitle()`, `.divider()`
+- `AccordionGroup(items, mode:, initiallyExpanded:, title:)` — A group of accordion rows with single- or multiple-open behavior (the reference `AccordionView` tracks a `Set` of open ids).
+- `AlertToast(title, handler:)` — Improved, token-bound rewrite of the reference AlertView — a solid-fill status banner (complements the light-surface InfoBanner).
+- `BlogCard(title:, excerpt:, readMoreTitle:, compact:, onReadMore:)` — Organism.
+- `Callout(text, type:, style:, showIcon:, actionTitle:, onAction:)` — Organism.
+- `Card(elevation:, padding:, title:, subtitle:, extraTitle:, onExtra:)` — Organism.
+- `CardStack(items, @ViewBuilder:)` — Organism.
+- `Carousel(items, loop:, currentIndex:, @ViewBuilder:)` — A generic paging carousel with dot indicators, optional autoplay and optional prev/next arrows. · modifiers: `.autoplay()`, `.arrows()`, `.dots()`, `.fade()`
+- `ChatBubble(text, side:, author:, time:, avatarSystemImage:)` — Organism.
+- `Counter(value:, label:)` — Organism.
+- `Coupon(code:, label:, style:, onCopy:)` — Organism.
+- `DataTable(title, align:, sortKey:)` — Organism.
+- `Diff(aspectRatio:, @ViewBuilder:)` — Organism.
+- `EmptyState(systemImage:, iconForeground:, iconBackground:, iconCircleSize:, title:, message: …)` — Improved, token-bound rewrite of the reference EmptyCardView.
+- `FloatingActionButton(systemImage:, label:, action:)` — Organism.
+- `Footer(title, action:)` — Organism.
+- `Gallery(items, columns:, aspect:, @ViewBuilder:)` — Organism.
+- `Hero(title:, subtitle:, ctaTitle:, dark:, action:)` — Organism.
+- `HeroSurface` — The default `Hero` surface.
+- `ImageCollage(urls, height:, spacing:, cornerRadius:, onTap:)` — A gallery collage of remote images with count-aware layouts (1 / 2 / 3 / 4+) and a "+N" overlay on the last visible tile.
+- `InfoBanner(message, type:, title:, links:)` — Improved, token-bound rewrite of the reference InfoMessage.
+- `KeyValueTable(label, value:, style:)` — Organism.
+- `ListRow(total:, each:, unit:)` — A flexible list row that consolidates the reference ListItem family (Default / Chevron / Checkbox / Radio / Menu / Quick-action) into one token-bound view.
+- `ListSectionHeader` — A non-interactive section-header row inside a list (Reference menu `.secondary`).
+- `ListView(items, header:, footer:, bordered:, loading:, split: …)` — Ant-style List container: optional header/footer, bordered surface, row dividers (split), and a loading (skeleton) state.
+- `MenuCard(title:, subtitle:, systemImage:, action:)` — Organism.
+- `NavigationBar(systemImage:, activeSystemImage:)` — Organism.
+- `NotificationCard(title:, message:, date:, isUnread:, type:, onClose:)` — Organism.
+- `PageHeader(systemImage:, handler:)` — Organism.
+- `PagingCarousel(items, peek:, spacing:, autoplay:, @ViewBuilder:)` — Custom drag-paging carousel with PEEKING neighbors + threshold snap (the reference `PagingScrollView`).
+- `PromoBanner(title:, subtitle:, systemImage:, ctaTitle:, tint:, action:)` — Organism.
+- `RatingSummary(score:, label:, reviewCount:, onReviews:)` — Organism.
+- `ResultView(status, title:, message:, primaryTitle:, onPrimary:)` — Ant-style "Result" template: a full-page status view for the outcome of an operation (success / info / warning / error) or an exception page (404 / 403 / 500), with up to two actions.
+- `SegmentedTabBar(title, caption:, systemImage:, trailingSystemImage:, badge:, isEnabled:)` — Tab bar with a selection binding and an animated underline. · modifiers: `.a11yID()`
+- `RadioCard(title, description:, isSelected:, isEnabled:, action:)` — Organisms.
 - `CheckboxCard`
-- `ThemePicker(selection:, themes:, onSelect:)`
-- `Timeline(title:, time:, description:, systemImage:, state:, color:)`
-- `Upload(id:, name:, status:)`
-- `UploadList`
-- `VideoPlayerView(url, progress:, isMuted:, onTap:)` — modifiers: `.autoplay()`, `.loop()`, `.muteToggle()`, `.muted()`, `.tapToToggle()`
+- `ThemePicker(selection:, themes:, onSelect:)` — A grid of `DaisyTheme` preview cards.
+- `Timeline(title:, time:, description:, systemImage:, state:, color:)` — Organism.
+- `Upload(id:, name:, status:)` — Organism.
+- `UploadList` — `Upload` wired to an `UploadController` — renders its files with remove + retry.
+- `VideoPlayerView(url, progress:, isMuted:, onTap:)` — Inline video on AVKit (reference `InlineVideoPlayerView`): autoplay, loop, mute, aspect-fill, and active-gating (only the visible item plays). · modifiers: `.autoplay()`, `.loop()`, `.muted()`, `.muteToggle()`, `.tapToToggle()`
 
 ## Chainable modifiers (all components)
 

--- a/tools/gen_skill.py
+++ b/tools/gen_skill.py
@@ -19,6 +19,18 @@ THEMES_OUT = ROOT / "skills/themekit/references/themes.md"
 LLMS_OUT = ROOT / "llms.txt"
 JSON_OUT = ROOT / "mcp/themekit.json"
 THEME_RE = re.compile(r'\.init\(\s*"(\w+)",\s*"([^"]+)"')
+THEME_FULL_RE = re.compile(
+    r'\.init\(\s*"(\w+)",\s*"([^"]+)",\s*primary:\s*"(\w+)",\s*secondary:\s*"(\w+)",'
+    r'\s*accent:\s*"(\w+)",\s*base:\s*"(\w+)"'
+)
+
+
+def full_themes():
+    src = THEMES_SRC.read_text(encoding="utf-8")
+    return [
+        {"id": m[0], "name": m[1], "primary": m[2], "secondary": m[3], "accent": m[4], "base": m[5]}
+        for m in THEME_FULL_RE.findall(src)
+    ]
 
 RULES = [
     "Read the theme via `@Environment(\\.theme) private var theme`; inject `.environment(Theme.shared)` once at the root.",
@@ -43,47 +55,71 @@ CATEGORIES = [("Atoms", "Atoms"), ("Molecules", "Molecules"), ("Organisms", "Org
 
 # `public struct Name: View` / `public struct Name<...>: View`
 STRUCT_RE = re.compile(r"^public struct (\w+)(?:<[^>]*>)?\s*:\s*View\b", re.M)
-# self-returning chainable modifiers: `func name(...) -> Self`
-MODIFIER_RE = re.compile(r"\bfunc (\w+)\s*\([^;{]*?\)\s*->\s*Self\b")
-# first public init's leading parameter labels (a usage hint, best-effort)
+# self-returning chainable modifiers: `func name(params) -> Self`
+MODIFIER_RE = re.compile(r"\bfunc (\w+)\s*\(([^;{]*?)\)\s*->\s*Self\b", re.S)
 INIT_RE = re.compile(r"public init\(\s*(.*?)\)\s*\{", re.S)
 
 
-def param_labels(swift: str) -> str:
-    m = INIT_RE.search(swift)
-    if not m:
-        return ""
-    body = m.group(1)
-    labels = []
-    depth = 0
-    token = ""
-    # split top-level commas only (ignore commas inside <>, (), [])
+def split_top(body: str):
+    """Split a param list on top-level commas only (ignore < > ( ) [ ] nesting)."""
+    out, depth, token = [], 0, ""
     for ch in body:
         if ch in "<([":
             depth += 1
         elif ch in ">)]":
             depth -= 1
         if ch == "," and depth == 0:
-            labels.append(token)
-            token = ""
+            out.append(token); token = ""
         else:
             token += ch
-    labels.append(token)
+    out.append(token)
+    return [p.strip() for p in out if p.strip()]
+
+
+def param_labels(swift: str) -> str:
+    m = INIT_RE.search(swift)
+    if not m:
+        return ""
     names = []
-    for p in labels:
-        p = p.strip()
-        if not p:
-            continue
-        # `_ title: String` -> "title" (positional) ; `label: String` -> "label:"
+    for p in split_top(m.group(1)):
         head = p.split(":")[0].strip()
         parts = head.split()
         if not parts:
             continue
-        if parts[0] == "_":
-            names.append(parts[1] if len(parts) > 1 else "_")
-        else:
-            names.append(parts[0] + ":")
+        names.append(parts[1] if parts[0] == "_" and len(parts) > 1 else parts[0] + ":")
     return ", ".join(names[:6]) + (" …" if len(names) > 6 else "")
+
+
+def doc_above(lines, idx) -> str:
+    """Contiguous `///` doc lines just above line `idx` (skips a blank/attr gap)."""
+    doc, i = [], idx - 1
+    while i >= 0:
+        s = lines[i].strip()
+        if s.startswith("///"):
+            doc.append(s[3:].strip())
+        elif s.startswith("@") or s.startswith("//") or s == "":
+            if s == "" and doc:
+                break
+            i -= 1
+            continue
+        else:
+            break
+        i -= 1
+    doc.reverse()
+    text = " ".join(d for d in doc if d).strip()
+    return text.split(". ")[0].rstrip(".") + ("." if text else "")  # first sentence
+
+
+def parse_modifiers(swift, lines):
+    found = {}
+    for m in MODIFIER_RE.finditer(swift):
+        name = m.group(1)
+        if name in found:
+            continue
+        params = re.sub(r"\s+", " ", m.group(2)).strip()
+        ln = swift.count("\n", 0, m.start())
+        found[name] = {"name": name, "signature": f"{name}({params})", "doc": doc_above(lines, ln)}
+    return found
 
 
 def collect():
@@ -94,16 +130,21 @@ def collect():
         base = COMPONENTS / folder
         for path in sorted(base.rglob("*.swift")):
             swift = path.read_text(encoding="utf-8")
-            structs = STRUCT_RE.findall(swift)
+            lines = swift.split("\n")
+            structs = [(m.group(1), swift[:m.start()].count("\n")) for m in STRUCT_RE.finditer(swift)]
             if not structs:
                 continue
-            mods = sorted(set(MODIFIER_RE.findall(swift)))
-            all_modifiers.update(mods)
-            primary = structs[0]
+            mods = parse_modifiers(swift, lines)
             primary_params = param_labels(swift)
-            for name in structs:
-                is_primary = name == primary
-                items.append((name, primary_params if is_primary else "", mods if is_primary else []))
+            for i, (name, ln) in enumerate(structs):
+                is_primary = i == 0
+                all_modifiers.update(mods.keys())
+                items.append({
+                    "name": name,
+                    "doc": doc_above(lines, ln),
+                    "params": primary_params if is_primary else "",
+                    "modifiers": list(mods.values()) if is_primary else [],
+                })
         out[label] = items
     return out, sorted(all_modifiers)
 
@@ -124,10 +165,11 @@ def render(cats, modifiers):
         items = cats[label]
         lines.append(f"## {label} ({len(items)})")
         lines.append("")
-        for name, params, mods in items:
-            sig = f"`{name}({params})`" if params else f"`{name}`"
-            extra = f" — modifiers: {', '.join('`.' + m + '()`' for m in mods)}" if mods else ""
-            lines.append(f"- {sig}{extra}")
+        for c in items:
+            sig = f"`{c['name']}({c['params']})`" if c["params"] else f"`{c['name']}`"
+            doc = f" — {c['doc']}" if c["doc"] else ""
+            extra = f" · modifiers: {', '.join('`.' + m['name'] + '()`' for m in c['modifiers'])}" if c["modifiers"] else ""
+            lines.append(f"- {sig}{doc}{extra}")
         lines.append("")
     lines.append("## Chainable modifiers (all components)")
     lines.append("")
@@ -192,7 +234,7 @@ def render_llms(cats, modifiers, themes):
         "",
     ]
     for label, _ in CATEGORIES:
-        names = ", ".join(f"`{n}`" for n, _, _ in cats[label])
+        names = ", ".join(f"`{c['name']}`" for c in cats[label])
         lines.append(f"## {label}")
         lines.append("")
         lines.append(names)
@@ -211,12 +253,16 @@ def render_llms(cats, modifiers, themes):
 def render_json(cats, modifiers, themes):
     components = []
     for label, _ in CATEGORIES:
-        for name, params, mods in cats[label]:
+        for c in cats[label]:
             components.append({
-                "name": name,
+                "name": c["name"],
                 "category": label,
-                "init": f"{name}({params})" if params else name,
-                "modifiers": [f".{m}()" for m in mods],
+                "doc": c["doc"],
+                "init": f"{c['name']}({c['params']})" if c["params"] else c["name"],
+                "modifiers": [
+                    {"name": m["name"], "signature": m["signature"], "doc": m["doc"]}
+                    for m in c["modifiers"]
+                ],
             })
     return json.dumps({
         "name": "themekit",
@@ -227,7 +273,7 @@ def render_json(cats, modifiers, themes):
         "tokens": TOKENS,
         "components": components,
         "modifiers": [f".{m}()" for m in modifiers],
-        "themes": [{"id": t[0], "name": t[1]} for t in themes],
+        "themes": full_themes(),
     }, indent=2)
 
 


### PR DESCRIPTION
Expands the ThemeKit MCP server from **7 → 12 tools**, plus **resources** and **prompts**. Backed by a richer `themekit.json` — `gen_skill.py` now also extracts each component's **doc summary**, each modifier's **full signature + doc**, and each theme preset's **primary/secondary/accent/base hexes**.

### New tools
- **`lint_snippet`** — flags ThemeKit anti-patterns (hardcoded colors / radius / fonts / padding, `isEnabled:` arg) with fixes.
- **`get_component`** — now returns the summary + modifier signatures + docs.
- **`scaffold_screen`** — starter form / list / detail / settings screens.
- **`generate_theme`** — a `ThemeConfig` apply snippet.
- **`theme_colors`** — a preset's swatch hexes.
- **`migrate_snippet`** — rewrites plain SwiftUI toward ThemeKit, with notes.

### Resources & prompts
- Resources: `themekit://guide`, `themekit://components`, `themekit://component/{name}`.
- Prompts: `themekit-screen`, `themekit-theme`, `migrate-to-themekit`.

Verified: `tsc` build clean; stdio smoke test lists **12 tools / 3 prompts** and exercises `lint_snippet` + `theme_colors`. mcp `1.0.0 → 1.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)