### PR TITLE
feat(mcp): validate_screen + theme_preview (PNG) tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ component + modifier and resolves colors from tokens, never hardcoded values.
 
 | Tool | What it does | How to use it |
 |---|---|---|
-| **MCP server** ([`mcp/`](mcp/)) | Components, modifiers, tokens and the 32 theme presets as **on-demand tools** (`get_component`, `search_components`, `list_themes`…) — the agent pulls focused context while it codes. | `claude mcp add themekit -- npx -y @isamercan/themekit-mcp` (or from the repo: `cd mcp && npm i && npm run build`). Works in any MCP editor — Cursor, Windsurf, Claude Code. |
+| **MCP server** ([`mcp/`](mcp/)) | Components, modifiers, tokens and the 32 theme presets as **on-demand tools** (`get_component`, `validate_screen`, `theme_preview`, `scaffold_screen`…) — the agent pulls focused context while it codes. | `claude mcp add themekit -- npx -y @isamercan/themekit-mcp` (or from the repo: `cd mcp && npm i && npm run build`). Works in any MCP editor — Cursor, Windsurf, Claude Code. |
 | **Agent skill** ([`skills/themekit/`](skills/themekit/)) | A Claude Code skill: idioms + patterns, every component's init & modifiers, the theme presets — generates correct ThemeKit code. | `/plugin marketplace add isamercan/ThemeKit` → `/plugin install themekit@themekit`, **or** copy `skills/themekit/` into `.claude/skills/` (zero-install). |
 | **`llms.txt`** | Structured LLM context about every component, modifier and theme — the [llms.txt](https://llmstxt.org) standard, at the repo root. | Point any `llms.txt`-aware editor (Cursor, Windsurf, Copilot…) at [`llms.txt`](llms.txt). |
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -15,11 +15,21 @@ The data lives in `themekit.json`, generated from the Swift source by
 |---|---|
 | `usage_guide` | The golden rules for writing ThemeKit code |
 | `list_components(category?)` | Components by Atom / Molecule / Organism |
-| `get_component(name)` | A component's init signature + chainable modifiers |
+| `get_component(name)` | A component's summary, init signature + chainable modifiers |
 | `search_components(query)` | Components matching a keyword (e.g. "date", "progress") |
+| `lint_snippet(swift)` | Flags ThemeKit anti-patterns (hardcoded colors / radius / fonts) with fixes |
+| `validate_screen(swift)` | Full screen check: anti-patterns + raw-SwiftUI with ThemeKit equivalents + a pass/fail verdict |
+| `scaffold_screen(kind)` | A starter form / list / detail / settings screen |
+| `migrate_snippet(swift)` | Rewrites plain SwiftUI toward ThemeKit, with notes |
 | `list_themes` | The bundled theme-preset ids |
-| `theme_snippet(id?)` | Swift code to apply a theme / show `ThemePicker` |
+| `theme_colors(id)` | A preset's primary / secondary / accent / base hexes |
+| `theme_preview(id)` | A **PNG swatch card** for a preset (renders inline) |
+| `theme_snippet(id?)` | Swift code to apply a preset / show `ThemePicker` |
+| `generate_theme(...)` | A `ThemeConfig` apply snippet from accent / base / secondary / accent |
 | `token_reference(kind?)` | Design tokens (colors, radius roles, spacing, semantic colors) |
+
+Plus resources (`themekit://guide`, `themekit://components`, `themekit://component/{name}`)
+and prompts (`themekit-screen`, `themekit-theme`, `migrate-to-themekit`).
 
 ## Install
 

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@isamercan/themekit-mcp",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@isamercan/themekit-mcp",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
+        "pngjs": "^7.0.0",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -17,6 +18,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.14.0",
+        "@types/pngjs": "^6.0.5",
         "typescript": "^5.5.0"
       }
     },
@@ -80,6 +82,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/accepts": {
@@ -848,6 +860,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/proxy-addr": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@isamercan/themekit-mcp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "MCP server for the ThemeKit SwiftUI design system \u2014 components, modifiers, tokens and theme presets on demand.",
   "type": "module",
   "bin": {
@@ -26,10 +26,12 @@
   "homepage": "https://github.com/isamercan/ThemeKit",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
+    "pngjs": "^7.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",
+    "@types/pngjs": "^6.0.5",
     "typescript": "^5.5.0"
   }
 }

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -10,6 +10,7 @@
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { PNG } from "pngjs";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -239,6 +240,86 @@ server.registerTool("migrate_snippet", {
   sub(/\.cornerRadius\(\s*\d+\s*\)/g, ".cornerRadius(Theme.RadiusRole.box.value)", "hardcoded radius → RadiusRole.box");
   sub(/\bToggle\(("[^"]*",\s*)?isOn:\s*(\$\w+)\)/g, "ThemeToggle(isOn: $2)", "Toggle → ThemeToggle");
   return text(`Suggested:\n\n\`\`\`swift\n${out}\n\`\`\`\n\nNotes:\n${notes.length ? notes.map((n) => `- ${n}`).join("\n") : "- (no automatic rewrites; check lint_snippet)"}\n\nReplace plain Button/TextField with PrimaryButton/TextInput, and any remaining hardcoded colors with theme tokens.`);
+});
+
+// raw-SwiftUI components that have a ThemeKit equivalent
+const PREFER_RULES: { re: RegExp; msg: string }[] = [
+  { re: /(?<![.\w])Button\s*\(/, msg: "Prefer a ThemeKit button: PrimaryButton / SecondaryButton / ThemeButton." },
+  { re: /(?<![.\w])TextField\s*\(/, msg: "Prefer TextInput (or MultiLineTextInput)." },
+  { re: /(?<!Theme)(?<![.\w])Toggle\s*\(/, msg: "Prefer ThemeToggle." },
+  { re: /(?<![.\w])Divider\s*\(\s*\)/, msg: "Prefer DividerView." },
+  { re: /(?<![.\w])ProgressView\s*\(/, msg: "Prefer Spinner or ProgressBar." },
+];
+
+server.registerTool("validate_screen", {
+  title: "Validate a ThemeKit screen",
+  description: "Full check of a SwiftUI screen: anti-patterns (hardcoded colors/radius/fonts), raw-SwiftUI components that have ThemeKit equivalents, and the ThemeKit components it uses. Returns a pass/fail verdict + fixes.",
+  inputSchema: { swift: z.string() },
+}, async ({ swift }) => {
+  const lines = swift.split("\n");
+  const issues: string[] = [];
+  lines.forEach((line, i) => {
+    for (const r of [...LINT_RULES, ...PREFER_RULES]) if (r.re.test(line)) issues.push(`L${i + 1}: ${r.msg}\n    ${line.trim()}`);
+  });
+  const names = new Set(data.components.map((c) => c.name));
+  const used = [...new Set((swift.match(/\b[A-Z]\w+(?=\s*[({.])/g) || []).filter((n) => names.has(n)))];
+  const head = issues.length
+    ? `✗ FAIL — ${issues.length} issue(s) to fix:`
+    : "✓ PASS — no ThemeKit issues found.";
+  const usedLine = used.length
+    ? `\n\nThemeKit components used (${used.length}): ${used.join(", ")}`
+    : "\n\n⚠️ No ThemeKit components detected — is this a ThemeKit screen?";
+  return text(`${head}${issues.length ? "\n\n" + issues.join("\n\n") : ""}${usedLine}`);
+});
+
+// ── Theme preview image ────────────────────────────────────────────────────
+
+function hexToRgb(h: string): [number, number, number] {
+  const s = h.replace("#", "");
+  return [parseInt(s.slice(0, 2), 16), parseInt(s.slice(2, 4), 16), parseInt(s.slice(4, 6), 16)];
+}
+
+/** A small PNG swatch card for a preset: primary / secondary / accent on its base. */
+function themePNG(t: ThemePreset): string {
+  const W = 480, H = 150;
+  const png = new PNG({ width: W, height: H });
+  const base = hexToRgb(t.base);
+  const isDark = (base[0] * 0.299 + base[1] * 0.587 + base[2] * 0.114) / 255 < 0.5;
+  const border: [number, number, number] = isDark ? [255, 255, 255] : [0, 0, 0];
+  const set = (x: number, y: number, c: [number, number, number], a = 255) => {
+    if (x < 0 || y < 0 || x >= W || y >= H) return;
+    const i = (W * y + x) << 2;
+    png.data[i] = c[0]; png.data[i + 1] = c[1]; png.data[i + 2] = c[2]; png.data[i + 3] = a;
+  };
+  const rect = (x0: number, y0: number, w: number, h: number, c: [number, number, number], a = 255) => {
+    for (let y = y0; y < y0 + h; y++) for (let x = x0; x < x0 + w; x++) set(x, y, c, a);
+  };
+  rect(0, 0, W, H, base);                          // paper
+  rect(0, 0, W, 8, hexToRgb(t.primary));           // top accent strip
+  const cols = [t.primary, t.secondary, t.accent].map(hexToRgb);
+  const pad = 28, gap = 20, sh = 78;
+  const sw = Math.round((W - pad * 2 - gap * 2) / 3);
+  cols.forEach((c, i) => {
+    const x = pad + i * (sw + gap), y = 44;
+    rect(x - 1, y - 1, sw + 2, sh + 2, border, 40);   // faint outline
+    rect(x, y, sw, sh, c);
+  });
+  return PNG.sync.write(png).toString("base64");
+}
+
+server.registerTool("theme_preview", {
+  title: "Theme preview image",
+  description: "A PNG swatch card for a theme preset — its primary / secondary / accent on its base surface.",
+  inputSchema: { id: z.string().describe('Preset id, e.g. "dracula"') },
+}, async ({ id }) => {
+  const t = data.themes.find((x) => x.id === id);
+  if (!t) return text(`No preset "${id}". Use list_themes.`);
+  return {
+    content: [
+      { type: "image" as const, data: themePNG(t), mimeType: "image/png" },
+      { type: "text" as const, text: `${t.name} — primary #${t.primary} · secondary #${t.secondary} · accent #${t.accent} · base #${t.base}` },
+    ],
+  };
 });
 
 // ── Resources (attachable context) ─────────────────────────────────────────


### PR DESCRIPTION
Two more MCP capabilities (**14 tools** total):

- **`validate_screen`** — a full-screen check: the lint anti-patterns **plus** raw-SwiftUI components that have ThemeKit equivalents (`Button → PrimaryButton`, `TextField → TextInput`, `Toggle → ThemeToggle`, `Divider → DividerView`, `ProgressView → Spinner/ProgressBar`), the ThemeKit components it detects, and a **PASS/FAIL verdict**.
- **`theme_preview`** — renders a **PNG swatch card** for a preset (primary / secondary / accent on its base surface) via `pngjs`, returned as inline MCP image content.

### Verified
`tsc` clean; smoke test lists **14 tools**, `validate_screen` flags a hardcoded color + a raw `Button`, `theme_preview` emits a valid 480×150 PNG (e.g. Dracula → pink/purple/orange on slate).

mcp/README tools table refreshed (was stale at 7); main README MCP row updated. mcp `1.1.1 → 1.2.0`; adds the pure-JS `pngjs` dep (npx-friendly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)