### PR TITLE
docs: serve the landing hero banner at full resolution

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -33,6 +33,9 @@ export default defineConfig({
       customCss: ['./src/styles/theme.css'],
       components: {
         Footer: './src/components/Footer.astro',
+        // Upstream Hero downscales the banner to 400px wide; our override
+        // serves it at 1x/2x of its display size so it stays sharp.
+        Hero: './src/components/Hero.astro',
       },
       sidebar: [
         {

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -1,0 +1,153 @@
+---
+import { Image } from 'astro:assets';
+import { LinkButton } from '@astrojs/starlight/components';
+
+// Starlight's `constants` module is not part of its public exports; this
+// mirrors PAGE_TITLE_ID ('_top') so the skip-link anchor keeps working.
+const PAGE_TITLE_ID = '_top';
+
+// Override of Starlight's built-in Hero. Upstream forces the hero image to
+// width/height 400, which downscales our 2536×1332 banner at build time and
+// makes it blurry once the custom hero CSS stretches it to fill its column.
+// Render at half the intrinsic size with 1x/2x densities instead, so the
+// browser gets a sharp asset on both standard and retina displays.
+
+const { data } = Astro.locals.starlightRoute.entry;
+const { title = data.title, tagline, image, actions = [] } = data.hero || {};
+
+let darkImage: ImageMetadata | undefined;
+let lightImage: ImageMetadata | undefined;
+let rawHtml: string | undefined;
+if (image) {
+	if ('file' in image) {
+		darkImage = image.file;
+	} else if ('dark' in image) {
+		darkImage = image.dark;
+		lightImage = image.light;
+	} else {
+		rawHtml = image.html;
+	}
+}
+
+const imageAttrs = (img: ImageMetadata) => ({
+	loading: 'eager' as const,
+	decoding: 'async' as const,
+	width: Math.round(img.width / 2),
+	height: Math.round(img.height / 2),
+	densities: [1, 2],
+	alt: image?.alt || '',
+});
+---
+
+<div class="hero">
+	{
+		darkImage && (
+			<Image
+				src={darkImage}
+				{...imageAttrs(darkImage)}
+				class:list={{ 'light:sl-hidden': Boolean(lightImage) }}
+			/>
+		)
+	}
+	{lightImage && <Image src={lightImage} {...imageAttrs(lightImage)} class="dark:sl-hidden" />}
+	{rawHtml && <div class="hero-html sl-flex" set:html={rawHtml} />}
+	<div class="sl-flex stack">
+		<div class="sl-flex copy">
+			<h1 id={PAGE_TITLE_ID} data-page-title set:html={title} />
+			{tagline && <div class="tagline" set:html={tagline} />}
+		</div>
+		{
+			actions.length > 0 && (
+				<div class="sl-flex actions">
+					{actions.map(
+						({ attrs: { class: className, ...attrs } = {}, icon, link: href, text, variant }) => (
+							<LinkButton {href} {variant} icon={icon?.name} class:list={[className]} {...attrs}>
+								{text}
+								{icon?.html && <Fragment set:html={icon.html} />}
+							</LinkButton>
+						)
+					)}
+				</div>
+			)
+		}
+	</div>
+</div>
+
+<style>
+	@layer starlight.core {
+		.hero {
+			display: grid;
+			align-items: center;
+			gap: 1rem;
+			padding-bottom: 1rem;
+		}
+
+		.hero > img,
+		.hero > .hero-html {
+			object-fit: contain;
+			width: min(70%, 20rem);
+			height: auto;
+			margin-inline: auto;
+		}
+
+		.stack {
+			flex-direction: column;
+			gap: clamp(1.5rem, calc(1.5rem + 1vw), 2rem);
+			text-align: center;
+		}
+
+		.copy {
+			flex-direction: column;
+			gap: 1rem;
+			align-items: center;
+		}
+
+		.copy > * {
+			max-width: 50ch;
+		}
+
+		h1 {
+			font-size: clamp(var(--sl-text-3xl), calc(0.25rem + 5vw), var(--sl-text-6xl));
+			line-height: var(--sl-line-height-headings);
+			font-weight: 600;
+			color: var(--sl-color-white);
+		}
+
+		.tagline {
+			font-size: clamp(var(--sl-text-base), calc(0.0625rem + 2vw), var(--sl-text-xl));
+			color: var(--sl-color-gray-2);
+		}
+
+		.actions {
+			gap: 1rem 2rem;
+			flex-wrap: wrap;
+			justify-content: center;
+		}
+
+		@media (min-width: 50rem) {
+			.hero {
+				grid-template-columns: 7fr 4fr;
+				gap: 3%;
+				padding-block: clamp(2.5rem, calc(1rem + 10vmin), 10rem);
+			}
+
+			.hero > img,
+			.hero > .hero-html {
+				order: 2;
+				width: min(100%, 25rem);
+			}
+
+			.stack {
+				text-align: start;
+			}
+
+			.copy {
+				align-items: flex-start;
+			}
+
+			.actions {
+				justify-content: flex-start;
+			}
+		}
+	}
+</style>


### PR DESCRIPTION
Starlight's built-in Hero downscales the hero image to 400px wide at build
time, which left the enlarged banner blurry once the custom hero CSS
stretched it across its column. Override the Hero component to emit the
banner at half its intrinsic size with a 1x/2x srcset (1268w + 2536w), so
it stays sharp on both standard and retina displays.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VEPT5CBue25qTb34CjxNFM