### PR TITLE
feat: travel component suite — 14 token-bound components (0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to **ThemeKit** are documented here. The format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (pre-1.0: breaking changes
 bump the minor).
 
+## [0.7.0] - 2026-07-03
+
+### Added — travel component suite (14 components)
+
+Domain components for flight / hotel / car booking, all **token-bound** and
+**modifier-based** per the R1–R7 contract (init carries content/bindings; every
+appearance axis is a chainable modifier). Registered in the Demo gallery; strings
+default to English.
+
+**Atoms**
+- `PriceTag` — currency + struck-through original + per-unit suffix + auto discount badge.
+- `PointsBadge` — loyalty points/miles pill (earn / redeem / balance).
+- `CountdownTimer` — live HH:MM:SS boxes (`TimelineView`), `.urgent` palette, `onFinish`.
+
+**Molecules**
+- `GuestSelector` — rooms & guests (adults/children/infants) from `QuantityStepper`, with a `GuestSelection` summary.
+- `AmenityGrid` — icon+label amenities, token-tinted, configurable columns.
+- `PriceHistogram` — price-distribution bars over a `RangeSlider` (in-range = accent).
+- `InstallmentSelector` — instalment plans (per-month + total), interest-free tag (TR taksit).
+- `CurrencyPicker` — symbol/code/name rows with a ticked selection; ships `Currency.common`.
+
+**Organisms**
+- `FlightCard` — airline · times + airport codes · flight-path line (duration/stops) · price + Select.
+- `FareSummary` — itemised fare lines (item/discount/total); total is a hero `PriceTag`.
+- `ReviewCard` — single review: `Avatar` + author + date + `ScoreBadge` + text + photo strip.
+- `LoyaltyCard` — tier · member · points on a brand gradient + progress to the next tier.
+- `SeatMap` — cabin seat grid with aisles, occupied/premium states, multi-select + `maxSelection`.
+- `LocationCard` — MapKit map preview + pin + address/distance (lat/lon convenience init).
+
+All reuse existing atoms where natural (PriceTag, Badge, ScoreBadge, Avatar, RangeSlider,
+QuantityStepper). MapKit is a system framework, so `LocationCard` stays in the zero-dependency core.
+
 ## [0.6.0] - 2026-07-03
 
 ### Added — `ThemeKitCalendar`: a token-bound date-range calendar (opt-in add-on)

--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -81,6 +81,23 @@ enum ComponentRegistry {
         .static("ShareButton", .atoms, usage: #"ShareButton(item: url)   // wraps SwiftUI ShareLink"#) {
             ShareButton(item: "https://github.com/isamercan/ThemeKit")
         },
+        .static("PriceTag", .atoms, usage: #"PriceTag(1_299).original(1_899).unit("/ night").size(.large).emphasis(.hero).discountBadge()"#) {
+            VStack(alignment: .leading, spacing: 12) {
+                PriceTag(1_299).original(1_899).unit("/ night").size(.large).emphasis(.hero).discountBadge()
+                PriceTag(2_499, currencyCode: "EUR").emphasis(.hero)
+                PriceTag(1_299).size(.small)
+            }
+        },
+        .static("PointsBadge", .atoms, usage: #"PointsBadge(1_250).unit("mil").style(.earn).size(.large)"#) {
+            VStack(alignment: .leading, spacing: 12) {
+                PointsBadge(1_250).unit("mil").style(.earn).size(.large)
+                PointsBadge(500).style(.redeem)
+                PointsBadge(8_430).style(.balance).icon("wallet.pass.fill")
+            }
+        },
+        .static("CountdownTimer", .atoms, usage: #"CountdownTimer(until: deadline).style(.urgent).size(.large)"#) {
+            CountdownTimer(until: .now.addingTimeInterval(9 * 60 + 58)).style(.urgent).size(.large)
+        },
 
         // MARK: Molecules
         .static("ColorField", .molecules, usage: #"ColorField("Brand color", selection: $color)"#) {

--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -47,6 +47,17 @@ struct StatefulPreview<Value, Content: View>: View {
     var body: some View { content($value) }
 }
 
+/// Two-binding demo for the price histogram + range filter.
+private struct PriceHistogramDemo: View {
+    @State private var low = 800.0
+    @State private var high = 3_200.0
+    var body: some View {
+        PriceHistogram(bins: [2, 5, 9, 14, 18, 22, 19, 12, 8, 5, 3, 2],
+                       lowerValue: $low, upperValue: $high, in: 0...5_000)
+            .frame(maxWidth: 340)
+    }
+}
+
 enum ComponentRegistry {
     static let all: [ComponentEntry] = [
         // MARK: Atoms
@@ -170,6 +181,19 @@ enum ComponentRegistry {
                 ThemeKit.Amenity("Gym", systemImage: "dumbbell"),
                 ThemeKit.Amenity("Pet friendly", systemImage: "pawprint"),
             ]).columns(2).frame(maxWidth: 340)
+        },
+        .static("PriceHistogram", .molecules, usage: #"PriceHistogram(bins: counts, lowerValue: $low, upperValue: $high, in: 0...5_000)"#) {
+            PriceHistogramDemo()
+        },
+        .static("InstallmentSelector", .molecules, usage: #"InstallmentSelector(total: 12_000, options: [1, 3, 6, 12], selection: $months).interestFreeUpTo(3)"#) {
+            StatefulPreview(3) { months in
+                InstallmentSelector(total: 12_000, options: [1, 3, 6, 12], selection: months).interestFreeUpTo(3).frame(maxWidth: 340)
+            }
+        },
+        .static("CurrencyPicker", .molecules, usage: #"CurrencyPicker(selection: $code, currencies: Currency.common)"#) {
+            StatefulPreview("TRY") { code in
+                CurrencyPicker(selection: code, currencies: ThemeKit.Currency.common).frame(maxWidth: 340)
+            }
         },
 
         // MARK: Organisms

--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -225,6 +225,21 @@ enum ComponentRegistry {
         .static("KeyValueTable", .organisms, usage: #"KeyValueTable(rows: [...]).title("Summary").bordered()"#) {
             KeyValueTable(rows: [.init("Status", value: "Active", style: .success), .init("Old price", value: "$5,000", style: .strikethrough), .init("Total", value: "$4,250")]).title("Reservation summary").bordered()
         },
+        .static("FlightCard", .organisms, usage: #"FlightCard(airline: "Anadolu Air", from: "IST", to: "ESB", departure: dep, arrival: arr).price(1_299).badge("Cheapest") { }"#) {
+            VStack(spacing: 12) {
+                FlightCard(airline: "Anadolu Air", from: "IST", to: "ESB", departure: .now, arrival: .now.addingTimeInterval(2 * 3_600 + 20 * 60)).price(1_299).badge("Cheapest").onSelect { }
+                FlightCard(airline: "Blue Wings", from: "IST", to: "AMS", departure: .now, arrival: .now.addingTimeInterval(4 * 3_600)).stops(1).price(3_499)
+            }.frame(maxWidth: 360)
+        },
+        .static("FareSummary", .organisms, usage: #"FareSummary([.item("Base fare", 1_100), .discount("Member", 100), .total("Total", 1_199)])"#) {
+            FareSummary([.item("Base fare", 1_100), .item("Taxes & fees", 199), .discount("Member discount", 100), .total("Total", 1_199)]).frame(maxWidth: 360)
+        },
+        .static("ReviewCard", .organisms, usage: #"ReviewCard(author: "Elif K.", score: 9.2, text: "…").date(d).verified()"#) {
+            ReviewCard(author: "Elif Kaya", score: 9.2, text: "Spotless rooms and a great location right by the marina. Breakfast was excellent.").date(.now).title("Would absolutely stay again").verified().frame(maxWidth: 360)
+        },
+        .static("LoyaltyCard", .organisms, usage: #"LoyaltyCard(tier: "Gold", points: 8_430).memberName("Elif K.").progress(0.62, toNextTier: "Platinum")"#) {
+            LoyaltyCard(tier: "Gold", points: 8_430).memberName("Elif Kaya").progress(0.62, toNextTier: "Platinum").frame(maxWidth: 360)
+        },
         .knob("Theme Injection", .organisms, demo: ThemeInjectionDemo(), usage: #"let ocean = Theme(); ocean.loadTheme(named: "oceanTheme")\nmySubtree.theme(ocean)   // re-skins just this subtree"#),
     ]
 

--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -35,6 +35,18 @@ struct ComponentEntry: Identifiable {
     }
 }
 
+/// Gives a `.static` gallery preview its own mutable `@State` so interactive
+/// components (steppers, toggles) work without a bespoke Demo view.
+struct StatefulPreview<Value, Content: View>: View {
+    @State private var value: Value
+    private let content: (Binding<Value>) -> Content
+    init(_ initial: Value, @ViewBuilder content: @escaping (Binding<Value>) -> Content) {
+        _value = State(initialValue: initial)
+        self.content = content
+    }
+    var body: some View { content($value) }
+}
+
 enum ComponentRegistry {
     static let all: [ComponentEntry] = [
         // MARK: Atoms
@@ -141,6 +153,24 @@ enum ComponentRegistry {
         .knob("ThemeToggle", .molecules, demo: ToggleDemo(), usage: #"ThemeToggle(isOn: $on).symbols(on: "checkmark")"#),
         .knob("ToggleGroup", .molecules, demo: ToggleGroupDemo(), usage: #"ToggleGroup(options: items, selection: $set, label: { $0 })"#),
         .knob("Tooltip", .molecules, demo: TooltipDemo(), usage: #"anchorView.tooltip("Hint", isPresented: $shown, edge: .top)"#),
+        .static("GuestSelector", .molecules, usage: #"GuestSelector(selection: $guests).showsRooms(false)"#) {
+            StatefulPreview(GuestSelection(rooms: 1, adults: 2, children: 1)) { guests in
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(guests.wrappedValue.summary).textStyle(.bodyBase400)
+                    GuestSelector(selection: guests)
+                }.frame(maxWidth: 340)
+            }
+        },
+        .static("AmenityGrid", .molecules, usage: #"AmenityGrid([Amenity("Free Wi-Fi", systemImage: "wifi"), …]).columns(2)"#) {
+            AmenityGrid([
+                ThemeKit.Amenity("Free Wi-Fi", systemImage: "wifi"),
+                ThemeKit.Amenity("Pool", systemImage: "figure.pool.swim"),
+                ThemeKit.Amenity("Breakfast", systemImage: "fork.knife"),
+                ThemeKit.Amenity("Parking", systemImage: "parkingsign"),
+                ThemeKit.Amenity("Gym", systemImage: "dumbbell"),
+                ThemeKit.Amenity("Pet friendly", systemImage: "pawprint"),
+            ]).columns(2).frame(maxWidth: 340)
+        },
 
         // MARK: Organisms
         .knob("Accordion", .organisms, demo: AccordionDemo(), usage: #"Accordion("Title", initiallyExpanded: false) { Text("Body") }"#),

--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -47,6 +47,19 @@ struct StatefulPreview<Value, Content: View>: View {
     var body: some View { content($value) }
 }
 
+/// Seat-map demo with a live multi-select set.
+private struct SeatMapDemo: View {
+    @State private var picked: Set<String> = ["12C"]
+    private var rows: [[SeatSlot]] {
+        (10...14).map { r in
+            [.seat(Seat("\(r)A", premium: r == 10)), .seat(Seat("\(r)B")), .seat(Seat("\(r)C", occupied: r == 12)),
+             .aisle,
+             .seat(Seat("\(r)D")), .seat(Seat("\(r)E", occupied: r == 13)), .seat(Seat("\(r)F"))]
+        }
+    }
+    var body: some View { SeatMap(rows: rows, selection: $picked).maxSelection(3) }
+}
+
 /// Two-binding demo for the price histogram + range filter.
 private struct PriceHistogramDemo: View {
     @State private var low = 800.0
@@ -263,6 +276,12 @@ enum ComponentRegistry {
         },
         .static("LoyaltyCard", .organisms, usage: #"LoyaltyCard(tier: "Gold", points: 8_430).memberName("Elif K.").progress(0.62, toNextTier: "Platinum")"#) {
             LoyaltyCard(tier: "Gold", points: 8_430).memberName("Elif Kaya").progress(0.62, toNextTier: "Platinum").frame(maxWidth: 360)
+        },
+        .static("SeatMap", .organisms, usage: #"SeatMap(rows: layout, selection: $picked).maxSelection(2)"#) {
+            SeatMapDemo()
+        },
+        .static("LocationCard", .organisms, usage: #"LocationCard(title: "Marina Bay Hotel", latitude: 38.42, longitude: 27.14).subtitle("…").distance("1.2 km")"#) {
+            LocationCard(title: "Marina Bay Hotel", latitude: 38.4237, longitude: 27.1428).subtitle("Kordon Cd. No:12, İzmir").distance("1.2 km to center").frame(maxWidth: 340)
         },
         .knob("Theme Injection", .organisms, demo: ThemeInjectionDemo(), usage: #"let ocean = Theme(); ocean.loadTheme(named: "oceanTheme")\nmySubtree.theme(ocean)   // re-skins just this subtree"#),
     ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ThemeKit
 
-> **Native, brand-neutral SwiftUI design system** — 119 token-bound components that
+> **Native, brand-neutral SwiftUI design system** — 133 token-bound components that
 > re-skin from a single accent color: light/dark, per-subtree, zero core dependencies.
 
 [![CI](https://github.com/isamercan/ThemeKit/actions/workflows/ci.yml/badge.svg)](https://github.com/isamercan/ThemeKit/actions/workflows/ci.yml)
@@ -13,7 +13,7 @@
 **[Docs](https://isamercan.github.io/ThemeKit/) · [API (DocC)](https://isamercan.github.io/ThemeKit/api/documentation/themekit) · [Wiki](https://github.com/isamercan/ThemeKit/wiki) · [npm (MCP)](https://www.npmjs.com/package/@isamercan/themekit-mcp) · [Releases](https://github.com/isamercan/ThemeKit/releases) · [Issues](https://github.com/isamercan/ThemeKit/issues) · [Changelog](CHANGELOG.md)**
 
 <p align="center">
-  <img src="Screenshots/Banner.png" alt="ThemeKit — native SwiftUI design system: 119 components, fully tokenized, per-subtree theming, Swift 6, Liquid Glass, light + dark" width="820">
+  <img src="Screenshots/Banner.png" alt="ThemeKit — native SwiftUI design system: 133 components, fully tokenized, per-subtree theming, Swift 6, Liquid Glass, light + dark" width="820">
 </p>
 
 > The banner above is rendered **by ThemeKit itself** (its own tokens + components) — the same render pipeline that paints every tile in the gallery.
@@ -49,7 +49,7 @@ import ThemeKit
   whole Ant-style palette on device.
 - 📸 **Snapshot + render testing** — every component renders to a theme-aware PNG via
   `ImageRenderer`; the suite guards tokens, themes, validation and renders.
-- **119 components** — Atoms / Molecules / Organisms, all token-bound.
+- **133 components** — Atoms / Molecules / Organisms, all token-bound.
 - **Runtime theming** — a Swift token generator + a live configurator turn any
   accent (or `base-100`) color into a full Ant-style palette on device (no Python,
   no baked files).
@@ -205,14 +205,14 @@ gallery, and a full booking flow built entirely from ThemeKit components.
 
 ## Components
 
-119 token-bound components, grouped by complexity:
+133 token-bound components, grouped by complexity:
 
-- **Atoms** (29) — `Badge`, `Chip`, `Avatar`, `Icon`, `Rating`, `Spinner`,
-  `StatusDot`, `Skeleton`, `ProgressBar`, `BorderBeam`, `RollingNumber`…
-- **Molecules** (46) — `TextInput`, `OTPInput`, `Select`, `Checkbox`,
-  `RadioGroup`, `Slider`, `RangeSlider`, `SearchBar`, `Tooltip`, `TimeField`, buttons…
-- **Organisms** (44) — `Card`, `Carousel`, `DataTable`, `Accordion`, `Steps`,
-  `Timeline`, `ResultView`, `Upload`, `Tour`, `NavigationBar`, `Sidebar`, `ThemePicker`…
+- **Atoms** (32) — `Badge`, `Chip`, `Avatar`, `Icon`, `Rating`, `Spinner`,
+  `StatusDot`, `ProgressBar`, `PriceTag`, `PointsBadge`, `CountdownTimer`…
+- **Molecules** (51) — `TextInput`, `OTPInput`, `Select`, `Checkbox`, `RangeSlider`,
+  `SearchBar`, `TimeField`, `GuestSelector`, `PriceHistogram`, `InstallmentSelector`, `CurrencyPicker`, buttons…
+- **Organisms** (50) — `Card`, `Carousel`, `DataTable`, `Accordion`, `Timeline`,
+  `NavigationBar`, `Sidebar`, `FlightCard`, `FareSummary`, `ReviewCard`, `LoyaltyCard`, `SeatMap`, `LocationCard`…
 
 Every component is curated by category in the [DocC catalog](#documentation).
 

--- a/Sources/ThemeKit/Components/Atoms/CountdownTimer.swift
+++ b/Sources/ThemeKit/Components/Atoms/CountdownTimer.swift
@@ -1,0 +1,156 @@
+//
+//  CountdownTimer.swift
+//  ThemeKit
+//
+//  A live countdown to a deadline — segmented HH:MM:SS boxes that tick every second
+//  via `TimelineView(.periodic)`. Token-bound; `.urgent` swaps to the error palette
+//  for "price held for 09:58" pressure. `onFinish` fires once when the deadline passes.
+//
+
+import SwiftUI
+
+public enum CountdownStyle {
+    /// Neutral surface boxes.
+    case standard
+    /// Error/red boxes — draws urgency (a held price, a flash sale).
+    case urgent
+
+    func foreground(_ theme: Theme) -> Color {
+        switch self {
+        case .standard: return theme.text(.textPrimary)
+        case .urgent: return theme.foreground(.systemcolorsFgError)
+        }
+    }
+    func background(_ theme: Theme) -> Color {
+        switch self {
+        case .standard: return theme.background(.bgSecondaryLight)
+        case .urgent: return theme.background(.systemcolorsBgErrorLight)
+        }
+    }
+}
+
+public enum CountdownSize {
+    case small, medium, large
+
+    var textStyle: TextStyle {
+        switch self {
+        case .small: return .labelSm700
+        case .medium: return .labelMd700
+        case .large: return .headingXs
+        }
+    }
+    var boxWidth: CGFloat {
+        switch self {
+        case .small: return 24
+        case .medium: return 32
+        case .large: return 40
+        }
+    }
+    var boxHeight: CGFloat {
+        switch self {
+        case .small: return 24
+        case .medium: return 32
+        case .large: return 44
+        }
+    }
+}
+
+/// A token-bound live countdown to `deadline`.
+///
+/// ```swift
+/// CountdownTimer(until: .now.addingTimeInterval(600))
+///     .style(.urgent).size(.large).showsDays(false) { /* expired */ }
+/// ```
+public struct CountdownTimer: View {
+    @Environment(\.theme) private var theme
+
+    private let deadline: Date
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var style: CountdownStyle = .standard
+    private var size: CountdownSize = .medium
+    private var showsDays: Bool = false
+    private var onFinish: (() -> Void)?
+
+    public init(until deadline: Date) {   // R1 — content
+        self.deadline = deadline
+    }
+
+    public var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            let remaining = max(0, deadline.timeIntervalSince(context.date))
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                let segs = segments(remaining)
+                ForEach(Array(segs.enumerated()), id: \.offset) { index, seg in
+                    if index > 0 { Text(":").textStyle(size.textStyle).foregroundStyle(style.foreground(theme)) }
+                    box(seg.value, label: seg.label)
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilityText(remaining))
+        }
+        .task(id: deadline) {
+            let secs = deadline.timeIntervalSinceNow
+            guard secs > 0 else { onFinish?(); return }
+            try? await Task.sleep(nanoseconds: UInt64(secs * 1_000_000_000))
+            onFinish?()
+        }
+    }
+
+    private func box(_ value: Int, label: String) -> some View {
+        VStack(spacing: 2) {
+            Text(String(format: "%02d", value))
+                .textStyle(size.textStyle)
+                .foregroundStyle(style.foreground(theme))
+                .frame(width: size.boxWidth, height: size.boxHeight)
+                .background(style.background(theme), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
+            if !label.isEmpty {
+                Text(label).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+            }
+        }
+    }
+
+    private func segments(_ remaining: TimeInterval) -> [(value: Int, label: String)] {
+        let total = Int(remaining)
+        let days = total / 86_400
+        let hours = (total % 86_400) / 3_600
+        let minutes = (total % 3_600) / 60
+        let seconds = total % 60
+        var out: [(Int, String)] = []
+        if showsDays { out.append((days, "days")) }
+        out.append((showsDays ? hours : hours + days * 24, "hrs"))
+        out.append((minutes, "min"))
+        out.append((seconds, "sec"))
+        return out
+    }
+
+    private func accessibilityText(_ remaining: TimeInterval) -> String {
+        remaining <= 0 ? "Time's up" : segments(remaining).map { "\($0.value) \($0.label)" }.joined(separator: " ")
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension CountdownTimer {
+    /// standard / urgent colour treatment.
+    func style(_ s: CountdownStyle) -> Self { copy { $0.style = s } }
+    /// Size tier: small / medium / large.
+    func size(_ s: CountdownSize) -> Self { copy { $0.size = s } }
+    /// Shows a leading days box (default false — HH rolls days into hours).
+    func showsDays(_ on: Bool) -> Self { copy { $0.showsDays = on } }
+    /// Called once when the deadline passes (also immediately if already past).
+    func onFinish(_ action: (() -> Void)?) -> Self { copy { $0.onFinish = action } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    VStack(spacing: 24) {
+        CountdownTimer(until: .now.addingTimeInterval(9 * 60 + 58)).style(.urgent).size(.large)
+        CountdownTimer(until: .now.addingTimeInterval(3 * 86_400 + 3_720)).showsDays(true)
+    }
+    .padding()
+}

--- a/Sources/ThemeKit/Components/Atoms/PointsBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/PointsBadge.swift
@@ -1,0 +1,129 @@
+//
+//  PointsBadge.swift
+//  ThemeKit
+//
+//  A loyalty points / miles pill (earn · redeem · balance). Token-bound: the colour
+//  comes from the theme, so it re-skins with the brand. Reused by LoyaltyCard.
+//
+
+import SwiftUI
+
+public enum PointsStyle {
+    /// Points you'll earn — success/green.
+    case earn
+    /// Points spent / redeemable — the brand accent.
+    case redeem
+    /// A neutral balance readout.
+    case balance
+
+    func foreground(_ theme: Theme) -> Color {
+        switch self {
+        case .earn: return theme.foreground(.systemcolorsFgSuccess)
+        case .redeem: return theme.foreground(.fgHero)
+        case .balance: return theme.text(.textPrimary)
+        }
+    }
+    func background(_ theme: Theme) -> Color {
+        switch self {
+        case .earn: return theme.background(.systemcolorsBgSuccessLight)
+        case .redeem: return theme.background(.bgHero)
+        case .balance: return theme.background(.bgSecondaryLight)
+        }
+    }
+}
+
+public enum PointsSize {
+    case small, medium, large
+
+    var height: CGFloat {
+        switch self {
+        case .small: return 20
+        case .medium: return 24
+        case .large: return 32
+        }
+    }
+    var textStyle: TextStyle {
+        switch self {
+        case .small: return .labelSm600
+        case .medium: return .labelBase600
+        case .large: return .labelMd600
+        }
+    }
+    var iconSize: CGFloat {
+        switch self {
+        case .small: return 12
+        case .medium: return 14
+        case .large: return 16
+        }
+    }
+}
+
+/// A token-bound loyalty-points pill.
+///
+/// ```swift
+/// PointsBadge(1_250).unit("mil").style(.earn).size(.large)   // "＋1.250 mil"
+/// ```
+public struct PointsBadge: View {
+    @Environment(\.theme) private var theme
+
+    private let points: Int
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var unit: String = "pts"
+    private var style: PointsStyle = .balance
+    private var size: PointsSize = .medium
+    private var systemImage: String = "star.circle.fill"
+    private var showsSign: Bool = true
+
+    public init(_ points: Int) {   // R1 — content
+        self.points = points
+    }
+
+    public var body: some View {
+        HStack(spacing: Theme.SpacingKey.xs.value) {
+            Image(systemName: systemImage).font(.system(size: size.iconSize))
+            Text(label).textStyle(size.textStyle)
+        }
+        .foregroundStyle(style.foreground(theme))
+        .padding(.horizontal, Theme.SpacingKey.sm.value)
+        .frame(height: size.height)
+        .background(style.background(theme), in: Capsule())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(label)
+    }
+
+    private var label: String {
+        let value = points.formatted(.number.grouping(.automatic))
+        let sign = (showsSign && style == .earn && points > 0) ? "＋" : ""
+        return "\(sign)\(value) \(unit)"
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension PointsBadge {
+    /// The points unit, e.g. `"pts"` / `"mil"`.
+    func unit(_ text: String) -> Self { copy { $0.unit = text } }
+    /// earn / redeem / balance colour treatment.
+    func style(_ s: PointsStyle) -> Self { copy { $0.style = s } }
+    /// Size tier: small / medium / large.
+    func size(_ s: PointsSize) -> Self { copy { $0.size = s } }
+    /// Leading SF Symbol (default `star.circle.fill`).
+    func icon(_ systemName: String) -> Self { copy { $0.systemImage = systemName } }
+    /// Shows a leading `＋` on earned points (default true).
+    func showsSign(_ on: Bool) -> Self { copy { $0.showsSign = on } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 12) {
+        PointsBadge(1_250).unit("mil").style(.earn).size(.large)
+        PointsBadge(500).style(.redeem)
+        PointsBadge(8_430).unit("pts").style(.balance).icon("wallet.pass.fill")
+    }
+    .padding()
+}

--- a/Sources/ThemeKit/Components/Atoms/PriceTag.swift
+++ b/Sources/ThemeKit/Components/Atoms/PriceTag.swift
@@ -1,0 +1,154 @@
+//
+//  PriceTag.swift
+//  ThemeKit
+//
+//  A formatted price — currency, optional struck-through original, per-unit suffix
+//  and an auto-computed discount badge. Token-bound; the emphasis colour comes from
+//  the theme so it re-skins with the brand. Reused by FlightCard / FareSummary / RoomCard.
+//
+
+import SwiftUI
+
+public enum PriceSize {
+    case small, medium, large, xlarge
+
+    var priceStyle: TextStyle {
+        switch self {
+        case .small: return .labelBase600
+        case .medium: return .heading3xs
+        case .large: return .headingXs
+        case .xlarge: return .headingSm
+        }
+    }
+    var originalStyle: TextStyle {
+        switch self {
+        case .small, .medium: return .bodySm400
+        case .large, .xlarge: return .bodyBase400
+        }
+    }
+    var unitStyle: TextStyle {
+        switch self {
+        case .small, .medium: return .bodySm400
+        case .large, .xlarge: return .bodyBase400
+        }
+    }
+}
+
+public enum PriceEmphasis {
+    /// Primary text colour — the default.
+    case standard
+    /// The brand accent — draws the eye to the headline price.
+    case hero
+    /// Success/green — a saving or a "free".
+    case success
+    /// Muted/secondary — a struck or secondary price.
+    case muted
+
+    func color(_ theme: Theme) -> Color {
+        switch self {
+        case .standard: return theme.text(.textPrimary)
+        case .hero: return theme.foreground(.fgHero)
+        case .success: return theme.foreground(.systemcolorsFgSuccess)
+        case .muted: return theme.text(.textTertiary)
+        }
+    }
+}
+
+/// A token-bound price label.
+///
+/// ```swift
+/// PriceTag(1_299, currencyCode: "TRY")
+///     .original(1_899).unit("/ night").size(.large).emphasis(.hero).discountBadge()
+/// ```
+public struct PriceTag: View {
+    @Environment(\.theme) private var theme
+
+    private let amount: Decimal
+    private let currencyCode: String
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var original: Decimal?
+    private var unit: String?
+    private var size: PriceSize = .medium
+    private var emphasis: PriceEmphasis = .standard
+    private var showsDiscountBadge: Bool = false
+    private var fractionDigits: Int = 0
+
+    public init(_ amount: Decimal, currencyCode: String = "TRY") {   // R1 — content
+        self.amount = amount
+        self.currencyCode = currencyCode
+    }
+
+    public var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.xs.value) {
+            if let original, original > amount {
+                Text(formatted(original))
+                    .textStyle(size.originalStyle)
+                    .strikethrough()
+                    .foregroundStyle(theme.text(.textTertiary))
+            }
+            Text(formatted(amount))
+                .textStyle(size.priceStyle)
+                .foregroundStyle(emphasis.color(theme))
+            if let unit {
+                Text(unit)
+                    .textStyle(size.unitStyle)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+            if showsDiscountBadge, let percent = discountPercent {
+                Badge("-\(percent)%").badgeStyle(.error).size(.small)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityText)
+    }
+
+    private func formatted(_ value: Decimal) -> String {
+        value.formatted(.currency(code: currencyCode).precision(.fractionLength(fractionDigits)))
+    }
+
+    private var discountPercent: Int? {
+        guard let original, original > 0, original > amount else { return nil }
+        let ratio = (original - amount) / original
+        return Int((ratio as NSDecimalNumber).doubleValue * 100 + 0.5)
+    }
+
+    private var accessibilityText: String {
+        var parts = [formatted(amount)]
+        if let unit { parts.append(unit) }
+        if let percent = discountPercent { parts.append("\(percent)% off") }
+        return parts.joined(separator: " ")
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension PriceTag {
+    /// A struck-through original price shown before the current one (enables the discount badge maths).
+    func original(_ amount: Decimal?) -> Self { copy { $0.original = amount } }
+    /// A per-unit suffix, e.g. `"/ night"` or `"/ kişi"`.
+    func unit(_ text: String?) -> Self { copy { $0.unit = text } }
+    /// Size tier: small / medium / large / xlarge.
+    func size(_ s: PriceSize) -> Self { copy { $0.size = s } }
+    /// Colour emphasis of the headline price.
+    func emphasis(_ e: PriceEmphasis) -> Self { copy { $0.emphasis = e } }
+    /// Shows a `-%NN` badge computed from the original vs current price.
+    func discountBadge(_ show: Bool = true) -> Self { copy { $0.showsDiscountBadge = show } }
+    /// Decimal places to render (default 0 — travel prices are usually whole).
+    func fractionDigits(_ n: Int) -> Self { copy { $0.fractionDigits = max(0, n) } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 16) {
+        PriceTag(1_299).size(.small)
+        PriceTag(1_299).original(1_899).unit("/ night").emphasis(.hero).discountBadge()
+        PriceTag(2_499, currencyCode: "EUR").size(.large).emphasis(.hero)
+        PriceTag(0).emphasis(.success)
+    }
+    .padding()
+}

--- a/Sources/ThemeKit/Components/Molecules/AmenityGrid.swift
+++ b/Sources/ThemeKit/Components/Molecules/AmenityGrid.swift
@@ -1,0 +1,116 @@
+//
+//  AmenityGrid.swift
+//  ThemeKit
+//
+//  A grid of icon + label amenities (wifi · pool · breakfast). Token-bound: the icon
+//  tint comes from the theme's accent, so it re-skins with the brand.
+//
+
+import SwiftUI
+
+/// One amenity — an SF Symbol and a label.
+public struct Amenity: Identifiable, Sendable, Hashable {
+    public let id: String
+    public let systemImage: String
+    public let label: String
+
+    public init(_ label: String, systemImage: String) {
+        self.id = label
+        self.label = label
+        self.systemImage = systemImage
+    }
+}
+
+public enum AmenitySize {
+    case small, medium, large
+
+    var iconSize: CGFloat {
+        switch self {
+        case .small: return 16
+        case .medium: return 20
+        case .large: return 24
+        }
+    }
+    var textStyle: TextStyle {
+        switch self {
+        case .small: return .bodySm400
+        case .medium: return .bodyBase400
+        case .large: return .bodyBase500
+        }
+    }
+}
+
+/// A token-bound amenity grid.
+///
+/// ```swift
+/// AmenityGrid([Amenity("Free Wi-Fi", systemImage: "wifi"),
+///              Amenity("Pool", systemImage: "figure.pool.swim")])
+///     .columns(2)
+/// ```
+public struct AmenityGrid: View {
+    @Environment(\.theme) private var theme
+
+    private let amenities: [Amenity]
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var columns: Int = 2
+    private var size: AmenitySize = .medium
+    private var tint: Color?
+
+    public init(_ amenities: [Amenity]) {   // R1 — content
+        self.amenities = amenities
+    }
+
+    public var body: some View {
+        LazyVGrid(columns: gridColumns, alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+            ForEach(amenities) { amenity in
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    Image(systemName: amenity.systemImage)
+                        .font(.system(size: size.iconSize))
+                        .foregroundStyle(tint ?? theme.foreground(.fgHero))
+                        .frame(width: size.iconSize + 4)
+                    Text(amenity.label)
+                        .textStyle(size.textStyle)
+                        .foregroundStyle(theme.text(.textPrimary))
+                        .lineLimit(2)
+                    Spacer(minLength: 0)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(amenity.label)
+            }
+        }
+    }
+
+    private var gridColumns: [GridItem] {
+        Array(repeating: GridItem(.flexible(), alignment: .leading), count: max(1, columns))
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension AmenityGrid {
+    /// Number of columns (default 2).
+    func columns(_ count: Int) -> Self { copy { $0.columns = max(1, count) } }
+    /// Size tier: small / medium / large.
+    func size(_ s: AmenitySize) -> Self { copy { $0.size = s } }
+    /// Overrides the icon tint (otherwise the theme accent).
+    func tint(_ color: Color?) -> Self { copy { $0.tint = color } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    AmenityGrid([
+        Amenity("Free Wi-Fi", systemImage: "wifi"),
+        Amenity("Pool", systemImage: "figure.pool.swim"),
+        Amenity("Breakfast", systemImage: "fork.knife"),
+        Amenity("Parking", systemImage: "parkingsign"),
+        Amenity("Gym", systemImage: "dumbbell"),
+        Amenity("Pet friendly", systemImage: "pawprint"),
+    ])
+    .columns(2)
+    .padding()
+}

--- a/Sources/ThemeKit/Components/Molecules/CurrencyPicker.swift
+++ b/Sources/ThemeKit/Components/Molecules/CurrencyPicker.swift
@@ -1,0 +1,109 @@
+//
+//  CurrencyPicker.swift
+//  ThemeKit
+//
+//  A currency chooser — symbol badge, ISO code and name, with the selected row ticked.
+//  Token-bound. Ships a `Currency.common` list; pass your own for more.
+//
+
+import SwiftUI
+
+/// One currency option.
+public struct Currency: Identifiable, Sendable, Hashable {
+    public var id: String { code }
+    public let code: String
+    public let symbol: String
+    public let name: String
+
+    public init(code: String, symbol: String, name: String) {
+        self.code = code
+        self.symbol = symbol
+        self.name = name
+    }
+
+    /// A small ready-made set for quick use.
+    public static let common: [Currency] = [
+        Currency(code: "TRY", symbol: "₺", name: "Turkish Lira"),
+        Currency(code: "USD", symbol: "$", name: "US Dollar"),
+        Currency(code: "EUR", symbol: "€", name: "Euro"),
+        Currency(code: "GBP", symbol: "£", name: "British Pound"),
+    ]
+}
+
+/// A token-bound currency picker.
+///
+/// ```swift
+/// CurrencyPicker(selection: $code, currencies: Currency.common)
+/// ```
+public struct CurrencyPicker: View {
+    @Environment(\.theme) private var theme
+
+    @Binding private var selection: String
+    private let currencies: [Currency]
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var showsName: Bool = true
+
+    public init(selection: Binding<String>, currencies: [Currency] = Currency.common) {
+        self._selection = selection
+        self.currencies = currencies
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(currencies.enumerated()), id: \.element.id) { index, currency in
+                if index > 0 { Divider().overlay(theme.border(.borderPrimary)) }
+                row(currency)
+            }
+        }
+    }
+
+    private func row(_ currency: Currency) -> some View {
+        let selected = selection == currency.code
+        return Button { selection = currency.code } label: {
+            HStack(spacing: Theme.SpacingKey.md.value) {
+                Text(currency.symbol)
+                    .textStyle(.labelMd700)
+                    .foregroundStyle(theme.foreground(.fgHero))
+                    .frame(width: 36, height: 36)
+                    .background(theme.background(.bgSecondaryLight), in: Circle())
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(currency.code).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+                    if showsName {
+                        Text(currency.name).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
+                    }
+                }
+                Spacer()
+                if selected {
+                    Image(systemName: "checkmark").font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(theme.foreground(.fgHero))
+                }
+            }
+            .padding(.vertical, Theme.SpacingKey.sm.value)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension CurrencyPicker {
+    /// Shows the full currency name under the code (default true).
+    func showsName(_ on: Bool) -> Self { copy { $0.showsName = on } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    struct Demo: View {
+        @State private var code = "TRY"
+        var body: some View {
+            CurrencyPicker(selection: $code).padding()
+        }
+    }
+    return Demo()
+}

--- a/Sources/ThemeKit/Components/Molecules/GuestSelector.swift
+++ b/Sources/ThemeKit/Components/Molecules/GuestSelector.swift
@@ -1,0 +1,138 @@
+//
+//  GuestSelector.swift
+//  ThemeKit
+//
+//  Rooms & guests picker (adults / children / infants) composed from QuantityStepper.
+//  Token-bound; a single `GuestSelection` binding carries the counts and a summary
+//  string for the trigger field. Default labels are English — override per modifier.
+//
+
+import SwiftUI
+
+/// The value a ``GuestSelector`` edits.
+public struct GuestSelection: Equatable, Sendable {
+    public var rooms: Int
+    public var adults: Int
+    public var children: Int
+    public var infants: Int
+
+    public init(rooms: Int = 1, adults: Int = 2, children: Int = 0, infants: Int = 0) {
+        self.rooms = rooms
+        self.adults = adults
+        self.children = children
+        self.infants = infants
+    }
+
+    /// A compact readout for a trigger field, e.g. `"1 room · 2 adults · 1 child"`.
+    public var summary: String {
+        func part(_ n: Int, _ singular: String, _ plural: String) -> String? {
+            n > 0 ? "\(n) \(n == 1 ? singular : plural)" : nil
+        }
+        return [
+            part(rooms, "room", "rooms"),
+            part(adults, "adult", "adults"),
+            part(children, "child", "children"),
+            part(infants, "infant", "infants"),
+        ].compactMap { $0 }.joined(separator: " · ")
+    }
+}
+
+private struct GuestRow: Identifiable {
+    let id = UUID()
+    let title: String
+    let subtitle: String?
+    let keyPath: WritableKeyPath<GuestSelection, Int>
+    let range: ClosedRange<Int>
+    let visible: Bool
+}
+
+/// A token-bound rooms & guests picker.
+///
+/// ```swift
+/// GuestSelector(selection: $guests).showsRooms(false)   // e.g. a flight passenger picker
+/// ```
+public struct GuestSelector: View {
+    @Environment(\.theme) private var theme
+    @Binding private var selection: GuestSelection
+
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var showsRooms: Bool = true
+    private var showsInfants: Bool = true
+    private var adultRange: ClosedRange<Int> = 1...16
+    private var childRange: ClosedRange<Int> = 0...10
+    private var infantRange: ClosedRange<Int> = 0...6
+    private var roomRange: ClosedRange<Int> = 1...8
+
+    public init(selection: Binding<GuestSelection>) {   // R1 — binding
+        self._selection = selection
+    }
+
+    private var rows: [GuestRow] {
+        [
+            GuestRow(title: "Rooms", subtitle: nil, keyPath: \.rooms, range: roomRange, visible: showsRooms),
+            GuestRow(title: "Adults", subtitle: "Age 13+", keyPath: \.adults, range: adultRange, visible: true),
+            GuestRow(title: "Children", subtitle: "Age 2–12", keyPath: \.children, range: childRange, visible: true),
+            GuestRow(title: "Infants", subtitle: "Under 2", keyPath: \.infants, range: infantRange, visible: showsInfants),
+        ].filter(\.visible)
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                if index > 0 { Divider().overlay(theme.border(.borderPrimary)) }
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(row.title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+                        if let subtitle = row.subtitle {
+                            Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
+                        }
+                    }
+                    Spacer()
+                    QuantityStepper(value: binding(for: row.keyPath), range: row.range)
+                }
+                .padding(.vertical, Theme.SpacingKey.sm.value)
+            }
+        }
+    }
+
+    private func binding(for keyPath: WritableKeyPath<GuestSelection, Int>) -> Binding<Int> {
+        Binding(get: { selection[keyPath: keyPath] }, set: { selection[keyPath: keyPath] = $0 })
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension GuestSelector {
+    /// Shows the Rooms row (default true — hide it for flight passenger pickers).
+    func showsRooms(_ on: Bool) -> Self { copy { $0.showsRooms = on } }
+    /// Shows the Infants row (default true).
+    func showsInfants(_ on: Bool) -> Self { copy { $0.showsInfants = on } }
+    /// Allowed adult count.
+    func adultRange(_ range: ClosedRange<Int>) -> Self { copy { $0.adultRange = range } }
+    /// Allowed children count.
+    func childRange(_ range: ClosedRange<Int>) -> Self { copy { $0.childRange = range } }
+    /// Allowed infant count.
+    func infantRange(_ range: ClosedRange<Int>) -> Self { copy { $0.infantRange = range } }
+    /// Allowed room count.
+    func roomRange(_ range: ClosedRange<Int>) -> Self { copy { $0.roomRange = range } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    struct Demo: View {
+        @State private var guests = GuestSelection(rooms: 1, adults: 2, children: 1)
+        var body: some View {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(guests.summary).textStyle(.bodyBase400)
+                GuestSelector(selection: $guests)
+            }
+            .padding()
+        }
+    }
+    return Demo()
+}

--- a/Sources/ThemeKit/Components/Molecules/InstallmentSelector.swift
+++ b/Sources/ThemeKit/Components/Molecules/InstallmentSelector.swift
@@ -1,0 +1,103 @@
+//
+//  InstallmentSelector.swift
+//  ThemeKit
+//
+//  Pick an instalment plan for a total (single payment · 3 · 6 · 12…). Each option
+//  shows the per-month amount and an optional interest-free tag. Token-bound; the
+//  selected option is accent-outlined.
+//
+
+import SwiftUI
+
+/// A token-bound instalment plan picker.
+///
+/// ```swift
+/// InstallmentSelector(total: 12_000, options: [1, 3, 6, 12], selection: $months)
+///     .interestFreeUpTo(3)
+/// ```
+public struct InstallmentSelector: View {
+    @Environment(\.theme) private var theme
+
+    private let total: Decimal
+    private let options: [Int]
+    @Binding private var selection: Int
+    private let currencyCode: String
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var interestFreeUpTo: Int = 0
+
+    public init(total: Decimal, options: [Int], selection: Binding<Int>, currencyCode: String = "TRY") {
+        self.total = total
+        self.options = options
+        self._selection = selection
+        self.currencyCode = currencyCode
+    }
+
+    public var body: some View {
+        VStack(spacing: Theme.SpacingKey.sm.value) {
+            ForEach(options, id: \.self) { count in
+                row(count)
+            }
+        }
+    }
+
+    private func row(_ count: Int) -> some View {
+        let selected = selection == count
+        return Button { selection = count } label: {
+            HStack(spacing: Theme.SpacingKey.md.value) {
+                Image(systemName: selected ? "largecircle.fill.circle" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(selected ? theme.foreground(.fgHero) : theme.text(.textTertiary))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(count <= 1 ? "Single payment" : "\(count) installments")
+                        .textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+                    if count > 1, count <= interestFreeUpTo {
+                        Text("Interest-free").textStyle(.bodySm400).foregroundStyle(theme.foreground(.systemcolorsFgSuccess))
+                    }
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    if count > 1 {
+                        Text("\(formatted(total / Decimal(count)))/mo")
+                            .textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+                    }
+                    Text(formatted(total)).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
+                }
+            }
+            .padding(Theme.SpacingKey.md.value)
+            .background(selected ? theme.background(.bgHero) : theme.background(.bgElevatorPrimary),
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+                .stroke(selected ? theme.foreground(.fgHero) : theme.border(.borderPrimary), lineWidth: selected ? 1.5 : 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func formatted(_ value: Decimal) -> String {
+        value.formatted(.currency(code: currencyCode).precision(.fractionLength(0)))
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension InstallmentSelector {
+    /// Instalment counts up to (and including) this are tagged "Interest-free".
+    func interestFreeUpTo(_ count: Int) -> Self { copy { $0.interestFreeUpTo = count } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    struct Demo: View {
+        @State private var months = 3
+        var body: some View {
+            InstallmentSelector(total: 12_000, options: [1, 3, 6, 12], selection: $months)
+                .interestFreeUpTo(3)
+                .padding()
+        }
+    }
+    return Demo()
+}

--- a/Sources/ThemeKit/Components/Molecules/PriceHistogram.swift
+++ b/Sources/ThemeKit/Components/Molecules/PriceHistogram.swift
@@ -1,0 +1,91 @@
+//
+//  PriceHistogram.swift
+//  ThemeKit
+//
+//  A price-distribution histogram over a RangeSlider — bars in the selected range are
+//  the brand accent, the rest are muted (the Airbnb-style price filter). Token-bound.
+//
+
+import SwiftUI
+
+/// A token-bound price histogram + range filter.
+///
+/// ```swift
+/// PriceHistogram(bins: counts, lowerValue: $low, upperValue: $high, in: 0...5_000)
+/// ```
+public struct PriceHistogram: View {
+    @Environment(\.theme) private var theme
+
+    private let bins: [Int]
+    @Binding private var lowerValue: Double
+    @Binding private var upperValue: Double
+    private let bounds: ClosedRange<Double>
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var barHeight: CGFloat = 56
+    private var accent: Color?
+
+    public init(bins: [Int], lowerValue: Binding<Double>, upperValue: Binding<Double>, in bounds: ClosedRange<Double>) {
+        self.bins = bins
+        self._lowerValue = lowerValue
+        self._upperValue = upperValue
+        self.bounds = bounds
+    }
+
+    public var body: some View {
+        VStack(spacing: Theme.SpacingKey.xs.value) {
+            HStack(alignment: .bottom, spacing: 2) {
+                ForEach(Array(bins.enumerated()), id: \.offset) { index, count in
+                    Capsule()
+                        .fill(isSelected(index) ? selectedColor : theme.background(.bgSecondary))
+                        .frame(height: max(3, barHeight * heightRatio(count)))
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .frame(height: barHeight, alignment: .bottom)
+            RangeSlider(lowerValue: $lowerValue, upperValue: $upperValue, in: bounds)
+        }
+    }
+
+    private var selectedColor: Color { accent ?? theme.foreground(.fgHero) }
+
+    private func heightRatio(_ count: Int) -> CGFloat {
+        let maxCount = bins.max() ?? 0
+        guard maxCount > 0 else { return 0 }
+        return CGFloat(count) / CGFloat(maxCount)
+    }
+
+    private func isSelected(_ index: Int) -> Bool {
+        guard !bins.isEmpty else { return false }
+        let width = (bounds.upperBound - bounds.lowerBound) / Double(bins.count)
+        let center = bounds.lowerBound + (Double(index) + 0.5) * width
+        return center >= lowerValue && center <= upperValue
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension PriceHistogram {
+    /// Max bar height in points (default 56).
+    func barHeight(_ height: CGFloat) -> Self { copy { $0.barHeight = height } }
+    /// Overrides the selected-bar colour (otherwise the theme accent).
+    func accent(_ color: Color?) -> Self { copy { $0.accent = color } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    struct Demo: View {
+        @State private var low = 800.0
+        @State private var high = 3_200.0
+        let bins = [2, 5, 9, 14, 18, 22, 19, 12, 8, 5, 3, 2]
+        var body: some View {
+            PriceHistogram(bins: bins, lowerValue: $low, upperValue: $high, in: 0...5_000)
+                .padding()
+        }
+    }
+    return Demo()
+}

--- a/Sources/ThemeKit/Components/Organisms/FareSummary.swift
+++ b/Sources/ThemeKit/Components/Organisms/FareSummary.swift
@@ -1,0 +1,94 @@
+//
+//  FareSummary.swift
+//  ThemeKit
+//
+//  An itemised price breakdown — base fare, taxes/fees, discounts, and an emphasised
+//  total. Token-bound; discounts read green, the total is a hero PriceTag.
+//
+
+import SwiftUI
+
+/// One line of a ``FareSummary``.
+public struct FareLine: Identifiable, Sendable {
+    public enum Kind: Sendable { case item, discount, total }
+    public let id = UUID()
+    let label: String
+    let amount: Decimal
+    let kind: Kind
+
+    /// A regular charge (base fare, taxes, a service fee…).
+    public static func item(_ label: String, _ amount: Decimal) -> FareLine { .init(label: label, amount: amount, kind: .item) }
+    /// A saving — rendered green with a leading minus.
+    public static func discount(_ label: String, _ amount: Decimal) -> FareLine { .init(label: label, amount: amount, kind: .discount) }
+    /// The emphasised total — rendered as a hero `PriceTag` under a divider.
+    public static func total(_ label: String, _ amount: Decimal) -> FareLine { .init(label: label, amount: amount, kind: .total) }
+}
+
+/// A token-bound fare breakdown.
+///
+/// ```swift
+/// FareSummary([
+///     .item("Base fare", 1_100),
+///     .item("Taxes & fees", 199),
+///     .discount("Member discount", 100),
+///     .total("Total", 1_199),
+/// ])
+/// ```
+public struct FareSummary: View {
+    @Environment(\.theme) private var theme
+
+    private let lines: [FareLine]
+    private let currencyCode: String
+
+    public init(_ lines: [FareLine], currencyCode: String = "TRY") {   // R1 — content
+        self.lines = lines
+        self.currencyCode = currencyCode
+    }
+
+    public var body: some View {
+        VStack(spacing: Theme.SpacingKey.sm.value) {
+            ForEach(lines) { line in
+                switch line.kind {
+                case .item:     row(line.label, formatted(line.amount), labelColor: theme.text(.textSecondary), valueColor: theme.text(.textPrimary))
+                case .discount: row(line.label, "-\(formatted(line.amount))", labelColor: theme.foreground(.systemcolorsFgSuccess), valueColor: theme.foreground(.systemcolorsFgSuccess))
+                case .total:    totalRow(line)
+                }
+            }
+        }
+    }
+
+    private func row(_ label: String, _ value: String, labelColor: Color, valueColor: Color) -> some View {
+        HStack {
+            Text(label).textStyle(.bodyBase400).foregroundStyle(labelColor)
+            Spacer()
+            Text(value).textStyle(.bodyBase500).foregroundStyle(valueColor)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label) \(value)")
+    }
+
+    private func totalRow(_ line: FareLine) -> some View {
+        VStack(spacing: Theme.SpacingKey.sm.value) {
+            Divider().overlay(theme.border(.borderPrimary))
+            HStack {
+                Text(line.label).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+                Spacer()
+                PriceTag(line.amount, currencyCode: currencyCode).size(.large).emphasis(.hero)
+            }
+        }
+    }
+
+    private func formatted(_ value: Decimal) -> String {
+        value.formatted(.currency(code: currencyCode).precision(.fractionLength(0)))
+    }
+}
+
+#Preview {
+    FareSummary([
+        .item("Base fare", 1_100),
+        .item("Taxes & fees", 199),
+        .discount("Member discount", 100),
+        .total("Total", 1_199),
+    ])
+    .padding()
+}

--- a/Sources/ThemeKit/Components/Organisms/FlightCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightCard.swift
@@ -1,0 +1,158 @@
+//
+//  FlightCard.swift
+//  ThemeKit
+//
+//  A flight result / itinerary segment — airline, departure→arrival times + airport
+//  codes, a flight-path line with duration and a stops label, and an optional price +
+//  select action. Token-bound; the surface, accent and price all come from the theme.
+//
+
+import SwiftUI
+
+/// A token-bound flight segment card.
+///
+/// ```swift
+/// FlightCard(airline: "Anadolu Air", from: "IST", to: "ESB",
+///            departure: dep, arrival: arr)
+///     .stops(1).price(1_299).badge("Cheapest") { book() }
+/// ```
+public struct FlightCard: View {
+    @Environment(\.theme) private var theme
+
+    // Required content (R1).
+    private let airline: String
+    private let origin: String
+    private let destination: String
+    private let departure: Date
+    private let arrival: Date
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var stops: Int = 0
+    private var price: Decimal?
+    private var currencyCode: String = "TRY"
+    private var airlineSystemImage: String = "airplane.circle.fill"
+    private var badge: String?
+    private var onSelect: (() -> Void)?
+
+    public init(airline: String, from origin: String, to destination: String, departure: Date, arrival: Date) {
+        self.airline = airline
+        self.origin = origin
+        self.destination = destination
+        self.departure = departure
+        self.arrival = arrival
+    }
+
+    public var body: some View {
+        VStack(spacing: Theme.SpacingKey.md.value) {
+            header
+            route
+            if price != nil || onSelect != nil { footer }
+        }
+        .padding(Theme.SpacingKey.md.value)
+        .background(theme.background(.bgElevatorPrimary), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous).stroke(theme.border(.borderPrimary), lineWidth: 1))
+    }
+
+    private var header: some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            Image(systemName: airlineSystemImage)
+                .font(.system(size: 20))
+                .foregroundStyle(theme.foreground(.fgHero))
+            Text(airline).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+            Spacer()
+            if let badge { Badge(badge).badgeStyle(.success).size(.small) }
+        }
+    }
+
+    private var route: some View {
+        HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
+            timeColumn(departure, code: origin, alignment: .leading)
+            pathView
+            timeColumn(arrival, code: destination, alignment: .trailing)
+        }
+    }
+
+    private func timeColumn(_ date: Date, code: String, alignment: HorizontalAlignment) -> some View {
+        VStack(alignment: alignment, spacing: 2) {
+            Text(date.formatted(date: .omitted, time: .shortened))
+                .textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
+            Text(code)
+                .textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary))
+        }
+    }
+
+    private var pathView: some View {
+        VStack(spacing: 4) {
+            Text(durationText).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+            HStack(spacing: 4) {
+                Circle().fill(theme.text(.textTertiary)).frame(width: 5, height: 5)
+                line
+                Image(systemName: "airplane").font(.system(size: 12)).foregroundStyle(theme.foreground(.fgHero))
+                line
+                Circle().fill(theme.text(.textTertiary)).frame(width: 5, height: 5)
+            }
+            Text(stopsText)
+                .textStyle(.overline400)
+                .foregroundStyle(stops == 0 ? theme.foreground(.systemcolorsFgSuccess) : theme.text(.textTertiary))
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var line: some View {
+        Rectangle().fill(theme.border(.borderPrimary)).frame(height: 1)
+    }
+
+    private var footer: some View {
+        HStack {
+            if let price { PriceTag(price, currencyCode: currencyCode).size(.large).emphasis(.hero) }
+            Spacer()
+            if let onSelect { PrimaryButton("Select") { onSelect() }.size(.small) }
+        }
+    }
+
+    private var durationText: String {
+        let minutes = max(0, Int(arrival.timeIntervalSince(departure) / 60))
+        let h = minutes / 60, m = minutes % 60
+        return h > 0 ? "\(h)h \(m)m" : "\(m)m"
+    }
+
+    private var stopsText: String {
+        switch stops {
+        case 0: return "Nonstop"
+        case 1: return "1 stop"
+        default: return "\(stops) stops"
+        }
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension FlightCard {
+    /// Number of stops (0 = nonstop, shown in green).
+    func stops(_ count: Int) -> Self { copy { $0.stops = max(0, count) } }
+    /// The fare, rendered as a hero `PriceTag` in the footer.
+    func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// A leading airline SF Symbol (default `airplane.circle.fill`).
+    func airlineIcon(_ systemName: String) -> Self { copy { $0.airlineSystemImage = systemName } }
+    /// A success badge in the header, e.g. `"Cheapest"`.
+    func badge(_ text: String?) -> Self { copy { $0.badge = text } }
+    /// Adds a "Select" button to the footer.
+    func onSelect(_ action: (() -> Void)?) -> Self { copy { $0.onSelect = action } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    let dep = Date()
+    let arr = dep.addingTimeInterval(2 * 3_600 + 20 * 60)
+    return VStack(spacing: 16) {
+        FlightCard(airline: "Anadolu Air", from: "IST", to: "ESB", departure: dep, arrival: arr)
+            .price(1_299).badge("Cheapest").onSelect { }
+        FlightCard(airline: "Blue Wings", from: "IST", to: "AMS", departure: dep, arrival: dep.addingTimeInterval(4 * 3_600))
+            .stops(1).price(3_499)
+    }
+    .padding()
+}

--- a/Sources/ThemeKit/Components/Organisms/LocationCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/LocationCard.swift
@@ -1,0 +1,103 @@
+//
+//  LocationCard.swift
+//  ThemeKit
+//
+//  A map preview + location info card — a non-interactive MapKit snapshot with a pin,
+//  a title, an address and an optional distance. Token-bound (info + surface). MapKit
+//  is a system framework, so this stays in the dependency-free core.
+//
+
+import SwiftUI
+import MapKit
+
+/// A token-bound location preview card.
+///
+/// ```swift
+/// LocationCard(title: "Marina Bay Hotel", coordinate: coord)
+///     .subtitle("Kordon Cd. No:12, İzmir").distance("1.2 km to center") { openMaps() }
+/// ```
+public struct LocationCard: View {
+    @Environment(\.theme) private var theme
+
+    // Required content (R1).
+    private let title: String
+    private let coordinate: CLLocationCoordinate2D
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var subtitle: String?
+    private var distance: String?
+    private var mapHeight: CGFloat = 140
+    private var spanMeters: CLLocationDistance = 800
+    private var onTap: (() -> Void)?
+
+    public init(title: String, coordinate: CLLocationCoordinate2D) {
+        self.title = title
+        self.coordinate = coordinate
+    }
+
+    /// Convenience — build from latitude/longitude without importing CoreLocation.
+    public init(title: String, latitude: Double, longitude: Double) {
+        self.init(title: title, coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude))
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Map(initialPosition: .region(region)) {
+                Marker(title, coordinate: coordinate)
+            }
+            .frame(height: mapHeight)
+            .allowsHitTesting(false)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+                if let subtitle {
+                    Label { Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)) }
+                    icon: { Image(systemName: "mappin.and.ellipse").foregroundStyle(theme.foreground(.fgHero)) }
+                        .labelStyle(.titleAndIcon)
+                }
+                if let distance {
+                    Label { Text(distance).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary)) }
+                    icon: { Image(systemName: "location.fill").foregroundStyle(theme.text(.textTertiary)) }
+                        .labelStyle(.titleAndIcon)
+                }
+            }
+            .padding(Theme.SpacingKey.md.value)
+        }
+        .background(theme.background(.bgElevatorPrimary))
+        .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous).stroke(theme.border(.borderPrimary), lineWidth: 1))
+        .contentShape(Rectangle())
+        .onTapGesture { onTap?() }
+    }
+
+    private var region: MKCoordinateRegion {
+        MKCoordinateRegion(center: coordinate, latitudinalMeters: spanMeters, longitudinalMeters: spanMeters)
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension LocationCard {
+    /// An address line under the title.
+    func subtitle(_ text: String?) -> Self { copy { $0.subtitle = text } }
+    /// A distance line, e.g. `"1.2 km to center"`.
+    func distance(_ text: String?) -> Self { copy { $0.distance = text } }
+    /// Map preview height in points (default 140).
+    func mapHeight(_ height: CGFloat) -> Self { copy { $0.mapHeight = height } }
+    /// The map's visible span in meters (default 800).
+    func spanMeters(_ meters: CLLocationDistance) -> Self { copy { $0.spanMeters = meters } }
+    /// Called when the card is tapped (e.g. open in Maps).
+    func onTap(_ action: (() -> Void)?) -> Self { copy { $0.onTap = action } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    LocationCard(title: "Marina Bay Hotel", coordinate: CLLocationCoordinate2D(latitude: 38.4237, longitude: 27.1428))
+        .subtitle("Kordon Cd. No:12, İzmir")
+        .distance("1.2 km to center")
+        .padding()
+}

--- a/Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift
@@ -1,0 +1,111 @@
+//
+//  LoyaltyCard.swift
+//  ThemeKit
+//
+//  A loyalty / membership card — tier, member, a points balance and optional progress
+//  to the next tier, on a brand gradient. Token-bound: the gradient is built from the
+//  theme's primary palette, so it re-skins with the brand.
+//
+
+import SwiftUI
+
+/// A token-bound loyalty membership card.
+///
+/// ```swift
+/// LoyaltyCard(tier: "Gold", points: 8_430)
+///     .memberName("Elif Kaya").progress(0.62, toNextTier: "Platinum")
+/// ```
+public struct LoyaltyCard: View {
+    @Environment(\.theme) private var theme
+
+    // Required content (R1).
+    private let tier: String
+    private let points: Int
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var memberName: String?
+    private var unit: String = "pts"
+    private var progress: Double?
+    private var nextTier: String?
+    private var systemImage: String = "seal.fill"
+    private var gradientOverride: [Color]?
+
+    public init(tier: String, points: Int) {
+        self.tier = tier
+        self.points = points
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+            HStack {
+                Text(tier.uppercased()).textStyle(.labelMd700).foregroundStyle(onCard)
+                Spacer()
+                Image(systemName: systemImage).font(.system(size: 20)).foregroundStyle(onCard)
+            }
+            if let memberName {
+                Text(memberName).textStyle(.bodyBase500).foregroundStyle(onCard.opacity(0.9))
+            }
+            Spacer(minLength: Theme.SpacingKey.sm.value)
+            HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.xs.value) {
+                Text(points.formatted(.number.grouping(.automatic)))
+                    .textStyle(.heading2xl).foregroundStyle(onCard)
+                Text(unit).textStyle(.bodyBase400).foregroundStyle(onCard.opacity(0.8))
+            }
+            if let progress { progressView(progress) }
+        }
+        .padding(Theme.SpacingKey.lg.value)
+        .frame(maxWidth: .infinity, minHeight: 180, alignment: .topLeading)
+        .background(gradient, in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+    }
+
+    private func progressView(_ value: Double) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(onCard.opacity(0.25))
+                    Capsule().fill(onCard).frame(width: geo.size.width * min(1, max(0, value)))
+                }
+            }
+            .frame(height: 6)
+            if let nextTier {
+                Text("\(Int((1 - min(1, max(0, value))) * 100))% to \(nextTier)")
+                    .textStyle(.bodySm400).foregroundStyle(onCard.opacity(0.85))
+            }
+        }
+    }
+
+    private var gradient: LinearGradient {
+        let colors = gradientOverride ?? [theme.palette(.primary600), theme.palette(.primary900)]
+        return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+
+    /// Text/marks drawn on the gradient — white for legibility on the brand fill.
+    private var onCard: Color { theme.text(.textSecondaryInverse) }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension LoyaltyCard {
+    /// The member's name, shown under the tier.
+    func memberName(_ name: String?) -> Self { copy { $0.memberName = name } }
+    /// The points unit (default `"pts"`).
+    func unit(_ text: String) -> Self { copy { $0.unit = text } }
+    /// Progress (0…1) to the next tier, with its name.
+    func progress(_ value: Double, toNextTier tier: String? = nil) -> Self { copy { $0.progress = value; $0.nextTier = tier } }
+    /// A tier SF Symbol (default `seal.fill`).
+    func icon(_ systemName: String) -> Self { copy { $0.systemImage = systemName } }
+    /// Overrides the brand gradient.
+    func gradient(_ colors: [Color]?) -> Self { copy { $0.gradientOverride = colors } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    LoyaltyCard(tier: "Gold", points: 8_430)
+        .memberName("Elif Kaya")
+        .progress(0.62, toNextTier: "Platinum")
+        .padding()
+}

--- a/Sources/ThemeKit/Components/Organisms/ReviewCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/ReviewCard.swift
@@ -1,0 +1,118 @@
+//
+//  ReviewCard.swift
+//  ThemeKit
+//
+//  A single guest review — avatar, author, date, a ScoreBadge, optional title, the
+//  review text, and an optional photo strip. The per-review counterpart to the
+//  aggregate RatingSummary. Token-bound.
+//
+
+import SwiftUI
+
+/// A token-bound single review card.
+///
+/// ```swift
+/// ReviewCard(author: "Elif K.", score: 9.2, text: "Spotless rooms, great location.")
+///     .date(reviewDate).title("Would stay again").verified()
+/// ```
+public struct ReviewCard: View {
+    @Environment(\.theme) private var theme
+
+    // Required content (R1).
+    private let author: String
+    private let score: Double
+    private let text: String
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var date: Date?
+    private var title: String?
+    private var verified: Bool = false
+    private var photos: [URL] = []
+
+    public init(author: String, score: Double, text: String) {
+        self.author = author
+        self.score = score
+        self.text = text
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+            header
+            if let title {
+                Text(title).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+            }
+            Text(text).textStyle(.bodyBase400).foregroundStyle(theme.text(.textSecondary))
+            if !photos.isEmpty { photoStrip }
+        }
+        .padding(Theme.SpacingKey.md.value)
+        .background(theme.background(.bgElevatorPrimary), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous).stroke(theme.border(.borderPrimary), lineWidth: 1))
+    }
+
+    private var header: some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            Avatar(.initials(initials)).size(.md)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: Theme.SpacingKey.xs.value) {
+                    Text(author).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+                    if verified {
+                        Image(systemName: "checkmark.seal.fill")
+                            .font(.system(size: 12))
+                            .foregroundStyle(theme.foreground(.fgHero))
+                    }
+                }
+                if let date {
+                    Text(date.formatted(date: .abbreviated, time: .omitted))
+                        .textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
+                }
+            }
+            Spacer()
+            ScoreBadge(score, large: false)
+        }
+    }
+
+    private var photoStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                ForEach(photos, id: \.self) { url in
+                    RemoteImage(url)
+                        .frame(width: 72, height: 72)
+                        .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
+                }
+            }
+        }
+    }
+
+    private var initials: String {
+        let parts = author.split(separator: " ")
+        let letters = parts.prefix(2).compactMap { $0.first }
+        return String(letters).uppercased()
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension ReviewCard {
+    /// The review date, shown under the author.
+    func date(_ date: Date?) -> Self { copy { $0.date = date } }
+    /// A bold one-line summary above the body.
+    func title(_ text: String?) -> Self { copy { $0.title = text } }
+    /// Shows a verified-stay seal next to the author.
+    func verified(_ on: Bool = true) -> Self { copy { $0.verified = on } }
+    /// A horizontal strip of review photos.
+    func photos(_ urls: [URL]) -> Self { copy { $0.photos = urls } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        ReviewCard(author: "Elif Kaya", score: 9.2, text: "Spotless rooms and a great location right by the marina. Breakfast was excellent.")
+            .date(.now).title("Would absolutely stay again").verified()
+        ReviewCard(author: "Marco P.", score: 7.4, text: "Good value, though the wifi was slow in the evenings.")
+    }
+    .padding()
+}

--- a/Sources/ThemeKit/Components/Organisms/SeatMap.swift
+++ b/Sources/ThemeKit/Components/Organisms/SeatMap.swift
@@ -1,0 +1,140 @@
+//
+//  SeatMap.swift
+//  ThemeKit
+//
+//  A cabin seat picker — a grid of seats with aisles, occupied/premium states and a
+//  multi-select binding. Token-bound: available / selected / occupied / premium all
+//  resolve from the theme. Suits flight & event seat selection.
+//
+
+import SwiftUI
+
+/// A single seat.
+public struct Seat: Identifiable, Sendable, Hashable {
+    public let id: String        // e.g. "12A"
+    public var isOccupied: Bool
+    public var isPremium: Bool
+
+    public init(_ id: String, occupied: Bool = false, premium: Bool = false) {
+        self.id = id
+        self.isOccupied = occupied
+        self.isPremium = premium
+    }
+}
+
+/// A cell in a seat row — a seat or an aisle gap.
+public enum SeatSlot: Sendable, Hashable { case seat(Seat), aisle }
+
+/// A token-bound seat map.
+///
+/// ```swift
+/// SeatMap(rows: layout, selection: $picked).maxSelection(2)
+/// ```
+public struct SeatMap: View {
+    @Environment(\.theme) private var theme
+
+    private let rows: [[SeatSlot]]
+    @Binding private var selection: Set<String>
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var maxSelection: Int = .max
+    private var seatSize: CGFloat = 34
+
+    public init(rows: [[SeatSlot]], selection: Binding<Set<String>>) {
+        self.rows = rows
+        self._selection = selection
+    }
+
+    public var body: some View {
+        VStack(spacing: Theme.SpacingKey.xs.value) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                HStack(spacing: Theme.SpacingKey.xs.value) {
+                    ForEach(Array(row.enumerated()), id: \.offset) { _, slot in
+                        switch slot {
+                        case .aisle: Color.clear.frame(width: seatSize * 0.6, height: seatSize)
+                        case .seat(let seat): seatView(seat)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func seatView(_ seat: Seat) -> some View {
+        let selected = selection.contains(seat.id)
+        return Button { toggle(seat) } label: {
+            RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
+                .fill(fill(seat, selected: selected))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
+                        .stroke(stroke(seat, selected: selected), lineWidth: 1)
+                )
+                .overlay(
+                    Image(systemName: selected ? "checkmark" : (seat.isOccupied ? "xmark" : "chair"))
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(content(seat, selected: selected))
+                )
+                .frame(width: seatSize, height: seatSize)
+        }
+        .buttonStyle(.plain)
+        .disabled(seat.isOccupied)
+        .accessibilityLabel("Seat \(seat.id)\(seat.isOccupied ? ", occupied" : selected ? ", selected" : "")")
+    }
+
+    private func toggle(_ seat: Seat) {
+        guard !seat.isOccupied else { return }
+        if selection.contains(seat.id) {
+            selection.remove(seat.id)
+        } else if selection.count < maxSelection {
+            selection.insert(seat.id)
+        }
+    }
+
+    private func fill(_ seat: Seat, selected: Bool) -> Color {
+        if selected { return theme.foreground(.fgHero) }
+        if seat.isOccupied { return theme.background(.bgSecondary) }
+        if seat.isPremium { return theme.background(.bgTurquoiseLight) }
+        return theme.background(.bgElevatorPrimary)
+    }
+    private func stroke(_ seat: Seat, selected: Bool) -> Color {
+        if selected { return theme.foreground(.fgHero) }
+        if seat.isPremium { return theme.background(.bgTurquoise) }
+        return theme.border(.borderPrimary)
+    }
+    private func content(_ seat: Seat, selected: Bool) -> Color {
+        if selected { return theme.text(.textSecondaryInverse) }
+        if seat.isOccupied { return theme.text(.textTertiary) }
+        return theme.text(.textSecondary)
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension SeatMap {
+    /// Max seats a user can pick at once (default unlimited).
+    func maxSelection(_ count: Int) -> Self { copy { $0.maxSelection = max(1, count) } }
+    /// Seat square size in points (default 34).
+    func seatSize(_ size: CGFloat) -> Self { copy { $0.seatSize = size } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    struct Demo: View {
+        @State private var picked: Set<String> = ["12C"]
+        var rows: [[SeatSlot]] {
+            (10...14).map { r in
+                [.seat(Seat("\(r)A", premium: r == 10)), .seat(Seat("\(r)B")), .seat(Seat("\(r)C", occupied: r == 12)),
+                 .aisle,
+                 .seat(Seat("\(r)D")), .seat(Seat("\(r)E", occupied: r == 13)), .seat(Seat("\(r)F"))]
+            }
+        }
+        var body: some View {
+            SeatMap(rows: rows, selection: $picked).maxSelection(3).padding()
+        }
+    }
+    return Demo()
+}


### PR DESCRIPTION
Adds a **travel-domain component suite** for flight / hotel / car booking flows. Every component is **token-bound** and **modifier-based** per the R1–R7 contract (init carries content/bindings; each appearance axis is a chainable modifier through the single copy-on-write helper), reuses existing atoms where natural, and defaults its strings to English.

## What's new (14 components)

**Atoms** — `PriceTag` (currency + struck original + per-unit + auto discount badge) · `PointsBadge` (loyalty pill) · `CountdownTimer` (live HH:MM:SS, `.urgent`, `onFinish`)

**Molecules** — `GuestSelector` (rooms & guests, from `QuantityStepper`) · `AmenityGrid` · `PriceHistogram` (bars over `RangeSlider`) · `InstallmentSelector` (taksit) · `CurrencyPicker`

**Organisms** — `FlightCard` (airline · times + codes · flight-path line · price + Select) · `FareSummary` (itemised → hero total) · `ReviewCard` (`Avatar`+`ScoreBadge`+photos) · `LoyaltyCard` (brand-gradient tier card) · `SeatMap` (cabin grid, multi-select) · `LocationCard` (MapKit preview + pin)

```swift
FlightCard(airline: "Anadolu Air", from: "IST", to: "ESB", departure: dep, arrival: arr)
    .stops(0).price(1_299).badge("Cheapest") { book() }

FareSummary([.item("Base fare", 1_100), .discount("Member", 100), .total("Total", 1_199)])
```

## Design notes

- **Reuse** — `PriceTag` powers `FlightCard`/`FareSummary`; `PointsBadge`→`LoyaltyCard`; `RangeSlider`→`PriceHistogram`; `QuantityStepper`→`GuestSelector`; `Avatar`/`ScoreBadge`→`ReviewCard`.
- **Zero-dep core preserved** — `LocationCard` uses **MapKit** (a system framework), so no new package dependency; a lat/lon convenience init means callers don't import CoreLocation.
- **Brand-neutral + token-bound** — every colour/spacing/radius/type resolves from the theme, so all 14 re-skin with presets and per-subtree `.theme(_:)`.
- English-default strings (a stray `puan`/`gece`/`indirim` was caught and fixed to `pts`/`night`/`off`).

## Verification

- **ThemeKit builds** (macOS + iOS); **Demo BUILD SUCCEEDED** — all 14 registered in the gallery (Atoms/Molecules/Organisms) and rendering.
- Adds a reusable `StatefulPreview` helper for interactive `.static` gallery demos.

Bumps `0.6.0 → 0.7.0`; README component count 119 → **133** (Atoms 32 · Molecules 51 · Organisms 50).

## Follow-up (not in this PR)

- Interactive knob-demo pages for the new components (currently `.static` previews) and snapshot tests, matching the older components' depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)