### PR TITLE
polish: id-safety, %02d UB, i18n verify, snapshot tests, visual QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ThemeKit
 
-> **Native, brand-neutral SwiftUI design system** — 133 token-bound components that
+> **Native, brand-neutral SwiftUI design system** — 135 token-bound components that
 > re-skin from a single accent color: light/dark, per-subtree, zero core dependencies.
 
 [![CI](https://github.com/isamercan/ThemeKit/actions/workflows/ci.yml/badge.svg)](https://github.com/isamercan/ThemeKit/actions/workflows/ci.yml)
@@ -13,7 +13,7 @@
 **[Docs](https://isamercan.github.io/ThemeKit/) · [API (DocC)](https://isamercan.github.io/ThemeKit/api/documentation/themekit) · [Wiki](https://github.com/isamercan/ThemeKit/wiki) · [npm (MCP)](https://www.npmjs.com/package/@isamercan/themekit-mcp) · [Releases](https://github.com/isamercan/ThemeKit/releases) · [Issues](https://github.com/isamercan/ThemeKit/issues) · [Changelog](CHANGELOG.md)**
 
 <p align="center">
-  <img src="Screenshots/Banner.png" alt="ThemeKit — native SwiftUI design system: 133 components, fully tokenized, per-subtree theming, Swift 6, Liquid Glass, light + dark" width="820">
+  <img src="Screenshots/Banner.png" alt="ThemeKit — native SwiftUI design system: 135 components, fully tokenized, per-subtree theming, Swift 6, Liquid Glass, light + dark" width="820">
 </p>
 
 > The banner above is rendered **by ThemeKit itself** (its own tokens + components) — the same render pipeline that paints every tile in the gallery.
@@ -49,7 +49,7 @@ import ThemeKit
   whole Ant-style palette on device.
 - 📸 **Snapshot + render testing** — every component renders to a theme-aware PNG via
   `ImageRenderer`; the suite guards tokens, themes, validation and renders.
-- **133 components** — Atoms / Molecules / Organisms, all token-bound.
+- **135 components** — Atoms / Molecules / Organisms, all token-bound.
 - **Runtime theming** — a Swift token generator + a live configurator turn any
   accent (or `base-100`) color into a full Ant-style palette on device (no Python,
   no baked files).
@@ -205,10 +205,10 @@ gallery, and a full booking flow built entirely from ThemeKit components.
 
 ## Components
 
-133 token-bound components, grouped by complexity:
+135 token-bound components, grouped by complexity:
 
-- **Atoms** (32) — `Badge`, `Chip`, `Avatar`, `Icon`, `Rating`, `Spinner`,
-  `StatusDot`, `ProgressBar`, `PriceTag`, `PointsBadge`, `CountdownTimer`…
+- **Atoms** (34) — `Badge`, `Chip`, `Avatar`, `Icon`, `Rating`, `Spinner`,
+  `StatusDot`, `ProgressBar`, `PriceTag`, `PointsBadge`, `CountdownTimer`, `QRCode`, `Barcode`…
 - **Molecules** (51) — `TextInput`, `OTPInput`, `Select`, `Checkbox`, `RangeSlider`,
   `SearchBar`, `TimeField`, `GuestSelector`, `PriceHistogram`, `InstallmentSelector`, `CurrencyPicker`, buttons…
 - **Organisms** (50) — `Card`, `Carousel`, `DataTable`, `Accordion`, `Timeline`,

--- a/Sources/ThemeKit/Components/Atoms/CountdownTimer.swift
+++ b/Sources/ThemeKit/Components/Atoms/CountdownTimer.swift
@@ -194,7 +194,7 @@ public struct CountdownTimer: View {
 
     /// Two-digit zero pad — avoids `String(format: "%02d", Int)`, which passes a 64-bit
     /// `Int` where `%d` expects a 32-bit `CInt` (undefined behaviour / crashes).
-    static func pad2(_ value: Int) -> String { value < 10 ? "0\(value)" : "\(value)" }
+    static func pad2(_ value: Int) -> String { zeroPad2(value) }
 
     /// Natural top-two-unit readout like `"9m 58s"` (pure; unit-tested).
     static func compactString(_ remaining: TimeInterval, showsDays: Bool) -> String {

--- a/Sources/ThemeKit/Components/Molecules/ProgressIndicator.swift
+++ b/Sources/ThemeKit/Components/Molecules/ProgressIndicator.swift
@@ -111,7 +111,7 @@ public struct ProgressIndicator: View {
         switch stepText {
         case .none: return ""
         case .slash: return "\(current) / \(total)"
-        case .padded: return String(format: "%02d | %02d", current, total)
+        case .padded: return "\(zeroPad2(current)) | \(zeroPad2(total))"
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/Accordion.swift
+++ b/Sources/ThemeKit/Components/Organisms/Accordion.swift
@@ -76,7 +76,7 @@ public struct Accordion<Content: View>: View {
             } label: {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
                     if let number {
-                        Text(String(format: "%02d", number))
+                        Text(zeroPad2(number))
                             .textStyle(titleSize.textStyle)
                             .foregroundStyle(titleColor)
                             .monospacedDigit()

--- a/Sources/ThemeKit/Components/Organisms/Counter.swift
+++ b/Sources/ThemeKit/Components/Organisms/Counter.swift
@@ -40,7 +40,7 @@ public struct Counter: View {
         HStack(spacing: Theme.SpacingKey.xs.value) {
             ForEach(segments) { segment in
                 VStack(spacing: 2) {
-                    Text(String(format: "%02d", segment.value))
+                    Text(zeroPad2(segment.value))
                         .textStyle(.labelMd700)
                         .monospacedDigit()
                         .foregroundStyle(theme.text(.textPrimary))

--- a/Sources/ThemeKit/Components/Organisms/FareSummary.swift
+++ b/Sources/ThemeKit/Components/Organisms/FareSummary.swift
@@ -62,7 +62,9 @@ public struct FareSummary: View {
 
     public var body: some View {
         VStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            ForEach(lines) { line in
+            // Position-keyed: robust to duplicate labels (two "Fee" lines) which would
+            // collide on the content-derived `id`. Fare lists are fixed-order, so index is stable.
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
                 switch line.kind {
                 case .item:     itemRow(line, value: formatted(line.amount), color: theme.text(.textSecondary), valueColor: theme.text(.textPrimary))
                 case .discount: itemRow(line, value: "-\(formatted(line.amount))", color: theme.foreground(.systemcolorsFgSuccess), valueColor: theme.foreground(.systemcolorsFgSuccess))

--- a/Sources/ThemeKit/Components/Organisms/FlightCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightCard.swift
@@ -140,7 +140,7 @@ public struct FlightCard: View {
     @ViewBuilder private var routeContent: some View {
         if let legs {
             VStack(spacing: density.scale(Theme.SpacingKey.md.value)) {
-                ForEach(Array(legs.enumerated()), id: \.element.id) { index, leg in
+                ForEach(Array(legs.enumerated()), id: \.offset) { index, leg in
                     if index > 0 { Divider().overlay(theme.border(.borderPrimary)) }
                     legRow(leg)
                 }

--- a/Sources/ThemeKit/Components/Organisms/FlightCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightCard.swift
@@ -152,7 +152,9 @@ public struct FlightCard: View {
 
     private func legRow(_ leg: FlightLeg) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            if (legs?.count ?? 0) > 1 {
+            // Per-leg airline only when it differs from the header airline (avoids
+            // repeating "Anadolu Air" on the first leg when the header already shows it).
+            if (legs?.count ?? 0) > 1, leg.airline != airline {
                 Text(leg.airline).textStyle(.overline500).foregroundStyle(theme.text(.textTertiary))
             }
             HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {

--- a/Sources/ThemeKit/Components/Organisms/ListRow.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListRow.swift
@@ -150,7 +150,7 @@ public struct ListRow: View {
             RemoteImage(leadingImageURL).ratio(1).cornerRadius(Theme.RadiusKey.sm.value)
                 .frame(width: 48, height: 48)
         } else if let number {
-            Text(String(format: "%02d", number))
+            Text(zeroPad2(number))
                 .textStyle(.labelMd700)
                 .foregroundStyle(isSelected ? theme.text(.textHero) : theme.text(.textPrimary))
                 .monospacedDigit()

--- a/Sources/ThemeKit/Theme/ThemeMotion.swift
+++ b/Sources/ThemeKit/Theme/ThemeMotion.swift
@@ -18,6 +18,11 @@ enum CoreImageContext {
     nonisolated(unsafe) static let shared = CIContext()
 }
 
+/// Two-digit zero pad, e.g. `3 → "03"`. Avoids `String(format: "%02d", Int)`, which
+/// passes a 64-bit `Int` where `%d` expects a 32-bit `CInt` (undefined behaviour).
+/// Values ≥ 10 (and negatives) pass through unpadded.
+func zeroPad2(_ value: Int) -> String { (value >= 0 && value < 10) ? "0\(value)" : "\(value)" }
+
 public extension Animation {
     /// Returns the animation, or `nil` when Reduce Motion is on — so components can
     /// write `withAnimation(.snappy.ifMotionAllowed(reduceMotion)) { … }`.

--- a/Tests/ThemeKitTests/Snapshot/TravelSnapshotTests.swift
+++ b/Tests/ThemeKitTests/Snapshot/TravelSnapshotTests.swift
@@ -1,0 +1,144 @@
+//
+//  TravelSnapshotTests.swift
+//  ThemeKitTests
+//
+//  Visual-regression coverage for the travel suite. Opt-in + iOS-only (see
+//  SnapshotSupport.swift); records references on the pinned Simulator, skips in CI.
+//
+//  Deterministic components only — CountdownTimer (ticks every second) and
+//  LocationCard (async MKMapSnapshotter) are excluded because their pixels change
+//  between renders. Bindings use `.constant` and dates are fixed so references
+//  are reproducible.
+//
+
+#if canImport(UIKit)
+import SnapshotTesting
+import SwiftUI
+import XCTest
+@testable import ThemeKit
+
+@MainActor
+final class TravelSnapshotTests: SnapshotTestCase {
+
+    private let dep = Date(timeIntervalSinceReferenceDate: 800_000_000)   // fixed → reproducible
+    private var arr: Date { dep.addingTimeInterval(2 * 3_600 + 20 * 60) }
+
+    // MARK: - Atoms
+
+    func testPriceTag_variants() {
+        assertComponentSnapshot(
+            VStack(alignment: .leading, spacing: 12) {
+                PriceTag(1_299).original(1_899).unit("/ night").size(.large).emphasis(.hero).discountBadge()
+                PriceTag(2_499, currencyCode: "EUR").from()
+                PriceTag(0).free()
+                PriceTag(1_299).soldOut()
+            }
+        )
+    }
+
+    func testPointsBadge_styles() {
+        assertComponentSnapshot(
+            VStack(alignment: .leading, spacing: 10) {
+                PointsBadge(1_250).unit("mil").style(.earn).size(.large)
+                PointsBadge(500).style(.redeem)
+                PointsBadge(8_430).style(.balance)
+            }
+        )
+    }
+
+    func testQRCode() { assertComponentSnapshot(QRCode("THEMEKIT-PASS-BID12025").size(140)) }
+
+    func testBarcode() { assertComponentSnapshot(Barcode("9824097217421298").height(52).showsValue()) }
+
+    // MARK: - Molecules
+
+    func testAmenityGrid_limitedAndHighlighted() {
+        assertComponentSnapshot(
+            AmenityGrid([
+                Amenity("Free Wi-Fi", systemImage: "wifi"),
+                Amenity("Pool", systemImage: "figure.pool.swim"),
+                Amenity("Breakfast", systemImage: "fork.knife"),
+                Amenity("Parking", systemImage: "parkingsign"),
+                Amenity("Gym", systemImage: "dumbbell"),
+                Amenity("Spa", systemImage: "sparkles"),
+            ]).columns(2).limit(4).highlighted(["Free Wi-Fi"])
+        )
+    }
+
+    func testPriceHistogram() {
+        assertComponentSnapshot(
+            PriceHistogram(bins: [2, 5, 9, 14, 18, 22, 19, 12, 8, 5, 3, 2],
+                           lowerValue: .constant(800), upperValue: .constant(3_200), in: 0...5_000)
+                .showsBounds().resultCount(87)
+        )
+    }
+
+    func testInstallmentSelector() {
+        assertComponentSnapshot(
+            InstallmentSelector(total: 12_000, options: [1, 3, 6, 12], selection: .constant(3))
+                .interestFreeUpTo(3).recommended(3)
+        )
+    }
+
+    func testCurrencyPicker() {
+        assertComponentSnapshot(
+            CurrencyPicker(selection: .constant("TRY"), currencies: Currency.common)
+        )
+    }
+
+    // MARK: - Organisms
+
+    func testFlightCard_single() {
+        assertComponentSnapshot(
+            FlightCard(airline: "Anadolu Air", from: "IST", to: "ESB", departure: dep, arrival: arr)
+                .price(1_299).badge("Cheapest").scarcity(5).onSelect { }
+        )
+    }
+
+    func testFlightCard_multiLeg() {
+        assertComponentSnapshot(
+            FlightCard(legs: [
+                FlightLeg(airline: "Anadolu Air", from: "IST", to: "AMS", departure: dep, arrival: dep.addingTimeInterval(4 * 3_600)),
+                FlightLeg(airline: "Blue Wings", from: "AMS", to: "IST", departure: dep.addingTimeInterval(72 * 3_600),
+                          arrival: dep.addingTimeInterval(78 * 3_600), stops: 1, layover: "1 stop · 2h 10m · CDG"),
+            ]).price(7_178).onSelect { }
+        )
+    }
+
+    func testFareSummary() {
+        assertComponentSnapshot(
+            FareSummary([
+                .item("Base fare", 1_100),
+                .item("Taxes & fees", 199),
+                .discount("Member discount", 100),
+                .total("Total", 1_199),
+            ])
+        )
+    }
+
+    func testReviewCard() {
+        assertComponentSnapshot(
+            ReviewCard(author: "Elif Kaya", score: 9.2, text: "Spotless rooms and a great location right by the marina.")
+                .date(dep).title("Would stay again").verified().stars()
+        )
+    }
+
+    func testLoyaltyCard() {
+        assertComponentSnapshot(
+            LoyaltyCard(tier: "Gold", points: 8_430).memberName("Elif Kaya").progress(0.62, toNextTier: "Platinum"),
+            width: 340
+        )
+    }
+
+    func testSeatMap_withLabelsAndLegend() {
+        let rows: [[SeatSlot]] = (10...13).map { r in
+            [.seat(Seat("\(r)A", premium: r == 10)), .seat(Seat("\(r)B")), .seat(Seat("\(r)C", occupied: r == 12)),
+             .aisle,
+             .seat(Seat("\(r)D")), .seat(Seat("\(r)E")), .seat(Seat("\(r)F"))]
+        }
+        assertComponentSnapshot(
+            SeatMap(rows: rows, selection: .constant(["12A"])).showsLabels().legend()
+        )
+    }
+}
+#endif


### PR DESCRIPTION
Post-review polish — the remaining actionable items from the architecture review.

- **Correctness:** id-collision-safe `ForEach` (position-keyed) on FareSummary/FlightCard; eradicated the last four `String(format:"%02d",Int)` UB sites (shared `zeroPad2`).
- **Visual QA:** ran every new/hardened feature in the simulator and looked — QRCode/Barcode, LoyaltyCard Canvas progress + logo + flip, FlightCard multi-leg, SeatMap passenger-assignment + labels + legend, LocationCard MKMapSnapshotter + directions. Fix caught: multi-leg no longer repeats the header airline on leg 1.
- **Tests:** 14 opt-in visual-regression snapshot tests (skip in CI; references recorded on the pinned Simulator).
- **Docs:** README component count 133 → 135.

ThemeKit + Demo build clean; 11 logic tests pass; 14 snapshot tests skip cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)