### PR TITLE
fix(buttons): single-line labels + ButtonGroup wraps instead of squeezing

### DIFF
--- a/Demo/Demo/Views/ThemesView.swift
+++ b/Demo/Demo/Views/ThemesView.swift
@@ -62,13 +62,15 @@ struct ThemesView: View {
                 Text("The quick brown fox jumps over the lazy dog.")
                     .textStyle(.bodyBase400)
                     .foregroundStyle(theme.text(.textSecondary))
-                // The three brand colors — primary / secondary / accent.
-                HStack(spacing: Theme.SpacingKey.sm.value) {
+                // The three brand colors — primary / secondary / accent. A ButtonGroup
+                // keeps each label on one line and wraps to the next row when they
+                // don't fit, instead of squeezing the text onto two lines.
+                ButtonGroup(.horizontal) {
                     ThemeButton("Primary", color: .primary, variant: .solid) {}
                     ThemeButton("Secondary", color: .secondary, variant: .solid) {}
                     ThemeButton("Accent", color: .accent, variant: .solid) {}
                 }
-                HStack(spacing: Theme.SpacingKey.sm.value) {
+                ButtonGroup(.horizontal) {
                     PrimaryButton("Continue") {}
                     SecondaryButton("Cancel") {}
                 }

--- a/Sources/ThemeKit/Components/Molecules/ButtonGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/ButtonGroup.swift
@@ -13,6 +13,10 @@ public enum ButtonGroupAxis {
 /// Molecule. Lays out related buttons in a vertical stack or a side-by-side row.
 /// Buttons are content-width by default (ideal for a horizontal row); for a
 /// vertical full-width CTA stack, pass the buttons `block: true`.
+///
+/// A horizontal group **wraps**: each button keeps its single-line label at its
+/// natural width and overflowing buttons flow to the next line, instead of being
+/// squeezed until the text wraps onto two lines.
 public struct ButtonGroup<Content: View>: View {
     private let axis: ButtonGroupAxis
     private let spacing: CGFloat
@@ -29,7 +33,9 @@ public struct ButtonGroup<Content: View>: View {
         case .vertical:
             VStack(spacing: spacing) { content() }
         case .horizontal:
-            HStack(spacing: spacing) { content() }
+            // FlowLayout (not HStack) so buttons wrap to the next line rather than
+            // compressing — hugs content when it fits, wraps when it doesn't.
+            FlowLayout(spacing: spacing, lineSpacing: spacing) { content() }
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
@@ -114,7 +114,10 @@ public struct ThemeButton: View {
                     Image(systemName: systemImage).font(.system(size: size.fontSize, weight: .semibold))
                 }
                 if let title, !isIconOnly {
-                    Text(title).textStyle(size.textStyle).underline(variant == .link)
+                    Text(title)
+                        .textStyle(size.textStyle)
+                        .underline(variant == .link)
+                        .lineLimit(1)              // a single-word label never wraps; a ButtonGroup flows instead
                 }
                 if let systemImage, iconPosition == .trailing, !isIconOnly {
                     Image(systemName: systemImage).font(.system(size: size.fontSize, weight: .semibold))

--- a/Sources/ThemeKit/Components/Molecules/FlowLayout.swift
+++ b/Sources/ThemeKit/Components/Molecules/FlowLayout.swift
@@ -1,0 +1,81 @@
+//
+//  FlowLayout.swift
+//  ThemeKit
+//
+//  A line-wrapping layout: places subviews left→right at their ideal size and wraps
+//  to a new line when the next one won't fit the proposed width. It hugs its content
+//  when everything fits, so it's a drop-in for an `HStack` that should wrap to the
+//  next line instead of squeezing its children. Reusable for any run of self-sizing
+//  views — buttons, chips, tags…
+//
+
+import SwiftUI
+
+public struct FlowLayout: Layout {
+    public var spacing: CGFloat
+    public var lineSpacing: CGFloat
+    public var alignment: HorizontalAlignment
+
+    public init(spacing: CGFloat = 8, lineSpacing: CGFloat = 8, alignment: HorizontalAlignment = .leading) {
+        self.spacing = spacing
+        self.lineSpacing = lineSpacing
+        self.alignment = alignment
+    }
+
+    public func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let rows = rows(maxWidth: maxWidth, subviews: subviews)
+        let width = rows.map(\.width).max() ?? 0
+        let height = rows.map(\.height).reduce(0, +) + lineSpacing * CGFloat(max(0, rows.count - 1))
+        // Hug content when it fits; only fill out to the proposed width once wrapped.
+        return CGSize(width: maxWidth.isFinite ? min(width, maxWidth) : width, height: height)
+    }
+
+    public func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        let rows = rows(maxWidth: bounds.width, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            var x: CGFloat
+            switch alignment {
+            case .center: x = bounds.minX + (bounds.width - row.width) / 2
+            case .trailing: x = bounds.maxX - row.width
+            default: x = bounds.minX
+            }
+            for item in row.items {
+                subviews[item.index].place(
+                    at: CGPoint(x: x, y: y + (row.height - item.size.height) / 2),
+                    proposal: ProposedViewSize(item.size)
+                )
+                x += item.size.width + spacing
+            }
+            y += row.height + lineSpacing
+        }
+    }
+
+    private func rows(maxWidth: CGFloat, subviews: Subviews) -> [Row] {
+        var rows: [Row] = []
+        var current = Row()
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            if !current.items.isEmpty, current.width + spacing + size.width > maxWidth {
+                rows.append(current)
+                current = Row()
+            }
+            current.append(index: index, size: size, spacing: spacing)
+        }
+        if !current.items.isEmpty { rows.append(current) }
+        return rows
+    }
+
+    private struct Row {
+        var items: [(index: Int, size: CGSize)] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+        mutating func append(index: Int, size: CGSize, spacing: CGFloat) {
+            if !items.isEmpty { width += spacing }
+            items.append((index, size))
+            width += size.width
+            height = max(height, size.height)
+        }
+    }
+}


### PR DESCRIPTION
A row of buttons that didn't fit was compressed until each label **wrapped onto two lines** (`Primar y`, `Second ary`). The rule should be: a single-word label stays on one line, and a button that won't fit flows to the next line.

## Before → after
At the card width, `Primary` + `Secondary` sit on line 1 and `Accent` wraps to line 2 — every label on a single line (was: 3 squeezed buttons with two-line text).

## Fixes
- **`ThemeButton` label → `.lineLimit(1)`** (the preset buttons already had this), so a label never wraps.
- **New reusable `FlowLayout`** (SwiftUI `Layout`): lays items out at their natural width and wraps the overflow to the next line; hugs content when it fits.
- **`ButtonGroup(.horizontal)` now uses `FlowLayout`** instead of a plain `HStack` — overflowing buttons flow to the next row instead of being squeezed. This is the general rule for a set of buttons.
- Themes-tab live preview uses `ButtonGroup(.horizontal)` for its brand-color row.

## Compatibility
Backward-compatible: short rows (`ButtonDock`, `NotificationCard`) hug content exactly as before — `FlowLayout` only wraps when content exceeds the available width. Full suite **184 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)