### PR TITLE
fix(travel): PointsBadge .redeem invisible text (blue-on-blue)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/PointsBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/PointsBadge.swift
@@ -19,7 +19,7 @@ public enum PointsStyle {
     func foreground(_ theme: Theme) -> Color {
         switch self {
         case .earn: return theme.foreground(.systemcolorsFgSuccess)
-        case .redeem: return theme.foreground(.fgHero)
+        case .redeem: return theme.text(.textSecondaryInverse)   // white on the brand fill
         case .balance: return theme.text(.textPrimary)
         }
     }


### PR DESCRIPTION
Running the Demo (Travel showcase) surfaced a contrast bug in the just-shipped `PointsBadge`: the `.redeem` style set **both** the foreground and the fill to the brand blue (`fgHero` text on `bgHero` fill), so the label was invisible.

**Fix:** `.redeem` foreground → `textSecondaryInverse` (white), giving readable **white-on-brand** — matching the solid-pill intent and staying distinct from the soft `.earn` (green-on-light-green).

Verified in the simulator: the `500 pts` redeem pill now reads clearly next to the `+1.250 mil` earn badge.

Caught by the `/run` workflow — launching the app and looking at the screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)