### PR TITLE
docs(wiki): English link labels + live docs links

### DIFF
--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -45,5 +45,5 @@ back/next arrows) are flipped via the library's RTL helper.
 
 iOS 17+ and macOS 14+.
 
-📖 Full API reference — build the DocC docs locally (the repo is private):
-`swift package --disable-sandbox preview-documentation --target ThemeKit`
+📖 Full API reference — the **[live DocC docs](https://isamercan.github.io/ThemeKit/documentation/themekit)**,
+or build locally: `swift package --disable-sandbox preview-documentation --target ThemeKit`

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -2,12 +2,13 @@
 
 > A token-driven, zero-dependency SwiftUI design system.
 
-A themable palette, 100+ token-bound SwiftUI components, a validation layer, and
+A themable palette, 117 token-bound SwiftUI components, a validation layer, and
 accessibility (Dynamic Type, VoiceOver, RTL) — all with no third-party
 dependencies in the core.
 
-📖 **Full DocC documentation** is built locally (the repo is private, so it isn't
-published to Pages):
+📖 **Full DocC documentation** is published at
+**[isamercan.github.io/ThemeKit](https://isamercan.github.io/ThemeKit/documentation/themekit)**,
+or build it locally:
 
 ```bash
 swift package --disable-sandbox preview-documentation --target ThemeKit
@@ -27,10 +28,11 @@ ContentView().themeKit()
 
 ## Where to go next
 
-- **[[Kurulum|Installation]]** — add the package to your project.
-- **[[SSS|FAQ]]** — common questions.
-- **[[Sorun Giderme|Troubleshooting]]** — fixes for typical issues.
-- **API reference** → build the DocC docs locally (command above)
+- **[[Installation]]** — add the package to your project.
+- **[[FAQ]]** — common questions.
+- **[[Troubleshooting]]** — fixes for typical issues.
+- **API reference** → the [live DocC docs](https://isamercan.github.io/ThemeKit/documentation/themekit)
 
-The detailed, styled DocC docs are built locally / downloaded from the **Docs**
-CI artifact. This wiki holds the light, fast-changing helper pages.
+The detailed, styled DocC docs live at
+[isamercan.github.io/ThemeKit](https://isamercan.github.io/ThemeKit/documentation/themekit).
+This wiki holds the light, fast-changing helper pages.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,3 +1,3 @@
 [Repo](https://github.com/isamercan/ThemeKit) ·
-DocC docs: build locally (`preview-documentation`) ·
+[Docs](https://isamercan.github.io/ThemeKit/documentation/themekit) ·
 MIT License

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,12 +1,11 @@
 - [[Home]]
-- [[Kurulum|Installation]]
-- [[SSS|FAQ]]
-- [[Sorun Giderme|Troubleshooting]]
+- [[Installation]]
+- [[FAQ]]
+- [[Troubleshooting]]
 - [[Versions and Releases|Versions-and-Releases]]
 - [[Roadmap]]
 - [[Contributing]]
 
 ---
 
-📖 DocC docs: build locally
-(`preview-documentation`)
+📖 [DocC docs](https://isamercan.github.io/ThemeKit/documentation/themekit)


### PR DESCRIPTION
Turkish wiki-link labels → English (Kurulum/SSS/Sorun Giderme) and the now-false 'repo is private / built locally' notes → the live docs link. 🤖 Generated with [Claude Code](https://claude.com/claude-code)