### PR TITLE
fix: Swift 6.2 strict-concurrency build breaks from #181

### DIFF
--- a/Sources/ThemeKit/Components/Molecules/PaymentCardField.swift
+++ b/Sources/ThemeKit/Components/Molecules/PaymentCardField.swift
@@ -125,7 +125,9 @@ public struct PaymentCardField: View {
         ))
     }
 
-    @ViewBuilder private func field(_ binding: Binding<String>, _ placeholder: String, role: FieldRole, keyboard: KeyboardKind = .default, secure: Bool = false, format: @escaping (String) -> String) -> some View {
+    @ViewBuilder private func field(_ binding: Binding<String>, _ placeholder: String, role: FieldRole,
+                                    keyboard: KeyboardKind = .default, secure: Bool = false,
+                                    format: @escaping (String) -> String) -> some View {
         Group {
             if secure {
                 SecureField(placeholder, text: binding)

--- a/Sources/ThemeKit/Components/Molecules/SelectStyle.swift
+++ b/Sources/ThemeKit/Components/Molecules/SelectStyle.swift
@@ -157,7 +157,7 @@ struct AnySelectStyle {
         AnySelectStyle(isDefault: true) { AnyView(DefaultSelectField(configuration: $0)) }
     }
 
-    func makeBody(configuration: SelectStyleConfiguration) -> AnyView { _makeBody(configuration) }
+    @MainActor func makeBody(configuration: SelectStyleConfiguration) -> AnyView { _makeBody(configuration) }
 }
 
 private struct SelectStyleKey: EnvironmentKey {

--- a/Sources/ThemeKit/Components/Organisms/BarStyle.swift
+++ b/Sources/ThemeKit/Components/Organisms/BarStyle.swift
@@ -78,7 +78,7 @@ enum BarMetrics {
 /// `BarStyleConfiguration`: they are component-owned modifiers, so the
 /// component plumbs them to the style through this internal environment value
 /// instead. Built-in styles honor them; custom styles may ignore them.
-struct BarChromeOverrides {
+struct BarChromeOverrides: Sendable {
     /// When non-`nil`, replaces the style's own surface fill.
     var surface: Theme.BackgroundColorKey?
     /// When `false`, suppresses the style's edge hairline (also used when a

--- a/Sources/ThemeKit/Theme/ColorTokens.generated.swift
+++ b/Sources/ThemeKit/Theme/ColorTokens.generated.swift
@@ -10,7 +10,7 @@
 import SwiftUI
 
 extension Theme {
-    public enum ForegroundColorKey: String, CaseIterable {
+    public enum ForegroundColorKey: String, CaseIterable, Sendable {
         case fgHero = "foreground.fg-hero"
         case fgSecondary = "foreground.fg-secondary"
         case fgTurquoise = "foreground.fg-turquoise"
@@ -23,7 +23,7 @@ extension Theme {
         case systemcolorsFgInfo = "foreground.systemcolors.fg-info"
     }
 
-    public enum BackgroundColorKey: String, CaseIterable {
+    public enum BackgroundColorKey: String, CaseIterable, Sendable {
         case bgWhite = "background.bg-white"
         case bgBase = "background.bg-base"
         case bgHero = "background.bg-hero"
@@ -51,7 +51,7 @@ extension Theme {
         case systemcolorsBgInfoLight = "background.systemcolors.bg-info-light"
     }
 
-    public enum BorderColorKey: String, CaseIterable {
+    public enum BorderColorKey: String, CaseIterable, Sendable {
         case borderHero = "border.border-hero"
         case borderPrimary = "border.border-primary"
         case borderOrange = "border.border-orange"
@@ -66,7 +66,7 @@ extension Theme {
         case systemcolorsBorderInfoLight = "border.systemcolors.border-info-light"
     }
 
-    public enum TextColorKey: String, CaseIterable {
+    public enum TextColorKey: String, CaseIterable, Sendable {
         case textPrimary = "text.text-primary"
         case textSecondary = "text.text-secondary"
         case textTertiary = "text.text-tertiary"
@@ -76,7 +76,7 @@ extension Theme {
         case textSecondaryInverse = "text.text-secondary-inverse"
     }
 
-    public enum PaletteColorKey: String, CaseIterable {
+    public enum PaletteColorKey: String, CaseIterable, Sendable {
         case primary50 = "palette.primary.50"
         case primary100 = "palette.primary.100"
         case primary200 = "palette.primary.200"

--- a/tools/gen_tokens.py
+++ b/tools/gen_tokens.py
@@ -334,7 +334,7 @@ for name, data in THEMES.items():
 
 # ---- Generate Swift color key enums ----
 def emit_enum(swift_name, cat, table):
-    lines = [f"    public enum {swift_name}: String, CaseIterable {{"]
+    lines = [f"    public enum {swift_name}: String, CaseIterable, Sendable {{"]
     for sub in table:
         lines.append(f'        case {case_name(sub)} = "{json_name(cat, sub)}"')
     lines.append("    }")


### PR DESCRIPTION
## Summary
Main stopped compiling locally under Swift 6.2 (Xcode toolchain, strict isolation checks) after #181 merged. Two errors, plus one error-level lint violation that blocked the pre-push CI gate:

- **`AnySelectStyle.makeBody`** (SelectStyle.swift): nonisolated method called the `@MainActor`-isolated `_makeBody` closure — marked the method `@MainActor`.
- **`BarChromeOverrides`** (BarStyle.swift): used as a nonisolated `EnvironmentKey.defaultValue`, so it must be `Sendable`. That in turn required the generated color-key enums to be `Sendable` (public enums get no implicit conformance) — added it to `ColorTokens.generated.swift` **and** to `tools/gen_tokens.py` so regeneration preserves it.
- **`PaymentCardField.field`**: 213-char signature exceeded the 200-char lint error limit — wrapped it.

## Test plan
- `swift build` clean on Swift 6.2
- `scripts/ci.sh` all gates green (ran via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)