### PR TITLE
docs(readme): light/dark image fragments instead of <picture> (mobile-app fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@
 ![Dependencies](https://img.shields.io/badge/Core%20dependencies-0-success.svg)
 
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="Screenshots/Banner-dark.png">
-    <img src="Screenshots/Banner.png" alt="ThemeKit — native SwiftUI design system: 117 components, fully tokenized, per-subtree theming, Swift 6, Liquid Glass, light + dark" width="820">
-  </picture>
+  <img src="Screenshots/Banner.png#gh-light-mode-only" alt="ThemeKit — native SwiftUI design system: 117 components, fully tokenized, per-subtree theming, Swift 6, Liquid Glass, light + dark" width="820">
+  <img src="Screenshots/Banner-dark.png#gh-dark-mode-only" alt="ThemeKit — native SwiftUI design system: 117 components, fully tokenized, per-subtree theming, Swift 6, Liquid Glass, light + dark" width="820">
 </p>
 
 > The banner above is rendered **by ThemeKit itself** (its own tokens + components) — so it re-skins light/dark for free, just like everything in the gallery.
@@ -208,7 +206,7 @@ Every component is curated by category in the [DocC catalog](#documentation).
 
 ## Component gallery
 
-Rendered straight from the library via `ImageRenderer` — **theme-aware** (GitHub serves the dark variant via `<picture>` to dark-mode readers) —
+Rendered straight from the library via `ImageRenderer` — **theme-aware** (GitHub serves the dark variant via `#gh-dark-mode-only` image fragments, which also render in the GitHub mobile app) —
 regenerate with `make screenshots`. Interactive overlays (Dialog, Drawer, Tour,
 BottomSheet…) and media components are best seen live in the [Demo app](#demo).
 
@@ -218,52 +216,52 @@ BottomSheet…) and media components are best seen live in the [Demo app](#demo)
 
 <table>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Avatar-dark.png"><img src="Screenshots/Avatar.png" width="184" alt="Avatar"></picture><br><sub><b>Avatar</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Badge-dark.png"><img src="Screenshots/Badge.png" width="223" alt="Badge"></picture><br><sub><b>Badge</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Chip-dark.png"><img src="Screenshots/Chip.png" width="233" alt="Chip"></picture><br><sub><b>Chip</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Avatar.png#gh-light-mode-only" width="184" alt="Avatar"><img src="Screenshots/Avatar-dark.png#gh-dark-mode-only" width="184" alt="Avatar"><br><sub><b>Avatar</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Badge.png#gh-light-mode-only" width="223" alt="Badge"><img src="Screenshots/Badge-dark.png#gh-dark-mode-only" width="223" alt="Badge"><br><sub><b>Badge</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Chip.png#gh-light-mode-only" width="233" alt="Chip"><img src="Screenshots/Chip-dark.png#gh-dark-mode-only" width="233" alt="Chip"><br><sub><b>Chip</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/CountBadge-dark.png"><img src="Screenshots/CountBadge.png" width="68" alt="CountBadge"></picture><br><sub><b>CountBadge</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Divider-dark.png"><img src="Screenshots/Divider.png" width="240" alt="Divider"></picture><br><sub><b>Divider</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Icon-dark.png"><img src="Screenshots/Icon.png" width="182" alt="Icon"></picture><br><sub><b>Icon</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/CountBadge.png#gh-light-mode-only" width="68" alt="CountBadge"><img src="Screenshots/CountBadge-dark.png#gh-dark-mode-only" width="68" alt="CountBadge"><br><sub><b>CountBadge</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Divider.png#gh-light-mode-only" width="240" alt="Divider"><img src="Screenshots/Divider-dark.png#gh-dark-mode-only" width="240" alt="Divider"><br><sub><b>Divider</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Icon.png#gh-light-mode-only" width="182" alt="Icon"><img src="Screenshots/Icon-dark.png#gh-dark-mode-only" width="182" alt="Icon"><br><sub><b>Icon</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Indicator-dark.png"><img src="Screenshots/Indicator.png" width="68" alt="Indicator"></picture><br><sub><b>Indicator</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/InputLabel-dark.png"><img src="Screenshots/InputLabel.png" width="93" alt="InputLabel"></picture><br><sub><b>InputLabel</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Kbd-dark.png"><img src="Screenshots/Kbd.png" width="94" alt="Kbd"></picture><br><sub><b>Kbd</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Indicator.png#gh-light-mode-only" width="68" alt="Indicator"><img src="Screenshots/Indicator-dark.png#gh-dark-mode-only" width="68" alt="Indicator"><br><sub><b>Indicator</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/InputLabel.png#gh-light-mode-only" width="93" alt="InputLabel"><img src="Screenshots/InputLabel-dark.png#gh-dark-mode-only" width="93" alt="InputLabel"><br><sub><b>InputLabel</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Kbd.png#gh-light-mode-only" width="94" alt="Kbd"><img src="Screenshots/Kbd-dark.png#gh-dark-mode-only" width="94" alt="Kbd"><br><sub><b>Kbd</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ProgressBar-dark.png"><img src="Screenshots/ProgressBar.png" width="240" alt="ProgressBar"></picture><br><sub><b>ProgressBar</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/RadialProgress-dark.png"><img src="Screenshots/RadialProgress.png" width="128" alt="RadialProgress"></picture><br><sub><b>RadialProgress</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Rating-dark.png"><img src="Screenshots/Rating.png" width="184" alt="Rating"></picture><br><sub><b>Rating</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ProgressBar.png#gh-light-mode-only" width="240" alt="ProgressBar"><img src="Screenshots/ProgressBar-dark.png#gh-dark-mode-only" width="240" alt="ProgressBar"><br><sub><b>ProgressBar</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/RadialProgress.png#gh-light-mode-only" width="128" alt="RadialProgress"><img src="Screenshots/RadialProgress-dark.png#gh-dark-mode-only" width="128" alt="RadialProgress"><br><sub><b>RadialProgress</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Rating.png#gh-light-mode-only" width="184" alt="Rating"><img src="Screenshots/Rating-dark.png#gh-dark-mode-only" width="184" alt="Rating"><br><sub><b>Rating</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/RollingNumber-dark.png"><img src="Screenshots/RollingNumber.png" width="138" alt="RollingNumber"></picture><br><sub><b>RollingNumber</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ScoreBadge-dark.png"><img src="Screenshots/ScoreBadge.png" width="64" alt="ScoreBadge"></picture><br><sub><b>ScoreBadge</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Skeleton-dark.png"><img src="Screenshots/Skeleton.png" width="240" alt="Skeleton"></picture><br><sub><b>Skeleton</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/RollingNumber.png#gh-light-mode-only" width="138" alt="RollingNumber"><img src="Screenshots/RollingNumber-dark.png#gh-dark-mode-only" width="138" alt="RollingNumber"><br><sub><b>RollingNumber</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ScoreBadge.png#gh-light-mode-only" width="64" alt="ScoreBadge"><img src="Screenshots/ScoreBadge-dark.png#gh-dark-mode-only" width="64" alt="ScoreBadge"><br><sub><b>ScoreBadge</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Skeleton.png#gh-light-mode-only" width="240" alt="Skeleton"><img src="Screenshots/Skeleton-dark.png#gh-dark-mode-only" width="240" alt="Skeleton"><br><sub><b>Skeleton</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Spinner-dark.png"><img src="Screenshots/Spinner.png" width="64" alt="Spinner"></picture><br><sub><b>Spinner</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/StatusDot-dark.png"><img src="Screenshots/StatusDot.png" width="211" alt="StatusDot"></picture><br><sub><b>StatusDot</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Swap-dark.png"><img src="Screenshots/Swap.png" width="72" alt="Swap"></picture><br><sub><b>Swap</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Spinner.png#gh-light-mode-only" width="64" alt="Spinner"><img src="Screenshots/Spinner-dark.png#gh-dark-mode-only" width="64" alt="Spinner"><br><sub><b>Spinner</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/StatusDot.png#gh-light-mode-only" width="211" alt="StatusDot"><img src="Screenshots/StatusDot-dark.png#gh-dark-mode-only" width="211" alt="StatusDot"><br><sub><b>StatusDot</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Swap.png#gh-light-mode-only" width="72" alt="Swap"><img src="Screenshots/Swap-dark.png#gh-dark-mode-only" width="72" alt="Swap"><br><sub><b>Swap</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Tag-dark.png"><img src="Screenshots/Tag.png" width="201" alt="Tag"></picture><br><sub><b>Tag</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/TextLink-dark.png"><img src="Screenshots/TextLink.png" width="161" alt="TextLink"></picture><br><sub><b>TextLink</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Title-dark.png"><img src="Screenshots/Title.png" width="240" alt="Title"></picture><br><sub><b>Title</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Tag.png#gh-light-mode-only" width="201" alt="Tag"><img src="Screenshots/Tag-dark.png#gh-dark-mode-only" width="201" alt="Tag"><br><sub><b>Tag</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/TextLink.png#gh-light-mode-only" width="161" alt="TextLink"><img src="Screenshots/TextLink-dark.png#gh-dark-mode-only" width="161" alt="TextLink"><br><sub><b>TextLink</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Title.png#gh-light-mode-only" width="240" alt="Title"><img src="Screenshots/Title-dark.png#gh-dark-mode-only" width="240" alt="Title"><br><sub><b>Title</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/InlineText-dark.png"><img src="Screenshots/InlineText.png" width="240" alt="InlineText"></picture><br><sub><b>InlineText</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/BorderBeam-dark.png"><img src="Screenshots/BorderBeam.png" width="232" alt="BorderBeam"></picture><br><sub><b>BorderBeam</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Join-dark.png"><img src="Screenshots/Join.png" width="234" alt="Join"></picture><br><sub><b>Join</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/InlineText.png#gh-light-mode-only" width="240" alt="InlineText"><img src="Screenshots/InlineText-dark.png#gh-dark-mode-only" width="240" alt="InlineText"><br><sub><b>InlineText</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/BorderBeam.png#gh-light-mode-only" width="232" alt="BorderBeam"><img src="Screenshots/BorderBeam-dark.png#gh-dark-mode-only" width="232" alt="BorderBeam"><br><sub><b>BorderBeam</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Join.png#gh-light-mode-only" width="234" alt="Join"><img src="Screenshots/Join-dark.png#gh-dark-mode-only" width="234" alt="Join"><br><sub><b>Join</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Mask-dark.png"><img src="Screenshots/Mask.png" width="240" alt="Mask"></picture><br><sub><b>Mask</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/TextRotate-dark.png"><img src="Screenshots/TextRotate.png" width="177" alt="TextRotate"></picture><br><sub><b>TextRotate</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Gauge-dark.png"><img src="Screenshots/Gauge.png" width="240" alt="Gauge"></picture><br><sub><b>Gauge</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Mask.png#gh-light-mode-only" width="240" alt="Mask"><img src="Screenshots/Mask-dark.png#gh-dark-mode-only" width="240" alt="Mask"><br><sub><b>Mask</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/TextRotate.png#gh-light-mode-only" width="177" alt="TextRotate"><img src="Screenshots/TextRotate-dark.png#gh-dark-mode-only" width="177" alt="TextRotate"><br><sub><b>TextRotate</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Gauge.png#gh-light-mode-only" width="240" alt="Gauge"><img src="Screenshots/Gauge-dark.png#gh-dark-mode-only" width="240" alt="Gauge"><br><sub><b>Gauge</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ShareButton-dark.png"><img src="Screenshots/ShareButton.png" width="146" alt="ShareButton"></picture><br><sub><b>ShareButton</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ShareButton.png#gh-light-mode-only" width="146" alt="ShareButton"><img src="Screenshots/ShareButton-dark.png#gh-dark-mode-only" width="146" alt="ShareButton"><br><sub><b>ShareButton</b></sub></td>
 </tr>
 </table>
 
@@ -271,63 +269,63 @@ BottomSheet…) and media components are best seen live in the [Demo app](#demo)
 
 <table>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Button-dark.png"><img src="Screenshots/Button.png" width="240" alt="Button"></picture><br><sub><b>Button</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ThemeButton-dark.png"><img src="Screenshots/ThemeButton.png" width="240" alt="ThemeButton"></picture><br><sub><b>ThemeButton</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Checkbox-dark.png"><img src="Screenshots/Checkbox.png" width="212" alt="Checkbox"></picture><br><sub><b>Checkbox</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Button.png#gh-light-mode-only" width="240" alt="Button"><img src="Screenshots/Button-dark.png#gh-dark-mode-only" width="240" alt="Button"><br><sub><b>Button</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ThemeButton.png#gh-light-mode-only" width="240" alt="ThemeButton"><img src="Screenshots/ThemeButton-dark.png#gh-dark-mode-only" width="240" alt="ThemeButton"><br><sub><b>ThemeButton</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Checkbox.png#gh-light-mode-only" width="212" alt="Checkbox"><img src="Screenshots/Checkbox-dark.png#gh-dark-mode-only" width="212" alt="Checkbox"><br><sub><b>Checkbox</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/CheckboxGroup-dark.png"><img src="Screenshots/CheckboxGroup.png" width="240" alt="CheckboxGroup"></picture><br><sub><b>CheckboxGroup</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/RadioButton-dark.png"><img src="Screenshots/RadioButton.png" width="171" alt="RadioButton"></picture><br><sub><b>RadioButton</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/RadioGroup-dark.png"><img src="Screenshots/RadioGroup.png" width="240" alt="RadioGroup"></picture><br><sub><b>RadioGroup</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/CheckboxGroup.png#gh-light-mode-only" width="240" alt="CheckboxGroup"><img src="Screenshots/CheckboxGroup-dark.png#gh-dark-mode-only" width="240" alt="CheckboxGroup"><br><sub><b>CheckboxGroup</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/RadioButton.png#gh-light-mode-only" width="171" alt="RadioButton"><img src="Screenshots/RadioButton-dark.png#gh-dark-mode-only" width="171" alt="RadioButton"><br><sub><b>RadioButton</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/RadioGroup.png#gh-light-mode-only" width="240" alt="RadioGroup"><img src="Screenshots/RadioGroup-dark.png#gh-dark-mode-only" width="240" alt="RadioGroup"><br><sub><b>RadioGroup</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ToggleGroup-dark.png"><img src="Screenshots/ToggleGroup.png" width="72" alt="ToggleGroup"></picture><br><sub><b>ToggleGroup</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ThemeToggle-dark.png"><img src="Screenshots/ThemeToggle.png" width="128" alt="ThemeToggle"></picture><br><sub><b>ThemeToggle</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/SegmentedControl-dark.png"><img src="Screenshots/SegmentedControl.png" width="240" alt="SegmentedControl"></picture><br><sub><b>SegmentedControl</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ToggleGroup.png#gh-light-mode-only" width="72" alt="ToggleGroup"><img src="Screenshots/ToggleGroup-dark.png#gh-dark-mode-only" width="72" alt="ToggleGroup"><br><sub><b>ToggleGroup</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ThemeToggle.png#gh-light-mode-only" width="128" alt="ThemeToggle"><img src="Screenshots/ThemeToggle-dark.png#gh-dark-mode-only" width="128" alt="ThemeToggle"><br><sub><b>ThemeToggle</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/SegmentedControl.png#gh-light-mode-only" width="240" alt="SegmentedControl"><img src="Screenshots/SegmentedControl-dark.png#gh-dark-mode-only" width="240" alt="SegmentedControl"><br><sub><b>SegmentedControl</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/QuantityStepper-dark.png"><img src="Screenshots/QuantityStepper.png" width="168" alt="QuantityStepper"></picture><br><sub><b>QuantityStepper</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Stat-dark.png"><img src="Screenshots/Stat.png" width="240" alt="Stat"></picture><br><sub><b>Stat</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Steps-dark.png"><img src="Screenshots/Steps.png" width="240" alt="Steps"></picture><br><sub><b>Steps</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/QuantityStepper.png#gh-light-mode-only" width="168" alt="QuantityStepper"><img src="Screenshots/QuantityStepper-dark.png#gh-dark-mode-only" width="168" alt="QuantityStepper"><br><sub><b>QuantityStepper</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Stat.png#gh-light-mode-only" width="240" alt="Stat"><img src="Screenshots/Stat-dark.png#gh-dark-mode-only" width="240" alt="Stat"><br><sub><b>Stat</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Steps.png#gh-light-mode-only" width="240" alt="Steps"><img src="Screenshots/Steps-dark.png#gh-dark-mode-only" width="240" alt="Steps"><br><sub><b>Steps</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Slider-dark.png"><img src="Screenshots/Slider.png" width="240" alt="Slider"></picture><br><sub><b>Slider</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Breadcrumbs-dark.png"><img src="Screenshots/Breadcrumbs.png" width="240" alt="Breadcrumbs"></picture><br><sub><b>Breadcrumbs</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/TextInput-dark.png"><img src="Screenshots/TextInput.png" width="240" alt="TextInput"></picture><br><sub><b>TextInput</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Slider.png#gh-light-mode-only" width="240" alt="Slider"><img src="Screenshots/Slider-dark.png#gh-dark-mode-only" width="240" alt="Slider"><br><sub><b>Slider</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Breadcrumbs.png#gh-light-mode-only" width="240" alt="Breadcrumbs"><img src="Screenshots/Breadcrumbs-dark.png#gh-dark-mode-only" width="240" alt="Breadcrumbs"><br><sub><b>Breadcrumbs</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/TextInput.png#gh-light-mode-only" width="240" alt="TextInput"><img src="Screenshots/TextInput-dark.png#gh-dark-mode-only" width="240" alt="TextInput"><br><sub><b>TextInput</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/FileInput-dark.png"><img src="Screenshots/FileInput.png" width="240" alt="FileInput"></picture><br><sub><b>FileInput</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Pagination-dark.png"><img src="Screenshots/Pagination.png" width="240" alt="Pagination"></picture><br><sub><b>Pagination</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Fieldset-dark.png"><img src="Screenshots/Fieldset.png" width="240" alt="Fieldset"></picture><br><sub><b>Fieldset</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/FileInput.png#gh-light-mode-only" width="240" alt="FileInput"><img src="Screenshots/FileInput-dark.png#gh-dark-mode-only" width="240" alt="FileInput"><br><sub><b>FileInput</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Pagination.png#gh-light-mode-only" width="240" alt="Pagination"><img src="Screenshots/Pagination-dark.png#gh-dark-mode-only" width="240" alt="Pagination"><br><sub><b>Pagination</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Fieldset.png#gh-light-mode-only" width="240" alt="Fieldset"><img src="Screenshots/Fieldset-dark.png#gh-dark-mode-only" width="240" alt="Fieldset"><br><sub><b>Fieldset</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/DateField-dark.png"><img src="Screenshots/DateField.png" width="240" alt="DateField"></picture><br><sub><b>DateField</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Select-dark.png"><img src="Screenshots/Select.png" width="240" alt="Select"></picture><br><sub><b>Select</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/MultiSelect-dark.png"><img src="Screenshots/MultiSelect.png" width="240" alt="MultiSelect"></picture><br><sub><b>MultiSelect</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/DateField.png#gh-light-mode-only" width="240" alt="DateField"><img src="Screenshots/DateField-dark.png#gh-dark-mode-only" width="240" alt="DateField"><br><sub><b>DateField</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Select.png#gh-light-mode-only" width="240" alt="Select"><img src="Screenshots/Select-dark.png#gh-dark-mode-only" width="240" alt="Select"><br><sub><b>Select</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/MultiSelect.png#gh-light-mode-only" width="240" alt="MultiSelect"><img src="Screenshots/MultiSelect-dark.png#gh-dark-mode-only" width="240" alt="MultiSelect"><br><sub><b>MultiSelect</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/TreeSelect-dark.png"><img src="Screenshots/TreeSelect.png" width="240" alt="TreeSelect"></picture><br><sub><b>TreeSelect</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Autocomplete-dark.png"><img src="Screenshots/Autocomplete.png" width="240" alt="Autocomplete"></picture><br><sub><b>Autocomplete</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/SearchBar-dark.png"><img src="Screenshots/SearchBar.png" width="240" alt="SearchBar"></picture><br><sub><b>SearchBar</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/TreeSelect.png#gh-light-mode-only" width="240" alt="TreeSelect"><img src="Screenshots/TreeSelect-dark.png#gh-dark-mode-only" width="240" alt="TreeSelect"><br><sub><b>TreeSelect</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Autocomplete.png#gh-light-mode-only" width="240" alt="Autocomplete"><img src="Screenshots/Autocomplete-dark.png#gh-dark-mode-only" width="240" alt="Autocomplete"><br><sub><b>Autocomplete</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/SearchBar.png#gh-light-mode-only" width="240" alt="SearchBar"><img src="Screenshots/SearchBar-dark.png#gh-dark-mode-only" width="240" alt="SearchBar"><br><sub><b>SearchBar</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/OTPInput-dark.png"><img src="Screenshots/OTPInput.png" width="240" alt="OTPInput"></picture><br><sub><b>OTPInput</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/InputNumber-dark.png"><img src="Screenshots/InputNumber.png" width="240" alt="InputNumber"></picture><br><sub><b>InputNumber</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/RangeSlider-dark.png"><img src="Screenshots/RangeSlider.png" width="240" alt="RangeSlider"></picture><br><sub><b>RangeSlider</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/OTPInput.png#gh-light-mode-only" width="240" alt="OTPInput"><img src="Screenshots/OTPInput-dark.png#gh-dark-mode-only" width="240" alt="OTPInput"><br><sub><b>OTPInput</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/InputNumber.png#gh-light-mode-only" width="240" alt="InputNumber"><img src="Screenshots/InputNumber-dark.png#gh-dark-mode-only" width="240" alt="InputNumber"><br><sub><b>InputNumber</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/RangeSlider.png#gh-light-mode-only" width="240" alt="RangeSlider"><img src="Screenshots/RangeSlider-dark.png#gh-dark-mode-only" width="240" alt="RangeSlider"><br><sub><b>RangeSlider</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/MultiLineTextInput-dark.png"><img src="Screenshots/MultiLineTextInput.png" width="240" alt="MultiLineTextInput"></picture><br><sub><b>MultiLineTextInput</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Tooltip-dark.png"><img src="Screenshots/Tooltip.png" width="60" alt="Tooltip"></picture><br><sub><b>Tooltip</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Chips-dark.png"><img src="Screenshots/Chips.png" width="132" alt="Chips"></picture><br><sub><b>Chips</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/MultiLineTextInput.png#gh-light-mode-only" width="240" alt="MultiLineTextInput"><img src="Screenshots/MultiLineTextInput-dark.png#gh-dark-mode-only" width="240" alt="MultiLineTextInput"><br><sub><b>MultiLineTextInput</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Tooltip.png#gh-light-mode-only" width="60" alt="Tooltip"><img src="Screenshots/Tooltip-dark.png#gh-dark-mode-only" width="60" alt="Tooltip"><br><sub><b>Tooltip</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Chips.png#gh-light-mode-only" width="132" alt="Chips"><img src="Screenshots/Chips-dark.png#gh-dark-mode-only" width="132" alt="Chips"><br><sub><b>Chips</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/FilterGroup-dark.png"><img src="Screenshots/FilterGroup.png" width="240" alt="FilterGroup"></picture><br><sub><b>FilterGroup</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ProgressIndicator-dark.png"><img src="Screenshots/ProgressIndicator.png" width="240" alt="ProgressIndicator"></picture><br><sub><b>ProgressIndicator</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ThemeController-dark.png"><img src="Screenshots/ThemeController.png" width="240" alt="ThemeController"></picture><br><sub><b>ThemeController</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/FilterGroup.png#gh-light-mode-only" width="240" alt="FilterGroup"><img src="Screenshots/FilterGroup-dark.png#gh-dark-mode-only" width="240" alt="FilterGroup"><br><sub><b>FilterGroup</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ProgressIndicator.png#gh-light-mode-only" width="240" alt="ProgressIndicator"><img src="Screenshots/ProgressIndicator-dark.png#gh-dark-mode-only" width="240" alt="ProgressIndicator"><br><sub><b>ProgressIndicator</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ThemeController.png#gh-light-mode-only" width="240" alt="ThemeController"><img src="Screenshots/ThemeController-dark.png#gh-dark-mode-only" width="240" alt="ThemeController"><br><sub><b>ThemeController</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Calendar-dark.png"><img src="Screenshots/Calendar.png" width="240" alt="Calendar"></picture><br><sub><b>Calendar</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ColorField-dark.png"><img src="Screenshots/ColorField.png" width="240" alt="ColorField"></picture><br><sub><b>ColorField</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Calendar.png#gh-light-mode-only" width="240" alt="Calendar"><img src="Screenshots/Calendar-dark.png#gh-dark-mode-only" width="240" alt="Calendar"><br><sub><b>Calendar</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ColorField.png#gh-light-mode-only" width="240" alt="ColorField"><img src="Screenshots/ColorField-dark.png#gh-dark-mode-only" width="240" alt="ColorField"><br><sub><b>ColorField</b></sub></td>
 </tr>
 </table>
 
@@ -335,53 +333,53 @@ BottomSheet…) and media components are best seen live in the [Demo app](#demo)
 
 <table>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Accordion-dark.png"><img src="Screenshots/Accordion.png" width="240" alt="Accordion"></picture><br><sub><b>Accordion</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/AlertToast-dark.png"><img src="Screenshots/AlertToast.png" width="240" alt="AlertToast"></picture><br><sub><b>AlertToast</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Callout-dark.png"><img src="Screenshots/Callout.png" width="240" alt="Callout"></picture><br><sub><b>Callout</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Accordion.png#gh-light-mode-only" width="240" alt="Accordion"><img src="Screenshots/Accordion-dark.png#gh-dark-mode-only" width="240" alt="Accordion"><br><sub><b>Accordion</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/AlertToast.png#gh-light-mode-only" width="240" alt="AlertToast"><img src="Screenshots/AlertToast-dark.png#gh-dark-mode-only" width="240" alt="AlertToast"><br><sub><b>AlertToast</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Callout.png#gh-light-mode-only" width="240" alt="Callout"><img src="Screenshots/Callout-dark.png#gh-dark-mode-only" width="240" alt="Callout"><br><sub><b>Callout</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Card-dark.png"><img src="Screenshots/Card.png" width="240" alt="Card"></picture><br><sub><b>Card</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ChatBubble-dark.png"><img src="Screenshots/ChatBubble.png" width="240" alt="ChatBubble"></picture><br><sub><b>ChatBubble</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Counter-dark.png"><img src="Screenshots/Counter.png" width="172" alt="Counter"></picture><br><sub><b>Counter</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Card.png#gh-light-mode-only" width="240" alt="Card"><img src="Screenshots/Card-dark.png#gh-dark-mode-only" width="240" alt="Card"><br><sub><b>Card</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ChatBubble.png#gh-light-mode-only" width="240" alt="ChatBubble"><img src="Screenshots/ChatBubble-dark.png#gh-dark-mode-only" width="240" alt="ChatBubble"><br><sub><b>ChatBubble</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Counter.png#gh-light-mode-only" width="172" alt="Counter"><img src="Screenshots/Counter-dark.png#gh-dark-mode-only" width="172" alt="Counter"><br><sub><b>Counter</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Coupon-dark.png"><img src="Screenshots/Coupon.png" width="240" alt="Coupon"></picture><br><sub><b>Coupon</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/EmptyState-dark.png"><img src="Screenshots/EmptyState.png" width="240" alt="EmptyState"></picture><br><sub><b>EmptyState</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/InfoBanner-dark.png"><img src="Screenshots/InfoBanner.png" width="240" alt="InfoBanner"></picture><br><sub><b>InfoBanner</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Coupon.png#gh-light-mode-only" width="240" alt="Coupon"><img src="Screenshots/Coupon-dark.png#gh-dark-mode-only" width="240" alt="Coupon"><br><sub><b>Coupon</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/EmptyState.png#gh-light-mode-only" width="240" alt="EmptyState"><img src="Screenshots/EmptyState-dark.png#gh-dark-mode-only" width="240" alt="EmptyState"><br><sub><b>EmptyState</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/InfoBanner.png#gh-light-mode-only" width="240" alt="InfoBanner"><img src="Screenshots/InfoBanner-dark.png#gh-dark-mode-only" width="240" alt="InfoBanner"><br><sub><b>InfoBanner</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/KeyValueTable-dark.png"><img src="Screenshots/KeyValueTable.png" width="240" alt="KeyValueTable"></picture><br><sub><b>KeyValueTable</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ListRow-dark.png"><img src="Screenshots/ListRow.png" width="240" alt="ListRow"></picture><br><sub><b>ListRow</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/NotificationCard-dark.png"><img src="Screenshots/NotificationCard.png" width="240" alt="NotificationCard"></picture><br><sub><b>NotificationCard</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/KeyValueTable.png#gh-light-mode-only" width="240" alt="KeyValueTable"><img src="Screenshots/KeyValueTable-dark.png#gh-dark-mode-only" width="240" alt="KeyValueTable"><br><sub><b>KeyValueTable</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ListRow.png#gh-light-mode-only" width="240" alt="ListRow"><img src="Screenshots/ListRow-dark.png#gh-dark-mode-only" width="240" alt="ListRow"><br><sub><b>ListRow</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/NotificationCard.png#gh-light-mode-only" width="240" alt="NotificationCard"><img src="Screenshots/NotificationCard-dark.png#gh-dark-mode-only" width="240" alt="NotificationCard"><br><sub><b>NotificationCard</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/PageHeader-dark.png"><img src="Screenshots/PageHeader.png" width="240" alt="PageHeader"></picture><br><sub><b>PageHeader</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/RatingSummary-dark.png"><img src="Screenshots/RatingSummary.png" width="240" alt="RatingSummary"></picture><br><sub><b>RatingSummary</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ResultView-dark.png"><img src="Screenshots/ResultView.png" width="240" alt="ResultView"></picture><br><sub><b>ResultView</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/PageHeader.png#gh-light-mode-only" width="240" alt="PageHeader"><img src="Screenshots/PageHeader-dark.png#gh-dark-mode-only" width="240" alt="PageHeader"><br><sub><b>PageHeader</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/RatingSummary.png#gh-light-mode-only" width="240" alt="RatingSummary"><img src="Screenshots/RatingSummary-dark.png#gh-dark-mode-only" width="240" alt="RatingSummary"><br><sub><b>RatingSummary</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ResultView.png#gh-light-mode-only" width="240" alt="ResultView"><img src="Screenshots/ResultView-dark.png#gh-dark-mode-only" width="240" alt="ResultView"><br><sub><b>ResultView</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/SegmentedTabBar-dark.png"><img src="Screenshots/SegmentedTabBar.png" width="240" alt="SegmentedTabBar"></picture><br><sub><b>SegmentedTabBar</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Timeline-dark.png"><img src="Screenshots/Timeline.png" width="240" alt="Timeline"></picture><br><sub><b>Timeline</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Upload-dark.png"><img src="Screenshots/Upload.png" width="240" alt="Upload"></picture><br><sub><b>Upload</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/SegmentedTabBar.png#gh-light-mode-only" width="240" alt="SegmentedTabBar"><img src="Screenshots/SegmentedTabBar-dark.png#gh-dark-mode-only" width="240" alt="SegmentedTabBar"><br><sub><b>SegmentedTabBar</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Timeline.png#gh-light-mode-only" width="240" alt="Timeline"><img src="Screenshots/Timeline-dark.png#gh-dark-mode-only" width="240" alt="Timeline"><br><sub><b>Timeline</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Upload.png#gh-light-mode-only" width="240" alt="Upload"><img src="Screenshots/Upload-dark.png#gh-dark-mode-only" width="240" alt="Upload"><br><sub><b>Upload</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/PromoBanner-dark.png"><img src="Screenshots/PromoBanner.png" width="240" alt="PromoBanner"></picture><br><sub><b>PromoBanner</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/ListView-dark.png"><img src="Screenshots/ListView.png" width="240" alt="ListView"></picture><br><sub><b>ListView</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/MenuCard-dark.png"><img src="Screenshots/MenuCard.png" width="240" alt="MenuCard"></picture><br><sub><b>MenuCard</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/PromoBanner.png#gh-light-mode-only" width="240" alt="PromoBanner"><img src="Screenshots/PromoBanner-dark.png#gh-dark-mode-only" width="240" alt="PromoBanner"><br><sub><b>PromoBanner</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/ListView.png#gh-light-mode-only" width="240" alt="ListView"><img src="Screenshots/ListView-dark.png#gh-dark-mode-only" width="240" alt="ListView"><br><sub><b>ListView</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/MenuCard.png#gh-light-mode-only" width="240" alt="MenuCard"><img src="Screenshots/MenuCard-dark.png#gh-dark-mode-only" width="240" alt="MenuCard"><br><sub><b>MenuCard</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/NavigationBar-dark.png"><img src="Screenshots/NavigationBar.png" width="240" alt="NavigationBar"></picture><br><sub><b>NavigationBar</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/FAB-dark.png"><img src="Screenshots/FAB.png" width="88" alt="FAB"></picture><br><sub><b>FAB</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Hero-dark.png"><img src="Screenshots/Hero.png" width="240" alt="Hero"></picture><br><sub><b>Hero</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/NavigationBar.png#gh-light-mode-only" width="240" alt="NavigationBar"><img src="Screenshots/NavigationBar-dark.png#gh-dark-mode-only" width="240" alt="NavigationBar"><br><sub><b>NavigationBar</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/FAB.png#gh-light-mode-only" width="88" alt="FAB"><img src="Screenshots/FAB-dark.png#gh-dark-mode-only" width="88" alt="FAB"><br><sub><b>FAB</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Hero.png#gh-light-mode-only" width="240" alt="Hero"><img src="Screenshots/Hero-dark.png#gh-dark-mode-only" width="240" alt="Hero"><br><sub><b>Hero</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/SelectionCards-dark.png"><img src="Screenshots/SelectionCards.png" width="240" alt="SelectionCards"></picture><br><sub><b>SelectionCards</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/CardStack-dark.png"><img src="Screenshots/CardStack.png" width="240" alt="CardStack"></picture><br><sub><b>CardStack</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Gallery-dark.png"><img src="Screenshots/Gallery.png" width="240" alt="Gallery"></picture><br><sub><b>Gallery</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/SelectionCards.png#gh-light-mode-only" width="240" alt="SelectionCards"><img src="Screenshots/SelectionCards-dark.png#gh-dark-mode-only" width="240" alt="SelectionCards"><br><sub><b>SelectionCards</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/CardStack.png#gh-light-mode-only" width="240" alt="CardStack"><img src="Screenshots/CardStack-dark.png#gh-dark-mode-only" width="240" alt="CardStack"><br><sub><b>CardStack</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Gallery.png#gh-light-mode-only" width="240" alt="Gallery"><img src="Screenshots/Gallery-dark.png#gh-dark-mode-only" width="240" alt="Gallery"><br><sub><b>Gallery</b></sub></td>
 </tr>
 <tr>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Footer-dark.png"><img src="Screenshots/Footer.png" width="240" alt="Footer"></picture><br><sub><b>Footer</b></sub></td>
-<td align="center" valign="top" width="33%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/Diff-dark.png"><img src="Screenshots/Diff.png" width="240" alt="Diff"></picture><br><sub><b>Diff</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Footer.png#gh-light-mode-only" width="240" alt="Footer"><img src="Screenshots/Footer-dark.png#gh-dark-mode-only" width="240" alt="Footer"><br><sub><b>Footer</b></sub></td>
+<td align="center" valign="top" width="33%"><img src="Screenshots/Diff.png#gh-light-mode-only" width="240" alt="Diff"><img src="Screenshots/Diff-dark.png#gh-dark-mode-only" width="240" alt="Diff"><br><sub><b>Diff</b></sub></td>
 </tr>
 </table>
 

--- a/scripts/gen-screenshots.sh
+++ b/scripts/gen-screenshots.sh
@@ -40,7 +40,10 @@ emit_category() {
             # small ones (Badge, Spinner) stay small instead of being upscaled.
             local pw; pw=$(sips -g pixelWidth "Screenshots/$name.png" 2>/dev/null | awk '/pixelWidth/{print $2}')
             local w=$(( ${pw:-480} / 2 )); [ "$w" -gt 240 ] && w=240
-            printf '<td align="center" valign="top" width="33%%"><picture><source media="(prefers-color-scheme: dark)" srcset="Screenshots/%s-dark.png"><img src="Screenshots/%s.png" width="%s" alt="%s"></picture><br><sub><b>%s</b></sub></td>\n' "$name" "$name" "$w" "$name" "$name"
+            # GitHub light/dark image fragments instead of <picture> — the GitHub
+            # mobile app doesn't render <picture> (shows broken), but it honors
+            # `#gh-light-mode-only` / `#gh-dark-mode-only`.
+            printf '<td align="center" valign="top" width="33%%"><img src="Screenshots/%s.png#gh-light-mode-only" width="%s" alt="%s"><img src="Screenshots/%s-dark.png#gh-dark-mode-only" width="%s" alt="%s"><br><sub><b>%s</b></sub></td>\n' "$name" "$w" "$name" "$name" "$w" "$name" "$name"
             i=$((i + 1))
             [ "$((i % COLS))" -eq 0 ] && echo "</tr>"
         done <<< "$names"


### PR DESCRIPTION
The GitHub **mobile app doesn't render `<picture>` elements** — so the component gallery (and the hero banner) showed **broken images on mobile** while working fine on the web. The whole gallery + hero were built from `<picture>`/`<source media>`.

## Fix
Switch to GitHub's **`#gh-light-mode-only` / `#gh-dark-mode-only` image fragments** — the recommended theme-aware approach that renders in the mobile app too, and keeps the automatic light/dark swap.

- `scripts/gen-screenshots.sh`: each gallery cell now emits two `<img>` (light + dark fragment) instead of a `<picture>`.
- README: regenerated the gallery (97 cells) + converted the hero banner; intro note updated.
- **Markup-only** — ran with `SKIP_RENDER`, so the PNGs are untouched; `<picture>` count in the README is now **0**.

> Note: if the breakage was actually private-repo image **auth** (the other suspect), that resolves on the public flip regardless — this fixes the `<picture>` half either way. Worth confirming on mobile which images were broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)