### PR TITLE
docs: enlarge the landing hero banner

### DIFF
--- a/website/src/styles/theme.css
+++ b/website/src/styles/theme.css
@@ -25,6 +25,20 @@
   width: auto;
 }
 
+/* The hero banner is a wide (≈1.9:1) marketing image; Starlight's default puts it
+   in the narrow 4fr column so it reads small. Give it the larger share and let it
+   fill the column. */
+@media (min-width: 50rem) {
+  .hero {
+    grid-template-columns: 4fr 6fr;
+  }
+}
+.hero > img {
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+}
+
 /* Component gallery cards (used on the Components page). */
 .tk-gallery {
   display: grid;


### PR DESCRIPTION
The landing hero banner (a wide ~1.9:1 marketing image) rendered small because Starlight's default hero puts the image in the narrow `4fr` column. This gives the banner the larger column share (`4fr` text / `6fr` image on ≥50rem) and lets it fill its column.

CSS-only change to `website/src/styles/theme.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)