### PR TITLE
feat: ThemeKitCalendar — token-bound date-range calendar (opt-in add-on, 0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to **ThemeKit** are documented here. The format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (pre-1.0: breaking changes
 bump the minor).
 
+## [0.6.0] - 2026-07-03
+
+### Added — `ThemeKitCalendar`: a token-bound date-range calendar (opt-in add-on)
+
+A new opt-in product wraps [Almanac](https://github.com/isamercan/Almanac) (a SwiftUI
+date-range calendar on HorizonCalendar) and drives its colours from ThemeKit tokens —
+so the calendar re-skins with the active preset and per-subtree `.theme(_:)` injection,
+like every other component.
+
+- **`DateRangePicker`** — a `View` wrapping Almanac's range picker with `.range` /
+  `.hotel` / `.rentACar` framing; reads `@Environment(\.theme)` and applies the
+  token-derived style automatically. Named to avoid `Foundation.Calendar` and echo
+  SwiftUI's `DatePicker`.
+- **The bridge** — `CalendarTheme(themeKit:)` / `CalendarStyle.themeKit(_:)` map Almanac's
+  ten semantic colour slots to ThemeKit tokens (`ink→text(.textPrimary)`,
+  `surface→background(.bgElevatorPrimary)`, `inBetweenFill→palette(.primary100)`, …).
+  `.themeKitCalendarStyle(_:)` applies it to any Almanac calendar view.
+- **Zero-dep core preserved** — Almanac is a **conditional, iOS-only** dependency of the
+  `ThemeKitCalendar` target (`.when(platforms: [.iOS])`); the sources are `#if os(iOS)`
+  guarded, so the core stays dependency-free and the package still builds on macOS.
+- Adds `Tests/ThemeKitCalendarTests` (iOS lane); `@_exported import Almanac` so one
+  `import ThemeKitCalendar` is enough.
+
 ## [0.5.0] - 2026-07-02
 
 The modifier refactor (R1–R7) completes: a full-library sweep converts the **58

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "42e1283b1d55be412b38c3790834d06efcc15a45bd19add062075759c4dd770a",
+  "originHash" : "7961d541b0587fac3a0e7606c34a824a094502821282a5a28c2fc43601735488",
   "pins" : [
+    {
+      "identity" : "almanac",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/isamercan/Almanac.git",
+      "state" : {
+        "revision" : "4ba4c199771718d71218940498f3b8fd25805602",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "horizoncalendar",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airbnb/HorizonCalendar.git",
+      "state" : {
+        "revision" : "a360d71a1255f0b24e378f2ee31a7a7d674a49b6",
+        "version" : "2.0.0"
+      }
+    },
     {
       "identity" : "lottie-ios",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -25,10 +25,21 @@ let package = Package(
             name: "ThemeKitLottie",
             targets: ["ThemeKitLottie"]
         ),
+        // Optional add-on — a token-bound date-range calendar, built on Almanac
+        // (→ HorizonCalendar, iOS-only). Import ONLY if you need it; the core stays
+        // dependency-free and cross-platform.
+        .library(
+            name: "ThemeKitCalendar",
+            targets: ["ThemeKitCalendar"]
+        ),
     ],
     dependencies: [
         // Used solely by the ThemeKitLottie add-on target.
         .package(url: "https://github.com/airbnb/lottie-ios.git", from: "4.4.0"),
+        // Used solely by the ThemeKitCalendar add-on target (iOS-only; pulls
+        // HorizonCalendar transitively). A conditional dependency keeps it off
+        // macOS builds, so the core package still builds everywhere.
+        .package(url: "https://github.com/isamercan/Almanac.git", from: "0.2.0"),
         // TEST-ONLY: visual regression (snapshot) testing. Never linked into the
         // shipped library — only the test target depends on it, so consumers
         // still get a zero-dependency core.
@@ -62,12 +73,29 @@ let package = Package(
                 .product(name: "Lottie", package: "lottie-ios"),
             ]
         ),
+        // Calendar add-on: core + Almanac. The Almanac product is linked ONLY on
+        // iOS (it's UIKit/HorizonCalendar-based); the sources are `#if os(iOS)`
+        // guarded so the target compiles to an empty module elsewhere.
+        .target(
+            name: "ThemeKitCalendar",
+            dependencies: [
+                "ThemeKit",
+                .product(name: "Almanac", package: "Almanac", condition: .when(platforms: [.iOS])),
+            ]
+        ),
         .testTarget(
             name: "ThemeKitTests",
             dependencies: [
                 "ThemeKit",
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ]
+        ),
+        // iOS-only: the sources are `#if os(iOS)` guarded, so on macOS this builds
+        // (and passes) as an empty test target — the calendar bridge is exercised
+        // on the iOS lane.
+        .testTarget(
+            name: "ThemeKitCalendarTests",
+            dependencies: ["ThemeKitCalendar", "ThemeKit"]
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ import ThemeKit
 - **Accessibility** — Dynamic Type and Reduce Motion honored throughout.
 - **Localization** — English-default strings via a bundled String Catalog (with
   Turkish), every default still overridable.
-- **Zero-dependency core** — Lottie is an opt-in, separate product.
+- 📅 **Calendar add-on** — `ThemeKitCalendar` adds a token-bound date-range picker
+  (`DateRangePicker`, built on [Almanac](https://github.com/isamercan/Almanac)) that
+  re-skins with the active theme; opt-in, iOS-only.
+- **Zero-dependency core** — Lottie and the Calendar are opt-in, separate products.
 - **DocC catalog**, a demo app, and a test suite.
 
 ## Requirements
@@ -66,7 +69,7 @@ import ThemeKit
 |---|---|
 | Platforms | iOS 17+ · macOS 14+ |
 | Swift tools | 6.2 |
-| Dependencies | none (core) · `lottie-ios` 4.4.0+ (only the Lottie add-on) |
+| Dependencies | none (core) · `lottie-ios` 4.4.0+ (Lottie add-on) · `Almanac` 0.2.0+ (Calendar add-on, iOS-only) |
 
 ## Installation
 
@@ -95,6 +98,7 @@ targets: [
 |---|---|---|
 | `ThemeKit` | none | the full design system (core) |
 | `ThemeKitLottie` | `lottie-ios` | adds Lottie (After Effects / JSON) animation views; pulls Lottie **only** if imported |
+| `ThemeKitCalendar` | `Almanac` (→ `HorizonCalendar`, iOS-only) | a token-bound date-range calendar (`DateRangePicker`) that re-skins with the active theme; pulls Almanac **only** if imported |
 
 ## Quick start
 

--- a/Sources/ThemeKitCalendar/CalendarTheme+ThemeKit.swift
+++ b/Sources/ThemeKitCalendar/CalendarTheme+ThemeKit.swift
@@ -1,0 +1,57 @@
+//
+//  CalendarTheme+ThemeKit.swift
+//  ThemeKitCalendar
+//
+//  Bridges Almanac's `CalendarTheme` / `CalendarStyle` to ThemeKit design tokens,
+//  so a calendar re-skins with the active `Theme` — including theme presets and
+//  per-subtree `.theme(_:)` injection — instead of carrying its own palette.
+//
+#if os(iOS)
+import SwiftUI
+import ThemeKit
+import Almanac
+
+public extension CalendarTheme {
+    /// A calendar color theme derived from a ThemeKit ``Theme``.
+    ///
+    /// Each of Almanac's ten semantic slots maps to a ThemeKit token, so the
+    /// calendar inherits the active brand + light/dark automatically:
+    ///
+    /// | Calendar slot | ThemeKit token |
+    /// |---|---|
+    /// | `ink` (text + selected fill) | `text(.textPrimary)` |
+    /// | `onInk` (on the selected fill) | `text(.textSecondaryInverse)` |
+    /// | `surface` (page / cell bg) | `background(.bgElevatorPrimary)` |
+    /// | `line` (borders / disabled) | `border(.borderPrimary)` |
+    /// | `weekendText` | `text(.textTertiary)` |
+    /// | `todayRing` | `foreground(.fgHero)` |
+    /// | `inBetweenFill` (in-range) | `palette(.primary100)` |
+    /// | `holidayDot` | `foreground(.systemcolorsFgError)` |
+    /// | `disabledButtonContainer` | `background(.bgSecondary)` |
+    /// | `disabledButtonContent` | `text(.textDisabled)` |
+    init(themeKit theme: Theme) {
+        self.init(
+            ink: theme.text(.textPrimary),
+            onInk: theme.text(.textSecondaryInverse),
+            surface: theme.background(.bgElevatorPrimary),
+            line: theme.border(.borderPrimary),
+            weekendText: theme.text(.textTertiary),
+            todayRing: theme.foreground(.fgHero),
+            inBetweenFill: theme.palette(.primary100),
+            holidayDot: theme.foreground(.systemcolorsFgError),
+            disabledButtonContainer: theme.background(.bgSecondary),
+            disabledButtonContent: theme.text(.textDisabled)
+        )
+    }
+}
+
+public extension CalendarStyle {
+    /// `CalendarStyle.standard` with its colors replaced by ThemeKit tokens.
+    /// Typography and metrics keep Almanac's tuned defaults.
+    static func themeKit(_ theme: Theme) -> CalendarStyle {
+        var style = CalendarStyle.standard
+        style.theme = CalendarTheme(themeKit: theme)
+        return style
+    }
+}
+#endif

--- a/Sources/ThemeKitCalendar/DateRangePicker.swift
+++ b/Sources/ThemeKitCalendar/DateRangePicker.swift
@@ -1,0 +1,74 @@
+//
+//  DateRangePicker.swift
+//  ThemeKitCalendar
+//
+//  A ThemeKit-themed date-range calendar. Wraps Almanac's `CalendarRangePickerView`
+//  and injects a `CalendarStyle` derived from the active ThemeKit `Theme`, so the
+//  calendar re-skins with the current preset / per-subtree theme with no manual
+//  colour wiring. Named `DateRangePicker` (not `Calendar`) to avoid colliding with
+//  `Foundation.Calendar` and to echo SwiftUI's `DatePicker`.
+//
+#if os(iOS)
+import SwiftUI
+import ThemeKit
+// Re-export so a single `import ThemeKitCalendar` also brings the Almanac types
+// callers need (CalendarPickerConfiguration, HolidayEntry, CalendarPickerResult…).
+@_exported import Almanac
+
+/// A token-bound date-range calendar.
+///
+/// ```swift
+/// DateRangePicker(.hotel, configuration: config) { result in
+///     print(result.goingDate, result.returnDate)
+/// }
+/// ```
+///
+/// The calendar's colours come from the active ``Theme`` (`@Environment(\.theme)`),
+/// so switching a preset or injecting `.theme(_:)` on a parent re-skins it too.
+public struct DateRangePicker: View {
+    /// The framing/titles of the picker — a plain range, or hotel / rent-a-car copy.
+    public enum Purpose: Sendable { case range, hotel, rentACar }
+
+    private let purpose: Purpose
+    private let configuration: CalendarPickerConfiguration
+    private let onApply: (CalendarPickerResult) -> Void
+    private let onCancel: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    public init(
+        _ purpose: Purpose = .range,
+        configuration: CalendarPickerConfiguration = .init(),
+        onApply: @escaping (CalendarPickerResult) -> Void,
+        onCancel: @escaping () -> Void = {}
+    ) {
+        self.purpose = purpose
+        self.configuration = configuration
+        self.onApply = onApply
+        self.onCancel = onCancel
+    }
+
+    public var body: some View {
+        picker.calendarStyle(.themeKit(theme))
+    }
+
+    @ViewBuilder private var picker: some View {
+        switch purpose {
+        case .range:
+            CalendarRangePickerView.rangeSelector(configuration: configuration, onApply: onApply, onCancel: onCancel)
+        case .hotel:
+            CalendarRangePickerView.hotel(configuration: configuration, onApply: onApply, onCancel: onCancel)
+        case .rentACar:
+            CalendarRangePickerView.rentACar(configuration: configuration, onApply: onApply, onCancel: onCancel)
+        }
+    }
+}
+
+public extension View {
+    /// Apply the ThemeKit-derived calendar style (from a specific `Theme`) to any
+    /// Almanac calendar view — the escape hatch when you compose Almanac directly.
+    func themeKitCalendarStyle(_ theme: Theme) -> some View {
+        calendarStyle(.themeKit(theme))
+    }
+}
+#endif

--- a/Tests/ThemeKitCalendarTests/CalendarThemeBridgeTests.swift
+++ b/Tests/ThemeKitCalendarTests/CalendarThemeBridgeTests.swift
@@ -1,0 +1,39 @@
+//
+//  CalendarThemeBridgeTests.swift
+//  ThemeKitCalendarTests
+//
+//  Verifies the ThemeKit → Almanac calendar bridge. iOS-only (Almanac is UIKit /
+//  HorizonCalendar based); on macOS this file is empty and the target passes.
+//
+#if os(iOS)
+import XCTest
+import SwiftUI
+import ThemeKit
+import Almanac
+@testable import ThemeKitCalendar
+
+final class CalendarThemeBridgeTests: XCTestCase {
+
+    func test_bridge_maps_themekit_tokens_to_calendar_slots() {
+        let theme = Theme.shared
+        let ct = CalendarTheme(themeKit: theme)
+
+        XCTAssertEqual(ct.ink, theme.text(.textPrimary))
+        XCTAssertEqual(ct.onInk, theme.text(.textSecondaryInverse))
+        XCTAssertEqual(ct.surface, theme.background(.bgElevatorPrimary))
+        XCTAssertEqual(ct.line, theme.border(.borderPrimary))
+        XCTAssertEqual(ct.weekendText, theme.text(.textTertiary))
+        XCTAssertEqual(ct.todayRing, theme.foreground(.fgHero))
+        XCTAssertEqual(ct.inBetweenFill, theme.palette(.primary100))
+        XCTAssertEqual(ct.holidayDot, theme.foreground(.systemcolorsFgError))
+    }
+
+    func test_style_themeKit_overrides_colors_and_keeps_almanac_defaults() {
+        let s = CalendarStyle.themeKit(Theme.shared)
+        XCTAssertEqual(s.theme, CalendarTheme(themeKit: Theme.shared))
+        // typography + metrics are untouched — still Almanac's tuned standard.
+        XCTAssertEqual(s.typography, CalendarStyle.standard.typography)
+        XCTAssertEqual(s.metrics, CalendarStyle.standard.metrics)
+    }
+}
+#endif


### PR DESCRIPTION
Brings your **[Almanac](https://github.com/isamercan/Almanac)** SwiftUI calendar into ThemeKit as an **opt-in product**, driven by design tokens so it re-skins with the active theme (presets + per-subtree `.theme(_:)`) like every other component.

## What's added

- **`DateRangePicker`** — a `View` wrapping Almanac's `CalendarRangePickerView` with `.range` / `.hotel` / `.rentACar` framing. Reads `@Environment(\.theme)` and auto-applies the token-derived `CalendarStyle`. Named to avoid `Foundation.Calendar` and echo SwiftUI's `DatePicker`.
- **The token bridge** — `CalendarTheme(themeKit:)` / `CalendarStyle.themeKit(_:)` map Almanac's 10 semantic colour slots to ThemeKit tokens (`ink→text(.textPrimary)`, `surface→background(.bgElevatorPrimary)`, `inBetweenFill→palette(.primary100)`, …). `.themeKitCalendarStyle(_:)` applies it to any Almanac calendar view. `@_exported import Almanac` so one import is enough.

```swift
import ThemeKitCalendar

DateRangePicker(.hotel, configuration: config) { result in
    print(result.goingDate, result.returnDate)   // re-skins with the active theme
}
```

## Apple-guideline design

- **SwiftPM:** a separate opt-in product; Almanac is a **conditional, iOS-only** dependency of the `ThemeKitCalendar` target (`.when(platforms: [.iOS])`) and the sources are `#if os(iOS)` guarded — so the **zero-dependency core is preserved** and the package still builds on macOS (empty module).
- **Swift API Design Guidelines:** clear naming (`DateRangePicker`, `themeKit:` label), no Foundation collision.
- **Swift 6:** `CalendarTheme` is `Sendable`, the view is `@MainActor`; builds under the package's `.v6` mode.
- **HIG:** Dynamic Type, dark mode, RTL, Reduce Motion inherited from Almanac; token theming layered on top.

## Verification

- **iOS build SUCCEEDED** (`ThemeKitCalendar` compiles against Almanac 0.2.0 / HorizonCalendar 2.0.0).
- **macOS** `swift build` complete (add-on compiles as an empty module).
- **`Tests/ThemeKitCalendarTests` 2/2 pass on iOS** (bridge maps tokens correctly; style overrides colours, keeps Almanac's typography/metrics).

Bumps `0.5.0 → 0.6.0`.

## Follow-up (not in this PR)

- **Demo gallery entry** — showing `DateRangePicker` live needs the Demo Xcode target to link the `ThemeKitCalendar` product (a `project.pbxproj` edit). Deferred to keep this PR to the package; the registry line is a one-liner once linked:
  `.static("DateRangePicker", .organisms, usage: "…") { DateRangePicker(.hotel, configuration: .init()) { _ in } }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)