### PR TITLE
chore: public launch — Pages workflow + badges + live docs link

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+name: Pages
+
+# Builds the DocC documentation and publishes it to GitHub Pages on every push to
+# main. Public repo → free macOS runner minutes. The manual artifact build in
+# docs.yml stays for local/offline use.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Sources/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-deploy:
+    name: Build DocC + deploy to Pages
+    runs-on: macos-15
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      # Project Pages serve under /<repo>/ — the base path must match or assets 404.
+      - name: Build DocC (static hosting)
+        run: |
+          swift package --disable-sandbox \
+            generate-documentation \
+            --target ThemeKit \
+            --transform-for-static-hosting \
+            --hosting-base-path ThemeKit \
+            --output-path ./docs-out
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs-out
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 > **Native, brand-neutral SwiftUI design system** — 117 token-bound components that
 > re-skin from a single accent color: light/dark, per-subtree, zero core dependencies.
 
+[![CI](https://github.com/isamercan/ThemeKit/actions/workflows/ci.yml/badge.svg)](https://github.com/isamercan/ThemeKit/actions/workflows/ci.yml)
 ![Swift](https://img.shields.io/badge/Swift-6.2-orange.svg)
 ![Platforms](https://img.shields.io/badge/Platforms-iOS%2017%20%7C%20macOS%2014-blue.svg)
 ![Dependencies](https://img.shields.io/badge/Core%20dependencies-0-success.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 <p align="center">
   <img src="Screenshots/Banner.png" alt="ThemeKit — native SwiftUI design system: 117 components, fully tokenized, per-subtree theming, Swift 6, Liquid Glass, light + dark" width="820">
@@ -76,9 +78,6 @@ targets: [
     ),
 ]
 ```
-
-> This is a **private** repository — resolving it requires GitHub access
-> (an authenticated SSH key or token).
 
 ### Products
 
@@ -594,8 +593,10 @@ full tool list and the `figma-mapping.json` schema.
 
 ## Documentation
 
+📖 **Live docs: [isamercan.github.io/ThemeKit](https://isamercan.github.io/ThemeKit/documentation/themekit)** — the DocC catalog, published from `main` on every push.
+
 A DocC catalog ships with the package
-(`Sources/ThemeKit/Documentation.docc`). Build it in Xcode via
+(`Sources/ThemeKit/Documentation.docc`). Build it locally in Xcode via
 **Product ▸ Build Documentation** (⌃⌘D), or from the command line:
 
 ```sh


### PR DESCRIPTION
Repo is now public. Adds the GitHub Pages DocC deploy workflow (`pages.yml`, base-path `ThemeKit`), CI + MIT badges, a live-docs link (isamercan.github.io/ThemeKit), and removes the private-repo note. Pages enabled with the Actions source; this merge triggers the first deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)