### PR TITLE
docs(readme): fix stale PrimaryButton(title:) example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: theme.spacing(.md)) {
             Text("Welcome").textStyle(.headingBase)
-            PrimaryButton(title: "Get started") { await signIn() }
+            PrimaryButton("Get started") { await signIn() }
         }
         .padding(theme.spacing(.base))
         .background(theme.background(.bgElevatorPrimary))


### PR DESCRIPTION
The Quick Start used `PrimaryButton(title: "Get started")`, but after the modifier refactor (#155) the button presets take the title **positionally**. Fixed to `PrimaryButton("Get started")` so the snippet compiles. Doc-only.