### PR TITLE
ci: deploy Pages when Screenshots/ changes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'Sources/**'
       - 'website/**'
+      - 'Screenshots/**'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
The Pages site copies its gallery images from `Screenshots/` at build time (`sync-screenshots.mjs` pre-build hook), but the deploy workflow only triggered on `Sources/**` and `website/**`. Result: #184 regenerated 50 component previews and no deploy fired — the site kept serving stale images until a manual `workflow_dispatch`. Add `Screenshots/**` to the push paths so preview regens deploy automatically.

## Test plan
- Manual dispatch already verifies the build works with the new images; this PR only widens the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)