### PR TITLE
docs: how to keep the MCP up to date (README + docs site)

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,24 @@ Then just ask: *"Build a sign-up screen. Use the ThemeKit skill."* Works with
 **Claude Code, Cursor, Windsurf, GitHub Copilot**, and any tool that supports MCP
 or `llms.txt`.
 
+**Keeping the MCP current** — the server ships to npm and is **updated
+regularly** (see the [changelog](mcp/CHANGELOG.md)). Because `npx` caches
+packages, an install that pins no version keeps running the release it first
+cached — pin `@latest` so it launches the newest each time, or clear the cache to
+refresh:
+
+```sh
+# always launch the latest published release
+claude mcp add themekit -- npx -y @isamercan/themekit-mcp@latest
+# or refresh a stale npx cache, then restart the server
+rm -rf ~/.npm/_npx
+```
+
+Check versions with `npm view @isamercan/themekit-mcp version`; the
+`get_migration_guide` tool summarizes what changed between any two. Running from
+the repo instead? `git pull && cd mcp && npm i && npm run build` tracks the very
+latest tools.
+
 ### Figma → SwiftUI
 
 The star tool, `design_to_code` (alias `figma_to_swiftui`), turns a Figma node into ThemeKit SwiftUI with

--- a/website/src/content/docs/ai/mcp.md
+++ b/website/src/content/docs/ai/mcp.md
@@ -33,9 +33,46 @@ Then just ask your agent:
 Works with **Claude Code, Cursor, Windsurf, GitHub Copilot**, and any tool that
 supports MCP.
 
+## Keeping it up to date
+
+The server is published to npm and **updated regularly** — browse the
+[changelog](https://github.com/isamercan/ThemeKit/blob/main/mcp/CHANGELOG.md) or
+the [npm page](https://www.npmjs.com/package/@isamercan/themekit-mcp) for the
+release history.
+
+`npx` caches packages, so an install that pins no version keeps running the
+release it first cached. Pin `@latest` so it fetches the newest each time the
+server starts:
+
+```sh
+claude mcp remove themekit
+claude mcp add themekit -- npx -y @isamercan/themekit-mcp@latest
+```
+
+Already set up without `@latest`? Clear the npx cache once, then it re-fetches on
+the next start:
+
+```sh
+rm -rf ~/.npm/_npx        # npx package cache
+```
+
+Check what you run against the latest published, and see what changed:
+
+```sh
+npm view @isamercan/themekit-mcp version   # latest on npm
+```
+
+The `get_migration_guide(from, to?)` tool also summarizes the diff (breaking
+first) between any two versions. Running from the repo instead? `git pull` in your
+clone and rebuild — this always tracks the very latest tools:
+
+```sh
+cd mcp && git pull && npm i && npm run build
+```
+
 ## What you get
 
-27 on-demand tools, in four groups.
+26 on-demand tools (plus a `figma_to_swiftui` backward-compat alias), in four groups.
 
 ### Read — context (kills hallucinated APIs)
 


### PR DESCRIPTION
## Why

Neither the README nor the docs site told users **how to pull new MCP releases** — and `npx` silently caches an unversioned package, so an editor can sit on a stale build with no signal that the server is actively maintained. This makes the "regularly updated" story visible and actionable.

## What changed (docs only)

- **README** — a *"Keeping the MCP current"* note after the AI-surfaces table: pin `@latest`, clear the npx cache (`rm -rf ~/.npm/_npx`), check the published version, or rebuild from the repo for the very latest tools.
- **Docs site** (`website/src/content/docs/ai/mcp.md`) — a new `## Keeping it up to date` section after Install, same guidance + links to the changelog and npm.
- **Tool count reconciled** — the docs said "27" (counting the `figma_to_swiftui` alias) while the README says 26. Both now read **"26 tools (+ figma_to_swiftui alias)"**.

Astro build passes locally (16 pages, `ai/mcp` renders the new section).

## ⚠️ Blocker to resolve before this is fully true — needs your call

**npm `latest` is still `2.7.0`, but the repo is `2.11.0`.** Versions 2.8.0 → 2.11.0 (the round-trip tools: `export_figma_variables`, `import_figma_variables`, `suggest_figma_mapping`, `design_md_to_themeconfig`) are in the CHANGELOG but **never published or tagged** — publishing is manual (no CI), and the last `mcp-v*` tag is `mcp-v2.7.0`.

So today `npx @isamercan/themekit-mcp@latest` returns 2.7.0, **without** the tools this session added and documented. Until 2.11.0 is published, "update to get the round-trip tools" isn't real — the repo-build path is the only way to get them.

**Recommended:** hold this PR until `npm publish` (2.11.0) + `git tag mcp-v2.11.0` are done, then merge — so the docs and npm agree. I did **not** publish or tag autonomously (outward-facing / hard to reverse). Say the word and I'll prep both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)