### PR TITLE
chore: MIT license + public-readiness hygiene

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to ThemeKit
+
+Thanks for your interest in improving ThemeKit! This guide covers the basics.
+
+## Development
+
+```sh
+make ci            # format-lint + lint + build + test (the full gate)
+swift test         # the test suite
+make screenshots   # re-render component PNGs + rebuild the README gallery
+make skill         # regenerate the MCP data, the Agent skill, and llms.txt
+```
+
+`make ci` is what the pre-push hook and CI run — keep it green.
+
+## Conventions
+
+- **Tokens, not literals.** Components never hardcode a color/radius/spacing/font —
+  every value resolves from the active `Theme`. New components must follow this.
+- **English strings.** All user-facing and placeholder text in the source, demo,
+  and docs is written in English. Localized translations live only in the bundled
+  String Catalog (`Resources/Localizable.xcstrings`).
+- **Accessibility.** Honor Dynamic Type and Reduce Motion; components read the
+  environment directly.
+- **Generated files stay generated.** Colors come from `tools/gen_tokens.py`
+  (`python3 tools/gen_tokens.py .`); the MCP data / skill / llms.txt come from
+  `make skill`. Don't hand-edit the generated outputs.
+
+## Pull requests
+
+- Branch off `main`, keep the change focused, and include tests where it makes sense.
+- Make sure `make ci` passes locally; CI runs the same gates on every PR.
+- Describe what changed and why; screenshots help for visual changes.
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 İsa Mercan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -637,8 +637,8 @@ green; the pre-push hook runs the same gates.
 
 ## License
 
-Proprietary — all rights reserved. (Replace with your chosen license before any
-public distribution.)
+[MIT](LICENSE) © 2026 İsa Mercan. Free for commercial and private use — keep the
+copyright notice; the software is provided without warranty.
 
 ## Acknowledgements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately rather than opening a public issue.
+
+Use GitHub's **[Report a vulnerability](https://github.com/isamercan/ThemeKit/security/advisories/new)**
+(Security → Advisories) to open a private advisory. Include:
+
+- a description of the issue and its impact,
+- steps to reproduce (a minimal sample if possible),
+- affected version(s).
+
+You can expect an initial response within a few days. Once a fix is available,
+we'll coordinate a disclosure and credit you if you'd like.
+
+## Scope
+
+ThemeKit is a UI component library with no networking in its core. The most
+relevant surface is the optional MCP server under [`mcp/`](mcp/) (which can read
+local files and call the Figma API when `FIGMA_TOKEN` is set) — reports there are
+especially welcome.

--- a/Tests/ThemeKitTests/Snapshot/FormControlSnapshotTests.swift
+++ b/Tests/ThemeKitTests/Snapshot/FormControlSnapshotTests.swift
@@ -26,7 +26,7 @@ final class FormControlSnapshotTests: SnapshotTestCase {
 
     func testTextInput_filled() {
         assertComponentSnapshot(
-            TextInput("Email", text: .constant("traveller@etstur.com"), leadingSystemImage: "envelope")
+            TextInput("Email", text: .constant("traveller@example.com"), leadingSystemImage: "envelope")
         )
     }
 


### PR DESCRIPTION
Clears the one true blocker to going public — **no repo visibility change here**, just the legal + hygiene prep.

- **Add `LICENSE` (MIT, © 2026 İsa Mercan).** README's License section now points to it instead of *"Proprietary — all rights reserved"*. The npm package (`mcp/package.json`) and Claude plugin (`.claude-plugin/plugin.json`) already declared `"license": "MIT"` — now backed by the actual file.
- **Add `CONTRIBUTING.md`** (dev gates, token-not-literal rule, English-only strings) and **`SECURITY.md`** (private advisory reporting).
- **Replace `traveller@etstur.com`** sample email with `traveller@example.com` (neutral placeholder, no employer domain).

After this, the remaining go-public steps are distribution (npm publish, plugin/skill verify), Pages/Wiki, and optional polish (templates, release) — none are blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)