### PR TITLE
feat(theme): auto-contrast on-solid content colors (legible on any accent)

### DIFF
--- a/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
@@ -105,7 +105,7 @@ private struct ThemedButton: View {
     private var foreground: Color {
         guard isEnabled else { return theme.text(.textDisabled) }
         switch style {
-        case .primary: return theme.foreground(.fgSecondary)   // white
+        case .primary: return SemanticColor.primary.onSolid   // auto-contrast on the primary fill
         case .secondary, .outline, .ghost, .link: return theme.text(.textHero)
         }
     }

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -68,7 +68,8 @@ private struct TooltipBubble: View {
     let maxWidth: CGFloat?
 
     private var bubbleColor: Color { style?.semantic.solid ?? theme.background(.bgTertiary) }
-    private var textColor: Color { style?.semantic.onSolid ?? theme.foreground(.fgSecondary) }
+    // Auto-contrast against whatever bubble is shown (styled solid or the dark default).
+    private var textColor: Color { ColorContrast.content(on: bubbleColor) }
 
     var body: some View {
         let bubble = Text(text)

--- a/Sources/ThemeKit/Extensions/ColorContrast.swift
+++ b/Sources/ThemeKit/Extensions/ColorContrast.swift
@@ -1,0 +1,49 @@
+//
+//  ColorContrast.swift
+//  ThemeKit
+//
+//  WCAG-style content contrast: pick a readable foreground (near-white / near-black)
+//  for a given background, so "content on a solid color" stays legible whatever the
+//  theme's accent is — a bright amber or yellow primary gets dark text, a deep navy
+//  gets white. The generator stays brand-agnostic; legibility is computed, not baked.
+//
+
+import SwiftUI
+
+enum ColorContrast {
+    /// Near-black content for light surfaces (slightly soft, not pure `#000`).
+    static let dark = Color(.sRGB, red: 0.08, green: 0.09, blue: 0.11, opacity: 1)
+    /// White content for dark surfaces.
+    static let light = Color.white
+
+    /// Approx. relative luminance of `dark`, for the contrast comparison below.
+    private static let darkLuminance = 0.01
+
+    /// The readable content color (near-white or near-black) for a background.
+    static func content(on background: Color) -> Color {
+        contentIsDark(on: background) ? dark : light
+    }
+
+    /// Whether dark content reads better than white on `background` (WCAG contrast).
+    static func contentIsDark(on background: Color) -> Bool {
+        let l = luminance(of: background)
+        let contrastWithWhite = 1.05 / (l + 0.05)
+        let contrastWithDark = (l + 0.05) / (darkLuminance + 0.05)
+        return contrastWithDark >= contrastWithWhite
+    }
+
+    /// WCAG relative luminance (0…1) of a color.
+    static func luminance(of color: Color) -> Double {
+        let (r, g, b) = components(of: color)
+        func lin(_ c: Double) -> Double { c <= 0.03928 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4) }
+        return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+    }
+
+    /// sRGB 0…1 components of a `Color`. Uses SwiftUI's cross-platform resolver
+    /// (iOS 17 / macOS 14), so it works the same in the app and in `swift test`.
+    static func components(of color: Color) -> (Double, Double, Double) {
+        let resolved = color.resolve(in: EnvironmentValues())
+        func clamp(_ v: Float) -> Double { min(max(Double(v), 0), 1) }
+        return (clamp(resolved.red), clamp(resolved.green), clamp(resolved.blue))
+    }
+}

--- a/Sources/ThemeKit/Theme/SemanticColor.swift
+++ b/Sources/ThemeKit/Theme/SemanticColor.swift
@@ -34,12 +34,11 @@ public enum SemanticColor: String, CaseIterable {
         }
     }
 
-    /// Foreground on top of the `solid` background.
+    /// Foreground on top of the `solid` background — **auto-contrasting**: a bright
+    /// accent (amber, yellow, light primary) gets dark content, a deep one gets white,
+    /// computed from the background's luminance rather than hardcoded per color.
     public var onSolid: Color {
-        switch self {
-        case .warning: return Theme.shared.text(.textPrimary)   // dark text on bright amber
-        default: return Theme.shared.foreground(.fgSecondary)   // white
-        }
+        ColorContrast.content(on: solid)
     }
 
     /// Light surface for the `soft` variant.

--- a/Tests/ThemeKitTests/ContentContrastTests.swift
+++ b/Tests/ThemeKitTests/ContentContrastTests.swift
@@ -1,0 +1,43 @@
+//
+//  ContentContrastTests.swift
+//  ThemeKitTests
+//
+//  Auto-contrast content colors: on-solid foreground must stay legible on light
+//  accents (dark text) and dark accents (white text) alike.
+//
+
+import XCTest
+import SwiftUI
+@testable import ThemeKit
+
+final class ContentContrastTests: XCTestCase {
+    override func tearDown() {
+        Theme.shared.loadTheme(named: "defaultTheme", dark: false)   // restore
+        super.tearDown()
+    }
+
+    func testLuminanceOrdersWhiteAboveBlack() {
+        XCTAssertGreaterThan(ColorContrast.luminance(of: .white), ColorContrast.luminance(of: .black))
+        XCTAssertTrue(ColorContrast.contentIsDark(on: .white), "white bg → dark content")
+        XCTAssertFalse(ColorContrast.contentIsDark(on: .black), "black bg → white content")
+    }
+
+    func testLightPrimaryTakesDarkContent() {
+        Theme.shared.apply(ThemeConfig(primaryHex: "e0a82e"))   // bumblebee amber — light
+        XCTAssertTrue(ColorContrast.contentIsDark(on: SemanticColor.primary.solid),
+                      "a light amber primary should take dark on-solid content")
+    }
+
+    func testDarkPrimaryKeepsWhiteContent() {
+        Theme.shared.apply(ThemeConfig(primaryHex: "056bfd"))   // default blue — deep
+        XCTAssertFalse(ColorContrast.contentIsDark(on: SemanticColor.primary.solid),
+                       "a deep blue primary should keep white on-solid content")
+    }
+
+    func testWarningStaysDark() {
+        // The old hardcoded `.warning → dark` rule is now derived, not special-cased.
+        Theme.shared.loadTheme(named: "defaultTheme", dark: false)
+        XCTAssertTrue(ColorContrast.contentIsDark(on: SemanticColor.warning.solid),
+                      "amber warning is light → dark content")
+    }
+}


### PR DESCRIPTION
Content on a filled/solid surface was hardcoded white (`fg-secondary`), so a **light accent** — amber, yellow, a pale primary — rendered white text on a light fill = unreadable. Now the on-solid foreground is **computed from the background's WCAG luminance**: light surfaces get near-black content, dark ones get white.

## Before / after (rendered)
PrimaryButton on a light amber (bumblebee) primary now has **dark** text; deep blue is **unchanged** (white).

| amber primary | blue primary |
|---|---|
| dark "Continue" ✅ (was white, unreadable) | white "Continue" (unchanged) |

## Changes
- **New `ColorContrast` util** — cross-platform via SwiftUI `Color.resolve(in:)` (works in the app *and* in `swift test`): relative luminance + readable-content pick.
- **`SemanticColor.onSolid` is now luminance-driven** instead of a hardcoded `.warning → dark, else → white` rule. Fixes every on-solid consumer at once: `ThemeButton(.solid)`, `Badge`, `Tag`, `CountBadge`, `FloatingActionButton`, styled `Tooltip`.
- **PrimaryButton** routes its label through `SemanticColor.primary.onSolid`.
- **Tooltip** content auto-contrasts against the actual bubble (styled or the dark default).

## Safety
Deep accents (blue/turquoise/navy) stay white — only light accents flip to dark, so the 3 bundled themes + dark-primary presets are visually unchanged. Brand-agnostic: legibility is computed, never baked.

**Tests:** `ContentContrastTests` (4 new) + full suite **184 green**.

## Follow-up
The small legacy filled controls (`Checkbox` / `RadioButton` / `Steps` / `Pagination` / `Slider`) still use the raw `fg-secondary` token directly — migrate them to the matching `.onSolid` in a later pass (lower-visibility checkmarks/dots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)