### PR TITLE
chore: English-only strings across source + demo

### DIFF
--- a/Demo/Demo/Examples/HotelCheckoutView.swift
+++ b/Demo/Demo/Examples/HotelCheckoutView.swift
@@ -35,20 +35,20 @@ struct HotelCheckoutView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                Steps([.init("Detay", state: .done), .init("Ödeme", state: .active), .init("Onay", state: .todo)])
+                Steps([.init("Details", state: .done), .init("Payment", state: .active), .init("Confirm", state: .todo)])
 
                 summaryCard
-                Fieldset("İletişim bilgileri") {
-                    TextInput("Ad Soyad", text: $name, placeholder: "Adın")
-                    TextInput("E-posta", text: $email, placeholder: "ornek@mail.com", leadingSystemImage: "envelope")
+                Fieldset("Contact details") {
+                    TextInput("Full name", text: $name, placeholder: "Your name")
+                    TextInput("Email", text: $email, placeholder: "you@example.com", leadingSystemImage: "envelope")
                 }
 
                 paymentMethod
                 if method == "card" {
-                    Fieldset("Kart bilgileri") {
-                        TextInput("Kart numarası", text: $cardNumber, placeholder: "0000 0000 0000 0000", leadingSystemImage: "creditcard")
+                    Fieldset("Card details") {
+                        TextInput("Card number", text: $cardNumber, placeholder: "0000 0000 0000 0000", leadingSystemImage: "creditcard")
                         HStack(spacing: 12) {
-                            TextInput("SKT", text: $expiry, placeholder: "AA/YY")
+                            TextInput("Expiry", text: $expiry, placeholder: "MM/YY")
                             TextInput("CVV", text: $cvv, placeholder: "123", isSecure: true)
                         }
                     }
@@ -61,22 +61,22 @@ struct HotelCheckoutView: View {
             .padding()
         }
         .background(Color(.systemGroupedBackground))
-        .navigationTitle("Ödeme")
+        .navigationTitle("Payment")
         .navigationBarTitleDisplayMode(.inline)
         .buttonDock {
             HStack(spacing: Theme.SpacingKey.md.value) {
                 VStack(alignment: .leading, spacing: 0) {
-                    Text("Toplam").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+                    Text("Total").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
                     Text(total.priceText).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
                 }
-                PrimaryButton("Öde", block: true) { showSuccess = true }.disabled(!acceptTerms)
+                PrimaryButton("Pay", block: true) { showSuccess = true }.disabled(!acceptTerms)
             }
             .padding(.bottom, 4)
         }
         .dialog(isPresented: $showSuccess,
-                title: "Rezervasyon onaylandı 🎉",
-                message: "\(hotel.name) için ödemen alındı. İyi tatiller!",
-                primaryTitle: "Ana sayfaya dön",
+                title: "Booking confirmed 🎉",
+                message: "Your payment for \(hotel.name) has been received. Enjoy your trip!",
+                primaryTitle: "Back to home",
                 onPrimary: { path.removeAll() })
     }
 
@@ -86,46 +86,46 @@ struct HotelCheckoutView: View {
                 Text(hotel.name).textStyle(.labelMd700).foregroundStyle(Theme.shared.text(.textPrimary))
                 HStack(spacing: 6) {
                     Icon(systemName: "calendar", size: .sm, color: Theme.shared.text(.textTertiary))
-                    Text("23 Haz – 26 Haz · \(nights) gece").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+                    Text("23 Jun – 26 Jun · \(nights) nights").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
                 }
-                if hotel.freeCancellation { Callout("Ücretsiz iptal", type: .success) }
+                if hotel.freeCancellation { Callout("Free cancellation", type: .success) }
             }
         }
     }
 
     private var paymentMethod: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Ödeme yöntemi").textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
-            RadioCard("Kredi / banka kartı", description: "Visa, Mastercard, Troy", isSelected: method == "card") { method = "card" }
-            RadioCard("Apple Pay", description: "Tek dokunuşla öde", isSelected: method == "applepay") { method = "applepay" }
-            RadioCard("Havale / EFT", description: "Banka havalesi", isSelected: method == "transfer") { method = "transfer" }
+            Text("Payment method").textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
+            RadioCard("Credit / debit card", description: "Visa, Mastercard, Amex", isSelected: method == "card") { method = "card" }
+            RadioCard("Apple Pay", description: "Pay with one tap", isSelected: method == "applepay") { method = "applepay" }
+            RadioCard("Bank transfer", description: "Pay directly from your bank", isSelected: method == "transfer") { method = "transfer" }
         }
     }
 
     private var couponSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .bottom, spacing: 10) {
-                TextInput("Kupon kodu", text: $coupon, placeholder: "ÖrN: SUMMER")
-                SecondaryButton("Uygula") { couponApplied = !coupon.isEmpty }
+                TextInput("Coupon code", text: $coupon, placeholder: "e.g. SUMMER")
+                SecondaryButton("Apply") { couponApplied = !coupon.isEmpty }
             }
-            if couponApplied { Callout("Kupon uygulandı · %10 indirim", type: .success) }
+            if couponApplied { Callout("Coupon applied · 10% off", type: .success) }
         }
     }
 
     private var priceTable: some View {
         KeyValueTable(rows: [
-            .init("\(nights) gece × \(hotel.pricePerNight.priceText)", value: subtotal.priceText),
-            couponApplied ? .init("İndirim", value: "-" + discount.priceText, style: .success) : .init("İndirim", value: "—", style: .muted),
-            .init("Vergi (%10)", value: tax.priceText, style: .muted),
-            .init("Toplam", value: total.priceText),
+            .init("\(nights) nights × \(hotel.pricePerNight.priceText)", value: subtotal.priceText),
+            couponApplied ? .init("Discount", value: "-" + discount.priceText, style: .success) : .init("Discount", value: "—", style: .muted),
+            .init("Tax (10%)", value: tax.priceText, style: .muted),
+            .init("Total", value: total.priceText),
         ])
     }
 
     private var termsRow: some View {
         HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
             Checkbox(isChecked: $acceptTerms)
-            InlineText("Devam ederek Koşullar ve Gizlilik Politikası'nı kabul ediyorum.",
-                       links: [("Koşullar", {}), ("Gizlilik Politikası", {})])
+            InlineText("By continuing, I accept the Terms and Privacy Policy.",
+                       links: [("Terms", {}), ("Privacy Policy", {})])
         }
     }
 }

--- a/Demo/Demo/Examples/HotelDetailView.swift
+++ b/Demo/Demo/Examples/HotelDetailView.swift
@@ -24,7 +24,7 @@ struct HotelDetailView: View {
                     .frame(maxWidth: .infinity)
                     .overlay(alignment: .bottomLeading) {
                         if hotel.discount != nil {
-                            Badge("Fırsat", style: .error, leadingSystemImage: "flame.fill").padding()
+                            Badge("Deal", style: .error, leadingSystemImage: "flame.fill").padding()
                         }
                     }
 
@@ -40,14 +40,14 @@ struct HotelDetailView: View {
 
                     Card {
                         HStack {
-                            Stat(title: "Gecelik", value: hotel.pricePerNight.priceText, systemImage: "tag")
+                            Stat(title: "Per night", value: hotel.pricePerNight.priceText, systemImage: "tag")
                             Spacer()
-                            Stat(title: "Yorum", value: "\(hotel.reviewCount)", systemImage: "text.bubble")
+                            Stat(title: "Reviews", value: "\(hotel.reviewCount)", systemImage: "text.bubble")
                         }
                     }
 
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Konum").textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
+                        Text("Location").textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
                         Map(initialPosition: .region(MKCoordinateRegion(center: hotel.coordinate, span: .init(latitudeDelta: 0.02, longitudeDelta: 0.02)))) {
                             Marker(hotel.name, coordinate: hotel.coordinate).tint(Theme.shared.background(.bgHero))
                         }
@@ -56,22 +56,22 @@ struct HotelDetailView: View {
                         .allowsHitTesting(false)
                         HStack(spacing: 4) {
                             Icon(systemName: "mappin.circle", size: .sm, color: Theme.shared.text(.textTertiary))
-                            Text(hotel.area + ", İstanbul").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+                            Text(hotel.area + ", Istanbul").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
                         }
                     }
 
                     VStack(spacing: 8) {
-                        Accordion("İptal politikası", leadingSystemImage: "calendar", initiallyExpanded: true) {
-                            Text(hotel.freeCancellation ? "Girişten 24 saat öncesine kadar ücretsiz iptal." : "İptal koşulları rezervasyon sırasında belirtilir.")
+                        Accordion("Cancellation policy", leadingSystemImage: "calendar", initiallyExpanded: true) {
+                            Text(hotel.freeCancellation ? "Free cancellation up to 24 hours before check-in." : "Cancellation terms are shown during booking.")
                         }
-                        Accordion("Otel kuralları", leadingSystemImage: "list.bullet") {
-                            Text("Giriş 14:00 · Çıkış 12:00 · Evcil hayvan kabul edilmez.")
+                        Accordion("House rules", leadingSystemImage: "list.bullet") {
+                            Text("Check-in 2:00 PM · Check-out 12:00 PM · No pets allowed.")
                         }
                     }
 
-                    Text("Yorumlar").textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
-                    ChatBubble("Harika bir konaklamaydı, manzara muhteşemdi!", side: .incoming, author: "Ayşe", time: "2 gün önce", avatarSystemImage: "person.fill")
-                    ChatBubble("Personel çok ilgiliydi, kesinlikle tavsiye ederim.", side: .incoming, author: "Mehmet", time: "1 hafta önce", avatarSystemImage: "person.fill")
+                    Text("Reviews").textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
+                    ChatBubble("It was a wonderful stay, the view was amazing!", side: .incoming, author: "Emma", time: "2 days ago", avatarSystemImage: "person.fill")
+                    ChatBubble("The staff were very attentive, I highly recommend it.", side: .incoming, author: "James", time: "1 week ago", avatarSystemImage: "person.fill")
                 }
                 .padding()
             }
@@ -93,9 +93,9 @@ struct HotelDetailView: View {
             HStack(spacing: Theme.SpacingKey.md.value) {
                 VStack(alignment: .leading, spacing: 0) {
                     Text(hotel.pricePerNight.priceText).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
-                    Text("/ gece").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+                    Text("/ night").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
                 }
-                PrimaryButton("Rezerve et", block: true) { path.append(.checkout(hotel)) }
+                PrimaryButton("Reserve", block: true) { path.append(.checkout(hotel)) }
             }
             .padding(.bottom, 4)
         }

--- a/Demo/Demo/Examples/HotelFavoritesView.swift
+++ b/Demo/Demo/Examples/HotelFavoritesView.swift
@@ -20,9 +20,9 @@ struct HotelFavoritesView: View {
         Group {
             if saved.isEmpty {
                 EmptyState(systemImage: "heart",
-                           title: "Henüz favorin yok",
-                           message: "Beğendiğin otelleri kalbe dokunarak buraya ekleyebilirsin.",
-                           buttonTitle: "Otellere göz at",
+                           title: "No favorites yet",
+                           message: "Tap the heart on hotels you like to save them here.",
+                           buttonTitle: "Browse hotels",
                            action: { if path.last == .favorites { path.removeLast() } })
                     .padding()
                     .frame(maxHeight: .infinity)
@@ -53,7 +53,7 @@ struct HotelFavoritesView: View {
             }
         }
         .background(Color(.systemGroupedBackground))
-        .navigationTitle("Favoriler · \(saved.count)")
+        .navigationTitle("Favorites · \(saved.count)")
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Demo/Demo/Examples/HotelModels.swift
+++ b/Demo/Demo/Examples/HotelModels.swift
@@ -28,16 +28,16 @@ struct Hotel: Identifiable, Hashable {
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
 
     static let samples: [Hotel] = [
-        Hotel(name: "Grand Bosphorus Hotel", area: "Beşiktaş", score: 9.2, scoreLabel: "Mükemmel", reviewCount: 1284,
+        Hotel(name: "Grand Bosphorus Hotel", area: "Besiktas", score: 9.2, scoreLabel: "Excellent", reviewCount: 1284,
               pricePerNight: 4250, oldPrice: 5200, discount: 18, amenities: ["wifi", "pool", "spa", "breakfast"], color: .blue, freeCancellation: true,
               coordinate: .init(latitude: 41.0438, longitude: 29.0094)),
-        Hotel(name: "Sea Pearl Resort", area: "Sarıyer", score: 8.7, scoreLabel: "Çok İyi", reviewCount: 642,
+        Hotel(name: "Sea Pearl Resort", area: "Sariyer", score: 8.7, scoreLabel: "Very Good", reviewCount: 642,
               pricePerNight: 3100, oldPrice: nil, discount: nil, amenities: ["wifi", "pool", "gym"], color: .teal, freeCancellation: true,
               coordinate: .init(latitude: 41.1670, longitude: 29.0578)),
-        Hotel(name: "Old City Boutique", area: "Fatih", score: 9.0, scoreLabel: "Mükemmel", reviewCount: 980,
+        Hotel(name: "Old City Boutique", area: "Fatih", score: 9.0, scoreLabel: "Excellent", reviewCount: 980,
               pricePerNight: 2750, oldPrice: 3000, discount: 8, amenities: ["wifi", "breakfast"], color: .orange, freeCancellation: false,
               coordinate: .init(latitude: 41.0186, longitude: 28.9497)),
-        Hotel(name: "Skyline Suites", area: "Şişli", score: 8.4, scoreLabel: "Çok İyi", reviewCount: 410,
+        Hotel(name: "Skyline Suites", area: "Sisli", score: 8.4, scoreLabel: "Very Good", reviewCount: 410,
               pricePerNight: 2200, oldPrice: nil, discount: nil, amenities: ["wifi", "gym", "parking"], color: .purple, freeCancellation: true,
               coordinate: .init(latitude: 41.0602, longitude: 28.9877)),
     ]
@@ -77,16 +77,16 @@ enum Amenity {
     static func label(_ key: String) -> String {
         switch key {
         case "wifi": return "Wifi"
-        case "pool": return "Havuz"
+        case "pool": return "Pool"
         case "spa": return "Spa"
-        case "breakfast": return "Kahvaltı"
-        case "gym": return "Spor salonu"
-        case "parking": return "Otopark"
+        case "breakfast": return "Breakfast"
+        case "gym": return "Gym"
+        case "parking": return "Parking"
         default: return key.capitalized
         }
     }
 }
 
 extension Int {
-    var priceText: String { "₺" + String(self).replacingOccurrences(of: "(?<=\\d)(?=(\\d{3})+$)", with: ".", options: .regularExpression) }
+    var priceText: String { "$" + String(self).replacingOccurrences(of: "(?<=\\d)(?=(\\d{3})+$)", with: ",", options: .regularExpression) }
 }

--- a/Demo/Demo/Examples/HotelResultsView.swift
+++ b/Demo/Demo/Examples/HotelResultsView.swift
@@ -28,21 +28,21 @@ struct HotelResultsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SegmentedControl(["Liste", "Harita"], selection: $mode)
+            SegmentedControl(["List", "Map"], selection: $mode)
                 .padding([.horizontal, .top])
 
             if mode == 0 { listView } else { mapView }
         }
         .background(Color(.systemGroupedBackground))
-        .navigationTitle("\(destination) · \(hotels.count) otel")
+        .navigationTitle("\(destination) · \(hotels.count) hotels")
         .navigationBarTitleDisplayMode(.inline)
     }
 
     private var listView: some View {
         ScrollView {
             VStack(spacing: 16) {
-                SegmentedControl(["Önerilen", "Fiyat", "Puan"], selection: $sort)
-                FilterGroup(options: ["Ücretsiz iptal", "Havuz", "Kahvaltı", "Spa"], selection: $filter) { $0 }
+                SegmentedControl(["Recommended", "Price", "Rating"], selection: $sort)
+                FilterGroup(options: ["Free cancellation", "Pool", "Breakfast", "Spa"], selection: $filter) { $0 }
 
                 ForEach(hotels) { hotel in
                     ZStack(alignment: .topTrailing) {
@@ -107,7 +107,7 @@ struct HotelCard: View {
                         .frame(maxWidth: .infinity)
                         .clipped()
                     if let discount = hotel.discount {
-                        Badge("%\(discount) indirim", style: .error, size: .small).padding(10)
+                        Badge("\(discount)% off", style: .error, size: .small).padding(10)
                     }
                 }
 
@@ -130,10 +130,10 @@ struct HotelCard: View {
                             Text(old.priceText).textStyle(.bodySm400).strikethrough().foregroundStyle(Theme.shared.text(.textTertiary))
                         }
                         Text(hotel.pricePerNight.priceText).textStyle(.headingSm).foregroundStyle(Theme.shared.text(.textPrimary))
-                        Text("/ gece").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+                        Text("/ night").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
                         Spacer()
                         if hotel.freeCancellation {
-                            Callout("Ücretsiz iptal", type: .success)
+                            Callout("Free cancellation", type: .success)
                         }
                     }
                     .padding(.top, 2)

--- a/Demo/Demo/Examples/HotelSearchView.swift
+++ b/Demo/Demo/Examples/HotelSearchView.swift
@@ -13,40 +13,40 @@ import ThemeKit
 struct HotelSearchView: View {
     @StateObject private var favorites = FavoritesStore()
     @State private var path: [HotelRoute] = []
-    @State private var destination = "İstanbul"
+    @State private var destination = "Istanbul"
     @State private var checkIn: Date? = .now
     @State private var checkOut: Date? = Calendar.current.date(byAdding: .day, value: 3, to: .now)
     @State private var guests = 2
-    @State private var tripType: String? = "Tatil"
+    @State private var tripType: String? = "Leisure"
 
     var body: some View {
         NavigationStack(path: $path) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
-                    Title("Konaklama bul", subtitle: "Dünya genelinde 2M+ otel")
+                    Title("Find your stay", subtitle: "2M+ hotels worldwide")
 
-                    PromoBanner(title: "Erken rezervasyon", subtitle: "Yaz tatilinde %30'a varan indirim",
-                                systemImage: "sun.max.fill", ctaTitle: "Keşfet", action: {})
+                    PromoBanner(title: "Early booking", subtitle: "Up to 30% off summer stays",
+                                systemImage: "sun.max.fill", ctaTitle: "Explore", action: {})
 
                     Card {
                         VStack(spacing: 14) {
-                            SearchBar(text: $destination, placeholder: "Nereye gidiyorsun?")
+                            SearchBar(text: $destination, placeholder: "Where are you going?")
                             HStack(spacing: 12) {
-                                DateField(label: "Giriş", date: $checkIn, style: .custom("EEE, d MMM"),
+                                DateField(label: "Check-in", date: $checkIn, style: .custom("EEE, d MMM"),
                                           allowClear: true, leadingSystemImage: "calendar")
-                                DateField(label: "Çıkış", date: $checkOut, style: .custom("EEE, d MMM"),
+                                DateField(label: "Check-out", date: $checkOut, style: .custom("EEE, d MMM"),
                                           allowClear: true, leadingSystemImage: "calendar")
                             }
-                            InputNumber(label: "Misafir sayısı", value: $guests, range: 1...9, large: true)
+                            InputNumber(label: "Guests", value: $guests, range: 1...9, large: true)
                         }
                     }
 
-                    FilterGroup(title: "Seyahat tipi", options: ["Tatil", "İş", "Aile", "Romantik"], selection: $tripType) { $0 }
+                    FilterGroup(title: "Trip type", options: ["Leisure", "Business", "Family", "Romantic"], selection: $tripType) { $0 }
                 }
                 .padding()
             }
             .background(Color(.systemGroupedBackground))
-            .navigationTitle("Otel Ara")
+            .navigationTitle("Search hotels")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button { path.append(.favorites) } label: {
@@ -65,7 +65,7 @@ struct HotelSearchView: View {
                 }
             }
             .buttonDock {
-                PrimaryButton("\(guests) misafir · Otelleri ara", block: true) { path.append(.results) }
+                PrimaryButton("\(guests) guests · Search hotels", block: true) { path.append(.results) }
                     .padding(.bottom, 4)
             }
             .onAppear {

--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -92,7 +92,7 @@ enum ComponentRegistry {
         .knob("ThemeButton", .molecules, demo: ThemeButtonDemo(), usage: #"ThemeButton("Save", color: .success, variant: .soft, size: .medium, shape: .pill) { }"#),
         .knob("Checkbox", .molecules, demo: CheckboxDemo(), usage: #"Checkbox("Accept terms", isChecked: $on, infoMessages: error ? [.init("Required", kind: .error)] : [])"#),
         .knob("CheckboxGroup", .molecules, demo: CheckboxGroupDemo(), usage: #"CheckboxGroup(options: items, selection: $set) { $0 }"#),
-        .knob("InputNumber", .molecules, demo: InputNumberDemo(), usage: #"InputNumber(label: "Max price", value: $n, range: 0...10000, step: 50, unit: "₺")"#),
+        .knob("InputNumber", .molecules, demo: InputNumberDemo(), usage: #"InputNumber(label: "Max price", value: $n, range: 0...10000, step: 50, unit: "$")"#),
         .knob("MultiLineTextInput", .molecules, demo: MultiLineDemo(), usage: #"MultiLineTextInput("Notes", text: $text, characterLimit: 200)"#),
         .knob("OTPInput", .molecules, demo: OTPDemo(), usage: #"OTPInput(code: $code, digitCount: 6, isSecure: true,\n         onComplete: { verify($0) }, resendInterval: 30, onResend: { resend() })"#),
         .knob("Breadcrumbs", .molecules, demo: BreadcrumbsDemo(), usage: #"Breadcrumbs([.init("Home", action: { }), .init("Current")], maxItems: 4)"#),
@@ -102,7 +102,7 @@ enum ComponentRegistry {
         .knob("Form", .molecules, demo: FormDemo(), usage: ##"@State var form = FormValidator<Field>([.email: [.required(), .email()]])\nform.validateAll([.email: email])  // → first invalid field, focuses it"##),
         .knob("FileInput", .molecules, demo: FileInputDemo(), usage: #"FileInput(label: "Passport", fileName: name) { pick() }"#),
         .knob("FilterGroup", .molecules, demo: FilterGroupDemo(), usage: #"FilterGroup(options: items, selection: $sel) { $0 }"#),
-        .knob("Chips", .molecules, demo: ChipsDemo(), usage: #"CompactChip(isSelected: $on, text: "Suit", price: "₺899", rating: 4.6)   // ChoseChip · ImageChip · FilterChip · ChipGroup"#),
+        .knob("Chips", .molecules, demo: ChipsDemo(), usage: #"CompactChip(isSelected: $on, text: "Suit", price: "$899", rating: 4.6)   // ChoseChip · ImageChip · FilterChip · ChipGroup"#),
         .knob("ProgressIndicator", .molecules, demo: ProgressIndicatorDemo(), usage: #"ProgressIndicator(variant: .carousel, current: 2, total: 8, stepText: .slash)"#),
         .knob("ThemeController", .molecules, demo: ThemeControllerDemo(), usage: #"ThemeController(options: [.init(name: "oceanTheme", label: "Ocean")], selectedName: $name)"#),
         .knob("Pagination", .molecules, demo: PaginationDemo(), usage: #"Pagination(current: $page, total: 50).window(sibling: 2).jumper()"#),
@@ -164,9 +164,9 @@ enum ComponentRegistry {
         .knob("NotificationCard", .organisms, demo: NotificationDemo(), usage: #"NotificationCard(title: "…", message: "…", date: "…", isUnread: true)"#),
         .knob("PageHeader", .organisms, demo: PageHeaderDemo(), usage: #"PageHeader("Title", subtitle: "…", onBack: { })"#),
         .knob("PromoBanner", .organisms, demo: PromoBannerDemo(), usage: #"PromoBanner(title: "…", systemImage: "sun.max.fill", ctaTitle: "Go", action: { })"#),
-        .knob("RatingSummary", .organisms, demo: RatingSummaryDemo(), usage: #"RatingSummary(score: 9.0, label: "Mükemmel", reviewCount: 1200)"#),
-        .knob("Result", .organisms, demo: ResultDemo(), usage: #"ResultView(.notFound, title: "Sayfa bulunamadı", message: "…", primaryTitle: "Ana sayfa") { }"#),
-        .knob("Popconfirm", .organisms, demo: PopconfirmDemo(), usage: ##"trigger.popconfirm(isPresented: $show, title: "Sil?", confirmTitle: "Sil") { delete() }"##),
+        .knob("RatingSummary", .organisms, demo: RatingSummaryDemo(), usage: #"RatingSummary(score: 9.0, label: "Excellent", reviewCount: 1200)"#),
+        .knob("Result", .organisms, demo: ResultDemo(), usage: #"ResultView(.notFound, title: "Page not found", message: "…", primaryTitle: "Home") { }"#),
+        .knob("Popconfirm", .organisms, demo: PopconfirmDemo(), usage: ##"trigger.popconfirm(isPresented: $show, title: "Delete?", confirmTitle: "Delete") { delete() }"##),
         .knob("Tour", .organisms, demo: TourDemo(), usage: ##"view.tourTarget("search");  root.tourHost(tour, steps: [TourStep("search", title: "…", message: "…")])"##),
         .knob("Dialog", .organisms, demo: DialogDemo(), usage: #"view.dialog(isPresented: $show, title: "…") { content } footer: { buttons }"#),
         .knob("SegmentedTabBar", .organisms, demo: SegmentedTabBarDemo(), usage: #"SegmentedTabBar([TabItem("Reviews", badge: "12"), TabItem("Off", isEnabled: false)], selection: $i)"#),
@@ -175,8 +175,8 @@ enum ComponentRegistry {
         .knob("Carousel", .organisms, demo: CarouselDemo(), usage: #"Carousel(items) { item in mediaView }.autoplay(2).arrows()"#),
         .knob("PagingCarousel", .organisms, demo: PagingCarouselDemo(), usage: #"PagingCarousel(items, peek: 36, autoplay: 2) { item in mediaView }"#),
         .knob("VideoPlayer", .organisms, demo: VideoPlayerDemo(), usage: #"VideoPlayerView(url).loop().muted().muteToggle()"#),
-        .static("KeyValueTable", .organisms, usage: #"KeyValueTable(rows: [...], title: "Özet", bordered: true)"#) {
-            KeyValueTable(rows: [.init("Status", value: "Aktif", style: .success), .init("Old price", value: "5.000 TL", style: .strikethrough), .init("Total", value: "4.250 TL")], title: "Rezervasyon özeti", bordered: true)
+        .static("KeyValueTable", .organisms, usage: #"KeyValueTable(rows: [...], title: "Summary", bordered: true)"#) {
+            KeyValueTable(rows: [.init("Status", value: "Active", style: .success), .init("Old price", value: "$5,000", style: .strikethrough), .init("Total", value: "$4,250")], title: "Reservation summary", bordered: true)
         },
         .knob("Theme Injection", .organisms, demo: ThemeInjectionDemo(), usage: #"let ocean = Theme(); ocean.loadTheme(named: "oceanTheme")\nmySubtree.theme(ocean)   // re-skins just this subtree"#),
     ]

--- a/Demo/Demo/Gallery/Demos/AtomDemos.swift
+++ b/Demo/Demo/Gallery/Demos/AtomDemos.swift
@@ -97,7 +97,7 @@ struct BadgeDemo: View {
         ]) {
             Badge(text, style: style, variant: variant, size: size,
                   leadingSystemImage: icon ? "star.fill" : nil,
-                  action: tappable ? { tapped += 1; flash("Badge tıklandı") } : nil)
+                  action: tappable ? { tapped += 1; flash("Badge tapped") } : nil)
                 .badgeShape(pill ? .pill : .rounded)
                 .badgeColor(gradient ? Theme.shared.foreground(.fgSecondary) : nil)
                 .gradient(gradient ? [SemanticColor.primary.base, SemanticColor.purple.base] : nil)
@@ -194,10 +194,10 @@ struct RatingDemo: View {
 
     var body: some View {
         ComponentStage("Rating", inspector: [("value", String(format: "%.1f", value)), ("layout", "\(layout)"), ("reviewTaps", "\(taps)")]) {
-            Rating(value: value, layout: layout, countLabel: "1.284 yorum")
+            Rating(value: value, layout: layout, countLabel: "1,284 reviews")
                 .allowHalf(allowHalf)
-                .onRate((interactive && layoutIdx == 0) ? { value = $0; flash("Puan: \(String(format: "%.1f", $0))") } : nil)
-                .onReviewTap(reviewLink ? { taps += 1; flash("Yorumlara dokunuldu") } : nil)
+                .onRate((interactive && layoutIdx == 0) ? { value = $0; flash("Rating: \(String(format: "%.1f", $0))") } : nil)
+                .onReviewTap(reviewLink ? { taps += 1; flash("Reviews tapped") } : nil)
         } knobs: {
             HStack { Text("Value"); SwiftUI.Slider(value: $value, in: 0...5, step: 0.1) }
             Picker("Layout", selection: $layoutIdx) { Text("Stars").tag(0); Text("Number").tag(1); Text("Number+text").tag(2) }.pickerStyle(.segmented)
@@ -224,7 +224,7 @@ struct SpinnerDemo: View {
 }
 
 struct TagDemo: View {
-    @State private var text = "İstanbul"
+    @State private var text = "Istanbul"
     @State private var removable = true
     @State private var icon = false
     @State private var styleIdx = 0   // 0 = neutral (no style)
@@ -238,7 +238,7 @@ struct TagDemo: View {
         ComponentStage("Tag", inspector: [("style", styles[styleIdx].0), ("variant", "\(variant)")]) {
             Tag(text, leadingSystemImage: icon ? "mappin" : nil,
                 style: styles[styleIdx].1, variant: variant,
-                onRemove: removable ? { flash("Tag silindi") } : nil)
+                onRemove: removable ? { flash("Tag removed") } : nil)
         } knobs: {
             TextField("Text", text: $text).textFieldStyle(.roundedBorder)
             Picker("Style", selection: $styleIdx) {

--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -20,7 +20,7 @@ struct ButtonDemo: View {
     @State private var helper = false
     @State private var asyncMode = false
 
-    private var helperText: String? { helper ? "KDV dahil fiyat" : nil }
+    private var helperText: String? { helper ? "VAT included" : nil }
     private func tapped() { flash("\(style.rawValue.capitalized) button tapped") }
     // Simulates a 1.2s network call; the button auto-shows a spinner then a checkmark.
     private func work() async {
@@ -86,12 +86,12 @@ struct CheckboxDemo: View {
 
     // Required-checkbox semantic: error only while unchecked (like reference shouldWarn).
     private var messages: [InfoMessage] {
-        (requiredError && !checked) ? [InfoMessage("Devam etmek için kabul edin", kind: .error)] : []
+        (requiredError && !checked) ? [InfoMessage("Accept to continue", kind: .error)] : []
     }
 
     var body: some View {
         ComponentStage("Checkbox", inspector: [("isChecked", "\(checked)"), ("type", typeIdx == 1 ? "inner" : typeIdx == 2 ? "customInner" : "plain")]) {
-            Checkbox(withLabel ? "Şartları ve koşulları kabul ediyorum" : nil, isChecked: $checked,
+            Checkbox(withLabel ? "I accept the terms and conditions" : nil, isChecked: $checked,
                      customSize: big ? 32 : nil, type: type,
                      isIndeterminate: indeterminate, alignment: .top,
                      infoMessages: messages)
@@ -120,7 +120,7 @@ struct RadioButtonDemo: View {
 
     var body: some View {
         ComponentStage("RadioButton", inspector: [("type", check ? "check" : "select"), ("style", inner ? "inner" : "plain")]) {
-            RadioButton(inlineLabel ? "Hatırla beni" : nil, isSelected: $selected,
+            RadioButton(inlineLabel ? "Remember me" : nil, isSelected: $selected,
                         type: check ? .check : .select,
                         style: inner ? .inner : .plain, padding: .medium)
                     .controlSize(small ? .small : .regular)
@@ -168,32 +168,32 @@ struct TextInputDemo: View {
     private var model: TextInputModel {
         switch mode {
         case .email:
-            var msgs = Validator.validate(text, [.required("E-posta zorunlu"), .email()], all: true)
+            var msgs = Validator.validate(text, [.required("Email is required"), .email()], all: true)
             if msgs.isEmpty, !text.isEmpty {   // clickable info link (reference clickableParts)
-                msgs = [InfoMessage("Bu e-posta kayıtlı. Giriş yap", kind: .info,
-                                    links: [("Giriş yap", { loggedIn = true })])]
+                msgs = [InfoMessage("This email is already registered. Log in", kind: .info,
+                                    links: [("Log in", { loggedIn = true })])]
             }
-            return TextInputModel(label: "E-posta", placeholder: "ad@sirket.com", leadingSystemImage: "envelope",
+            return TextInputModel(label: "Email", placeholder: "name@company.com", leadingSystemImage: "envelope",
                                   allowClear: true, infoMessages: msgs,
                                   keyboardType: .emailAddress, textContentType: .emailAddress,
                                   submitLabel: .next, autocapitalization: .never, autocorrectionDisabled: true)
         case .password:
-            return TextInputModel(label: "Şifre", isSecure: true, maxLength: 24, showCount: true, textContentType: .password, submitLabel: .go)
+            return TextInputModel(label: "Password", isSecure: true, maxLength: 24, showCount: true, textContentType: .password, submitLabel: .go)
         case .bio:
             // Soft limit: typing past 80 is allowed; the counter turns red instead of truncating.
-            return TextInputModel(label: "Hakkımda", placeholder: "Kısaca kendinden bahset", maxLength: 80,
+            return TextInputModel(label: "About me", placeholder: "Tell us a bit about yourself", maxLength: 80,
                                   showCount: true, hardLimit: false, countStyle: .remaining)
         case .card:
-            return TextInputModel(label: "Kart No", placeholder: "0000 0000 0000 0000", leadingSystemImage: "creditcard",
+            return TextInputModel(label: "Card number", placeholder: "0000 0000 0000 0000", leadingSystemImage: "creditcard",
                                   formatter: .creditCard())
         case .phone:
-            return TextInputModel(label: "Telefon", placeholder: "0### ### ## ##", leadingSystemImage: "phone",
+            return TextInputModel(label: "Phone", placeholder: "0### ### ## ##", leadingSystemImage: "phone",
                                   formatter: .phoneTR)
         case .currency:
-            return TextInputModel(label: "Tutar", placeholder: "₺0", leadingSystemImage: "turkishlirasign.circle",
+            return TextInputModel(label: "Amount", placeholder: "$0", leadingSystemImage: "dollarsign.circle",
                                   formatter: .currency())
         case .addons:
-            return TextInputModel(label: "Alan adı", placeholder: "siteniz", addonBefore: "https://", addonAfter: ".com.tr")
+            return TextInputModel(label: "Domain name", placeholder: "yoursite", addonBefore: "https://", addonAfter: ".com")
         }
     }
 
@@ -276,14 +276,14 @@ struct RangeSliderDemo: View {
         ComponentStage("RangeSlider", inspector: [("range", "\(Int(lo))–\(Int(hi))"), ("onChangeEnd", lastCommit)]) {
             if inputs {
                 RangeSlider(lowerValue: $lo, upperValue: $hi, in: 0...1000, step: 50)
-                    .inputs(titles: ("En az ₺", "En çok ₺"))
+                    .inputs(titles: ("Min $", "Max $"))
                     .onChangeEnd { l, u in lastCommit = "\(Int(l))–\(Int(u))" }
                     .disabled(!enabled)
             } else {
                 RangeSlider(lowerValue: $lo, upperValue: $hi, in: 0...1000, step: 50)
                     .marks(marks ? [0, 250, 500, 750, 1000] : [])
                     .onChangeEnd { l, u in lastCommit = "\(Int(l))–\(Int(u))" }
-                    .valueLabel { "\(Int($0)) ₺" }
+                    .valueLabel { "$\(Int($0))" }
                     .disabled(!enabled)
             }
         } knobs: {
@@ -332,16 +332,16 @@ struct InputNumberDemo: View {
     @State private var large = true
     @State private var showError = false
     @State private var editable = true
-    @State private var priceMode = false   // toggles a step:50 + "₺" unit config
+    @State private var priceMode = false   // toggles a step:50 + "$" unit config
 
     var body: some View {
         ComponentStage("InputNumber", inspector: [("value", "\(value)"), ("editable", "\(editable)")]) {
             if priceMode {
-                InputNumber(label: "Max price", value: $value, range: 0...10000, step: 50, unit: "₺",
+                InputNumber(label: "Max price", value: $value, range: 0...10000, step: 50, unit: "$",
                             hint: "Type or step by 50", large: large)
                     .editable(editable)
             } else {
-                InputNumber(label: "Guests", value: $value, range: 1...9, unit: "kişi",
+                InputNumber(label: "Guests", value: $value, range: 1...9, unit: "guests",
                             hint: showError ? nil : "Type a number or use ± ",
                             errorText: showError ? "Too many" : nil, large: large)
                     .editable(editable)
@@ -350,7 +350,7 @@ struct InputNumberDemo: View {
             Text("editable = type the value directly (Ant InputNumber); ± steps by `step`.").font(.caption).foregroundStyle(.secondary)
             Stepper("Value: \(value)", value: $value, in: 0...10000)
             Toggle("Editable (type to enter)", isOn: $editable)
-            Toggle("Price mode (step 50, ₺)", isOn: $priceMode)
+            Toggle("Price mode (step 50, $)", isOn: $priceMode)
             Toggle("Large", isOn: $large)
             Toggle("Error state", isOn: $showError)
         }
@@ -385,8 +385,8 @@ struct PaginationDemo: View {
             Pagination(current: $page, total: Int(total))
                 .simple(simple)
                 .window(sibling: wideWindow ? 2 : 1)
-                .jumper(jumper && !simple, title: "Git")
-                .showTotal(showTotal ? { _, t in "\(t) sayfa" } : nil)
+                .jumper(jumper && !simple, title: "Go")
+                .showTotal(showTotal ? { _, t in "\(t) pages" } : nil)
         } knobs: {
             Stepper("Current: \(page)", value: $page, in: 1...Int(total))
             HStack { Text("Total"); SwiftUI.Slider(value: $total, in: 3...50, step: 1) }

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -135,9 +135,9 @@ struct SearchBarDemo: View {
     @State private var back = false
     @State private var trailing = true
     @State private var typeahead = true
-    @State private var recent = ["İstanbul", "Bursa"]
+    @State private var recent = ["Istanbul", "Bursa"]
 
-    private let cities = ["İstanbul", "İzmir", "İzmit", "Ankara", "Antalya", "Bursa", "Adana"]
+    private let cities = ["Istanbul", "Izmir", "Izmit", "Ankara", "Antalya", "Bursa", "Adana"]
 
     var body: some View {
         ComponentStage("SearchBar", inspector: [("text", "\"\(text)\""), ("suggestions", "\(typeahead)"), ("recent", "\(recent.count)")]) {
@@ -168,10 +168,10 @@ struct SelectDemo: View {
     @State private var filled = false
 
     private var selectView: some View {
-        Select("Şehir", sections: [
-            .init("Marmara", ["İstanbul", "Bursa", "Kocaeli"]),
-            .init("Ege", ["İzmir", "Aydın", "Muğla"]),
-            .init("İç Anadolu", ["Ankara", "Konya"]),
+        Select("City", sections: [
+            .init("Marmara", ["Istanbul", "Bursa", "Kocaeli"]),
+            .init("Aegean", ["Izmir", "Aydin", "Mugla"]),
+            .init("Central Anatolia", ["Ankara", "Konya"]),
         ], selection: $city, allowClear: clearable, searchable: searchable, isLoading: loading,
            isOptionEnabled: disableSoldOut ? { $0 != "Konya" } : nil) { $0 }
     }
@@ -189,21 +189,21 @@ struct SelectDemo: View {
             Toggle("Allow clear", isOn: $clearable)
             Toggle("Loading (async)", isOn: $loading)
             Toggle("Disable \"Konya\"", isOn: $disableSoldOut)
-            Text(searchable ? "Tap → açılır panel: ara, loading & \"No results\" durumları." : "Tap → native Menu (gruplu Section'lar).").font(.caption).foregroundStyle(.secondary)
+            Text(searchable ? "Tap → expanding panel: search, loading & \"No results\" states." : "Tap → native Menu (grouped Sections).").font(.caption).foregroundStyle(.secondary)
             Button("Clear") { city = nil }
         }
     }
 }
 
 struct MultiSelectDemo: View {
-    @State private var picks: Set<String> = ["İstanbul", "Ankara", "İzmir", "Bursa"]
+    @State private var picks: Set<String> = ["Istanbul", "Ankara", "Izmir", "Bursa"]
     @State private var searchable = true
     @State private var clearable = true
     @State private var capTags = true
     @State private var enabled = true
     @State private var loading = false
     @State private var disableSoldOut = false   // marks "Adana" disabled
-    private let cities = ["İstanbul", "Ankara", "İzmir", "Antalya", "Bursa", "Adana", "Konya"]
+    private let cities = ["Istanbul", "Ankara", "Izmir", "Antalya", "Bursa", "Adana", "Konya"]
 
     var body: some View {
         ComponentStage("MultiSelect", inspector: [("count", "\(picks.count)"), ("loading", "\(loading)")]) {
@@ -221,18 +221,18 @@ struct MultiSelectDemo: View {
             Toggle("Loading (async)", isOn: $loading)
             Toggle("Disable \"Adana\"", isOn: $disableSoldOut)
             Toggle("Enabled", isOn: $enabled)
-            Button("Reset") { picks = ["İstanbul", "Ankara", "İzmir", "Bursa"] }
+            Button("Reset") { picks = ["Istanbul", "Ankara", "Izmir", "Bursa"] }
         }
     }
 }
 
 struct SelectBoxDemo: View {
-    @State private var country: String? = "Türkiye"
+    @State private var country: String? = "Turkey"
     @State private var error = false
     @State private var enabled = true
     var body: some View {
         ComponentStage("SelectBox", inspector: [("selection", country ?? "nil"), ("isEnabled", "\(enabled)")]) {
-            SelectBox(label: "Country", options: ["Türkiye", "Germany", "France"], selection: $country,
+            SelectBox(label: "Country", options: ["Turkey", "Germany", "France"], selection: $country,
                       hint: error ? nil : "Pick your country", errorText: error ? "Required" : nil) { $0 }
             .disabled(!enabled)
         } knobs: {
@@ -331,7 +331,7 @@ struct CheckboxGroupDemo: View {
     var body: some View {
         ComponentStage("CheckboxGroup", inspector: [("selected", sel.sorted().joined(separator: ", "))]) {
             CheckboxGroup(title: "Amenities", options: options, selection: $sel,
-                          selectAllTitle: selectAll ? "Tümünü seç" : nil,
+                          selectAllTitle: selectAll ? "Select all" : nil,
                           isOptionEnabled: disableParking ? { $0 != "Parking" } : nil) { $0 }
                 .disabled(!enabled)
         } knobs: {
@@ -389,12 +389,12 @@ struct AutocompleteDemo: View {
     @State private var text = ""
     @State private var asyncMode = false
     @State private var disableSoldOut = false
-    private let cities = ["İstanbul", "İzmir", "İzmit", "Ankara", "Antalya", "Bursa"]
+    private let cities = ["Istanbul", "Izmir", "Izmit", "Ankara", "Antalya", "Bursa"]
     private var enabledPredicate: ((String) -> Bool)? {
-        disableSoldOut ? { $0 != "İzmit" } : nil
+        disableSoldOut ? { $0 != "Izmit" } : nil
     }
     var body: some View {
-        ComponentStage("Autocomplete", inspector: [("text", "\"\(text)\""), ("mode", asyncMode ? "async" : "static"), ("disabled", disableSoldOut ? "İzmit" : "—")]) {
+        ComponentStage("Autocomplete", inspector: [("text", "\"\(text)\""), ("mode", asyncMode ? "async" : "static"), ("disabled", disableSoldOut ? "Izmit" : "—")]) {
             if asyncMode {
                 Autocomplete(label: "Destination", text: $text, suggest: { query in
                     try? await Task.sleep(nanoseconds: 400_000_000)   // simulate network
@@ -407,7 +407,7 @@ struct AutocompleteDemo: View {
             }
         } knobs: {
             Toggle("Async (remote-style)", isOn: $asyncMode)
-            Toggle("Disable “İzmit”", isOn: $disableSoldOut)
+            Toggle("Disable “Izmit”", isOn: $disableSoldOut)
             Text("Type to filter suggestions.").font(.footnote).foregroundStyle(.secondary)
         }
     }
@@ -426,12 +426,12 @@ struct CardDemo: View {
 
     private var cardBody: some View {
         Card(elevation: elevation, padding: padding,
-             title: header ? "Rezervasyon" : nil,
-             subtitle: header ? "2 gece · 2 misafir" : nil,
-             extraTitle: header ? "Detay" : nil,
-             onExtra: header ? { flash("Detay") } : nil,
+             title: header ? "Reservation" : nil,
+             subtitle: header ? "2 nights · 2 guests" : nil,
+             extraTitle: header ? "Details" : nil,
+             onExtra: header ? { flash("Details") } : nil,
              isLoading: loading,
-             action: tappable ? { taps += 1; flash("Card tıklandı") } : nil) {
+             action: tappable ? { taps += 1; flash("Card tapped") } : nil) {
             VStack(alignment: .leading, spacing: 8) {
                 Text(tappable ? "Tappable card" : "Card body").textStyle(.headingSm)
                 Text(tappable ? "Press me — scales with feedback." : "Supporting body text inside a card surface.")
@@ -469,12 +469,12 @@ struct EmptyStateDemo: View {
         ComponentStage("EmptyState", inspector: [("media", animated ? "gif" : customImage ? "custom" : "symbol")]) {
             if animated {
                 EmptyState(animatedURL: gifURL, imageMaxHeight: 140,
-                           title: "Yükleniyor", message: "İçerik hazırlanıyor…",
-                           buttonTitle: hasButton ? "Yenile" : nil, action: hasButton ? { flash("EmptyState: Yenile") } : nil)
+                           title: "Loading", message: "Preparing content…",
+                           buttonTitle: hasButton ? "Refresh" : nil, action: hasButton ? { flash("EmptyState: Refresh") } : nil)
             } else if customImage {
                 EmptyState(image: Image(systemName: "sailboat.fill"), imageMaxHeight: 120,
-                           title: "Sepetin boş", message: "Henüz bir şey eklemedin.",
-                           buttonTitle: hasButton ? "Keşfet" : nil, action: hasButton ? { flash("EmptyState: Keşfet") } : nil)
+                           title: "Your cart is empty", message: "You haven't added anything yet.",
+                           buttonTitle: hasButton ? "Explore" : nil, action: hasButton ? { flash("EmptyState: Explore") } : nil)
             } else {
                 EmptyState(systemImage: "magnifyingglass",
                            iconForeground: tintIcon ? Theme.shared.foreground(.systemcolorsFgWarning) : nil,
@@ -516,26 +516,26 @@ struct ListRowDemo: View {
         case .toggle: return .toggle($on)
         case .checkmark: return .checkmark(on)
         case .checkbox: return .checkbox($agree)
-        case .button: return .button("Düzenle", action: { flash("ListRow: Düzenle") })
-        case .price: return .price(.init(total: "₺14.400", each: "₺1.200", unit: "/ ay"))
-        case .status: return .status("Müsait", systemImage: "checkmark.seal.fill")
+        case .button: return .button("Edit", action: { flash("ListRow: Edit") })
+        case .price: return .price(.init(total: "$14,400", each: "$1,200", unit: "/ month"))
+        case .status: return .status("Available", systemImage: "checkmark.seal.fill")
         case .none: return .none
         }
     }
 
     private var imageURL: URL? { URL(string: "https://picsum.photos/seed/listrow/120") }
-    private var meta: ListRowMeta? { withMeta ? ListRowMeta(rating: 8.4, sentiment: "Mükemmel", commentLabel: "1.284 yorum") : nil }
+    private var meta: ListRowMeta? { withMeta ? ListRowMeta(rating: 8.4, sentiment: "Excellent", commentLabel: "1,284 reviews") : nil }
     private var infos: [ListRowInfo] {
-        moreInfo ? [ListRowInfo(systemImage: "checkmark", "Ücretsiz iptal"),
-                    ListRowInfo(systemImage: "wifi", "Ücretsiz wifi"),
-                    ListRowInfo("Kapıda ödeme yok")] : []
+        moreInfo ? [ListRowInfo(systemImage: "checkmark", "Free cancellation"),
+                    ListRowInfo(systemImage: "wifi", "Free wifi"),
+                    ListRowInfo("No payment on arrival")] : []
     }
 
     var body: some View {
         ComponentStage("ListRow", inspector: [("trailing", kind.rawValue), ("leading", lead.rawValue)]) {
             VStack(spacing: 0) {
-                ListSectionHeader("Konaklama")
-                ListRow("Grand Hotel İstanbul", subtitle: subtitle ? "Deniz manzaralı · Kahvaltı dahil" : nil,
+                ListSectionHeader("Accommodation")
+                ListRow("Grand Hotel Istanbul", subtitle: subtitle ? "Sea view · Breakfast included" : nil,
                         number: lead == .number ? 1 : nil,
                         leadingSystemImage: lead == .icon ? "building.2" : nil,
                         leadingImageURL: lead == .image ? imageURL : nil,
@@ -543,8 +543,8 @@ struct ListRowDemo: View {
                         alertCount: alert ? 3 : nil,
                         meta: meta, infos: infos, isSelected: selected,
                         multilineTitle: moreInfo,
-                        infoAction: kind == .price ? { flash("ListRow: fiyat bilgisi") } : nil,
-                        trailing: trailing, action: { flash("ListRow tıklandı") })
+                        infoAction: kind == .price ? { flash("ListRow: price info") } : nil,
+                        trailing: trailing, action: { flash("ListRow tapped") })
             }
         } knobs: {
             Picker("Trailing", selection: $kind) { ForEach(Kind.allCases, id: \.self) { Text($0.rawValue).tag($0) } }
@@ -568,20 +568,20 @@ struct NotificationDemo: View {
     var body: some View {
         ComponentStage("NotificationCard", inspector: [("isUnread", "\(unread)"), ("type", typed ? "success" : "default")]) {
             if actions {
-                NotificationCard(title: "Tatilinle İlgili Bir Önerimiz Var",
-                                 message: "Hilton İstanbul rezervasyonuna 24 gün kaldı.",
-                                 date: "5 Aralık 2024", isUnread: unread, type: type,
-                                 onClose: closable ? { flash("Notification kapatıldı") } : nil) {
+                NotificationCard(title: "We Have a Suggestion for Your Holiday",
+                                 message: "24 days left until your Hilton Istanbul reservation.",
+                                 date: "December 5, 2024", isUnread: unread, type: type,
+                                 onClose: closable ? { flash("Notification dismissed") } : nil) {
                     ButtonGroup(.horizontal) {
-                        SecondaryButton("Sonra", size: .small) { flash("Notification: Sonra") }
-                        PrimaryButton("İncele", size: .small) { flash("Notification: İncele") }
+                        SecondaryButton("Later", size: .small) { flash("Notification: Later") }
+                        PrimaryButton("View", size: .small) { flash("Notification: View") }
                     }
                 }
             } else {
-                NotificationCard(title: "Tatilinle İlgili Bir Önerimiz Var",
-                                 message: "Hilton İstanbul rezervasyonuna 24 gün kaldı.",
-                                 date: "5 Aralık 2024", isUnread: unread, type: type,
-                                 onClose: closable ? { flash("Notification kapatıldı") } : nil)
+                NotificationCard(title: "We Have a Suggestion for Your Holiday",
+                                 message: "24 days left until your Hilton Istanbul reservation.",
+                                 date: "December 5, 2024", isUnread: unread, type: type,
+                                 onClose: closable ? { flash("Notification dismissed") } : nil)
             }
         } knobs: {
             Toggle("Unread", isOn: $unread)
@@ -600,9 +600,9 @@ struct PageHeaderDemo: View {
     var body: some View {
         ComponentStage("PageHeader") {
             PageHeader("Search results", subtitle: subtitle ? "128 hotels" : nil,
-                       tags: tags ? [.init("Aktif", style: .success), .init("Beta", style: .info)] : [],
-                       onBack: back ? { flash("PageHeader: geri") } : nil,
-                       actions: actions ? [.init(systemImage: "slider.horizontal.3", handler: { flash("PageHeader: filtre") }), .init(systemImage: "heart", handler: { flash("PageHeader: favori") })] : [])
+                       tags: tags ? [.init("Active", style: .success), .init("Beta", style: .info)] : [],
+                       onBack: back ? { flash("PageHeader: back") } : nil,
+                       actions: actions ? [.init(systemImage: "slider.horizontal.3", handler: { flash("PageHeader: filter") }), .init(systemImage: "heart", handler: { flash("PageHeader: favorite") })] : [])
         } knobs: {
             Toggle("Back button", isOn: $back)
             Toggle("Subtitle", isOn: $subtitle)
@@ -617,7 +617,7 @@ struct RatingSummaryDemo: View {
     @State private var reviews = true
     var body: some View {
         ComponentStage("RatingSummary", inspector: [("score", String(format: "%.1f", score))]) {
-            RatingSummary(score: score, label: "Mükemmel", reviewCount: reviews ? 1200 : nil, onReviews: reviews ? { flash("Yorumlara dokunuldu") } : nil)
+            RatingSummary(score: score, label: "Excellent", reviewCount: reviews ? 1200 : nil, onReviews: reviews ? { flash("Reviews tapped") } : nil)
         } knobs: {
             HStack { Text("Score"); SwiftUI.Slider(value: $score, in: 0...10, step: 0.1) }
             Toggle("Review count", isOn: $reviews)
@@ -629,9 +629,9 @@ struct BlogCardDemo: View {
     @State private var compact = false
     var body: some View {
         ComponentStage("BlogCard", inspector: [("compact", "\(compact)")]) {
-            BlogCard(title: "Kapadokya'yı Tek Başına Keşfetmeye Ne Dersin?",
-                     excerpt: "Kimine göre doğanın bir mucizesi, kimine göre periler diyarı…",
-                     compact: compact, onReadMore: { flash("BlogCard: devamını oku") }) {
+            BlogCard(title: "How About Exploring Cappadocia on Your Own?",
+                     excerpt: "To some a miracle of nature, to others a fairyland…",
+                     compact: compact, onReadMore: { flash("BlogCard: read more") }) {
                 Theme.shared.background(.bgTertiary)
             }
         } knobs: {
@@ -659,7 +659,7 @@ struct GalleryDemo: View {
 }
 
 struct UploadDemo: View {
-    private struct DemoUploadError: LocalizedError { var errorDescription: String? { "Dosya çok büyük" } }
+    private struct DemoUploadError: LocalizedError { var errorDescription: String? { "File too large" } }
 
     @State private var uploads = UploadController()
     @State private var counter = 0
@@ -669,7 +669,7 @@ struct UploadDemo: View {
         ComponentStage("Upload", inspector: [("files", "\(uploads.files.count)"), ("picked", "\(picked.count)/3")]) {
             VStack(spacing: 20) {
                 UploadList(controller: uploads) { start(fail: false) }
-                Upload(prompt: "En fazla 3 fotoğraf yükleyebilirsin.", buttonTitle: "Fotoğraf ekle",
+                Upload(prompt: "You can upload up to 3 photos.", buttonTitle: "Add photo",
                        files: picked, maxCount: 3,
                        onPick: { picked.append(.init(name: "img-\(picked.count + 1).jpg", status: .done)) },
                        onRemove: { file in picked.removeAll { $0.id == file.id } })
@@ -768,10 +768,10 @@ struct StatDemo: View {
     private var statTrend: StatTrend? { trend == .up ? .up("+12%") : trend == .down ? .down("-3%") : nil }
     @ViewBuilder private var statView: some View {
         if animated {
-            Stat(title: "Total bookings", value: count, suffix: "₺", isLoading: loading,
+            Stat(title: "Total bookings", value: count, suffix: "$", isLoading: loading,
                  description: "this month", systemImage: figure ? "ticket" : nil, trend: statTrend)
         } else {
-            Stat(title: "Total bookings", value: "1,284", suffix: "₺", isLoading: loading,
+            Stat(title: "Total bookings", value: "1,284", suffix: "$", isLoading: loading,
                  description: "this month", systemImage: figure ? "ticket" : nil, trend: statTrend)
         }
     }
@@ -801,7 +801,7 @@ struct StepsDemo: View {
     @State private var progressDot = false
     @State private var percent = false
     private let titles = ["Cart", "Address", "Payment", "Done"]
-    private let subs = ["2 items", "İstanbul", "Card ••42", "Confirm"]
+    private let subs = ["2 items", "Istanbul", "Card ••42", "Confirm"]
     private var steps: [Steps.Step] {
         titles.enumerated().map { i, t in
             let state: StepState = (error && i == active) ? .error
@@ -812,7 +812,7 @@ struct StepsDemo: View {
     }
     var body: some View {
         ComponentStage("Steps", inspector: [("active", "\(active)"), ("progressDot", "\(progressDot)")]) {
-            Steps(steps, axis: vertical ? .vertical : .horizontal, progressDot: progressDot) { active = $0; flash("Adım \($0 + 1) seçildi") }
+            Steps(steps, axis: vertical ? .vertical : .horizontal, progressDot: progressDot) { active = $0; flash("Step \($0 + 1) selected") }
         } knobs: {
             Stepper("Active: \(active)", value: $active, in: 0...3)
             Text("Tip: tap a step to jump to it.").font(.caption).foregroundStyle(.secondary)
@@ -828,7 +828,7 @@ struct StepsDemo: View {
 struct BreadcrumbsDemo: View {
     @State private var depth = 6.0
     @State private var collapse = true
-    private let all = ["Home", "Hotels", "Turkey", "Marmara", "İstanbul", "Grand Hotel"]
+    private let all = ["Home", "Hotels", "Turkey", "Marmara", "Istanbul", "Grand Hotel"]
     var body: some View {
         ComponentStage("Breadcrumbs", inspector: [("depth", "\(Int(depth))"), ("maxItems", collapse ? "4" : "—")]) {
             Breadcrumbs(all.prefix(Int(depth)).enumerated().map { i, t in .init(t, action: i < Int(depth) - 1 ? { flash("Breadcrumb: \(t)") } : nil) },
@@ -853,13 +853,13 @@ struct TimelineDemo: View {
     var body: some View {
         ComponentStage("Timeline", inspector: [("active", "\(Int(step))"), ("axis", horizontal ? "horizontal" : "vertical"), ("mode", modeLabel), ("reverse", "\(reverse)")]) {
             Timeline([
-                .init(title: "Sipariş", time: "09:24", systemImage: "cart", state: .done, color: .success),
-                .init(title: "Hazırlanıyor", time: "09:40", systemImage: "shippingbox", state: Int(step) > 1 ? .done : .active),
+                .init(title: "Order", time: "09:24", systemImage: "cart", state: .done, color: .success),
+                .init(title: "Preparing", time: "09:40", systemImage: "shippingbox", state: Int(step) > 1 ? .done : .active),
                 failed
-                    ? .init(title: "Hata", time: "09:45", description: horizontal ? nil : "Kartı tekrar dene.", state: .error)
-                    : .init(title: "Yolda", time: "—", systemImage: "truck.box", state: Int(step) > 2 ? .done : Int(step) == 2 ? .active : .todo),
+                    ? .init(title: "Error", time: "09:45", description: horizontal ? nil : "Try your card again.", state: .error)
+                    : .init(title: "On the way", time: "—", systemImage: "truck.box", state: Int(step) > 2 ? .done : Int(step) == 2 ? .active : .todo),
             ], axis: horizontal ? .horizontal : .vertical, mode: mode, reverse: reverse,
-               pending: (!horizontal && pending) ? "Kurye bekleniyor…" : nil)
+               pending: (!horizontal && pending) ? "Waiting for courier…" : nil)
         } knobs: {
             Stepper("Active: \(Int(step))", value: $step, in: 0...3)
             Toggle("Horizontal", isOn: $horizontal)
@@ -881,9 +881,9 @@ struct ChatBubbleDemo: View {
     @State private var meta = true
     var body: some View {
         ComponentStage("ChatBubble", inspector: [("side", outgoing ? "outgoing" : "incoming")]) {
-            ChatBubble("Merhaba! Rezervasyonunuz onaylandı.",
+            ChatBubble("Hello! Your reservation is confirmed.",
                        side: outgoing ? .outgoing : .incoming,
-                       author: meta ? "Destek" : nil, time: meta ? "09:24" : nil,
+                       author: meta ? "Support" : nil, time: meta ? "09:24" : nil,
                        avatarSystemImage: avatar ? "person.fill" : nil)
         } knobs: {
             Toggle("Outgoing", isOn: $outgoing)
@@ -899,7 +899,7 @@ struct DrawerDemo: View {
     @State private var trailing = false
     var body: some View {
         ComponentStage("Drawer", inspector: [("isPresented", "\(open)"), ("edge", trailing ? "trailing" : "leading")]) {
-            PrimaryButton("Open drawer") { open = true; flash("Drawer açıldı") }
+            PrimaryButton("Open drawer") { open = true; flash("Drawer opened") }
                 .frame(maxWidth: .infinity, minHeight: 160)
                 .drawer(isPresented: $open, edge: trailing ? .trailing : .leading) {
                     VStack(alignment: .leading, spacing: 12) {
@@ -983,7 +983,7 @@ struct HeroDemo: View {
     @State private var cta = true
     var body: some View {
         ComponentStage("Hero", inspector: [("dark", "\(dark)")]) {
-            Hero(title: dark ? "Summer Sale" : "Discover İstanbul",
+            Hero(title: dark ? "Summer Sale" : "Discover Istanbul",
                  subtitle: subtitle ? "Hand-picked stays at the best prices." : nil,
                  ctaTitle: cta ? "Explore" : nil, dark: dark, action: cta ? { flash("Hero: Explore") } : nil)
         } knobs: {
@@ -1006,7 +1006,7 @@ struct FABDemo: View {
                 .init(systemImage: "camera", label: "Photo", action: { flash("FAB: Photo") }),
                 .init(systemImage: "doc", label: "Document", action: { flash("FAB: Document") }),
                 .init(systemImage: "link", label: "Link", action: { flash("FAB: Link") }),
-            ] : [], shape: square ? .square : .circle, color: color, badge: badge ? 3 : nil, action: { flash("FAB tıklandı") })
+            ] : [], shape: square ? .square : .circle, color: color, badge: badge ? 3 : nil, action: { flash("FAB tapped") })
             .frame(maxWidth: .infinity, minHeight: 220, alignment: .bottomTrailing)
         } knobs: {
             Toggle("Speed dial", isOn: $speedDial)
@@ -1065,11 +1065,11 @@ struct DateFieldDemo: View {
         case .custom: return .custom("EEE, d MMM")
         }
     }
-    private var messages: [InfoMessage] { error ? [InfoMessage("Tarih zorunlu", kind: .error)] : [] }
+    private var messages: [InfoMessage] { error ? [InfoMessage("Date is required", kind: .error)] : [] }
 
     var body: some View {
         ComponentStage("DateField", inspector: [("style", styleSel.rawValue), ("value", date.map { $0.formatted(date: .abbreviated, time: .omitted) } ?? "nil")]) {
-            DateField(label: "Tarih", date: $date, style: style,
+            DateField(label: "Date", date: $date, style: style,
                       components: withTime ? .dateAndTime : .date,
                       infoMessages: messages, allowClear: clearable,
                       leadingSystemImage: "calendar")
@@ -1106,7 +1106,7 @@ struct DataTableDemo: View {
             DataTable(columns: [
                 .init("Hotel", sortKey: { .string($0.hotel) }) { $0.hotel },
                 .init("Nights", align: .center, sortKey: { .number(Double($0.nights)) }) { "\($0.nights)" },
-                .init("Price", align: .trailing, sortKey: { .number($0.price) }) { "₺\(Int($0.price))" },
+                .init("Price", align: .trailing, sortKey: { .number($0.price) }) { "$\(Int($0.price))" },
             ], rows: rows, striped: striped, selection: selectable ? $selected : nil,
                pageSize: paged ? 4 : nil, isLoading: loading)
         } knobs: {
@@ -1177,14 +1177,14 @@ struct FileInputDemo: View {
     @State private var error = false
     @State private var clearable = true
     private var messages: [InfoMessage] {
-        error ? [InfoMessage("Dosya 5 MB'tan küçük olmalı", kind: .error)] : []
+        error ? [InfoMessage("File must be smaller than 5 MB", kind: .error)] : []
     }
     var body: some View {
         ComponentStage("FileInput", inspector: [("fileName", picked ? "passport-scan.jpg" : "nil"), ("error", "\(error)")]) {
             FileInput(label: "Passport", fileName: picked ? "passport-scan.jpg" : nil,
                       infoMessages: messages,
-                      onPick: { picked = true; flash("FileInput: dosya seçildi") },
-                      onClear: clearable ? { picked = false; flash("FileInput: temizlendi") } : nil)
+                      onPick: { picked = true; flash("FileInput: file selected") },
+                      onClear: clearable ? { picked = false; flash("FileInput: cleared") } : nil)
         } knobs: {
             Toggle("File chosen", isOn: $picked)
             Toggle("Validation error", isOn: $error)
@@ -1203,7 +1203,7 @@ struct ThemeControllerDemo: View {
                     .init(name: "oceanTheme", label: "Ocean"),
                     .init(name: "sunsetTheme", label: "Sunset"),
                 ], selectedName: $name)
-                PrimaryButton("Sample button") { flash("Sample button tıklandı") }
+                PrimaryButton("Sample button") { flash("Sample button tapped") }
             }
         } knobs: {
             Text("Switches Theme.shared live.").font(.footnote).foregroundStyle(.secondary)
@@ -1233,7 +1233,7 @@ struct ThemeButtonDemo: View {
                          systemImage: (icon || iconOnly) ? "star.fill" : nil,
                          iconPosition: trailingIcon ? .trailing : .leading,
                          color: color, variant: variant, size: size, shape: shape,
-                         block: block && !iconOnly, isLoading: $loading) { flash("ThemeButton tıklandı") }
+                         block: block && !iconOnly, isLoading: $loading) { flash("ThemeButton tapped") }
         } knobs: {
             Picker("Color", selection: $color) { ForEach(SemanticColor.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) } }
             Picker("Variant", selection: $variant) { ForEach(ButtonVariant.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) } }
@@ -1317,9 +1317,9 @@ struct FeedbackDemo: View {
     var body: some View {
         ComponentStage("Feedback", inspector: [("level", "global"), ("last action", last)]) {
             VStack(spacing: 12) {
-                ThemeButton("Toast göster", color: kind.semanticColor, block: true) {
-                    feedback.toast("\(kind.rawValue.capitalized) mesajı",
-                                   message: "Bu bir \(kind.rawValue) bildirimi.", kind: kind)
+                ThemeButton("Show toast", color: kind.semanticColor, block: true) {
+                    feedback.toast("\(kind.rawValue.capitalized) message",
+                                   message: "This is a \(kind.rawValue) notification.", kind: kind)
                     last = "toast: \(kind.rawValue)"
                 }
                 ThemeButton("Stack (3 toast)", color: kind.semanticColor, variant: .soft, block: true) {
@@ -1327,37 +1327,37 @@ struct FeedbackDemo: View {
                     last = "stack: 3"
                 }
                 ThemeButton("Undo (action + sticky)", variant: .outline, block: true) {
-                    feedback.toast("Mesaj silindi", kind: .info,
-                                   action: ToastAction("Geri al") { feedback.toast("Geri alındı", kind: .success) },
+                    feedback.toast("Message deleted", kind: .info,
+                                   action: ToastAction("Undo") { feedback.toast("Undone", kind: .success) },
                                    duration: nil)
                     last = "undo toast"
                 }
-                ThemeButton("Async görev (task)", variant: .outline, block: true) {
+                ThemeButton("Async task (task)", variant: .outline, block: true) {
                     Task {
-                        await feedback.toastTask(loading: "Kaydediliyor…", success: "Kaydedildi") {
+                        await feedback.toastTask(loading: "Saving…", success: "Saved") {
                             try await Task.sleep(nanoseconds: 1_500_000_000)
                         }
                     }
                     last = "async task"
                 }
-                ThemeButton("Bildirim göster (notification)", color: kind.semanticColor, variant: .soft, block: true) {
-                    feedback.notify("\(kind.rawValue.capitalized)", message: "Üstten gelen bir bildirim.", kind: kind)
+                ThemeButton("Show notification (notification)", color: kind.semanticColor, variant: .soft, block: true) {
+                    feedback.notify("\(kind.rawValue.capitalized)", message: "A notification from the top.", kind: kind)
                     last = "notify: \(kind.rawValue)"
                 }
-                ThemeButton("Yükleniyor (loading)", systemImage: "arrow.clockwise", variant: .outline, block: true) {
-                    feedback.loading("Kaydediliyor…")
+                ThemeButton("Loading (loading)", systemImage: "arrow.clockwise", variant: .outline, block: true) {
+                    feedback.loading("Saving…")
                     last = "loading"
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) {
-                        feedback.dismissLoading(); feedback.toast("Kaydedildi", kind: .success)
+                        feedback.dismissLoading(); feedback.toast("Saved", kind: .success)
                     }
                 }
-                ThemeButton("Onay iste (confirm)", color: .error, variant: .outline, block: true) {
+                ThemeButton("Ask for confirmation (confirm)", color: .error, variant: .outline, block: true) {
                     feedback.confirm(
-                        title: "Rezervasyonu iptal et?",
-                        message: "Bu işlem geri alınamaz.",
-                        primaryTitle: "İptal et", primaryKind: .error,
-                        onPrimary: { last = "confirmed"; feedback.toast("İptal edildi", kind: .success); flash("Onaylandı") },
-                        secondaryTitle: "Vazgeç", onSecondary: { last = "dismissed"; flash("Vazgeçildi") }
+                        title: "Cancel reservation?",
+                        message: "This action cannot be undone.",
+                        primaryTitle: "Cancel reservation", primaryKind: .error,
+                        onPrimary: { last = "confirmed"; feedback.toast("Cancelled", kind: .success); flash("Confirmed") },
+                        secondaryTitle: "Cancel", onSecondary: { last = "dismissed"; flash("Dismissed") }
                     )
                 }
             }
@@ -1370,10 +1370,10 @@ struct FeedbackDemo: View {
         .onAppear {
             // Screenshot hook: launch with `-feedbackDemo toast|confirm|notify`.
             switch UserDefaults.standard.string(forKey: "feedbackDemo") {
-            case "toast": feedback.toast("Kaydedildi", message: "Değişiklikler kaydedildi.", kind: .success)
-            case "notify": feedback.notify("Yeni mesaj", message: "Rezervasyonunuz onaylandı.", kind: .info)
-            case "confirm": feedback.confirm(title: "Rezervasyonu iptal et?", message: "Bu işlem geri alınamaz.",
-                                             primaryTitle: "İptal et", primaryKind: .error, secondaryTitle: "Vazgeç")
+            case "toast": feedback.toast("Saved", message: "Your changes have been saved.", kind: .success)
+            case "notify": feedback.notify("New message", message: "Your reservation has been confirmed.", kind: .info)
+            case "confirm": feedback.confirm(title: "Cancel reservation?", message: "This action cannot be undone.",
+                                             primaryTitle: "Cancel reservation", primaryKind: .error, secondaryTitle: "Cancel")
             default: break
             }
         }
@@ -1387,21 +1387,21 @@ struct ResultDemo: View {
 
     private var copy: (String, String) {
         switch status {
-        case .success: return ("Rezervasyon onaylandı", "Onay e-postası gönderildi.")
-        case .info: return ("Bilgilendirme", "İşleminiz sıraya alındı.")
-        case .warning: return ("Ödeme beklemede", "Banka onayı bekleniyor.")
-        case .error: return ("Ödeme başarısız", "Kart bilgilerinizi kontrol edip tekrar deneyin.")
-        case .notFound: return ("Sayfa bulunamadı", "Aradığınız sayfa taşınmış veya silinmiş olabilir.")
-        case .forbidden: return ("Erişim engellendi", "Bu sayfayı görüntüleme yetkiniz yok.")
-        case .serverError: return ("Bir şeyler ters gitti", "Sunucu hatası oluştu, lütfen tekrar deneyin.")
+        case .success: return ("Reservation confirmed", "A confirmation email has been sent.")
+        case .info: return ("Information", "Your request has been queued.")
+        case .warning: return ("Payment pending", "Waiting for bank approval.")
+        case .error: return ("Payment failed", "Check your card details and try again.")
+        case .notFound: return ("Page not found", "The page you're looking for may have been moved or deleted.")
+        case .forbidden: return ("Access denied", "You don't have permission to view this page.")
+        case .serverError: return ("Something went wrong", "A server error occurred, please try again.")
         }
     }
 
     var body: some View {
         ComponentStage("Result", inspector: [("status", status.rawValue), ("code", status.codeText)]) {
             ResultView(status, title: copy.0, message: copy.1,
-                       primaryTitle: "Tekrar dene", onPrimary: { flash("Result: Tekrar dene") },
-                       secondaryTitle: "Ana sayfa", onSecondary: { flash("Result: Ana sayfa") })
+                       primaryTitle: "Try again", onPrimary: { flash("Result: Try again") },
+                       secondaryTitle: "Home", onSecondary: { flash("Result: Home") })
         } knobs: {
             Picker("Status", selection: $status) {
                 ForEach(ResultStatus.allCases, id: \.self) { Text($0.rawValue).tag($0) }
@@ -1469,14 +1469,14 @@ struct PopconfirmDemo: View {
     @State private var last = "—"
     var body: some View {
         ComponentStage("Popconfirm", inspector: [("isPresented", "\(show)"), ("edge", "\(edge)"), ("last", last)]) {
-            ThemeButton("Sil", systemImage: "trash", color: .error, variant: .soft) { show.toggle() }
-                .popconfirm(isPresented: $show, title: "Bu öğeyi sil?", message: "Bu işlem geri alınamaz.",
-                            confirmTitle: "Sil", cancelTitle: "Vazgeç", edge: edge,
+            ThemeButton("Delete", systemImage: "trash", color: .error, variant: .soft) { show.toggle() }
+                .popconfirm(isPresented: $show, title: "Delete this item?", message: "This action cannot be undone.",
+                            confirmTitle: "Delete", cancelTitle: "Cancel", edge: edge,
                             onConfirm: {
                                 if asyncConfirm { try? await Task.sleep(nanoseconds: 1_200_000_000) }
-                                last = "confirmed"; flash("Popconfirm onaylandı")
+                                last = "confirmed"; flash("Popconfirm confirmed")
                             },
-                            onCancel: { last = "cancelled"; flash("Popconfirm iptal edildi") })
+                            onCancel: { last = "cancelled"; flash("Popconfirm cancelled") })
                 .padding(80)
         } knobs: {
             Toggle("Async confirm (1.2s)", isOn: $asyncConfirm)
@@ -1497,16 +1497,16 @@ struct TreeSelectDemo: View {
     @State private var loading = false
     @State private var disableIzmir = false
     private let tree = [
-        TreeNode(id: "tr", "Türkiye", systemImage: "flag", children: [
-            TreeNode(id: "ist", "İstanbul"), TreeNode(id: "ank", "Ankara"), TreeNode(id: "izm", "İzmir"),
+        TreeNode(id: "tr", "Turkey", systemImage: "flag", children: [
+            TreeNode(id: "ist", "Istanbul"), TreeNode(id: "ank", "Ankara"), TreeNode(id: "izm", "Izmir"),
         ]),
-        TreeNode(id: "de", "Almanya", systemImage: "flag", children: [
-            TreeNode(id: "ber", "Berlin"), TreeNode(id: "mun", "Münih"),
+        TreeNode(id: "de", "Germany", systemImage: "flag", children: [
+            TreeNode(id: "ber", "Berlin"), TreeNode(id: "mun", "Munich"),
         ]),
     ]
     var body: some View {
         ComponentStage("TreeSelect", inspector: [("selected", "\(picks.count)"), ("cascade", "\(cascade)"), ("loading", "\(loading)")]) {
-            TreeSelect(label: "Şehirler", nodes: tree, selection: $picks,
+            TreeSelect(label: "Cities", nodes: tree, selection: $picks,
                        cascade: cascade, searchable: searchable, initiallyExpanded: ["tr", "de"],
                        isLoading: loading, isNodeEnabled: disableIzmir ? { $0.id != "izm" } : nil)
                 .id("\(cascade)\(searchable)\(loading)\(disableIzmir)")
@@ -1514,7 +1514,7 @@ struct TreeSelectDemo: View {
             Toggle("Cascade (parent ↔ child + indeterminate)", isOn: $cascade)
             Toggle("Searchable", isOn: $searchable)
             Toggle("Loading", isOn: $loading)
-            Toggle("Disable “İzmir”", isOn: $disableIzmir)
+            Toggle("Disable “Izmir”", isOn: $disableIzmir)
             Button("Reset") { picks = ["ist"] }
         }
     }
@@ -1530,15 +1530,15 @@ struct TourDemo: View {
                     tourIcon("heart", "fav")
                     tourIcon("person.crop.circle", "profile")
                 }
-                ThemeButton("Turu başlat", systemImage: "play.fill", block: true) { tour.start(); flash("Tur başlatıldı") }
+                ThemeButton("Start tour", systemImage: "play.fill", block: true) { tour.start(); flash("Tour started") }
             }
             .tourHost(tour, steps: [
-                TourStep("search", title: "Arama", message: "Buradan otel arayabilirsiniz."),
-                TourStep("fav", title: "Favoriler", message: "Beğendiklerinizi kaydedin."),
-                TourStep("profile", title: "Profil", message: "Hesabınızı buradan yönetin."),
+                TourStep("search", title: "Search", message: "Search for hotels here."),
+                TourStep("fav", title: "Favorites", message: "Save the ones you like."),
+                TourStep("profile", title: "Profile", message: "Manage your account here."),
             ])
         } knobs: {
-            Button("Turu başlat") { tour.start() }
+            Button("Start tour") { tour.start() }
         }
         .onAppear {
             // Screenshot hook: launch with `-startTour YES`.
@@ -1564,10 +1564,10 @@ struct FormDemo: View {
     private enum Field { case email, password, plan, terms }
 
     @State private var form = FormValidator<Field>([
-        .email: [.required("E-posta zorunlu"), .email()],
-        .password: [.required("Şifre zorunlu"), .password(minLength: 8)],
-        .plan: [.required("Bir paket seçin")],
-        .terms: [.required("Devam etmek için kabul edin")],
+        .email: [.required("Email is required"), .email()],
+        .password: [.required("Password is required"), .password(minLength: 8)],
+        .plan: [.required("Select a plan")],
+        .terms: [.required("Accept to continue")],
     ])
     @State private var email = ""
     @State private var password = ""
@@ -1584,33 +1584,33 @@ struct FormDemo: View {
     var body: some View {
         ComponentStage("Form", inspector: [("valid", submitted ? "\(form.isValid)" : "—"), ("focused", "\(form.focusedField.map { "\($0)" } ?? "—")")]) {
             VStack(spacing: Theme.SpacingKey.md.value) {
-                Fieldset("Hesap oluştur", helper: "Tüm alanlar zorunlu.") {
-                    TextInput(TextInputModel(label: "E-posta", leadingSystemImage: "envelope",
+                Fieldset("Create account", helper: "All fields are required.") {
+                    TextInput(TextInputModel(label: "Email", leadingSystemImage: "envelope",
                                              infoMessages: form.messages(for: .email)),
                               text: $email, externalFocus: form.focusBinding(.email))
                         .a11yID("form.email")
-                    TextInput(TextInputModel(label: "Şifre (8+, büyük harf, rakam)", isSecure: true,
+                    TextInput(TextInputModel(label: "Password (8+, uppercase, number)", isSecure: true,
                                              infoMessages: form.messages(for: .password)),
                               text: $password, externalFocus: form.focusBinding(.password))
                         .a11yID("form.password")
-                    RadioGroup(title: "Paket", options: ["Standart", "Pro"], selection: $plan,
+                    RadioGroup(title: "Plan", options: ["Standard", "Pro"], selection: $plan,
                                infoMessages: form.messages(for: .plan)) { $0 }
                     .a11yID("form.plan")
-                    Checkbox("Şartları ve koşulları kabul ediyorum", isChecked: $terms,
+                    Checkbox("I accept the terms and conditions", isChecked: $terms,
                              infoMessages: form.messages(for: .terms))
                     .a11yID("form.terms")
                 }
                 if done {
-                    InfoBanner("Hesabınız oluşturuldu.", type: .success)
+                    InfoBanner("Your account has been created.", type: .success)
                 }
-                ThemeButton("Kayıt ol", block: true, accessibilityID: "form.submit") {
+                ThemeButton("Sign up", block: true, accessibilityID: "form.submit") {
                     let firstInvalid = form.validateAll(values)
                     submitted = true
                     done = firstInvalid == nil
                 }
             }
         } knobs: {
-            Text("Boş submit → e-posta/şifre + RadioGroup + Checkbox hepsi hata gösterir; ilk hatalı text alan odaklanır.").font(.caption).foregroundStyle(.secondary)
+            Text("Empty submit → email/password + RadioGroup + Checkbox all show errors; focus jumps to the first invalid text field.").font(.caption).foregroundStyle(.secondary)
             Button("Reset") { email = ""; password = ""; plan = nil; terms = false; submitted = false; done = false; form.reset() }
         }
         .onChange(of: values.description) { _, _ in if submitted { _ = form.validateAll(values) } }
@@ -1632,9 +1632,9 @@ struct FormDemo: View {
 struct ListDemo: View {
     private struct Row: Identifiable { let id = UUID(); let title: String; let subtitle: String; let icon: String }
     private let rows = [
-        Row(title: "Hesabım", subtitle: "Profil ve güvenlik", icon: "person.circle"),
-        Row(title: "Bildirimler", subtitle: "E-posta ve push", icon: "bell"),
-        Row(title: "Dil", subtitle: "Türkçe", icon: "globe"),
+        Row(title: "My account", subtitle: "Profile and security", icon: "person.circle"),
+        Row(title: "Notifications", subtitle: "Email and push", icon: "bell"),
+        Row(title: "Language", subtitle: "English", icon: "globe"),
     ]
     @State private var withHeader = true
     @State private var bordered = true
@@ -1644,8 +1644,8 @@ struct ListDemo: View {
 
     var body: some View {
         ComponentStage("List", inspector: [("count", "\(empty ? 0 : rows.count)"), ("bordered", "\(bordered)"), ("empty", "\(empty)")]) {
-            ListView(empty ? [] : rows, header: withHeader ? "Ayarlar" : nil, footer: withHeader ? "\(empty ? 0 : rows.count) öğe" : nil,
-                     bordered: bordered, loading: loading, split: split, emptyText: "Henüz ayar yok") { row in
+            ListView(empty ? [] : rows, header: withHeader ? "Settings" : nil, footer: withHeader ? "\(empty ? 0 : rows.count) items" : nil,
+                     bordered: bordered, loading: loading, split: split, emptyText: "No settings yet") { row in
                 ListRow(row.title, subtitle: row.subtitle, leadingSystemImage: row.icon, action: { flash("List: \(row.title)") })
             }
         } knobs: {
@@ -1697,7 +1697,7 @@ struct ImageCollageDemo: View {
     }
     var body: some View {
         ComponentStage("ImageCollage", inspector: [("images", "\(Int(count))")]) {
-            ImageCollage(urls, height: 220, onTap: { flash("ImageCollage: \($0 + 1). görsel") })
+            ImageCollage(urls, height: 220, onTap: { flash("ImageCollage: image \($0 + 1)") })
         } knobs: {
             HStack { Text("Images"); SwiftUI.Slider(value: $count, in: 1...8, step: 1) }
             Text("Layouts adapt: 1 · 2 · 3 · 4+ with a +N overlay on the last tile.").font(.caption).foregroundStyle(.secondary)
@@ -1708,9 +1708,9 @@ struct ImageCollageDemo: View {
 struct AccordionGroupDemo: View {
     private struct FAQ: Identifiable { let id = UUID(); let q: String; let a: String }
     private let faqs = [
-        FAQ(q: "İptal edebilir miyim?", a: "Evet, girişten 24 saat öncesine kadar ücretsiz iptal."),
-        FAQ(q: "Ödeme seçenekleri neler?", a: "Kredi/banka kartı ve havale/EFT kabul edilir."),
-        FAQ(q: "Evcil hayvan kabul ediliyor mu?", a: "Küçük ırk evcil hayvanlar ek ücretle kabul edilir."),
+        FAQ(q: "Can I cancel?", a: "Yes, free cancellation up to 24 hours before check-in."),
+        FAQ(q: "What are the payment options?", a: "Credit/debit cards and bank transfers are accepted."),
+        FAQ(q: "Are pets allowed?", a: "Small-breed pets are allowed for an extra fee."),
     ]
     @State private var multi = false
 
@@ -1730,8 +1730,8 @@ struct AccordionGroupDemo: View {
 
 struct PagingCarouselDemo: View {
     private struct Slide: Identifiable { let id = UUID(); let color: Color; let title: String }
-    private let slides = [Slide(color: .blue, title: "Bir"), Slide(color: .teal, title: "İki"),
-                          Slide(color: .orange, title: "Üç"), Slide(color: .purple, title: "Dört")]
+    private let slides = [Slide(color: .blue, title: "One"), Slide(color: .teal, title: "Two"),
+                          Slide(color: .orange, title: "Three"), Slide(color: .purple, title: "Four")]
     @State private var autoplay = false
     @State private var peek = 36.0
 
@@ -1798,7 +1798,7 @@ struct ChipsDemo: View {
     @State private var kind: Kind = .compact
     @State private var a = true
     @State private var b = false
-    @State private var multi: Set<String> = ["Wifi", "Havuz"]
+    @State private var multi: Set<String> = ["Wifi", "Pool"]
     @State private var square = false
 
     private var imageURL: URL? { URL(string: "https://picsum.photos/seed/imgchip/200/300") }
@@ -1809,11 +1809,11 @@ struct ChipsDemo: View {
                 switch kind {
                 case .compact:
                     HStack(spacing: 12) {
-                        CompactChip(isSelected: $a, text: "Standart Oda", price: "₺399,90", rating: 4.6)
-                        CompactChip(isSelected: $b, text: "Suit Oda", price: "₺899,90")
+                        CompactChip(isSelected: $a, text: "Standard Room", price: "$399.90", rating: 4.6)
+                        CompactChip(isSelected: $b, text: "Suite Room", price: "$899.90")
                     }
                 case .chose:
-                    ChoseChip(isSelected: $a, title: "Esnek Tarife", description: "Ücretsiz iptal",
+                    ChoseChip(isSelected: $a, title: "Flexible rate", description: "Free cancellation",
                               rating: 4.8, showFree: true, systemImage: "wind")
                 case .image:
                     HStack(spacing: 12) {
@@ -1822,11 +1822,11 @@ struct ChipsDemo: View {
                     }
                 case .filter:
                     HStack(spacing: 8) {
-                        FilterChip("İstanbul", shape: square ? .square : .pill) { flash("FilterChip: İstanbul") }
-                        FilterChip("4+ yıldız", shape: square ? .square : .pill) { flash("FilterChip: 4+ yıldız") }
+                        FilterChip("Istanbul", shape: square ? .square : .pill) { flash("FilterChip: Istanbul") }
+                        FilterChip("4+ stars", shape: square ? .square : .pill) { flash("FilterChip: 4+ stars") }
                     }
                 case .group:
-                    ChipGroup(title: "Olanaklar", options: ["Wifi", "Havuz", "Spa", "Otopark", "Restoran"], selection: $multi) { $0 }
+                    ChipGroup(title: "Amenities", options: ["Wifi", "Pool", "Spa", "Parking", "Restaurant"], selection: $multi) { $0 }
                 }
             }
         } knobs: {
@@ -1845,30 +1845,30 @@ struct DialogDemo: View {
     var body: some View {
         ComponentStage("Dialog", inspector: [("accepted", "\(accepted)"), ("deleted", "\(deleted)")]) {
             VStack(spacing: 12) {
-                PrimaryButton("Sözleşmeyi aç") { show = true; flash("Dialog açıldı") }
-                OutlineButton("Hesabı sil (async)") { deleted = false; showConfirm = true }
-                Text(accepted ? "Kabul edildi ✓" : "Henüz onaylanmadı")
+                PrimaryButton("Open agreement") { show = true; flash("Dialog opened") }
+                OutlineButton("Delete account (async)") { deleted = false; showConfirm = true }
+                Text(accepted ? "Accepted ✓" : "Not yet accepted")
                     .textStyle(.labelSm600).foregroundStyle(Theme.shared.text(.textSecondary))
             }
             .frame(maxWidth: .infinity)
             .frame(height: 220)
-            .dialog(isPresented: $showConfirm, title: "Hesabı sil?", message: "Bu işlem geri alınamaz.",
-                    primaryTitle: "Sil", onPrimary: {
+            .dialog(isPresented: $showConfirm, title: "Delete account?", message: "This action cannot be undone.",
+                    primaryTitle: "Delete", onPrimary: {
                         try? await Task.sleep(nanoseconds: 1_200_000_000)   // async work; OK spins
-                        deleted = true; flash("Hesap silindi")
-                    }, secondaryTitle: "Vazgeç", onSecondary: { flash("Vazgeçildi") }, kind: .error)
-            .dialog(isPresented: $show, title: "Kullanım Koşulları", afterClose: {}) {
+                        deleted = true; flash("Account deleted")
+                    }, secondaryTitle: "Cancel", onSecondary: { flash("Dismissed") }, kind: .error)
+            .dialog(isPresented: $show, title: "Terms of Use", afterClose: {}) {
                 VStack(alignment: .leading, spacing: 12) {
                     ForEach(1...8, id: \.self) { i in
-                        Text("\(i). Madde").textStyle(.labelBase700).foregroundStyle(Theme.shared.text(.textPrimary))
-                        Text("Bu uzun metin, dialog içeriğinin kaydırılabilir olduğunu gösterir. Footer sabit kalır.")
+                        Text("Article \(i)").textStyle(.labelBase700).foregroundStyle(Theme.shared.text(.textPrimary))
+                        Text("This long text shows that the dialog content is scrollable. The footer stays pinned.")
                             .textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
                     }
                 }
             } footer: {
                 HStack(spacing: 12) {
-                    OutlineButton("Vazgeç") { show = false; flash("Dialog: Vazgeç") }
-                    PrimaryButton("Kabul et") { accepted = true; show = false; flash("Dialog onaylandı") }
+                    OutlineButton("Cancel") { show = false; flash("Dialog: Cancel") }
+                    PrimaryButton("Accept") { accepted = true; show = false; flash("Dialog accepted") }
                 }
             }
         } knobs: {
@@ -1911,22 +1911,22 @@ struct MicroMotionDemo: View {
     var body: some View {
         ComponentStage("Micro-motion", inspector: [("microAnimations", "\(enabled)")]) {
             VStack(spacing: 18) {
-                Text("Bu alt-ağaç: .microAnimations(\(enabled ? "true" : "false")) — basınca scale, seçimde kayma.")
+                Text("This subtree: .microAnimations(\(enabled ? "true" : "false")) — scale on press, slide on selection.")
                     .font(.footnote).foregroundStyle(.secondary).multilineTextAlignment(.center)
-                PrimaryButton("Bana bas (micro press)") { flash("Tap") }
-                SegmentedControl(["Gün", "Hafta", "Ay"], selection: $sel)
+                PrimaryButton("Press me (micro press)") { flash("Tap") }
+                SegmentedControl(["Day", "Week", "Month"], selection: $sel)
                 ThemeToggle(isOn: $on)
 
                 DividerView(size: .small)
-                Text("Per-component override — bu buton her zaman kapalı:")
+                Text("Per-component override — this button is always off:")
                     .font(.footnote).foregroundStyle(.secondary).multilineTextAlignment(.center)
-                SecondaryButton("Hareketsiz (.microAnimations(false))") { flash("Tap") }
+                SecondaryButton("Static (.microAnimations(false))") { flash("Tap") }
                     .microAnimations(false)
             }
             .microAnimations(enabled)
         } knobs: {
-            Toggle("Micro-animations (bu alt-ağaç)", isOn: $enabled)
-            Text("Tema geneli için: Configurator → “Micro-animations”. Reduce Motion her zaman kazanır.")
+            Toggle("Micro-animations (this subtree)", isOn: $enabled)
+            Text("Theme-wide: Configurator → “Micro-animations”. Reduce Motion always wins.")
                 .font(.footnote).foregroundStyle(.secondary)
         }
     }

--- a/Demo/Demo/Gallery/Demos/OrganismDemos.swift
+++ b/Demo/Demo/Gallery/Demos/OrganismDemos.swift
@@ -21,8 +21,8 @@ struct AccordionDemo: View {
 
     var body: some View {
         ComponentStage("Accordion", inspector: [("titleSize", sizeIdx == 0 ? "large" : sizeIdx == 2 ? "small" : "medium"), ("indicator", indicatorIdx == 1 ? "plusMinus" : "chevron")]) {
-            Accordion("İade politikanız nedir?", initiallyExpanded: expanded) {
-                Text("Satın alımdan sonraki 14 gün içinde iade talep edebilirsiniz.")
+            Accordion("What is your return policy?", initiallyExpanded: expanded) {
+                Text("You can request a return within 14 days of purchase.")
             }
             .number(number ? 1 : nil)
             .indicator(indicator)
@@ -76,7 +76,7 @@ struct AlertToastDemo: View {
 
     var body: some View {
         ComponentStage("AlertToast", inspector: [("type", "\(type)")]) {
-            AlertToast("Saved successfully", message: message ? "Your changes were stored." : nil, type: type, onClose: closable ? { flash("AlertToast kapatıldı") } : nil)
+            AlertToast("Saved successfully", message: message ? "Your changes were stored." : nil, type: type, onClose: closable ? { flash("AlertToast closed") } : nil)
         } knobs: {
             Picker("Type", selection: $type) {
                 Text("Success").tag(AlertToastType.success); Text("Warning").tag(AlertToastType.warning); Text("Danger").tag(AlertToastType.danger); Text("Info").tag(AlertToastType.info)
@@ -98,10 +98,10 @@ struct InfoBannerDemo: View {
     @State private var tapped = 0
 
     private var message: String {
-        inlineLink ? "Rezervasyonun onaylandı. Detaylar için bilet sayfasına git." : "This is an informational message."
+        inlineLink ? "Your reservation is confirmed. Go to the ticket page for details." : "This is an informational message."
     }
     private var links: [(substring: String, action: () -> Void)] {
-        inlineLink ? [("bilet sayfasına", { tapped += 1 })] : []
+        inlineLink ? [("ticket page", { tapped += 1 })] : []
     }
 
     var body: some View {
@@ -109,7 +109,7 @@ struct InfoBannerDemo: View {
             InfoBanner(message, type: type, title: title ? "Heads up" : nil, links: links,
                        showIcon: showIcon, banner: banner,
                        actionTitle: action ? "Undo" : nil, onAction: action ? { flash("InfoBanner: Undo") } : nil,
-                       onDismiss: dismissable ? { flash("InfoBanner kapatıldı") } : nil)
+                       onDismiss: dismissable ? { flash("InfoBanner closed") } : nil)
         } knobs: {
             Picker("Type", selection: $type) {
                 Text("Neutral").tag(InfoBannerType.neutral); Text("Info").tag(InfoBannerType.info); Text("Success").tag(InfoBannerType.success); Text("Warning").tag(InfoBannerType.warning); Text("Error").tag(InfoBannerType.error)
@@ -194,7 +194,7 @@ struct SegmentedTabBarDemo: View {
     @State private var captions = false
     @State private var card = false
     @State private var editable = false
-    @State private var cardTabs = ["Sekme 1", "Sekme 2", "Sekme 3"]
+    @State private var cardTabs = ["Tab 1", "Tab 2", "Tab 3"]
     @State private var nextTab = 4
 
     var body: some View {
@@ -204,16 +204,16 @@ struct SegmentedTabBarDemo: View {
                                 onClose: editable ? { idx in
                                     cardTabs.remove(at: idx)
                                     if selection >= cardTabs.count { selection = max(0, cardTabs.count - 1) }
-                                    flash("Sekme kapatıldı")
+                                    flash("Tab closed")
                                 } : nil,
                                 onAdd: editable ? {
-                                    cardTabs.append("Sekme \(nextTab)"); nextTab += 1; selection = cardTabs.count - 1
-                                    flash("Sekme eklendi")
+                                    cardTabs.append("Tab \(nextTab)"); nextTab += 1; selection = cardTabs.count - 1
+                                    flash("Tab added")
                                 } : nil)
             } else if captions && !scrollable {
-                SegmentedTabBar([TabItem("Ekonomi", caption: "₺2.450", systemImage: "airplane"),
-                                 TabItem("Business", caption: "₺6.900", trailingSystemImage: "star.fill"),
-                                 TabItem("First", caption: "Dolu", isEnabled: false)], selection: $selection)
+                SegmentedTabBar([TabItem("Economy", caption: "$2,450", systemImage: "airplane"),
+                                 TabItem("Business", caption: "$6,900", trailingSystemImage: "star.fill"),
+                                 TabItem("First", caption: "Full", isEnabled: false)], selection: $selection)
             } else if rich && !scrollable {
                 SegmentedTabBar([TabItem("Overview", systemImage: "square.grid.2x2"),
                                  TabItem("Reviews", badge: "12"),
@@ -239,7 +239,7 @@ struct SelectionCardsDemo: View {
     var body: some View {
         ComponentStage("SelectionCards", inspector: [("kind", useCheckbox ? "checkbox" : "radio")]) {
             if useCheckbox {
-                CheckboxCard("Add checked bag", description: "+₺250", isChecked: checked) { checked.toggle(); flash("CheckboxCard: \(checked ? "seçildi" : "kaldırıldı")") }
+                CheckboxCard("Add checked bag", description: "+$250", isChecked: checked) { checked.toggle(); flash("CheckboxCard: \(checked ? "selected" : "removed")") }
             } else {
                 VStack(spacing: 12) {
                     RadioCard("Standard", description: "Free delivery in 3–5 days", isSelected: radio == "std") { radio = "std"; flash("RadioCard: Standard") }

--- a/Demo/Demo/Views/ThemeConfiguratorView.swift
+++ b/Demo/Demo/Views/ThemeConfiguratorView.swift
@@ -115,11 +115,11 @@ struct ThemeConfiguratorView: View {
             Card {
                 VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
                     HStack {
-                        Text("Başlık").textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
+                        Text("Title").textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
                         Spacer()
-                        Badge("Yeni", style: .info)
+                        Badge("New", style: .info)
                     }
-                    Text("Tema canlı olarak yeniden üretiliyor — primary, secondary, accent, yüzeyler hepsi.")
+                    Text("The theme regenerates live — primary, secondary, accent, surfaces, all of it.")
                         .textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
                     HStack(spacing: Theme.SpacingKey.sm.value) {
                         PrimaryButton("Primary") {}
@@ -127,16 +127,16 @@ struct ThemeConfiguratorView: View {
                         OutlineButton("Outline") {}
                     }
                     HStack(spacing: Theme.SpacingKey.sm.value) {
-                        Chip("Seçili", isSelected: $chipOn, selectionStyle: .solid)
-                        Chip("Boş", isSelected: .constant(false))
+                        Chip("Selected", isSelected: $chipOn, selectionStyle: .solid)
+                        Chip("Empty", isSelected: .constant(false))
                     }
                     HStack(spacing: Theme.SpacingKey.sm.value) {
-                        InfoBanner("Bilgi", type: .info)
-                        InfoBanner("Başarılı", type: .success)
+                        InfoBanner("Info", type: .info)
+                        InfoBanner("Success", type: .success)
                     }
                     HStack(spacing: Theme.SpacingKey.sm.value) {
-                        InfoBanner("Uyarı", type: .warning)
-                        InfoBanner("Hata", type: .error)
+                        InfoBanner("Warning", type: .warning)
+                        InfoBanner("Error", type: .error)
                     }
                     ladder("Primary", .primary)
                     ladder("Secondary", .secondary)
@@ -205,15 +205,15 @@ struct ThemeConfiguratorView: View {
                     .font(.caption).foregroundStyle(.secondary)
 
                 codeCard("theme.json  (Codable recipe)", configJSON) {
-                    UIPasteboard.general.string = configJSON; flash("Config JSON kopyalandı")
+                    UIPasteboard.general.string = configJSON; flash("Config JSON copied")
                 }
                 codeCard("Apply (Swift)", usageSwift) {
-                    UIPasteboard.general.string = usageSwift; flash("Swift kodu kopyalandı")
+                    UIPasteboard.general.string = usageSwift; flash("Swift code copied")
                 }
                 Button {
                     if let data = Theme.shared.generatedTokenJSON(for: draft.themeConfig),
                        let s = String(data: data, encoding: .utf8) {
-                        UIPasteboard.general.string = s; flash("Full token JSON kopyalandı (\(data.count) byte)")
+                        UIPasteboard.general.string = s; flash("Full token JSON copied (\(data.count) bytes)")
                     }
                 } label: {
                     Label("Copy full token JSON (Python-free, bundle + loadTheme)", systemImage: "doc.on.doc").font(.caption)

--- a/Demo/Demo/Views/ThemeGalleryView.swift
+++ b/Demo/Demo/Views/ThemeGalleryView.swift
@@ -41,7 +41,7 @@ struct ThemeGalleryView: View {
                 Image(systemName: "slider.horizontal.3")
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Theme Generator").textStyle(.labelBase600)
-                    Text("Primary · secondary · accent · base + ölçek").textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                    Text("Primary · secondary · accent · base + scale").textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
                 }
                 Spacer()
                 Image(systemName: "chevron.right").font(.caption).foregroundStyle(.secondary)

--- a/Sources/ThemeKit/Components/Atoms/Rating.swift
+++ b/Sources/ThemeKit/Components/Atoms/Rating.swift
@@ -12,7 +12,7 @@ public enum RatingLayout {
     case stars
     /// A bold number + a single star glyph.
     case numberRate
-    /// A bold number + a sentiment word (e.g. "8.4 Mükemmel"). `sentiment` text.
+    /// A bold number + a sentiment word (e.g. "8.4 Excellent"). `sentiment` text.
     case rateNumberText
 }
 

--- a/Sources/ThemeKit/Components/Atoms/Tag.swift
+++ b/Sources/ThemeKit/Components/Atoms/Tag.swift
@@ -82,7 +82,7 @@ public struct Tag: View {
 #Preview {
     VStack(alignment: .leading, spacing: 12) {
         HStack {
-            Tag("İstanbul", onRemove: {})
+            Tag("Istanbul", onRemove: {})
             Tag("Beach", leadingSystemImage: "beach.umbrella")
             Tag("5 stars")
         }

--- a/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
+++ b/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
@@ -203,7 +203,7 @@ public struct Autocomplete: View {
         @State var text = ""
         var body: some View {
             Autocomplete(label: "Destination", text: $text,
-                         suggestions: ["İstanbul", "İzmir", "İzmit", "Ankara", "Antalya", "Bursa"])
+                         suggestions: ["Istanbul", "Izmir", "Izmit", "Ankara", "Antalya", "Bursa"])
                 .padding()
         }
     }
@@ -213,7 +213,7 @@ public struct Autocomplete: View {
 #Preview("Async") {
     struct Demo: View {
         @State var text = ""
-        let cities = ["İstanbul", "İzmir", "İzmit", "Ankara", "Antalya", "Bursa"]
+        let cities = ["Istanbul", "Izmir", "Izmit", "Ankara", "Antalya", "Bursa"]
         var body: some View {
             Autocomplete(label: "Destination", text: $text, suggest: { query in
                 try? await Task.sleep(nanoseconds: 400_000_000)   // simulate network

--- a/Sources/ThemeKit/Components/Molecules/Breadcrumbs.swift
+++ b/Sources/ThemeKit/Components/Molecules/Breadcrumbs.swift
@@ -106,10 +106,10 @@ public struct Breadcrumbs: View {
 
 #Preview {
     VStack(alignment: .leading, spacing: 16) {
-        Breadcrumbs([.init("Home", action: {}), .init("Hotels", action: {}), .init("İstanbul", action: {}), .init("Grand Hotel")])
+        Breadcrumbs([.init("Home", action: {}), .init("Hotels", action: {}), .init("Istanbul", action: {}), .init("Grand Hotel")])
         Breadcrumbs([
             .init("Home", action: {}), .init("Hotels", action: {}), .init("Turkey", action: {}),
-            .init("Marmara", action: {}), .init("İstanbul", action: {}), .init("Grand Hotel"),
+            .init("Marmara", action: {}), .init("Istanbul", action: {}), .init("Grand Hotel"),
         ], maxItems: 4)
     }
     .padding()

--- a/Sources/ThemeKit/Components/Molecules/Chips.swift
+++ b/Sources/ThemeKit/Components/Molecules/Chips.swift
@@ -303,16 +303,16 @@ public struct ChipGroup<Option: Hashable>: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     HStack {
-                        CompactChip(isSelected: $a, text: "Standart Oda", price: "₺399,90", rating: 4.6)
-                        CompactChip(isSelected: $b, text: "Suit Oda", price: "₺899,90")
+                        CompactChip(isSelected: $a, text: "Standard Room", price: "$399.90", rating: 4.6)
+                        CompactChip(isSelected: $b, text: "Suite Room", price: "$899.90")
                     }
-                    ChoseChip(isSelected: $c, title: "Esnek Tarife", description: "Ücretsiz iptal",
+                    ChoseChip(isSelected: $c, title: "Flexible rate", description: "Free cancellation",
                               rating: 4.8, showFree: true, systemImage: "wind")
                     HStack {
-                        FilterChip("İstanbul") {}
-                        FilterChip("4+ yıldız", shape: .square) {}
+                        FilterChip("Istanbul") {}
+                        FilterChip("4+ stars", shape: .square) {}
                     }
-                    ChipGroup(title: "Olanaklar", options: ["Wifi", "Havuz", "Spa", "Otopark"], selection: $multi) { $0 }
+                    ChipGroup(title: "Amenities", options: ["Wifi", "Pool", "Spa", "Parking"], selection: $multi) { $0 }
                 }
                 .padding()
             }

--- a/Sources/ThemeKit/Components/Molecules/InputNumber.swift
+++ b/Sources/ThemeKit/Components/Molecules/InputNumber.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// pill-shaped QuantityStepper.)
 /// Reference: Ant Design `InputNumber` / Chakra `NumberInput` — the value is
 /// directly editable (type a number, clamped to `range` on commit), steppers move
-/// by `step`, and an optional `unit` suffix labels the value (e.g. "kişi", "₺").
+/// by `step`, and an optional `unit` suffix labels the value (e.g. "guest", "$").
 public struct InputNumber: View {
     @Environment(\.theme) private var theme
 
@@ -208,9 +208,9 @@ private extension View {
         @State var price = 500
         var body: some View {
             VStack(spacing: 16) {
-                InputNumber(label: "Adults", value: $a, range: 1...9, unit: "kişi", hint: "Type or step.", large: true)
+                InputNumber(label: "Adults", value: $a, range: 1...9, unit: "guest", hint: "Type or step.", large: true)
                 InputNumber(label: "Children", value: $b, errorText: "Too many")
-                InputNumber(label: "Max price", value: $price, range: 0...10000, step: 50, unit: "₺")
+                InputNumber(label: "Max price", value: $price, range: 0...10000, step: 50, unit: "$")
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
@@ -202,8 +202,8 @@ public struct MultiSelect<Option: Hashable>: View {
 
 #Preview {
     struct Demo: View {
-        @State var picks: Set<String> = ["İstanbul"]
-        let cities = ["İstanbul", "Ankara", "İzmir", "Antalya", "Bursa", "Adana"]
+        @State var picks: Set<String> = ["Istanbul"]
+        let cities = ["Istanbul", "Ankara", "Izmir", "Antalya", "Bursa", "Adana"]
         var body: some View {
             MultiSelect(label: "Cities", options: cities, selection: $picks) { $0 }
                 .padding()

--- a/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
@@ -170,12 +170,12 @@ public struct RadioButtonGroup<Option: Hashable>: View {
 #Preview {
     struct Demo: View {
         @State var sel: String? = "Economy"
-        @State var seg: String? = "Gün"
+        @State var seg: String? = "Day"
         var body: some View {
             VStack(spacing: 24) {
                 RadioGroup(title: "Class", options: ["Economy", "Business", "First"], selection: $sel) { $0 }
-                RadioButtonGroup(options: ["Gün", "Hafta", "Ay"], selection: $seg, style: .solid) { $0 }
-                RadioButtonGroup(options: ["Gün", "Hafta", "Ay"], selection: $seg, style: .outline, expandsHorizontally: true) { $0 }
+                RadioButtonGroup(options: ["Day", "Week", "Month"], selection: $seg, style: .solid) { $0 }
+                RadioButtonGroup(options: ["Day", "Week", "Month"], selection: $seg, style: .outline, expandsHorizontally: true) { $0 }
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
+++ b/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
@@ -258,7 +258,7 @@ public struct RangeSlider: View {
         var body: some View {
             RangeSlider(lowerValue: $lo, upperValue: $hi, in: 0...1000, step: 50)
                 .marks([0, 250, 500, 750, 1000])
-                .valueLabel { "\(Int($0)) ₺" }
+                .valueLabel { "\(Int($0)) $" }
                 .padding()
         }
     }
@@ -278,6 +278,6 @@ public extension RangeSlider {
     }
     /// Fires with the snapped (lower, upper) pair when a drag ends.
     func onChangeEnd(_ action: ((Double, Double) -> Void)?) -> Self { var copy = self; copy.onChangeEnd = action; return copy }
-    /// Formats the value readout shown above each thumb (e.g. "₺500").
+    /// Formats the value readout shown above each thumb (e.g. "$500").
     func valueLabel(_ format: ((Double) -> String)?) -> Self { var copy = self; copy.valueLabel = format; return copy }
 }

--- a/Sources/ThemeKit/Components/Molecules/SearchBar.swift
+++ b/Sources/ThemeKit/Components/Molecules/SearchBar.swift
@@ -375,7 +375,7 @@ public struct SearchBar: View {
 #Preview("Suggestions + recent") {
     struct Demo: View {
         @State var text = ""
-        let cities = ["İstanbul", "İzmir", "İzmit", "Ankara", "Antalya", "Bursa"]
+        let cities = ["Istanbul", "Izmir", "Izmit", "Ankara", "Antalya", "Bursa"]
         var body: some View {
             SearchBar(
                 text: $text,

--- a/Sources/ThemeKit/Components/Molecules/Select.swift
+++ b/Sources/ThemeKit/Components/Molecules/Select.swift
@@ -272,8 +272,8 @@ public struct Select<Option: Hashable>: View {
         @State var city: String?
         var body: some View {
             VStack(spacing: 16) {
-                Select("City", options: ["İstanbul", "Ankara", "İzmir"], selection: $city, allowClear: true) { $0 }
-                Select("Searchable", sections: [.init("Marmara", ["İstanbul", "Bursa"]), .init("Ege", ["İzmir", "Aydın"])],
+                Select("City", options: ["Istanbul", "Ankara", "Izmir"], selection: $city, allowClear: true) { $0 }
+                Select("Searchable", sections: [.init("Marmara", ["Istanbul", "Bursa"]), .init("Aegean", ["Izmir", "Aydin"])],
                        selection: $city, searchable: true) { $0 }
             }
             .padding()

--- a/Sources/ThemeKit/Components/Molecules/SelectBox.swift
+++ b/Sources/ThemeKit/Components/Molecules/SelectBox.swift
@@ -107,7 +107,7 @@ public struct SelectBox<Option: Hashable>: View {
         @State var country: String?
         var body: some View {
             VStack(spacing: 16) {
-                SelectBox(label: "Country", options: ["Türkiye", "Germany", "France"], selection: $country, hint: "Pick your country") { $0 }
+                SelectBox(label: "Country", options: ["Turkey", "Germany", "France"], selection: $country, hint: "Pick your country") { $0 }
                 SelectBox(label: "City", options: ["A", "B"], selection: .constant(nil), errorText: "Required") { $0 }
             }
             .padding()

--- a/Sources/ThemeKit/Components/Molecules/Stat.swift
+++ b/Sources/ThemeKit/Components/Molecules/Stat.swift
@@ -158,6 +158,6 @@ public struct Stat: View {
         PreviewCase("Default")  { Stat(title: "Bookings", value: "1,284", systemImage: "ticket", trend: .up("+12%")) }
         PreviewCase("Loading")  { Stat(title: "Bookings", value: "0", isLoading: true) }
         PreviewCase("Down")     { Stat(title: "Cancellations", value: "32", trend: .down("-3%")) }
-        PreviewCase("Centered") { Stat(title: "Revenue", value: "₺48,210", systemImage: "creditcard").statStyle(.centered) }
+        PreviewCase("Centered") { Stat(title: "Revenue", value: "$48,210", systemImage: "creditcard").statStyle(.centered) }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/TextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInput.swift
@@ -469,7 +469,7 @@ private extension TextInputCapitalization {
                           submitLabel: .next, autocapitalization: .never, autocorrectionDisabled: true)
                     .a11yID("loginEmail")
                 // Password manager autofill on a secure field.
-                TextInput(TextInputModel(label: "Şifre", isSecure: true, maxLength: 24, showCount: true,
+                TextInput(TextInputModel(label: "Password", isSecure: true, maxLength: 24, showCount: true,
                                          textContentType: .password,
                                          submitLabel: .go), text: $pass)
                     .a11yID("loginPass")

--- a/Sources/ThemeKit/Components/Molecules/TextInputFormatter.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInputFormatter.swift
@@ -41,8 +41,8 @@ public struct TextInputFormatter {
         }
     }
 
-    /// Thousands-grouped amount with an optional currency symbol (e.g. "₺1.234.567").
-    public static func currency(symbol: String = "₺", grouping: String = ".") -> TextInputFormatter {
+    /// Thousands-grouped amount with an optional currency symbol (e.g. "$1,234,567").
+    public static func currency(symbol: String = "$", grouping: String = ",") -> TextInputFormatter {
         TextInputFormatter { raw in
             let digits = raw.filter(\.isNumber)
             guard !digits.isEmpty else { return "" }

--- a/Sources/ThemeKit/Components/Molecules/TreeSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/TreeSelect.swift
@@ -262,17 +262,17 @@ public struct TreeSelect: View {
     struct Demo: View {
         @State var picks: Set<String> = ["ist"]
         let tree = [
-            TreeNode(id: "tr", "Türkiye", systemImage: "flag", children: [
-                TreeNode(id: "ist", "İstanbul"),
+            TreeNode(id: "tr", "Turkey", systemImage: "flag", children: [
+                TreeNode(id: "ist", "Istanbul"),
                 TreeNode(id: "ank", "Ankara"),
             ]),
-            TreeNode(id: "de", "Almanya", systemImage: "flag", children: [
+            TreeNode(id: "de", "Germany", systemImage: "flag", children: [
                 TreeNode(id: "ber", "Berlin"),
-                TreeNode(id: "mun", "Münih"),
+                TreeNode(id: "mun", "Munich"),
             ]),
         ]
         var body: some View {
-            TreeSelect(label: "Şehirler", nodes: tree, selection: $picks, initiallyExpanded: ["tr"]).padding()
+            TreeSelect(label: "Cities", nodes: tree, selection: $picks, initiallyExpanded: ["tr"]).padding()
         }
     }
     return Demo()

--- a/Sources/ThemeKit/Components/Organisms/AccordionGroup.swift
+++ b/Sources/ThemeKit/Components/Organisms/AccordionGroup.swift
@@ -81,8 +81,8 @@ public struct AccordionGroup<Item: Identifiable, Content: View>: View {
 
 #Preview {
     struct FAQ: Identifiable { let id = UUID(); let q: String; let a: String }
-    let faqs = [FAQ(q: "İptal edebilir miyim?", a: "Evet, 24 saat öncesine kadar ücretsiz."),
-                FAQ(q: "Ödeme seçenekleri?", a: "Kredi kartı ve havale.")]
+    let faqs = [FAQ(q: "Can I cancel?", a: "Yes, free up to 24 hours before."),
+                FAQ(q: "Payment options?", a: "Credit card and bank transfer.")]
     return VStack(spacing: 24) {
         AccordionGroup(faqs, mode: .single) { $0.q } content: { Text($0.a).textStyle(.bodyBase400) }
         AccordionGroup(faqs, mode: .multiple) { $0.q } content: { Text($0.a).textStyle(.bodyBase400) }

--- a/Sources/ThemeKit/Components/Organisms/BlogCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/BlogCard.swift
@@ -88,12 +88,12 @@ public struct BlogCard<Media: View>: View {
 #Preview {
     @Previewable @Environment(\.theme) var theme
     VStack(spacing: 20) {
-        BlogCard(title: "Kapadokya'yı Tek Başına Keşfetmeye Ne Dersin?",
-                 excerpt: "Kimine göre doğanın bir mucizesi, kimine göre periler diyarı…",
+        BlogCard(title: "How About Exploring Cappadocia on Your Own?",
+                 excerpt: "To some a miracle of nature, to others a fairyland…",
                  onReadMore: {}) {
             theme.background(.bgTertiary)
         }
-        BlogCard(title: "Kapadokya'yı Tek Başına Keşfetmeye Ne Dersin?", compact: true, onReadMore: {}) {
+        BlogCard(title: "How About Exploring Cappadocia on Your Own?", compact: true, onReadMore: {}) {
             theme.background(.bgTertiary)
         }
     }

--- a/Sources/ThemeKit/Components/Organisms/ChatBubble.swift
+++ b/Sources/ThemeKit/Components/Organisms/ChatBubble.swift
@@ -65,8 +65,8 @@ public struct ChatBubble: View {
 
 #Preview {
     VStack(spacing: 12) {
-        ChatBubble("Merhaba! Rezervasyonunuz onaylandı.", side: .incoming, author: "Destek", time: "09:24", avatarSystemImage: "person.fill")
-        ChatBubble("Teşekkürler, harika!", side: .outgoing, time: "09:25", avatarSystemImage: "person.fill")
+        ChatBubble("Hello! Your reservation is confirmed.", side: .incoming, author: "Support", time: "09:24", avatarSystemImage: "person.fill")
+        ChatBubble("Thanks, great!", side: .outgoing, time: "09:25", avatarSystemImage: "person.fill")
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/Counter.swift
+++ b/Sources/ThemeKit/Components/Organisms/Counter.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 /// Organism. Displays numeric values in labelled boxes — e.g. a countdown
-/// (Gün / Saat / Dakika).
+/// (Day / Hour / Minute).
 public struct Counter: View {
     @Environment(\.theme) private var theme
 

--- a/Sources/ThemeKit/Components/Organisms/DataTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/DataTable.swift
@@ -291,7 +291,7 @@ private struct DefaultTextCell: View {
                 .init("Hotel", sortKey: { .string($0.hotel) }) { $0.hotel },
                 .init("Nights", align: .center, sortKey: { .number(Double($0.nights)) }) { "\($0.nights)" },
                 .init("Price", align: .trailing, sortKey: { .number($0.price) }) { row in
-                    Text("₺\(Int(row.price))").textStyle(.labelSm700)
+                    Text("$\(Int(row.price))").textStyle(.labelSm700)
                 },
             ], rows: rows, selection: $selected)
             .padding()

--- a/Sources/ThemeKit/Components/Organisms/Hero.swift
+++ b/Sources/ThemeKit/Components/Organisms/Hero.swift
@@ -88,7 +88,7 @@ public extension Hero where Background == HeroSurface {
 
 #Preview {
     VStack(spacing: 16) {
-        Hero(title: "Discover İstanbul", subtitle: "Hand-picked stays at the best prices.", ctaTitle: "Explore", action: {})
+        Hero(title: "Discover Istanbul", subtitle: "Hand-picked stays at the best prices.", ctaTitle: "Explore", action: {})
         Hero(title: "Summer Sale", subtitle: "Up to 30% off", ctaTitle: "Shop now", dark: true, action: {})
     }
     .padding()

--- a/Sources/ThemeKit/Components/Organisms/KeyValueTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/KeyValueTable.swift
@@ -91,10 +91,10 @@ public struct KeyValueTable: View {
 
 #Preview {
     KeyValueTable(rows: [
-        .init("Status", value: "Aktif", style: .success),
-        .init("Old price", value: "5.000 TL", style: .strikethrough),
-        .init("Total", value: "4.250 TL"),
-        .init("Refund", value: "İptal Edildi", style: .error),
+        .init("Status", value: "Active", style: .success),
+        .init("Old price", value: "$5,000", style: .strikethrough),
+        .init("Total", value: "$4,250"),
+        .init("Refund", value: "Cancelled", style: .error),
     ])
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/ListRow.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListRow.swift
@@ -366,14 +366,14 @@ public struct ListSectionHeader: View {
                     ListRow("Accept terms", leadingSystemImage: "doc.text", trailing: .checkbox($agree))
                     DividerView(size: .small)
                     ListRow("Premium plan", subtitle: "Billed monthly", number: 1, isSelected: plan,
-                            trailing: .price(.init(total: "₺14.400", each: "₺1.200", unit: "/ ay")), action: { plan.toggle() })
+                            trailing: .price(.init(total: "$14,400", each: "$1,200", unit: "/ month")), action: { plan.toggle() })
                     DividerView(size: .small)
-                    ListRow("Grand Hotel", subtitle: "İstanbul · Deniz manzarası",
+                    ListRow("Grand Hotel", subtitle: "Istanbul · Sea view",
                             leadingSystemImage: "building.2",
-                            meta: ListRowMeta(rating: 8.4, sentiment: "Mükemmel", commentLabel: "1.284 yorum"),
-                            trailing: .status("Müsait", systemImage: "checkmark.seal.fill"), action: {})
+                            meta: ListRowMeta(rating: 8.4, sentiment: "Excellent", commentLabel: "1,284 reviews"),
+                            trailing: .status("Available", systemImage: "checkmark.seal.fill"), action: {})
                     DividerView(size: .small)
-                    ListRow("Update payment", trailing: .button("Düzenle", action: {}))
+                    ListRow("Update payment", trailing: .button("Edit", action: {}))
                 }
                 .padding()
             }

--- a/Sources/ThemeKit/Components/Organisms/ListView.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListView.swift
@@ -121,14 +121,14 @@ public struct ListView<Item: Identifiable, Row: View>: View {
 
 #Preview {
     struct Row: Identifiable { let id = UUID(); let title: String; let subtitle: String }
-    let rows = [Row(title: "Hesabım", subtitle: "Profil ve güvenlik"),
-                Row(title: "Bildirimler", subtitle: "E-posta ve push"),
-                Row(title: "Dil", subtitle: "Türkçe")]
+    let rows = [Row(title: "My Account", subtitle: "Profile & security"),
+                Row(title: "Notifications", subtitle: "Email & push"),
+                Row(title: "Language", subtitle: "English")]
     return VStack(spacing: 24) {
-        ListView(rows, header: "Ayarlar", footer: "3 öğe") { row in
+        ListView(rows, header: "Settings", footer: "3 items") { row in
             ListRow(row.title, subtitle: row.subtitle, action: {})
         }
-        ListView(rows, header: "Yükleniyor", loading: true) { _ in EmptyView() }
+        ListView(rows, header: "Loading", loading: true) { _ in EmptyView() }
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
@@ -95,16 +95,16 @@ public extension NotificationCard where Actions == EmptyView {
 
 #Preview {
     VStack(spacing: 12) {
-        NotificationCard(title: "Tatilinle İlgili Bir Önerimiz Var",
-                         message: "Hilton İstanbul oteline yaptığın rezervasyona 24 gün kaldı.",
-                         date: "5 Aralık Perşembe 2024", isUnread: true) {
+        NotificationCard(title: "We Have a Suggestion for Your Holiday",
+                         message: "24 days left until your reservation at Hilton Istanbul.",
+                         date: "Thursday, December 5, 2024", isUnread: true) {
             ButtonGroup(.horizontal) {
                 SecondaryButton("Sec", size: .small) {}
                 PrimaryButton("Pri", size: .small) {}
             }
         }
-        NotificationCard(title: "Tatilin başlamasına 7 gün kaldı",
-                         message: "Rixos Sungate", date: "28 Kasım 2024")
+        NotificationCard(title: "7 days left until your holiday begins",
+                         message: "Rixos Sungate", date: "November 28, 2024")
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/PagingCarousel.swift
+++ b/Sources/ThemeKit/Components/Organisms/PagingCarousel.swift
@@ -80,8 +80,8 @@ public struct PagingCarousel<Item: Identifiable, Content: View>: View {
 
 #Preview {
     struct Slide: Identifiable { let id = UUID(); let color: Color; let title: String }
-    let slides = [Slide(color: .blue, title: "Bir"), Slide(color: .teal, title: "İki"),
-                  Slide(color: .orange, title: "Üç"), Slide(color: .purple, title: "Dört")]
+    let slides = [Slide(color: .blue, title: "One"), Slide(color: .teal, title: "Two"),
+                  Slide(color: .orange, title: "Three"), Slide(color: .purple, title: "Four")]
     return PagingCarousel(slides, peek: 36, autoplay: 2) { s in
         s.color.opacity(0.3).overlay(Text(s.title).font(.title))
     }

--- a/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
+++ b/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
@@ -120,8 +120,8 @@ public extension View {
         @State var show = true
         var body: some View {
             ThemeButton("Delete", color: .error, variant: .soft) { show.toggle() }
-                .popconfirm(isPresented: $show, title: "Bu öğeyi sil?", message: "Geri alınamaz.",
-                            confirmTitle: "Sil", cancelTitle: "Vazgeç") {}
+                .popconfirm(isPresented: $show, title: "Delete this item?", message: "This can't be undone.",
+                            confirmTitle: "Delete", cancelTitle: "Cancel") {}
                 .padding(80)
         }
     }

--- a/Sources/ThemeKit/Components/Organisms/RatingSummary.swift
+++ b/Sources/ThemeKit/Components/Organisms/RatingSummary.swift
@@ -50,9 +50,9 @@ public struct RatingSummary: View {
 
 #Preview {
     VStack(spacing: 12) {
-        RatingSummary(score: 9.0, label: "Mükemmel", reviewCount: 1200, onReviews: {})
-        RatingSummary(score: 8.5, label: "Çok İyi", reviewCount: 340)
-        RatingSummary(score: 9.8, label: "Mükemmel")
+        RatingSummary(score: 9.0, label: "Excellent", reviewCount: 1200, onReviews: {})
+        RatingSummary(score: 8.5, label: "Very Good", reviewCount: 340)
+        RatingSummary(score: 9.8, label: "Excellent")
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/ResultView.swift
+++ b/Sources/ThemeKit/Components/Organisms/ResultView.swift
@@ -136,13 +136,13 @@ public struct ResultView: View {
 #Preview {
     ScrollView {
         VStack(spacing: 40) {
-            ResultView(.success, title: "Rezervasyon onaylandı",
-                       message: "Onay e-postası gönderildi.",
-                       primaryTitle: "Detaylar", onPrimary: {},
-                       secondaryTitle: "Ana sayfa", onSecondary: {})
-            ResultView(.notFound, title: "Sayfa bulunamadı",
-                       message: "Aradığınız sayfa taşınmış veya silinmiş olabilir.",
-                       primaryTitle: "Ana sayfaya dön", onPrimary: {})
+            ResultView(.success, title: "Reservation confirmed",
+                       message: "A confirmation email has been sent.",
+                       primaryTitle: "Details", onPrimary: {},
+                       secondaryTitle: "Home", onSecondary: {})
+            ResultView(.notFound, title: "Page not found",
+                       message: "The page you're looking for may have been moved or deleted.",
+                       primaryTitle: "Back to home", onPrimary: {})
         }
         .padding()
     }

--- a/Sources/ThemeKit/Components/Organisms/SelectionCards.swift
+++ b/Sources/ThemeKit/Components/Organisms/SelectionCards.swift
@@ -102,7 +102,7 @@ public struct CheckboxCard: View {
             VStack(spacing: 12) {
                 RadioCard("Standard", description: "Free delivery in 3–5 days", isSelected: radio == "std") { radio = "std" }
                 RadioCard("Express", description: "Next-day delivery", isSelected: radio == "exp") { radio = "exp" }
-                CheckboxCard("Add checked bag", description: "+₺250", isChecked: bag) { bag.toggle() }
+                CheckboxCard("Add checked bag", description: "+$250", isChecked: bag) { bag.toggle() }
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Organisms/Timeline.swift
+++ b/Sources/ThemeKit/Components/Organisms/Timeline.swift
@@ -222,7 +222,7 @@ public struct Timeline: View {
             ], pending: "Awaiting courier…")
 
             Timeline([
-                .init(title: "Departure", time: "08:00", description: "İstanbul (IST)", systemImage: "airplane.departure", state: .done),
+                .init(title: "Departure", time: "08:00", description: "Istanbul (IST)", systemImage: "airplane.departure", state: .done),
                 .init(title: "Layover", time: "12:30", description: "Munich (MUC)", systemImage: "clock", state: .active),
                 .init(title: "Arrival", time: "16:45", description: "Barcelona (BCN)", systemImage: "airplane.arrival", state: .todo),
             ], mode: .alternate)

--- a/Sources/ThemeKit/Components/Organisms/Upload.swift
+++ b/Sources/ThemeKit/Components/Organisms/Upload.swift
@@ -228,7 +228,7 @@ public struct UploadList: View {
     Upload(files: [
         UploadFile(name: "room-1.jpg", status: .uploading(0.6)),
         UploadFile(name: "room-2.jpg", status: .done),
-        UploadFile(name: "huge-file.jpg", status: .failed("Dosya çok büyük")),
+        UploadFile(name: "huge-file.jpg", status: .failed("File too large")),
     ], onRetry: { _ in })
     .padding()
 }

--- a/Sources/ThemeKit/Validation/Validators.swift
+++ b/Sources/ThemeKit/Validation/Validators.swift
@@ -48,7 +48,7 @@ public enum Validators {
         requireUppercase: Bool = true, requireDigit: Bool = true, requireSpecial: Bool = false
     ) -> Bool {
         guard s.count >= minLength else { return false }
-        if requireUppercase, !matches(s, #"[A-ZĞÜŞİÖÇ]"#) { return false }
+        if requireUppercase, !matches(s, #"\p{Lu}"#) { return false }   // any Unicode uppercase letter
         if requireDigit, !matches(s, #"\d"#) { return false }
         if requireSpecial, !matches(s, #"[^A-Za-z0-9]"#) { return false }
         return true


### PR DESCRIPTION
Convert every Turkish user-facing / sample / preview / doc string in the library source and the demo app to natural English, ahead of going public (international audience). Done as a parallel sweep, then verified end-to-end.

## What changed (47 files)
- **`Sources/ThemeKit`** — ~75 lines across 29 files, all in `#Preview` sample data and a few doc-comment examples (shipped component logic has no hardcoded user strings). Cities → English exonyms, sample content → English; value↔option pairs translated together so matching still holds.
- **Demo app** — the hotel-booking example flow, the component gallery/demos, and the configurator/themes views (~430 text units). US-style currency (`$`, comma grouping) and 12-hour times where natural.
- **Validation** — the password "has uppercase" check now uses the Unicode property `\p{Lu}` (any uppercase letter) instead of an ASCII/Turkish-specific class — English source **and** more correct internationally.
- **`TextInputFormatter.currency`** default → `"$"` / `","` (was `₺` / `"."`); all `₺` and a stray `turkishlirasign.circle` icon → USD equivalents.

## Preserved deliberately
- The bundled **Turkish translation** in `Localizable.xcstrings` — it's a localization *feature*, kept (README's "with Turkish" claim stays true).
- The `İsa Mercan` author headers, and all identifiers / storage keys / ISO locale codes (`id: "tr"`, `phoneTR`, …).

## Verification
- `git grep` for Turkish letters → **0** (outside the catalog + author headers); `₺` → **0**.
- `swift build` + Demo `xcodebuild` + **184 tests** all green.

## Follow-ups (separate)
- `Tests/ScreenshotGenerator.swift` has Turkish sample strings baked into the README gallery PNGs → needs a `make screenshots` re-render.
- The Turkish internal docs (`docs/AUDIT.md`, `PROJE-TANITIM.md`, `ACCESSIBILITY-AUDIT.md`) — keep / translate / move to Wiki is a go-public decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)