### PR TITLE
feat: Design Mode — import a design.md to re-skin every component

### DIFF
--- a/Demo/Demo/ContentView.swift
+++ b/Demo/Demo/ContentView.swift
@@ -22,6 +22,10 @@ struct ContentView: View {
                 .tabItem { Label("Themes", systemImage: "swatchpalette") }
                 .tag(1)
 
+            DesignModeView()
+                .tabItem { Label("Design", systemImage: "wand.and.stars") }
+                .tag(6)
+
             ThemeGalleryView()
                 .tabItem { Label("Colors", systemImage: "paintpalette") }
                 .tag(2)

--- a/Demo/Demo/DemoTheme.swift
+++ b/Demo/Demo/DemoTheme.swift
@@ -68,9 +68,13 @@ final class DemoThemeStore: ObservableObject {
     /// The generated/preset recipe currently driving the theme — what the Theme
     /// Configurator seeds from. `nil` when a bundled JSON theme is active.
     @Published private(set) var activeConfig: ThemeConfig?
+    /// The `design.md` spec id whose import produced the active theme, if any.
+    /// Drives the "active design mode" badge; `nil` for presets / bundled themes.
+    @Published private(set) var activeDesignSpecID: String?
 
     private static let presetKey = "selectedThemePreset"
     private static let customKey = "selectedThemeCustomConfig"
+    private static let designSpecKey = "selectedDesignSpecID"
 
     init() {
         current = DemoTheme.stored
@@ -80,6 +84,7 @@ final class DemoThemeStore: ObservableObject {
         if let data = UserDefaults.standard.data(forKey: Self.customKey),
            let cfg = try? ThemeConfig(jsonData: data) {
             activeConfig = cfg
+            activeDesignSpecID = UserDefaults.standard.string(forKey: Self.designSpecKey)
             isDark = cfg.dark
             Theme.shared.apply(cfg)
         } else if let id = UserDefaults.standard.string(forKey: Self.presetKey),
@@ -102,6 +107,7 @@ final class DemoThemeStore: ObservableObject {
     func select(_ theme: DemoTheme) {
         presetID = nil
         activeConfig = nil
+        clearDesignSpec()
         UserDefaults.standard.removeObject(forKey: Self.presetKey)
         UserDefaults.standard.removeObject(forKey: Self.customKey)
         current = theme
@@ -113,6 +119,7 @@ final class DemoThemeStore: ObservableObject {
         // returns to the bundled theme, where the scheme switch applies.
         presetID = nil
         activeConfig = nil
+        clearDesignSpec()
         UserDefaults.standard.removeObject(forKey: Self.presetKey)
         UserDefaults.standard.removeObject(forKey: Self.customKey)
         isDark = dark
@@ -124,22 +131,46 @@ final class DemoThemeStore: ObservableObject {
         presetID = theme.id
         activeConfig = theme.config
         isDark = theme.isDark
+        clearDesignSpec()
         UserDefaults.standard.removeObject(forKey: Self.customKey)
         UserDefaults.standard.set(theme.id, forKey: Self.presetKey)
         theme.apply()
     }
 
+    private func clearDesignSpec() {
+        activeDesignSpecID = nil
+        UserDefaults.standard.removeObject(forKey: Self.designSpecKey)
+    }
+
     /// Commits a recipe from the Theme Configurator: applies it, persists it, and
     /// makes it the active theme so the switcher + dark state stay in sync.
     func applyGenerated(_ config: ThemeConfig) {
+        applyGenerated(config, designSpecID: nil)
+    }
+
+    /// As `applyGenerated`, but records the originating design.md id (for the
+    /// "active design mode" badge). Passing `nil` clears the provenance.
+    func applyGenerated(_ config: ThemeConfig, designSpecID: String?) {
         presetID = nil
         activeConfig = config
         isDark = config.dark
+        activeDesignSpecID = designSpecID
         UserDefaults.standard.removeObject(forKey: Self.presetKey)
+        if let id = designSpecID {
+            UserDefaults.standard.set(id, forKey: Self.designSpecKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.designSpecKey)
+        }
         if let data = try? config.jsonData() {
             UserDefaults.standard.set(data, forKey: Self.customKey)
         }
         Theme.shared.apply(config)
+    }
+
+    /// Commits a parsed `design.md` result: applies its config and remembers which
+    /// spec produced it. Reuses the existing custom-config persistence.
+    func applyDesign(_ result: DesignParseResult, specID: String?) {
+        applyGenerated(result.config, designSpecID: specID)
     }
 
     /// Re-applies whatever theme is currently active — used to discard the

--- a/Demo/Demo/Views/DemoDesignResolver.swift
+++ b/Demo/Demo/Views/DemoDesignResolver.swift
@@ -1,0 +1,121 @@
+//
+//  DemoDesignResolver.swift
+//  Demo
+//  Created by İsa Mercan on 30.06.2026.
+//
+//  The Demo's optional LLM path for Design Mode. ThemeKit's core ships only the
+//  `DesignSpecResolving` protocol (no networking); this Demo type provides a
+//  concrete resolver that calls the Anthropic Messages API to turn a free-form
+//  `design.md` into a `ThemeConfig`. It's used only when an API key is present;
+//  otherwise the app passes `nil` and `DesignMode.resolve` uses the on-device
+//  heuristic parser.
+//
+
+import Foundation
+import ThemeKit
+
+enum DemoDesignResolver {
+    /// A fast, inexpensive model is plenty for this structured-extraction task.
+    static let model = "claude-haiku-4-5-20251001"
+    static let endpoint = URL(string: "https://api.anthropic.com/v1/messages")!
+
+    /// Builds a resolver for the given key, or `nil` when the key is blank (so the
+    /// caller falls back to the heuristic parser).
+    static func make(apiKey: String) -> DesignSpecResolving? {
+        let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { return nil }
+        return ClosureDesignResolver { markdown, seed in
+            try await resolve(markdown: markdown, seed: seed, apiKey: key)
+        }
+    }
+
+    private static func resolve(markdown: String, seed: ThemeConfig, apiKey: String) async throws -> DesignParseResult {
+        let system = """
+        You convert a free-form design document into a ThemeKit ThemeConfig.
+        Respond with ONLY a JSON object, no prose, with these keys:
+        primaryHex (6-digit RRGGBB, no #), baseHex, secondaryHex, accentHex (all optional RRGGBB),
+        tint (0..0.25), dark (bool), font (one of "Montserrat","System","SystemRounded","SystemSerif","SystemMono"),
+        fontScale, radiusScale, spacingScale, shadowScale (positive multipliers near 1.0).
+        Infer every value from the document's described look and feel.
+        """
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 512,
+            "system": system,
+            "messages": [["role": "user", "content": markdown]],
+        ]
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 30
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw ResolverError.status(http.statusCode, String(data: data, encoding: .utf8) ?? "")
+        }
+
+        let text = try extractText(from: data)
+        let json = try extractJSONObject(from: text)
+        let config = try JSONDecoder().decode(ThemeConfig.self, from: Data(json.utf8))
+
+        return DesignParseResult(
+            config: config,
+            confidence: .high,
+            method: .resolver("claude"),
+            extracted: extractedFields(config),
+            warnings: []
+        )
+    }
+
+    // MARK: - Response parsing
+
+    private static func extractText(from data: Data) throws -> String {
+        guard let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = obj["content"] as? [[String: Any]] else {
+            throw ResolverError.malformed
+        }
+        let text = content.compactMap { $0["text"] as? String }.joined()
+        guard !text.isEmpty else { throw ResolverError.malformed }
+        return text
+    }
+
+    /// Pulls the first JSON object out of the model's reply (tolerates code fences).
+    private static func extractJSONObject(from text: String) throws -> String {
+        guard let start = text.firstIndex(of: "{"), let end = text.lastIndex(of: "}"), start < end else {
+            throw ResolverError.malformed
+        }
+        return String(text[start...end])
+    }
+
+    private static func extractedFields(_ cfg: ThemeConfig) -> [DesignParseResult.Field: String] {
+        var e: [DesignParseResult.Field: String] = [
+            .primary: "#\(cfg.primaryHex)",
+            .tint: String(format: "%.2f", cfg.tint),
+            .dark: "\(cfg.dark)",
+            .font: cfg.font,
+            .radiusScale: String(format: "%.2f", cfg.radiusScale),
+            .spacingScale: String(format: "%.2f", cfg.spacingScale),
+            .shadowScale: String(format: "%.2f", cfg.shadowScale),
+        ]
+        if let b = cfg.baseHex { e[.base] = "#\(b)" }
+        if let s = cfg.secondaryHex { e[.secondary] = "#\(s)" }
+        if let a = cfg.accentHex { e[.accent] = "#\(a)" }
+        return e
+    }
+
+    enum ResolverError: LocalizedError {
+        case status(Int, String)
+        case malformed
+
+        var errorDescription: String? {
+            switch self {
+            case .status(let code, _): return "Anthropic API returned status \(code)."
+            case .malformed: return "Could not read a ThemeConfig from the model's response."
+            }
+        }
+    }
+}

--- a/Demo/Demo/Views/DesignModeView.swift
+++ b/Demo/Demo/Views/DesignModeView.swift
@@ -1,0 +1,265 @@
+//
+//  DesignModeView.swift
+//  Demo
+//  Created by İsa Mercan on 30.06.2026.
+//
+//  Design Mode tab — bring every component into another app's look by importing a
+//  free-form `design.md` (bundled catalog, file picker, or remote URL) or pasting
+//  one. The markdown is parsed into a `ThemeConfig` (heuristic on-device, or
+//  refined by Claude when an API key is set), previewed for confirmation, then
+//  applied via the existing `DemoThemeStore` so it persists and re-skins the app.
+//
+
+import SwiftUI
+import ThemeKit
+import UniformTypeIdentifiers
+
+struct DesignModeView: View {
+    @EnvironmentObject private var store: DemoThemeStore
+    @Environment(Theme.self) private var theme
+
+    @AppStorage("themekit.anthropicKey") private var anthropicKey = ""
+
+    private enum Tab: String, CaseIterable, Identifiable { case catalog = "Catalog", importer = "Import"; var id: String { rawValue } }
+    @State private var tab: Tab = .catalog
+
+    @State private var specs: [DesignSpec] = []
+    @State private var urlText = ""
+    @State private var pasteText = ""
+    @State private var showFileImporter = false
+    @State private var loading = false
+    @State private var errorMessage: String?
+
+    // The confirm/preview sheet payload.
+    @State private var preview: PreviewPayload?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                    header
+                    Picker("Source", selection: $tab) {
+                        ForEach(Tab.allCases) { Text($0.rawValue).tag($0) }
+                    }
+                    .pickerStyle(.segmented)
+
+                    switch tab {
+                    case .catalog: catalogSection
+                    case .importer: importSection
+                    }
+                }
+                .padding()
+            }
+            .background(theme.background(.bgElevatorPrimary).ignoresSafeArea())
+            .navigationTitle("Design Mode")
+            .overlay { if loading { ProgressView().controlSize(.large) } }
+        }
+        .onAppear { if specs.isEmpty { specs = DesignSpecCatalog.bundled() } }
+        .fileImporter(isPresented: $showFileImporter, allowedContentTypes: importableTypes) { result in
+            handleFileImport(result)
+        }
+        .alert("Couldn't import design", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            Button("OK", role: .cancel) {}
+        } message: { Text(errorMessage ?? "") }
+        .sheet(item: $preview) { payload in
+            DesignPreviewSheet(payload: payload) { committed in
+                if committed {
+                    store.applyDesign(payload.result, specID: payload.spec.specIDForPersistence)
+                } else {
+                    store.reapplyActive()   // revert the live preview
+                }
+                preview = nil
+            }
+            .environmentObject(store)
+            .environment(theme)
+        }
+    }
+
+    // MARK: Sections
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Import a design.md and re-skin every component.")
+                .textStyle(.bodyBase400)
+                .foregroundStyle(theme.text(.textSecondary))
+            HStack(spacing: 6) {
+                Image(systemName: anthropicKey.isEmpty ? "cpu" : "sparkles")
+                Text(anthropicKey.isEmpty ? "Parsing on-device (heuristic)" : "Refined by Claude")
+            }
+            .textStyle(.labelSm700)
+            .foregroundStyle(theme.text(.textTertiary))
+            if let id = store.activeDesignSpecID {
+                Text("Active design mode: \(id)")
+                    .textStyle(.labelSm700)
+                    .foregroundStyle(theme.text(.textHero))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var catalogSection: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 220, maximum: 320), spacing: 12)], spacing: 12) {
+            ForEach(specs) { spec in
+                Button { startPreview(for: spec) } label: { specCard(spec) }
+                    .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func specCard(_ spec: DesignSpec) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(spec.title)
+                .textStyle(.labelLg600)
+                .foregroundStyle(theme.text(.textPrimary))
+            if let summary = spec.summary {
+                Text(summary)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(theme.text(.textSecondary))
+                    .lineLimit(3)
+            }
+            HStack {
+                Spacer()
+                Text(store.activeDesignSpecID == spec.id ? "Active" : "Apply")
+                    .textStyle(.labelSm700)
+                    .foregroundStyle(theme.text(.textHero))
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+                .stroke(store.activeDesignSpecID == spec.id ? theme.border(.borderHero) : theme.border(.borderPrimary), lineWidth: 1)
+        )
+    }
+
+    private var importSection: some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("From a file").textStyle(.headingSm).foregroundStyle(.secondary)
+                Text("Pick another app's design.md (or any .md / .txt) from Files.")
+                    .textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                OutlineButton("Choose design.md…") { showFileImporter = true }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("From a URL").textStyle(.headingSm).foregroundStyle(.secondary)
+                HStack {
+                    TextField("https://…/design.md", text: $urlText)
+                        .textFieldStyle(.roundedBorder)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                    PrimaryButton("Fetch") { startRemoteImport() }
+                        .disabled(urlText.isEmpty)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Paste markdown").textStyle(.headingSm).foregroundStyle(.secondary)
+                TextEditor(text: $pasteText)
+                    .frame(minHeight: 120)
+                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(theme.border(.borderPrimary)))
+                OutlineButton("Use pasted design") { startPasteImport() }
+                    .disabled(pasteText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+
+            keySection
+        }
+    }
+
+    private var keySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("AI parsing (optional)").textStyle(.headingSm).foregroundStyle(.secondary)
+            Text("Add an Anthropic API key to let Claude interpret free-form docs. Leave empty to parse on-device.")
+                .textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+            SecureField("sk-ant-…", text: $anthropicKey)
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+        }
+    }
+
+    // MARK: Actions
+
+    private func startPreview(for spec: DesignSpec) {
+        loading = true
+        Task { @MainActor in
+            let resolver = DemoDesignResolver.make(apiKey: anthropicKey)
+            let seed = store.activeConfig ?? ThemeConfig()
+            let result = await DesignMode.resolve(spec, seed: seed, using: resolver)
+            Theme.shared.apply(result.config)   // live preview; reverted on cancel
+            loading = false
+            preview = PreviewPayload(spec: spec, result: result)
+        }
+    }
+
+    private func startRemoteImport() {
+        guard let url = URL(string: urlText.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            errorMessage = "That doesn't look like a valid URL."
+            return
+        }
+        loading = true
+        Task { @MainActor in
+            do {
+                let spec = try await DesignSpecCatalog.load(remoteURL: url)
+                await finishImport(spec)
+            } catch {
+                loading = false
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func startPasteImport() {
+        let spec = DesignSpecCatalog.pasted(pasteText)
+        loading = true
+        Task { @MainActor in await finishImport(spec) }
+    }
+
+    private func handleFileImport(_ result: Result<URL, Error>) {
+        switch result {
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+        case .success(let url):
+            let scoped = url.startAccessingSecurityScopedResource()
+            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+            do {
+                let spec = try DesignSpecCatalog.load(fileURL: url)
+                loading = true
+                Task { @MainActor in await finishImport(spec) }
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    @MainActor
+    private func finishImport(_ spec: DesignSpec) async {
+        let resolver = DemoDesignResolver.make(apiKey: anthropicKey)
+        let seed = store.activeConfig ?? ThemeConfig()
+        let result = await DesignMode.resolve(spec, seed: seed, using: resolver)
+        Theme.shared.apply(result.config)
+        loading = false
+        preview = PreviewPayload(spec: spec, result: result)
+    }
+
+    private var importableTypes: [UTType] {
+        [UTType(filenameExtension: "md"), UTType(filenameExtension: "markdown"), .plainText, .text]
+            .compactMap { $0 }
+    }
+}
+
+/// A spec + its parsed result, carried into the confirm sheet.
+struct PreviewPayload: Identifiable {
+    let id = UUID()
+    let spec: DesignSpec
+    let result: DesignParseResult
+}
+
+private extension DesignSpec {
+    /// Only bundled specs get a persisted id badge (file/remote/pasted are one-offs).
+    var specIDForPersistence: String? {
+        if case .bundled = source { return id }
+        return nil
+    }
+}

--- a/Demo/Demo/Views/DesignPreviewSheet.swift
+++ b/Demo/Demo/Views/DesignPreviewSheet.swift
@@ -1,0 +1,140 @@
+//
+//  DesignPreviewSheet.swift
+//  Demo
+//  Created by İsa Mercan on 30.06.2026.
+//
+//  Confirm step for an imported design.md. The parsed config is already applied
+//  live (so the preview shows real ThemeKit components in the new look); this
+//  sheet surfaces exactly what was derived from the free text — values, warnings,
+//  and a confidence badge — before the user commits or reverts.
+//
+
+import SwiftUI
+import ThemeKit
+
+struct DesignPreviewSheet: View {
+    @Environment(Theme.self) private var theme
+    let payload: PreviewPayload
+    /// Called with `true` to commit, `false` to revert.
+    let onFinish: (Bool) -> Void
+
+    private var result: DesignParseResult { payload.result }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                    provenance
+                    livePreview.id(theme.revision)
+                    derivedValues
+                    if !result.warnings.isEmpty { warnings }
+                }
+                .padding()
+            }
+            .navigationTitle(payload.spec.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { onFinish(false) }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Apply") { onFinish(true) }.fontWeight(.semibold)
+                }
+            }
+            .interactiveDismissDisabled()   // force an explicit Apply / Cancel
+        }
+    }
+
+    private var provenance: some View {
+        HStack(spacing: 8) {
+            Label(methodLabel, systemImage: methodIcon)
+            Spacer()
+            Text(confidenceLabel)
+                .textStyle(.labelSm700)
+                .padding(.horizontal, 10).padding(.vertical, 4)
+                .background(confidenceColor.opacity(0.15), in: Capsule())
+                .foregroundStyle(confidenceColor)
+        }
+        .textStyle(.labelSm700)
+        .foregroundStyle(theme.text(.textSecondary))
+    }
+
+    private var livePreview: some View {
+        Card {
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+                HStack {
+                    Text("Live preview").textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
+                    Spacer()
+                    Badge("New", style: .info)
+                }
+                Text("Every component re-skins to the imported look.")
+                    .textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                ButtonGroup(.horizontal) {
+                    PrimaryButton("Primary") {}
+                    SecondaryButton("Secondary") {}
+                    OutlineButton("Outline") {}
+                }
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    InfoBanner("Info", type: .info)
+                    InfoBanner("Success", type: .success)
+                }
+            }
+        }
+    }
+
+    private var derivedValues: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Derived from design.md").textStyle(.headingSm).foregroundStyle(.secondary)
+            ForEach(DesignParseResult.Field.allCases, id: \.self) { field in
+                if let value = result.extracted[field] {
+                    HStack {
+                        Text(field.rawValue).textStyle(.labelSm700).foregroundStyle(theme.text(.textSecondary))
+                        Spacer()
+                        Text(value).font(.system(size: 12, design: .monospaced)).foregroundStyle(theme.text(.textPrimary))
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(theme.background(.bgElevatorPrimary), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private var warnings: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(result.warnings, id: \.self) { warning in
+                Label(warning, systemImage: "exclamationmark.triangle")
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+        }
+    }
+
+    // MARK: Labels
+
+    private var methodLabel: String {
+        switch result.method {
+        case .heuristic: return "Parsed on-device"
+        case .resolver(let name): return "Refined by \(name.capitalized)"
+        }
+    }
+    private var methodIcon: String {
+        switch result.method {
+        case .heuristic: return "cpu"
+        case .resolver: return "sparkles"
+        }
+    }
+    private var confidenceLabel: String {
+        switch result.confidence {
+        case .low: return "Low confidence"
+        case .medium: return "Medium confidence"
+        case .high: return "High confidence"
+        }
+    }
+    private var confidenceColor: Color {
+        switch result.confidence {
+        case .low: return .orange
+        case .medium: return .yellow
+        case .high: return .green
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ import ThemeKit
 - 🎨 **Figma → SwiftUI** — the MCP's `figma_to_swiftui` turns a Figma node into
   token-matched, verified-API ThemeKit code with a mapping report (see the
   **Advanced — Figma → SwiftUI & MCP** section).
+- 🪄 **Design Mode** — point ThemeKit at a free-form `design.md` (or a bundled style
+  — Linear, Notion, iOS, Brutalist, Pastel) and it re-skins **every** component to
+  match, via an offline heuristic parser (+ an optional LLM path).
 - 🤖 **AI-native** — a 19-tool **MCP server**, a Claude Code **Agent skill**, and an
   **`llms.txt`**, so agents generate correct, token-bound UI — all from one source.
 - 🧩 **Design tokens everywhere** — colors / radius / spacing from JSON, typography /

--- a/Sources/ThemeKit/Resources/DesignSpecs/brutalist.design.md
+++ b/Sources/ThemeKit/Resources/DesignSpecs/brutalist.design.md
@@ -1,0 +1,28 @@
+---
+title: Brutalist
+summary: Sharp square corners, flat surfaces, and a bold high-contrast accent.
+---
+
+# Brutalist
+
+Raw and unapologetic. **Square corners**, **no shadows**, **flat** surfaces and a
+single **bold, vibrant** accent on a stark white page. Spacing is **compact** and
+deliberate; the type is **monospaced** for a utilitarian, terminal feel. This is a
+**light theme** that trades softness for structure.
+
+- Primary / brand: `#FF3B00`
+- Background / surface: `#FFFFFF`
+- Mood: light, sharp, flat, mono
+
+```themekit
+primary: #FF3B00
+base: #FFFFFF
+secondary: #111111
+accent: #0000FF
+dark: false
+tint: 0.0
+radiusScale: 0.3
+spacingScale: 0.85
+shadowScale: 0.0
+font: SystemMono
+```

--- a/Sources/ThemeKit/Resources/DesignSpecs/ios-native.design.md
+++ b/Sources/ThemeKit/Resources/DesignSpecs/ios-native.design.md
@@ -1,0 +1,29 @@
+---
+title: iOS Native
+summary: A bright, system-font look with iOS blue and rounded, elevated cards.
+---
+
+# iOS Native
+
+The familiar **light** iOS aesthetic: the **system font** (San Francisco), the
+classic iOS blue **brand color**, generously **rounded** corners and **elevated**,
+floating cards. Spacing is comfortable and the palette leans **vibrant** so tint
+buttons and toggles pop against the grouped-background surface.
+
+- Primary / brand: `#007AFF`
+- Background / surface: `#F2F2F7`
+- Accent / highlight: `#34C759`
+- Mood: light, rounded, elevated, vibrant
+
+```themekit
+primary: #007AFF
+base: #F2F2F7
+secondary: #5856D6
+accent: #34C759
+dark: false
+tint: 0.1
+radiusScale: 1.3
+spacingScale: 1.0
+shadowScale: 1.2
+font: System
+```

--- a/Sources/ThemeKit/Resources/DesignSpecs/linear-dark.design.md
+++ b/Sources/ThemeKit/Resources/DesignSpecs/linear-dark.design.md
@@ -1,0 +1,30 @@
+---
+title: Linear (Dark)
+summary: A focused, high-contrast dark product UI with an indigo brand accent.
+---
+
+# Linear (Dark)
+
+A calm, **dark theme** built for focus. The surface is a deep slate that recedes,
+while a single indigo **primary / brand color** carries every action. Corners are
+*slightly rounded*, spacing stays **compact and dense**, and shadows are kept
+**flat** — depth comes from contrast, not elevation. The palette is restrained,
+nearly monochrome, with the accent doing all the talking.
+
+- Primary / brand: `#5E6AD2`
+- Background / surface: `#0E0E10`
+- Accent / highlight: `#7C8AFF`
+- Mood: dark, compact, sharp
+
+```themekit
+primary: #5E6AD2
+base: #0E0E10
+secondary: #8A93B5
+accent: #7C8AFF
+dark: true
+tint: 0.05
+radiusScale: 0.8
+spacingScale: 0.85
+shadowScale: 0.4
+font: System
+```

--- a/Sources/ThemeKit/Resources/DesignSpecs/notion-minimal.design.md
+++ b/Sources/ThemeKit/Resources/DesignSpecs/notion-minimal.design.md
@@ -1,0 +1,29 @@
+---
+title: Notion Minimal
+summary: A light, paper-white workspace with neutral ink and airy spacing.
+---
+
+# Notion Minimal
+
+A **light theme** that gets out of the way. The surface is a warm paper white, the
+type is near-black ink, and color is used sparingly. Spacing is **airy and
+spacious** so dense documents stay readable; corners are only *slightly rounded*
+and shadows are **subtle**. The palette is essentially **monochrome**, with a
+muted blue brand for links and primary actions.
+
+- Primary / brand: `#2383E2`
+- Background / surface / paper: `#FFFFFF`
+- Mood: light, airy, neutral
+
+```themekit
+primary: #2383E2
+base: #FFFFFF
+secondary: #6B7280
+accent: #0B6E99
+dark: false
+tint: 0.02
+radiusScale: 0.7
+spacingScale: 1.25
+shadowScale: 0.6
+font: System
+```

--- a/Sources/ThemeKit/Resources/DesignSpecs/pastel-soft.design.md
+++ b/Sources/ThemeKit/Resources/DesignSpecs/pastel-soft.design.md
@@ -1,0 +1,30 @@
+---
+title: Pastel Soft
+summary: Gentle lavender brand, rounded pill shapes, soft shadows on a light base.
+---
+
+# Pastel Soft
+
+A friendly, **light** theme of soft pastels. The **brand color** is a gentle
+lavender, corners are **fully rounded** into pills, and shadows are **soft**.
+Spacing is **airy** and the type uses the **rounded** system font for a warm,
+approachable feel. The tint stays low so the pastels read as calm rather than loud.
+
+- Primary / brand: `#B5A8F0`
+- Background / surface / paper: `#FBF7FF`
+- Secondary: `#F6CBD1`
+- Accent / highlight: `#A8E6D6`
+- Mood: light, rounded, soft
+
+```themekit
+primary: #B5A8F0
+base: #FBF7FF
+secondary: #F6CBD1
+accent: #A8E6D6
+dark: false
+tint: 0.06
+radiusScale: 1.4
+spacingScale: 1.2
+shadowScale: 0.7
+font: SystemRounded
+```

--- a/Sources/ThemeKit/Theme/DesignMode/DesignMarkdownParser.swift
+++ b/Sources/ThemeKit/Theme/DesignMode/DesignMarkdownParser.swift
@@ -1,0 +1,359 @@
+//
+//  DesignMarkdownParser.swift
+//  ThemeKit
+//  Created by İsa Mercan on 30.06.2026.
+//
+//  Turns a free-form `design.md` into a `ThemeConfig`. The heuristic parser is
+//  deterministic, offline and *total* — it always returns an applicable config
+//  (seeded from `seed` so unspecified fields keep sensible defaults). It is the
+//  floor under the optional LLM/MCP resolver (`DesignSpecResolving`).
+//
+//  Foundation-only (no SwiftUI): pure string work, fully unit-testable.
+//
+
+import Foundation
+
+/// Parses a markdown design document into a `ThemeConfig` + provenance.
+public protocol DesignMarkdownParsing: Sendable {
+    /// - Parameters:
+    ///   - markdown: the raw `design.md` text.
+    ///   - seed: defaults for fields the document doesn't specify.
+    func parse(_ markdown: String, seed: ThemeConfig) -> DesignParseResult
+}
+
+public extension DesignMarkdownParsing {
+    func parse(_ markdown: String) -> DesignParseResult { parse(markdown, seed: .default) }
+}
+
+/// A dependency-free, deterministic parser. Extraction order (each step only
+/// overwrites a field when it finds a value, starting from `seed`):
+/// 1. An explicit structured block (` ```themekit ` / ` ```json ` / `---` front-matter)
+///    of `key: value` pairs wins outright → high confidence.
+/// 2. Label-aware hex colors (primary / base / secondary / accent).
+/// 3. Light/dark keywords, with a fallback inference from the base color's luminance.
+/// 4. Roundedness / density / font / shadow / tint keyword cues → scale knobs.
+public struct HeuristicDesignParser: DesignMarkdownParsing, Sendable {
+    public init() {}
+
+    public func parse(_ markdown: String, seed: ThemeConfig) -> DesignParseResult {
+        // 1) Structured block short-circuit — the authoritative path.
+        if let structured = parseStructured(markdown, seed: seed) {
+            return structured
+        }
+
+        var config = seed
+        var extracted: [DesignParseResult.Field: String] = [:]
+        var warnings: [String] = []
+        var hexHits = 0
+        var keywordHits = 0
+
+        let lower = markdown.lowercased()
+
+        // 2) Label-aware hex colors.
+        var sawDarkHint = false
+        if let primary = labeledHex(in: markdown, labels: ["primary", "brand color", "main color", "tint color"]) {
+            config.primaryHex = primary; extracted[.primary] = "#\(primary)"; hexHits += 1
+        }
+        if let base = labeledHex(in: markdown, labels: ["base", "background", "surface", "paper", "canvas", "page"]) {
+            config.baseHex = base; extracted[.base] = "#\(base)"; hexHits += 1
+            sawDarkHint = luminance(ofHex: base) < 0.4
+        }
+        if let secondary = labeledHex(in: markdown, labels: ["secondary"]) {
+            config.secondaryHex = secondary; extracted[.secondary] = "#\(secondary)"; hexHits += 1
+        }
+        if let accent = labeledHex(in: markdown, labels: ["accent", "highlight"]) {
+            config.accentHex = accent; extracted[.accent] = "#\(accent)"; hexHits += 1
+        }
+        // Fallback: first unlabeled hex becomes primary when nothing labeled it.
+        if extracted[.primary] == nil, let first = firstHex(in: markdown) {
+            config.primaryHex = first; extracted[.primary] = "#\(first)"; hexHits += 1
+            warnings.append("No labeled primary color found — used the first hex in the document.")
+        }
+
+        // 3) Light/dark.
+        if containsAny(lower, ["dark mode", "dark theme", "midnight", "night theme", "on dark", "dark ui"]) {
+            config.dark = true; extracted[.dark] = "true"; keywordHits += 1
+        } else if containsAny(lower, ["light mode", "light theme", "bright", "on light", "light ui"]) {
+            config.dark = false; extracted[.dark] = "false"; keywordHits += 1
+        } else if sawDarkHint {
+            config.dark = true; extracted[.dark] = "true (inferred from a dark base color)"
+            warnings.append("Dark mode inferred from the base color's luminance.")
+        }
+
+        // 4) Roundedness → radiusScale.
+        if let r = scaleFromKeywords(lower, mapping: [
+            (["sharp", "square corners", "no radius", "no rounding", "hard edges", "brutalist"], 0.3),
+            (["slightly rounded", "subtle radius", "small corners"], 0.7),
+            (["rounded", "soft corners", "friendly", "pill", "very rounded", "fully rounded"], 1.4),
+        ]) {
+            config.radiusScale = r; extracted[.radiusScale] = fmt(r); keywordHits += 1
+        }
+
+        // 4) Spacing density → spacingScale.
+        if let s = scaleFromKeywords(lower, mapping: [
+            (["compact", "dense", "tight", "condensed"], 0.82),
+            (["airy", "spacious", "generous spacing", "roomy", "breathing room"], 1.3),
+        ]) {
+            config.spacingScale = s; extracted[.spacingScale] = fmt(s); keywordHits += 1
+        }
+
+        // 4) Shadow / elevation → shadowScale.
+        if let sh = scaleFromKeywords(lower, mapping: [
+            (["flat", "no shadow", "no shadows", "shadowless", "no elevation"], 0),
+            (["subtle shadow", "soft shadow"], 0.7),
+            (["elevated", "floating", "deep shadow", "strong shadow", "heavy shadow"], 1.5),
+        ]) {
+            config.shadowScale = sh; extracted[.shadowScale] = fmt(sh); keywordHits += 1
+        }
+
+        // 4) Tint strength.
+        if let t = scaleFromKeywords(lower, mapping: [
+            (["monochrome", "grayscale", "greyscale", "neutral palette", "no tint"], 0),
+            (["vibrant", "saturated", "colorful", "bold colors"], 0.12),
+        ]) {
+            config.tint = t; extracted[.tint] = fmt(t); keywordHits += 1
+        }
+
+        // 4) Font family cues (only families the engine renders, see `Theme.makeFont`).
+        if let font = fontFromKeywords(lower) {
+            config.font = font; extracted[.font] = font; keywordHits += 1
+        }
+
+        let confidence: DesignParseResult.Confidence
+        if hexHits >= 1 && keywordHits >= 1 {
+            confidence = .medium
+        } else if hexHits >= 1 || keywordHits >= 1 {
+            confidence = .low
+        } else {
+            confidence = .low
+            warnings.append("Nothing recognizable found — fell back to the seed theme. Add colors or descriptive words.")
+        }
+
+        return DesignParseResult(config: config, confidence: confidence, method: .heuristic,
+                                 extracted: extracted, warnings: warnings)
+    }
+
+    // MARK: - Structured block
+
+    /// Looks for an authoritative `key: value` block: a fenced ` ```themekit ` or
+    /// ` ```json ` block, or YAML-style `---` front-matter. Returns `nil` when none
+    /// carries recognizable keys, so the prose heuristics run instead.
+    private func parseStructured(_ markdown: String, seed: ThemeConfig) -> DesignParseResult? {
+        // A) ```json block → decode straight into ThemeConfig.
+        if let json = fencedBlock(in: markdown, languages: ["json"]),
+           let data = json.data(using: .utf8),
+           let cfg = try? ThemeConfig(jsonData: data) {
+            return DesignParseResult(config: cfg, confidence: .high, method: .heuristic,
+                                     extracted: extracted(from: cfg),
+                                     warnings: [])
+        }
+
+        // B) ```themekit block or front-matter → key: value lines.
+        let block = fencedBlock(in: markdown, languages: ["themekit", "theme", "tokens"])
+            ?? frontMatter(in: markdown)
+        guard let block, let result = applyKeyValues(block, to: seed) else { return nil }
+        return result
+    }
+
+    /// Parses `key: value` lines into a config. Returns `nil` if no key was recognized.
+    private func applyKeyValues(_ block: String, to seed: ThemeConfig) -> DesignParseResult? {
+        var config = seed
+        var extracted: [DesignParseResult.Field: String] = [:]
+        var recognized = false
+
+        for rawLine in block.split(whereSeparator: { $0 == "\n" || $0 == "\r" }) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let key = line[..<colon].trimmingCharacters(in: .whitespaces).lowercased()
+            var value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            value = value.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            guard !value.isEmpty else { continue }
+
+            switch key {
+            case "primary", "primaryhex", "brand":
+                if let h = normalizeHex(value) { config.primaryHex = h; extracted[.primary] = "#\(h)"; recognized = true }
+            case "base", "basehex", "background", "surface":
+                if let h = normalizeHex(value) { config.baseHex = h; extracted[.base] = "#\(h)"; recognized = true }
+            case "secondary", "secondaryhex":
+                if let h = normalizeHex(value) { config.secondaryHex = h; extracted[.secondary] = "#\(h)"; recognized = true }
+            case "accent", "accenthex":
+                if let h = normalizeHex(value) { config.accentHex = h; extracted[.accent] = "#\(h)"; recognized = true }
+            case "tint":
+                if let d = Double(value) { config.tint = clamp(d, 0, 0.25); extracted[.tint] = fmt(config.tint); recognized = true }
+            case "dark", "darkmode":
+                let b = boolValue(value); config.dark = b; extracted[.dark] = "\(b)"; recognized = true
+            case "font", "fontfamily":
+                if let f = fontFamily(value) { config.font = f; extracted[.font] = f; recognized = true }
+            case "fontscale":
+                if let d = Double(value) { config.fontScale = d; extracted[.fontScale] = fmt(d); recognized = true }
+            case "radiusscale", "radius":
+                if let d = Double(value) { config.radiusScale = d; extracted[.radiusScale] = fmt(d); recognized = true }
+            case "spacingscale", "spacing":
+                if let d = Double(value) { config.spacingScale = d; extracted[.spacingScale] = fmt(d); recognized = true }
+            case "shadowscale", "shadow":
+                if let d = Double(value) { config.shadowScale = d; extracted[.shadowScale] = fmt(d); recognized = true }
+            default:
+                continue
+            }
+        }
+        guard recognized else { return nil }
+        return DesignParseResult(config: config, confidence: .high, method: .heuristic,
+                                 extracted: extracted, warnings: [])
+    }
+
+    // MARK: - Extraction helpers
+
+    /// All recognizable values of a fully-known config (used after a ```json decode).
+    private func extracted(from cfg: ThemeConfig) -> [DesignParseResult.Field: String] {
+        var e: [DesignParseResult.Field: String] = [
+            .primary: "#\(cfg.primaryHex)",
+            .tint: fmt(cfg.tint),
+            .dark: "\(cfg.dark)",
+            .font: cfg.font,
+            .fontScale: fmt(cfg.fontScale),
+            .radiusScale: fmt(cfg.radiusScale),
+            .spacingScale: fmt(cfg.spacingScale),
+            .shadowScale: fmt(cfg.shadowScale),
+        ]
+        if let b = cfg.baseHex { e[.base] = "#\(b)" }
+        if let s = cfg.secondaryHex { e[.secondary] = "#\(s)" }
+        if let a = cfg.accentHex { e[.accent] = "#\(a)" }
+        return e
+    }
+
+    /// First hex AT OR AFTER the earliest matched label on a line, so a line like
+    /// "secondary #A and accent #B" associates each hex with its own label
+    /// (falls back to any hex on the line if none follows the label).
+    private func labeledHex(in text: String, labels: [String]) -> String? {
+        for rawLine in text.split(whereSeparator: { $0 == "\n" || $0 == "\r" }) {
+            let line = String(rawLine).lowercased()
+            guard let labelStart = labels.compactMap({ line.range(of: $0)?.lowerBound }).min() else { continue }
+            if let hex = firstHex(in: String(line[labelStart...])) { return hex }
+            if let hex = firstHex(in: line) { return hex }
+        }
+        return nil
+    }
+
+    /// First hex colour anywhere in `text`, normalized to 6-digit lowercase.
+    private func firstHex(in text: String) -> String? {
+        let ns = text as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        // 6-digit first, then 3-digit. `#` optional; require a word boundary so we
+        // don't grab the leading 6 chars of an 8-digit RRGGBBAA value mid-token.
+        for pattern in ["#([0-9a-fA-F]{6})\\b", "#([0-9a-fA-F]{3})\\b"] {
+            guard let re = try? NSRegularExpression(pattern: pattern) else { continue }
+            if let m = re.firstMatch(in: text, range: range), m.numberOfRanges > 1 {
+                let hex = ns.substring(with: m.range(at: 1))
+                return expandHex(hex)
+            }
+        }
+        return nil
+    }
+
+    private func containsAny(_ haystack: String, _ needles: [String]) -> Bool {
+        needles.contains { haystack.contains($0) }
+    }
+
+    private func scaleFromKeywords(_ text: String, mapping: [([String], Double)]) -> Double? {
+        for (keywords, value) in mapping where containsAny(text, keywords) { return value }
+        return nil
+    }
+
+    private func fontFromKeywords(_ text: String) -> String? {
+        if containsAny(text, ["serif"]) && !text.contains("sans-serif") && !text.contains("sans serif") { return "SystemSerif" }
+        if containsAny(text, ["monospace", "monospaced", "mono font", "code font", "terminal"]) { return "SystemMono" }
+        if containsAny(text, ["rounded font", "rounded type", "sf rounded"]) { return "SystemRounded" }
+        if containsAny(text, ["system font", "native font", "san francisco", "sf pro"]) { return "System" }
+        if containsAny(text, ["montserrat"]) { return "Montserrat" }
+        return nil
+    }
+
+    /// Map a free `font:` value onto a renderable family (else nil).
+    private func fontFamily(_ value: String) -> String? {
+        let v = value.lowercased()
+        switch v {
+        case "system": return "System"
+        case "systemrounded", "rounded": return "SystemRounded"
+        case "systemserif", "serif": return "SystemSerif"
+        case "systemmono", "mono", "monospace", "monospaced": return "SystemMono"
+        case "montserrat": return "Montserrat"
+        default:
+            // Unknown branded sans → Montserrat (the bundled custom family).
+            return "Montserrat"
+        }
+    }
+
+    // MARK: - Markdown block helpers
+
+    /// Returns the body of the first fenced code block whose language tag is in
+    /// `languages` (case-insensitive).
+    private func fencedBlock(in markdown: String, languages: [String]) -> String? {
+        let langs = languages.map { $0.lowercased() }
+        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var i = 0
+        while i < lines.count {
+            let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```") {
+                let lang = trimmed.dropFirst(3).trimmingCharacters(in: .whitespaces).lowercased()
+                var body: [String] = []
+                var j = i + 1
+                while j < lines.count, !lines[j].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+                    body.append(lines[j]); j += 1
+                }
+                if langs.contains(lang) { return body.joined(separator: "\n") }
+                i = j + 1
+                continue
+            }
+            i += 1
+        }
+        return nil
+    }
+
+    /// Returns YAML-style front-matter (between leading `---` fences), if present.
+    private func frontMatter(in markdown: String) -> String? {
+        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard let first = lines.first?.trimmingCharacters(in: .whitespaces), first == "---" else { return nil }
+        var body: [String] = []
+        var j = 1
+        while j < lines.count, lines[j].trimmingCharacters(in: .whitespaces) != "---" {
+            body.append(lines[j]); j += 1
+        }
+        return j < lines.count ? body.joined(separator: "\n") : nil
+    }
+
+    // MARK: - Value helpers
+
+    private func normalizeHex(_ raw: String) -> String? {
+        let s = raw.hasPrefix("#") ? String(raw.dropFirst()) : raw
+        let hex = s.trimmingCharacters(in: .whitespaces)
+        if hex.count == 6, hex.allSatisfy(\.isHexDigit) { return hex.lowercased() }
+        if hex.count == 3, hex.allSatisfy(\.isHexDigit) { return expandHex(hex) }
+        return nil
+    }
+
+    /// Expand a 3-digit hex (`abc`) to 6 (`aabbcc`); pass 6-digit through, lowercased.
+    private func expandHex(_ hex: String) -> String {
+        if hex.count == 3 {
+            return hex.lowercased().map { "\($0)\($0)" }.joined()
+        }
+        return hex.lowercased()
+    }
+
+    private func boolValue(_ raw: String) -> Bool {
+        ["true", "yes", "on", "1", "dark", "enabled"].contains(raw.lowercased())
+    }
+
+    /// Relative luminance (0…1) of a 6-digit hex, for dark inference.
+    private func luminance(ofHex hex: String) -> Double {
+        let h = expandHex(hex)
+        guard h.count == 6, let v = Int(h, radix: 16) else { return 1 }
+        let r = Double((v >> 16) & 0xff) / 255
+        let g = Double((v >> 8) & 0xff) / 255
+        let b = Double(v & 0xff) / 255
+        func lin(_ c: Double) -> Double { c <= 0.03928 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4) }
+        return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+    }
+
+    private func clamp(_ v: Double, _ lo: Double, _ hi: Double) -> Double { min(max(v, lo), hi) }
+    private func fmt(_ v: Double) -> String { String(format: "%.2f", v) }
+}

--- a/Sources/ThemeKit/Theme/DesignMode/DesignMode.swift
+++ b/Sources/ThemeKit/Theme/DesignMode/DesignMode.swift
@@ -1,0 +1,59 @@
+//
+//  DesignMode.swift
+//  ThemeKit
+//  Created by İsa Mercan on 30.06.2026.
+//
+//  The public façade for Design Mode: parse a `design.md` into a `ThemeConfig`
+//  (heuristic, or resolver-with-fallback) and apply it — which re-skins every
+//  component through the existing `Theme.apply(_:)`.
+//
+//  Typical flow:
+//    let spec   = try DesignSpecCatalog.load(fileURL: pickedURL)
+//    let result = await DesignMode.resolve(spec, seed: currentConfig, using: myResolver)
+//    // …show result.extracted / result.warnings for confirmation…
+//    DesignMode.apply(result)         // @MainActor — re-skins all components
+//
+
+import SwiftUI
+
+public enum DesignMode {
+
+    /// Heuristic-only parse — synchronous, offline, always returns a config.
+    public static func parse(
+        _ spec: DesignSpec,
+        seed: ThemeConfig = .default,
+        parser: DesignMarkdownParsing = HeuristicDesignParser()
+    ) -> DesignParseResult {
+        parser.parse(spec.rawMarkdown, seed: seed)
+    }
+
+    /// Resolver-first parse with a guaranteed heuristic fallback. Never throws —
+    /// if `resolver` is nil, throws, or fails, the heuristic result is returned.
+    public static func resolve(
+        _ spec: DesignSpec,
+        seed: ThemeConfig = .default,
+        using resolver: DesignSpecResolving?,
+        parser: DesignMarkdownParsing = HeuristicDesignParser()
+    ) async -> DesignParseResult {
+        if let resolver {
+            do {
+                return try await resolver.resolve(spec.rawMarkdown, seed: seed)
+            } catch {
+                var fallback = parser.parse(spec.rawMarkdown, seed: seed)
+                fallback.warnings.insert(
+                    "AI resolver failed (\(error.localizedDescription)) — parsed on-device instead.",
+                    at: 0
+                )
+                return fallback
+            }
+        }
+        return parser.parse(spec.rawMarkdown, seed: seed)
+    }
+
+    /// Applies a parsed result to `theme` — re-skinning every component. Main-actor
+    /// confined because `Theme` is applied from the main thread.
+    @MainActor
+    public static func apply(_ result: DesignParseResult, to theme: Theme = .shared) {
+        theme.apply(result.config)
+    }
+}

--- a/Sources/ThemeKit/Theme/DesignMode/DesignSpec.swift
+++ b/Sources/ThemeKit/Theme/DesignMode/DesignSpec.swift
@@ -1,0 +1,90 @@
+//
+//  DesignSpec.swift
+//  ThemeKit
+//  Created by İsa Mercan on 30.06.2026.
+//
+//  Design Mode — bring every component into a target look by importing another
+//  app's free-form `design.md` (file / URL / bundled catalog) and turning it into
+//  a `ThemeConfig`, then applying it with `Theme.shared.apply(_:)` (which already
+//  re-skins all components). `DesignSpec` is the imported document; a parser /
+//  resolver turns it into a `DesignParseResult` (an always-applicable config plus
+//  the provenance the confirm UI shows).
+//
+
+import Foundation
+
+/// An imported design document: a free-form markdown describing an app's look,
+/// plus where it came from. Parsed into a `ThemeConfig` by `DesignMode`.
+public struct DesignSpec: Identifiable, Equatable, Sendable {
+    /// Stable slug, e.g. `"linear-dark"` (bundled filename) or a derived id.
+    public let id: String
+    /// Human title for the catalog card (first `#` heading or `title:` front-matter).
+    public let title: String
+    /// One-line description (first paragraph or `summary:` front-matter).
+    public let summary: String?
+    /// Where this spec was loaded from.
+    public let source: Source
+    /// The raw markdown — the parser/resolver's only input.
+    public let rawMarkdown: String
+
+    public enum Source: Equatable, Sendable {
+        case bundled(resource: String)
+        case file(URL)
+        case remote(URL)
+        case pasted
+    }
+
+    public init(id: String, title: String, summary: String? = nil,
+                source: Source, rawMarkdown: String) {
+        self.id = id
+        self.title = title
+        self.summary = summary
+        self.source = source
+        self.rawMarkdown = rawMarkdown
+    }
+}
+
+/// The result of parsing a `DesignSpec`: an always-applicable `ThemeConfig` plus
+/// how it was derived. `extracted` + `warnings` are what the confirm/preview UI
+/// surfaces so the user sees what ambiguous free text became before committing.
+public struct DesignParseResult: Equatable, Sendable {
+    /// The portable recipe to apply via `Theme.apply(_:)`. Always present.
+    public var config: ThemeConfig
+    /// How confident we are in `config` (drives the UI badge).
+    public var confidence: Confidence
+    /// Which path produced `config`.
+    public var method: Method
+    /// Human-readable derived values, keyed by field — shown in the confirm step.
+    public var extracted: [Field: String]
+    /// Notes about defaults/fallbacks the parser had to make.
+    public var warnings: [String]
+
+    public enum Confidence: Int, Comparable, Sendable {
+        case low, medium, high
+        public static func < (l: Self, r: Self) -> Bool { l.rawValue < r.rawValue }
+    }
+
+    public enum Method: Equatable, Sendable {
+        case heuristic
+        case resolver(String)
+    }
+
+    /// The recipe fields a `design.md` can drive — used as keys in `extracted`.
+    public enum Field: String, Sendable, CaseIterable {
+        case primary, base, secondary, accent
+        case tint, dark, font
+        case radiusScale, spacingScale, fontScale, shadowScale
+    }
+
+    public init(config: ThemeConfig,
+                confidence: Confidence = .low,
+                method: Method = .heuristic,
+                extracted: [Field: String] = [:],
+                warnings: [String] = []) {
+        self.config = config
+        self.confidence = confidence
+        self.method = method
+        self.extracted = extracted
+        self.warnings = warnings
+    }
+}

--- a/Sources/ThemeKit/Theme/DesignMode/DesignSpecCatalog.swift
+++ b/Sources/ThemeKit/Theme/DesignMode/DesignSpecCatalog.swift
@@ -1,0 +1,205 @@
+//
+//  DesignSpecCatalog.swift
+//  ThemeKit
+//  Created by İsa Mercan on 30.06.2026.
+//
+//  Loads `design.md` specs from three sources: the bundled catalog (shipped with
+//  the package), a local file (the file picker's URL), and a remote https URL.
+//  Networking is Foundation-only (`URLSession`) — no third-party dependency — and
+//  is hardened: https-only, a byte cap, and a text content-type check. The fetched
+//  body is treated as untrusted text (the parser never executes it).
+//
+
+import Foundation
+
+public enum DesignSpecError: Error, LocalizedError, Equatable {
+    case notFound
+    case unreadable
+    case insecureURL
+    case tooLarge(Int)
+    case badResponse(Int)
+    case notText
+
+    public var errorDescription: String? {
+        switch self {
+        case .notFound: return "The design file could not be found."
+        case .unreadable: return "The design file could not be read as text."
+        case .insecureURL: return "Only https URLs are allowed."
+        case .tooLarge(let max): return "The file is larger than the \(max / 1024) KB limit."
+        case .badResponse(let code): return "The server responded with status \(code)."
+        case .notText: return "The URL did not return a text/markdown document."
+        }
+    }
+}
+
+public enum DesignSpecCatalog {
+
+    /// Subdirectory under the package's resource bundle where `*.design.md` live.
+    static let bundledSubdirectory = "DesignSpecs"
+    /// Default cap for remote fetches (256 KB) — design docs are small.
+    public static let defaultMaxBytes = 256 * 1024
+
+    // MARK: - Bundled
+
+    /// Every bundled design spec, sorted by title. Empty if none ship (or aren't
+    /// discoverable — the catalog test guards against that).
+    ///
+    /// `.process("Resources")` flattens subdirectories (the bundled fonts and theme
+    /// JSON are found at the bundle root too), so we scan the root for `*.design.md`
+    /// and fall back to the `DesignSpecs/` subdirectory in case a future toolchain
+    /// preserves the hierarchy.
+    public static func bundled() -> [DesignSpec] {
+        var urls = (Bundle.module.urls(forResourcesWithExtension: "md", subdirectory: nil) ?? [])
+            .filter { $0.lastPathComponent.hasSuffix(".design.md") }
+        if urls.isEmpty {
+            urls = Bundle.module.urls(forResourcesWithExtension: "md", subdirectory: bundledSubdirectory) ?? []
+        }
+        return urls
+            .compactMap { try? spec(fromFileURL: $0, source: .bundled(resource: idForBundled($0))) }
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+    }
+
+    /// A single bundled spec by id (its filename slug, e.g. `"linear-dark"`).
+    public static func bundled(id: String) -> DesignSpec? {
+        bundled().first { $0.id == id }
+    }
+
+    // MARK: - File
+
+    /// Loads a spec from a local file URL (e.g. the document picker's result).
+    /// The caller owns security-scoped access around this call.
+    public static func load(fileURL: URL) throws -> DesignSpec {
+        try spec(fromFileURL: fileURL, source: .file(fileURL))
+    }
+
+    // MARK: - Remote
+
+    /// Fetches a remote markdown document and parses its metadata. Hardened:
+    /// https-only, `maxBytes` cap, and a text content-type check.
+    public static func load(
+        remoteURL: URL,
+        session: URLSession = .shared,
+        maxBytes: Int = defaultMaxBytes
+    ) async throws -> DesignSpec {
+        guard remoteURL.scheme?.lowercased() == "https" else { throw DesignSpecError.insecureURL }
+
+        var request = URLRequest(url: remoteURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 20
+        request.setValue("text/markdown, text/plain;q=0.9, */*;q=0.1", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+
+        if let http = response as? HTTPURLResponse {
+            guard (200..<300).contains(http.statusCode) else { throw DesignSpecError.badResponse(http.statusCode) }
+            if let type = http.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
+               !type.isEmpty,
+               !(type.contains("text/") || type.contains("markdown") || type.contains("octet-stream")) {
+                throw DesignSpecError.notText
+            }
+        }
+        guard data.count <= maxBytes else { throw DesignSpecError.tooLarge(maxBytes) }
+        guard let markdown = String(data: data, encoding: .utf8) else { throw DesignSpecError.unreadable }
+
+        return makeSpec(
+            id: slug(remoteURL.deletingPathExtension().lastPathComponent),
+            markdown: markdown,
+            source: .remote(remoteURL)
+        )
+    }
+
+    // MARK: - Pasted
+
+    /// Wraps raw pasted markdown as a spec.
+    public static func pasted(_ markdown: String, id: String = "pasted") -> DesignSpec {
+        makeSpec(id: id, markdown: markdown, source: .pasted)
+    }
+
+    // MARK: - Construction
+
+    private static func spec(fromFileURL url: URL, source: DesignSpec.Source) throws -> DesignSpec {
+        guard let data = try? Data(contentsOf: url) else { throw DesignSpecError.notFound }
+        guard let markdown = String(data: data, encoding: .utf8) else { throw DesignSpecError.unreadable }
+        let id: String
+        if case .bundled(let resource) = source { id = resource } else { id = idForBundled(url) }
+        return makeSpec(id: id, markdown: markdown, source: source)
+    }
+
+    /// Builds a `DesignSpec`, deriving title/summary from the markdown.
+    private static func makeSpec(id: String, markdown: String, source: DesignSpec.Source) -> DesignSpec {
+        let meta = metadata(from: markdown)
+        let title = meta.title ?? prettify(id)
+        return DesignSpec(id: id, title: title, summary: meta.summary, source: source, rawMarkdown: markdown)
+    }
+
+    /// `linear-dark.design.md` → `linear-dark`.
+    private static func idForBundled(_ url: URL) -> String {
+        var name = url.deletingPathExtension().lastPathComponent   // drops ".md"
+        if name.hasSuffix(".design") { name = String(name.dropLast(".design".count)) }
+        return slug(name)
+    }
+
+    // MARK: - Metadata
+
+    /// Title (front-matter `title:` or first `#` heading) and summary (front-matter
+    /// `summary:` or the first prose paragraph).
+    private static func metadata(from markdown: String) -> (title: String?, summary: String?) {
+        var title: String?
+        var summary: String?
+        var inFrontMatter = false
+        var inCodeFence = false
+
+        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        for (index, raw) in lines.enumerated() {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+
+            if index == 0, line == "---" { inFrontMatter = true; continue }
+            if inFrontMatter {
+                if line == "---" { inFrontMatter = false; continue }
+                if let v = frontMatterValue(line, key: "title") { title = title ?? v }
+                if let v = frontMatterValue(line, key: "summary") { summary = summary ?? v }
+                continue
+            }
+
+            if line.hasPrefix("```") { inCodeFence.toggle(); continue }
+            if inCodeFence { continue }
+
+            if title == nil, line.hasPrefix("# ") {
+                title = String(line.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+                continue
+            }
+            if summary == nil, !line.isEmpty, !line.hasPrefix("#"), !line.hasPrefix("---"),
+               !line.hasPrefix(">"), !line.hasPrefix("```") {
+                summary = line
+            }
+            if title != nil, summary != nil { break }
+        }
+        return (title, summary)
+    }
+
+    private static func frontMatterValue(_ line: String, key: String) -> String? {
+        guard let colon = line.firstIndex(of: ":") else { return nil }
+        guard line[..<colon].trimmingCharacters(in: .whitespaces).lowercased() == key else { return nil }
+        let value = line[line.index(after: colon)...]
+            .trimmingCharacters(in: .whitespaces)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+        return value.isEmpty ? nil : value
+    }
+
+    // MARK: - String helpers
+
+    private static func slug(_ raw: String) -> String {
+        let lowered = raw.lowercased()
+        let mapped = lowered.map { ch -> Character in
+            (ch.isLetter || ch.isNumber) ? ch : "-"
+        }
+        let collapsed = String(mapped).split(separator: "-", omittingEmptySubsequences: true).joined(separator: "-")
+        return collapsed.isEmpty ? "design" : collapsed
+    }
+
+    private static func prettify(_ id: String) -> String {
+        id.split(separator: "-")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+}

--- a/Sources/ThemeKit/Theme/DesignMode/DesignSpecResolver.swift
+++ b/Sources/ThemeKit/Theme/DesignMode/DesignSpecResolver.swift
@@ -1,0 +1,36 @@
+//
+//  DesignSpecResolver.swift
+//  ThemeKit
+//  Created by İsa Mercan on 30.06.2026.
+//
+//  The optional LLM/MCP path. The core ships ONLY this protocol + a closure
+//  adapter — no networking, no LLM client (the core stays zero-dependency and
+//  network-free). A host (e.g. the Demo) injects a resolver that routes the raw
+//  `design.md` to an LLM / the MCP and returns a richer `DesignParseResult`. When
+//  it throws or returns nil, the caller falls back to the heuristic parser.
+//
+
+import Foundation
+
+/// Host-implemented bridge from a free-form `design.md` to a `ThemeConfig`.
+public protocol DesignSpecResolving: Sendable {
+    /// - Parameters:
+    ///   - markdown: the raw design document.
+    ///   - seed: defaults for fields the resolver can't determine.
+    /// - Returns: a parsed result; throwing → the caller uses the heuristic instead.
+    func resolve(_ markdown: String, seed: ThemeConfig) async throws -> DesignParseResult
+}
+
+/// Wraps a closure as a `DesignSpecResolving`, so a host can plug in an LLM/MCP
+/// call without declaring a new type.
+public struct ClosureDesignResolver: DesignSpecResolving, Sendable {
+    private let body: @Sendable (String, ThemeConfig) async throws -> DesignParseResult
+
+    public init(_ body: @escaping @Sendable (String, ThemeConfig) async throws -> DesignParseResult) {
+        self.body = body
+    }
+
+    public func resolve(_ markdown: String, seed: ThemeConfig) async throws -> DesignParseResult {
+        try await body(markdown, seed)
+    }
+}

--- a/Tests/ThemeKitTests/DesignCatalogTests.swift
+++ b/Tests/ThemeKitTests/DesignCatalogTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import ThemeKit
+
+final class DesignCatalogTests: XCTestCase {
+
+    func testBundledCatalogIsDiscoverable() {
+        let specs = DesignSpecCatalog.bundled()
+        XCTAssertFalse(specs.isEmpty, "No bundled *.design.md resources were found in Bundle.module")
+        // Unique ids, non-empty titles.
+        XCTAssertEqual(Set(specs.map(\.id)).count, specs.count)
+        for spec in specs {
+            XCTAssertFalse(spec.title.isEmpty, "\(spec.id) has an empty title")
+            if case .bundled = spec.source {} else {
+                XCTFail("\(spec.id) is not marked as bundled")
+            }
+        }
+    }
+
+    func testEveryBundledSpecParsesHighConfidence() {
+        // Proves the fenced ```themekit blocks are valid AND the resources are
+        // discoverable end-to-end.
+        let specs = DesignSpecCatalog.bundled()
+        XCTAssertFalse(specs.isEmpty)
+        for spec in specs {
+            let result = DesignMode.parse(spec)
+            XCTAssertEqual(result.confidence, .high, "\(spec.id) did not parse at high confidence")
+            XCTAssertEqual(result.config.primaryHex.count, 6, "\(spec.id) has a malformed primary hex")
+        }
+    }
+
+    func testBundledLookupById() {
+        let specs = DesignSpecCatalog.bundled()
+        let first = specs.first!
+        XCTAssertEqual(DesignSpecCatalog.bundled(id: first.id)?.id, first.id)
+        XCTAssertNil(DesignSpecCatalog.bundled(id: "does-not-exist"))
+    }
+
+    func testPastedSpec() {
+        let spec = DesignSpecCatalog.pasted("# Pasted\nprimary #abcdef")
+        XCTAssertEqual(spec.source, .pasted)
+        XCTAssertEqual(spec.title, "Pasted")
+        XCTAssertEqual(DesignMode.parse(spec).config.primaryHex, "abcdef")
+    }
+
+    func testRemoteRejectsNonHTTPS() async {
+        do {
+            _ = try await DesignSpecCatalog.load(remoteURL: URL(string: "http://example.com/x.md")!)
+            XCTFail("Expected an insecureURL error")
+        } catch let error as DesignSpecError {
+            XCTAssertEqual(error, .insecureURL)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testResolverFallsBackToHeuristic() async {
+        let spec = DesignSpecCatalog.pasted("primary #123456")
+        struct Boom: Error {}
+        let failing = ClosureDesignResolver { _, _ in throw Boom() }
+        let result = await DesignMode.resolve(spec, using: failing)
+        XCTAssertEqual(result.method, .heuristic)
+        XCTAssertEqual(result.config.primaryHex, "123456")
+        XCTAssertTrue(result.warnings.contains { $0.contains("AI resolver failed") })
+    }
+
+    func testResolverResultIsUsedWhenItSucceeds() async {
+        let spec = DesignSpecCatalog.pasted("ignored prose")
+        let cfg = ThemeConfig(primaryHex: "abcdef", dark: true)
+        let resolver = ClosureDesignResolver { _, _ in
+            DesignParseResult(config: cfg, confidence: .high, method: .resolver("test"))
+        }
+        let result = await DesignMode.resolve(spec, using: resolver)
+        XCTAssertEqual(result.method, .resolver("test"))
+        XCTAssertEqual(result.config, cfg)
+    }
+
+    @MainActor
+    func testApplyReskinsTheme() {
+        let spec = DesignSpecCatalog.pasted("""
+        ```themekit
+        primary: #65c3c8
+        base: #faf7f5
+        dark: false
+        ```
+        """)
+        let result = DesignMode.parse(spec)
+        DesignMode.apply(result)
+        XCTAssertEqual(Theme.shared.currentConfig?.primaryHex, "65c3c8")
+        XCTAssertEqual(Theme.shared.currentConfig?.baseHex, "faf7f5")
+        // restore default so other tests aren't affected
+        Theme.shared.loadTheme(named: Theme.defaultThemeName)
+    }
+}

--- a/Tests/ThemeKitTests/DesignParserTests.swift
+++ b/Tests/ThemeKitTests/DesignParserTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import ThemeKit
+
+final class DesignParserTests: XCTestCase {
+    private let parser = HeuristicDesignParser()
+
+    // MARK: - Structured blocks
+
+    func testThemekitBlockWins() {
+        let md = """
+        # Some App
+        Lots of prose that says light and rounded to try to mislead the heuristics.
+
+        ```themekit
+        primary: #5E6AD2
+        base: #0E0E10
+        secondary: #8A93B5
+        accent: #7C8AFF
+        dark: true
+        tint: 0.05
+        radiusScale: 0.8
+        spacingScale: 0.85
+        shadowScale: 0.4
+        font: System
+        ```
+        """
+        let r = parser.parse(md)
+        XCTAssertEqual(r.confidence, .high)
+        XCTAssertEqual(r.config.primaryHex, "5e6ad2")
+        XCTAssertEqual(r.config.baseHex, "0e0e10")
+        XCTAssertEqual(r.config.secondaryHex, "8a93b5")
+        XCTAssertEqual(r.config.accentHex, "7c8aff")
+        XCTAssertTrue(r.config.dark)
+        XCTAssertEqual(r.config.tint, 0.05, accuracy: 0.0001)
+        XCTAssertEqual(r.config.radiusScale, 0.8, accuracy: 0.0001)
+        XCTAssertEqual(r.config.font, "System")
+    }
+
+    func testJSONBlockDecodesToConfig() throws {
+        let cfg = ThemeConfig(primaryHex: "ff0066", baseHex: "101014", dark: true, font: "SystemMono")
+        let json = String(data: try cfg.jsonData(), encoding: .utf8)!
+        let md = """
+        # JSON spec
+        ```json
+        \(json)
+        ```
+        """
+        let r = parser.parse(md)
+        XCTAssertEqual(r.confidence, .high)
+        XCTAssertEqual(r.config, cfg)
+    }
+
+    func testFrontMatterKeyValues() {
+        let md = """
+        ---
+        title: My Theme
+        primary: #112233
+        dark: yes
+        radius: 1.4
+        ---
+        # My Theme
+        body text
+        """
+        let r = parser.parse(md)
+        XCTAssertEqual(r.confidence, .high)
+        XCTAssertEqual(r.config.primaryHex, "112233")
+        XCTAssertTrue(r.config.dark)
+        XCTAssertEqual(r.config.radiusScale, 1.4, accuracy: 0.0001)
+    }
+
+    // MARK: - Prose heuristics
+
+    func testLabeledHexExtraction() {
+        let md = """
+        Our primary brand color is #5E6AD2.
+        The background surface is #0E0E10.
+        The secondary color is #8A93B5 and the accent highlight is #7C8AFF.
+        """
+        let r = parser.parse(md)
+        XCTAssertEqual(r.config.primaryHex, "5e6ad2")
+        XCTAssertEqual(r.config.baseHex, "0e0e10")
+        XCTAssertEqual(r.config.secondaryHex, "8a93b5")
+        XCTAssertEqual(r.config.accentHex, "7c8aff")
+    }
+
+    func testUnlabeledFirstHexBecomesPrimaryWithWarning() {
+        let r = parser.parse("Brand vibe: #abcdef somewhere in here.")
+        XCTAssertEqual(r.config.primaryHex, "abcdef")
+        XCTAssertFalse(r.warnings.isEmpty)
+    }
+
+    func testThreeDigitHexExpands() {
+        let r = parser.parse("primary color #f0c")
+        XCTAssertEqual(r.config.primaryHex, "ff00cc")
+    }
+
+    func testDarkKeyword() {
+        let r = parser.parse("A sleek dark mode interface. primary #336699")
+        XCTAssertTrue(r.config.dark)
+    }
+
+    func testDarkInferredFromBaseLuminance() {
+        // No explicit dark/light words, but the base is near-black → infer dark.
+        let r = parser.parse("background surface is #0a0a0a, primary #3366ff")
+        XCTAssertTrue(r.config.dark)
+        XCTAssertTrue(r.warnings.contains { $0.lowercased().contains("luminance") })
+    }
+
+    func testRoundednessMapsToRadiusScale() {
+        XCTAssertLessThan(parser.parse("sharp square corners, primary #111111").config.radiusScale, 0.5)
+        XCTAssertGreaterThan(parser.parse("fully rounded pill shapes, primary #111111").config.radiusScale, 1.2)
+    }
+
+    func testDensityMapsToSpacingScale() {
+        XCTAssertLessThan(parser.parse("compact dense layout, primary #111111").config.spacingScale, 1.0)
+        XCTAssertGreaterThan(parser.parse("airy spacious layout, primary #111111").config.spacingScale, 1.1)
+    }
+
+    func testShadowMapsToShadowScale() {
+        XCTAssertEqual(parser.parse("flat, no shadows, primary #111111").config.shadowScale, 0, accuracy: 0.0001)
+        XCTAssertGreaterThan(parser.parse("elevated floating cards, primary #111111").config.shadowScale, 1.0)
+    }
+
+    func testFontKeywords() {
+        XCTAssertEqual(parser.parse("uses a monospace code font, primary #111111").config.font, "SystemMono")
+        XCTAssertEqual(parser.parse("a serif editorial feel, primary #111111").config.font, "SystemSerif")
+        XCTAssertEqual(parser.parse("the native system font, primary #111111").config.font, "System")
+    }
+
+    // MARK: - Totality
+
+    func testEmptyInputReturnsSeedAndWarns() {
+        let seed = ThemeConfig(primaryHex: "abc123", dark: true)
+        let r = parser.parse("   \n\n  ", seed: seed)
+        XCTAssertEqual(r.config, seed)
+        XCTAssertEqual(r.confidence, .low)
+        XCTAssertFalse(r.warnings.isEmpty)
+    }
+
+    func testUnspecifiedFieldsKeepSeed() {
+        let seed = ThemeConfig(primaryHex: "000000", font: "Montserrat", radiusScale: 1.7)
+        // Only specifies a primary; radius/font should stay seeded.
+        let r = parser.parse("primary #abcdef", seed: seed)
+        XCTAssertEqual(r.config.primaryHex, "abcdef")
+        XCTAssertEqual(r.config.radiusScale, 1.7, accuracy: 0.0001)
+        XCTAssertEqual(r.config.font, "Montserrat")
+    }
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -239,6 +239,56 @@ server.registerTool("generate_theme", {
   return text(`Theme.shared.apply(ThemeConfig(${a.join(", ")}))`);
 });
 
+server.registerTool("design_md_to_themeconfig", {
+  title: "design.md → ThemeConfig",
+  description:
+    "Turn a free-form design.md into a ThemeKit ThemeConfig. You (the client) read the markdown and infer each value; this tool validates/normalizes them (clamps tint, lowercases hex, whitelists the font) and emits both the `Theme.shared.apply(ThemeConfig(...))` snippet and a matching theme.json block for `ThemeConfig(jsonData:)`. Every component re-skins to the result.",
+  inputSchema: {
+    primaryHex: z.string().describe("6-digit RRGGBB derived from the doc's brand/primary color"),
+    baseHex: z.string().optional().describe("Surface / background (daisyUI base-100)"),
+    secondaryHex: z.string().optional(),
+    accentHex: z.string().optional(),
+    tint: z.number().min(0).max(0.25).optional().describe("How strongly the accent bleeds into neutrals"),
+    dark: z.boolean().optional(),
+    font: z.enum(["Montserrat", "System", "SystemRounded", "SystemSerif", "SystemMono"]).optional(),
+    fontScale: z.number().optional(),
+    radiusScale: z.number().optional().describe("≈1.0; <1 sharper corners, >1 rounder"),
+    spacingScale: z.number().optional().describe("≈1.0; <1 compact, >1 airy"),
+    shadowScale: z.number().optional().describe("0 flat … >1 elevated"),
+    notes: z.string().optional().describe("What in the doc drove each choice (echoed for confirmation)"),
+  },
+}, async (a) => {
+  const hex = (h?: string) => (h ? h.replace(/^#/, "").toLowerCase() : undefined);
+  const isHex6 = (h?: string) => !!h && /^[0-9a-f]{6}$/.test(h);
+  const primary = hex(a.primaryHex);
+  if (!isHex6(primary)) return text(`Invalid primaryHex "${a.primaryHex}" — expected 6-digit RRGGBB.`);
+
+  const clamp = (v: number, lo: number, hi: number) => Math.min(Math.max(v, lo), hi);
+  const cfg: Record<string, string | number | boolean> = { primaryHex: primary! };
+  const base = hex(a.baseHex); if (isHex6(base)) cfg.baseHex = base!;
+  const sec = hex(a.secondaryHex); if (isHex6(sec)) cfg.secondaryHex = sec!;
+  const acc = hex(a.accentHex); if (isHex6(acc)) cfg.accentHex = acc!;
+  if (a.tint !== undefined) cfg.tint = clamp(a.tint, 0, 0.25);
+  if (a.dark !== undefined) cfg.dark = a.dark;
+  if (a.font) cfg.font = a.font;
+  if (a.fontScale !== undefined) cfg.fontScale = a.fontScale;
+  if (a.radiusScale !== undefined) cfg.radiusScale = a.radiusScale;
+  if (a.spacingScale !== undefined) cfg.spacingScale = a.spacingScale;
+  if (a.shadowScale !== undefined) cfg.shadowScale = a.shadowScale;
+
+  const args = Object.entries(cfg)
+    .map(([k, v]) => (typeof v === "string" ? `${k}: "${v}"` : `${k}: ${v}`))
+    .join(", ");
+  const lines = [
+    a.notes ? `// ${a.notes}` : undefined,
+    `Theme.shared.apply(ThemeConfig(${args}))`,
+    ``,
+    `// or ship it as theme.json and apply with ThemeConfig(jsonData:):`,
+    JSON.stringify(cfg, null, 2),
+  ].filter(Boolean) as string[];
+  return text(lines.join("\n"));
+});
+
 // ── Theme preview image (pngjs) ────────────────────────────────────────────
 
 function hexToRgb(h: string): [number, number, number] {

--- a/mcp/test/build.test.mjs
+++ b/mcp/test/build.test.mjs
@@ -11,7 +11,7 @@ const data = JSON.parse(readFileSync(join(here, "..", "data", "themekit.json"), 
 test("catalog is populated", () => {
   assert.ok(data.components.length >= 110, `expected ≥110 components, got ${data.components.length}`);
   assert.ok(data.modifiers.length >= 50);
-  assert.ok(data.themes.length === 32);
+  assert.ok(data.themes.length >= 33, `expected ≥33 theme presets, got ${data.themes.length}`);
 });
 
 test("Badge API is precise (from the symbol graph, not regex)", () => {


### PR DESCRIPTION
Brings the **Design Mode** feature (drafted on `claude/design-mode-component-switch-walump`) onto current `main` — taking **only** the new feature, so today's work (Pages root redirect, English wiki, README links/badges/SPM 0.3.0) is **untouched**.

## What it does
Point ThemeKit at a free-form `design.md` (bundled catalog, file picker, URL, or pasted text) → it parses the look into a `ThemeConfig` → `Theme.apply` re-skins all 117 token-bound components.

- **Core** (`Sources/ThemeKit/Theme/DesignMode/`): `DesignSpec`, `HeuristicDesignParser` (offline, deterministic, total), `DesignSpecCatalog` (bundled `*.design.md` + hardened HTTPS import), a pluggable async resolver. 5 bundled specs: linear-dark, notion-minimal, ios-native, brutalist, pastel-soft.
- **Demo**: a **Design** tab (`DesignModeView` + `DesignPreviewSheet`), design provenance in `DemoThemeStore`, optional Anthropic resolver.
- **MCP**: `design_md_to_themeconfig` tool.
- **Tests**: `DesignParserTests` + `DesignCatalogTests`.

## Fixes (the feature was never compiled/tested in its origin session)
- `DesignMarkdownParser.labeledHex`: grab the hex **at/after** the matched label, not the first on the line — fixes `accent` picking the `secondary`'s hex on a shared line.
- Drop bare `brand` from the primary labels (→ `brand color`) so `Brand vibe: #abc` is treated as unlabeled (warns) rather than a labeled primary.
- `mcp build.test`: theme-preset assertion `32` → `≥33` (the Default preset — this was already stale on `main`).

## Verification
`swift build` + **206 tests** + Demo `xcodebuild` + **10 MCP tests** — all green. Confirmed `pages.yml`, `wiki/`, and the README's links/badges are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)