### PR TITLE
docs(readme): top links row + npm badge (all URLs reachable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 ![Platforms](https://img.shields.io/badge/Platforms-iOS%2017%20%7C%20macOS%2014-blue.svg)
 ![Dependencies](https://img.shields.io/badge/Core%20dependencies-0-success.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![npm](https://img.shields.io/npm/v/@isamercan/themekit-mcp?label=mcp%20%C2%B7%20npm&color=cb3837)](https://www.npmjs.com/package/@isamercan/themekit-mcp)
+
+**[Docs](https://isamercan.github.io/ThemeKit/documentation/themekit) · [Wiki](https://github.com/isamercan/ThemeKit/wiki) · [npm (MCP)](https://www.npmjs.com/package/@isamercan/themekit-mcp) · [Releases](https://github.com/isamercan/ThemeKit/releases) · [Issues](https://github.com/isamercan/ThemeKit/issues) · [Changelog](CHANGELOG.md)**
 
 <p align="center">
   <img src="Screenshots/Banner.png" alt="ThemeKit — native SwiftUI design system: 117 components, fully tokenized, per-subtree theming, Swift 6, Liquid Glass, light + dark" width="820">


### PR DESCRIPTION
Adds a links row (Docs · Wiki · npm · Releases · Issues · Changelog) + an npm version badge so every key URL is reachable from the README top. 🤖 Generated with [Claude Code](https://claude.com/claude-code)