### PR TITLE
feat: PageHeader design-system rewrite + SearchSummary molecule

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -604,22 +604,184 @@ struct NotificationDemo: View {
 }
 
 struct PageHeaderDemo: View {
-    @State private var back = true
-    @State private var subtitle = true
-    @State private var actions = true
-    @State private var tags = false
+    enum Variant: String, CaseIterable, Identifiable {
+        case iconButtons = "Header · Icon Buttons"
+        case header = "Header"
+        case tabs = "Tab"
+        case progress = "Progress"
+        case stepper = "Stepper"
+        case withButton = "with Button"
+        case withSearchBar = "With Search Bar"
+        case searchInput = "with search Input"
+        case brand = "Brand"
+        case brandNoBg = "brand-no bg"
+        case onImage = "On Image"
+        case wsbOnImage = "With Search Bar · On Image"
+        case onMap = "On Map"
+        var id: String { rawValue }
+
+        // Which of the design-system variables this style exposes (mirrors Figma).
+        var hasBackNav: Bool { ![.withButton, .brand, .brandNoBg].contains(self) }
+        var hasActions: Bool { ![.brand, .brandNoBg, .searchInput].contains(self) }
+        var hasShowTitle: Bool { [.header, .tabs, .progress, .stepper, .withButton, .onImage, .onMap].contains(self) }
+        var hasTitleField: Bool { hasShowTitle || self == .iconButtons }
+        var hasSummary: Bool { [.iconButtons, .withSearchBar, .wsbOnImage, .onMap].contains(self) }
+    }
+
+    @State private var variant: Variant = .iconButtons
+    // Common variables
+    @State private var backNav = true
+    @State private var firstAction = true
+    @State private var secAction = true
+    @State private var showTitle = true
+    @State private var titleText = "Title"
+    // Style-specific
+    @State private var progressValue = 0.5
+    @State private var tab = 0
+    @State private var query = ""
+    // Search summary variables
+    @State private var summarySelected = false
+    @State private var summaryBg = false
+    @State private var timeText = "12 – 16 Jul"
+    @State private var adults = 2
+    @State private var showChild = true
+    @State private var childCount = 1
+    @State private var showRoom = true
+    @State private var roomCount = 1
+
+    /// Builds the bound ``SearchSummary`` sub-component from the live knobs.
+    private func makeSummary(title: String? = nil, forceBoxed: Bool = false) -> SearchSummary {
+        var s = SearchSummary(time: timeText, adults: adults)
+        if let title { s = s.title(title) }
+        if showChild { s = s.children(childCount) }
+        if showRoom { s = s.rooms(roomCount) }
+        s = s.boxed(forceBoxed || summaryBg)
+        if summarySelected { s = s.prompt("Select dates for price") }   // Figma "Selected" = empty prompt
+        return s
+    }
+
+    /// Trailing actions gated by the First/Sec Action toggles (Figma order: sec, first).
+    private func actions(sec: PageHeader.Action, first: PageHeader.Action) -> [PageHeader.Action] {
+        var a: [PageHeader.Action] = []
+        if secAction { a.append(sec) }
+        if firstAction { a.append(first) }
+        return a
+    }
+    private var onBackAction: (() -> Void)? { backNav ? { flash("Back") } : nil }
+
     var body: some View {
-        ComponentStage("PageHeader") {
-            PageHeader("Search results")
-                .subtitle(subtitle ? "128 hotels" : nil)
-                .tags(tags ? [.init("Active", style: .success), .init("Beta", style: .info)] : [])
-                .onBack(back ? { flash("PageHeader: back") } : nil)
-                .actions(actions ? [.init(systemImage: "slider.horizontal.3", handler: { flash("PageHeader: filter") }), .init(systemImage: "heart", handler: { flash("PageHeader: favorite") })] : [])
+        ComponentStage("PageHeader", inspector: [("style", variant.rawValue)]) {
+            headerView(variant)
         } knobs: {
-            Toggle("Back button", isOn: $back)
-            Toggle("Subtitle", isOn: $subtitle)
-            Toggle("Status tags", isOn: $tags)
-            Toggle("Actions", isOn: $actions)
+            Picker("Variant", selection: $variant) {
+                ForEach(Variant.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.menu)
+            if variant.hasShowTitle { Toggle("Show Title", isOn: $showTitle) }
+            if variant.hasTitleField && (!variant.hasShowTitle || showTitle) {
+                LabeledContent("Title") { TextField("Title", text: $titleText).multilineTextAlignment(.trailing) }
+            }
+            if variant.hasBackNav { Toggle("Back Navigation Icon", isOn: $backNav) }
+            if variant.hasActions {
+                Toggle("First Action Items", isOn: $firstAction)
+                Toggle("Sec Action Item", isOn: $secAction)
+            }
+            if variant == .progress {
+                HStack { Text("Progress Value"); SwiftUI.Slider(value: $progressValue, in: 0...1) }
+            }
+            if variant.hasSummary {
+                Text("Search summary").font(.caption.weight(.bold)).foregroundStyle(.secondary)
+                Toggle("Selected", isOn: $summarySelected)
+                Toggle("Bg", isOn: $summaryBg)
+                LabeledContent("Time") { TextField("Time", text: $timeText).multilineTextAlignment(.trailing) }
+                Stepper("Adult Number: \(adults)", value: $adults, in: 1...30)
+                Toggle("Show child", isOn: $showChild)
+                if showChild { Stepper("Child Number: \(childCount)", value: $childCount, in: 0...20) }
+                Toggle("Show room", isOn: $showRoom)
+                if showRoom { Stepper("Room Number: \(roomCount)", value: $roomCount, in: 1...20) }
+            }
+        }
+    }
+
+    @ViewBuilder private func headerView(_ variant: Variant) -> some View {
+        let compare = PageHeader.Action(systemImage: "square.on.square", accessibilityLabel: "Compare") { flash("Compare") }
+        let search = PageHeader.Action(systemImage: "magnifyingglass", accessibilityLabel: "Search") { flash("Search") }
+        let save = PageHeader.Action(systemImage: "heart", accessibilityLabel: "Save") { flash("Save") }
+        let share = PageHeader.Action(systemImage: "square.and.arrow.up", accessibilityLabel: "Share") { flash("Share") }
+        let close = PageHeader.Action(systemImage: "xmark", accessibilityLabel: "Close") { flash("Close") }
+        switch variant {
+        case .iconButtons:
+            PageHeader(titleText)
+                .onBack(onBackAction)
+                .searchSummary(makeSummary(title: titleText))
+                .actions(actions(sec: compare, first: search))
+        case .header:
+            PageHeader(titleText).showTitle(showTitle)
+                .onBack(onBackAction)
+                .actions(actions(sec: compare, first: search))
+        case .tabs:
+            PageHeader(titleText).showTitle(showTitle)
+                .onBack(onBackAction)
+                .tabs(["Tab 1", "Tab 2", "Tab 3", "Tab 4", "Tab 5"], selected: tab) { tab = $0 }
+                .actions(actions(sec: compare, first: search))
+        case .progress:
+            PageHeader(titleText).showTitle(showTitle).onBack(onBackAction).progress(progressValue)
+                .actions(actions(sec: compare, first: search))
+        case .stepper:
+            PageHeader(titleText).showTitle(showTitle).onBack(onBackAction).stepper(current: 1, total: 3)
+                .actions(actions(sec: compare, first: search))
+        case .withButton:
+            withButtonHeader(search: search)
+        case .withSearchBar:
+            PageHeader(titleText)
+                .onBack(onBackAction)
+                .searchSummary(makeSummary(forceBoxed: true))
+                .actions(actions(sec: save, first: share))
+        case .searchInput:
+            PageHeader("Search").onBack(onBackAction)
+                .searchField(text: $query, placeholder: "Search") { flash("Submit: \(query)") }
+        case .brand:
+            PageHeader("Brand")
+                .logo(Text("etstur").font(.system(size: 22, weight: .heavy)).foregroundStyle(SemanticColor.primary.onSolid))
+                .pageHeaderStyle(.brand)
+        case .brandNoBg:
+            PageHeader("Brand")
+                .logo(Text("etstur").font(.system(size: 22, weight: .heavy)).foregroundStyle(SemanticColor.primary.accent))
+                .pageHeaderStyle(.brandNoBackground)
+        case .onImage:
+            PageHeader(titleText).showTitle(showTitle)
+                .onBack(onBackAction)
+                .actions(actions(sec: save, first: close))
+                .pageHeaderStyle(.onImage)
+                .padding(.vertical, 24)
+                .background(Color(white: 0.75))
+        case .wsbOnImage:
+            PageHeader(titleText)
+                .onBack(onBackAction)
+                .searchSummary(makeSummary(forceBoxed: true))
+                .actions(actions(sec: save, first: share))
+                .pageHeaderStyle(.onImage)
+                .padding(.vertical, 24)
+                .background(Color(white: 0.75))
+        case .onMap:
+            PageHeader(titleText)
+                .onBack(onBackAction)
+                .searchSummary(makeSummary(title: showTitle ? titleText : nil))
+                .mapFilter(systemImage: "line.3.horizontal.decrease", accessibilityLabel: "Filter") { flash("Filter") }
+                .pageHeaderStyle(.onImage)
+                .padding(.vertical, 24)
+                .background(Color(white: 0.8))
+        }
+    }
+
+    /// with Button: sec = the brand pill, first = the search icon (Figma order).
+    @ViewBuilder private func withButtonHeader(search: PageHeader.Action) -> some View {
+        let base = PageHeader(titleText).showTitle(showTitle)
+            .actions(firstAction ? [search] : [])
+        if secAction {
+            base.primaryButton("Notify me", systemImage: "megaphone.fill") { flash("Notify me") }
+        } else {
+            base
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/SearchSummary.swift
+++ b/Sources/ThemeKit/Components/Molecules/SearchSummary.swift
@@ -1,0 +1,179 @@
+//
+//  SearchSummary.swift
+//  ThemeKit
+//
+//  Molecule. A compact travel search summary — an optional location title over a
+//  `date · guests` line: the date range, then `adults · children · rooms` chips
+//  separated from the date by a soft hairline. Mirrors the design-system
+//  "Search summary" element used inside ``PageHeader`` (and reusable on its own).
+//
+//  Two independent axes (the design-system Selected × Bg matrix):
+//    • content — the filled guest summary, or a hero **prompt** empty state
+//      ("select dates") via `.prompt(_:)`
+//    • container — flush/inline, or a soft **boxed** pill via `.boxed()`
+//
+//      SearchSummary(time: "12 – 16 Jul", adults: 2)
+//          .title("Antalya Hotels").children(1).rooms(1)
+//          .boxed()                     // the pill presentation
+//          .onTap { editSearch() }      // tappable to re-open the search
+//
+//  Token-bound and brand-neutral: numbers + a preformatted date string in, no
+//  domain model. Icons are configurable SF Symbols with travel defaults.
+//
+
+import SwiftUI
+
+public struct SearchSummary: View {
+    @Environment(\.theme) private var theme
+
+    private let time: String?
+    private let adults: Int
+    // Content/appearance — mutated only through the modifiers below.
+    private var title: String?
+    private var children: Int?
+    private var rooms: Int?
+    private var boxed = false
+    private var showsPrompt = false
+    private var promptText: String?
+    private var onTap: (() -> Void)?
+    private var adultIcon = "person.fill"
+    private var childIcon = "figure.child"
+    private var roomIcon = "bed.double.fill"
+
+    public init(time: String?, adults: Int) {
+        self.time = time
+        self.adults = adults
+    }
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+    }
+
+    public var body: some View {
+        if let onTap {
+            Button(action: onTap) { container }.buttonStyle(.plain)
+        } else {
+            container
+        }
+    }
+
+    private var container: some View {
+        content
+            .padding(.horizontal, boxed ? Theme.SpacingKey.sm.value : 0)
+            .padding(.vertical, boxed ? Theme.SpacingKey.xs.value : 0)
+            .frame(maxWidth: boxed ? .infinity : nil)
+            .frame(minHeight: boxed ? Theme.SpacingKey.lg.value : nil)   // 32pt pill
+            .background {
+                if boxed {
+                    shape.fill(theme.background(.bgElevatorPrimary))
+                        .overlay(shape.strokeBorder(theme.background(.bgElevatorTertiary), lineWidth: 1))
+                }
+            }
+            .contentShape(Rectangle())
+            .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder private var content: some View {
+        if showsPrompt {
+            // Empty state — a hero call-to-action instead of the guest summary.
+            Text(promptText ?? String(themeKit: "Select dates for price"))
+                .textStyle(.labelSm600)
+                .foregroundStyle(theme.text(.textHero))
+                .lineLimit(1)
+        } else if let title {
+            VStack(spacing: 0) {
+                Text(title)
+                    .textStyle(.bodyMd500)
+                    .foregroundStyle(theme.text(.textPrimary))
+                    .lineLimit(1)
+                summaryLine
+            }
+        } else {
+            summaryLine
+        }
+    }
+
+    /// `date · | · adults · children · rooms`.
+    private var summaryLine: some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            if let time {
+                Text(time)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(theme.text(.textTertiary))
+                    .opacity(0.9)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            if time != nil {
+                Rectangle().fill(theme.background(.bgElevatorTertiary)).frame(width: 1, height: 12)
+            }
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                paxChip(adultIcon, adults)
+                if let children { paxChip(childIcon, children) }
+                if let rooms { paxChip(roomIcon, rooms) }
+            }
+            .fixedSize(horizontal: true, vertical: false)
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func paxChip(_ systemImage: String, _ value: Int) -> some View {
+        HStack(spacing: Theme.SpacingKey.xs.value) {
+            Icon(systemName: systemImage).size(.xs).colorOverride(theme.text(.textTertiary))
+            Text("\(value)")
+                .textStyle(.bodySm400)
+                .foregroundStyle(theme.text(.textTertiary))
+                .opacity(0.9)
+        }
+    }
+}
+
+// MARK: - Modifiers (copy-on-write · single mutation point)
+
+public extension SearchSummary {
+    /// Location title shown above the date/guests line.
+    func title(_ text: String?) -> Self { copy { $0.title = text } }
+    /// Children count chip (hidden when `nil`).
+    func children(_ count: Int?) -> Self { copy { $0.children = count } }
+    /// Rooms count chip (hidden when `nil`).
+    func rooms(_ count: Int?) -> Self { copy { $0.rooms = count } }
+    /// Wrap in the soft pill surface (bg + hairline) — the search-bar presentation.
+    func boxed(_ on: Bool = true) -> Self { copy { $0.boxed = on } }
+    /// Empty state — replace the guest summary with a hero call-to-action (e.g.
+    /// "select dates"); pass a custom message or use the default.
+    func prompt(_ text: String? = nil) -> Self { copy { $0.showsPrompt = true; $0.promptText = text } }
+    /// Make the whole summary tappable (re-open the search).
+    func onTap(_ action: @escaping () -> Void) -> Self { copy { $0.onTap = action } }
+    /// Override the guest icons (defaults: person / child / bed).
+    func icons(adult: String? = nil, child: String? = nil, room: String? = nil) -> Self {
+        copy {
+            if let adult { $0.adultIcon = adult }
+            if let child { $0.childIcon = child }
+            if let room { $0.roomIcon = room }
+        }
+    }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview("States: data/prompt × inline/boxed") {
+    VStack(alignment: .leading, spacing: 16) {
+        Group {
+            Text("data · inline").font(.caption2).foregroundStyle(.secondary)
+            SearchSummary(time: "12 – 16 Jul", adults: 2).children(1).rooms(1)
+            Text("data · boxed").font(.caption2).foregroundStyle(.secondary)
+            SearchSummary(time: "12 – 16 Jul", adults: 2).children(1).rooms(1).boxed()
+            Text("prompt · inline").font(.caption2).foregroundStyle(.secondary)
+            SearchSummary(time: nil, adults: 0).prompt()
+            Text("prompt · boxed").font(.caption2).foregroundStyle(.secondary)
+            SearchSummary(time: nil, adults: 0).prompt().boxed()
+            Text("with title").font(.caption2).foregroundStyle(.secondary)
+            SearchSummary(time: "12 – 16 Jul", adults: 2).title("Antalya Hotels").children(1).rooms(1)
+        }
+    }
+    .padding()
+    .environment(Theme.shared)
+}

--- a/Sources/ThemeKit/Components/Organisms/PageHeader.swift
+++ b/Sources/ThemeKit/Components/Organisms/PageHeader.swift
@@ -6,39 +6,48 @@
 
 import SwiftUI
 
-/// Organism. Screen header: optional back button, title + subtitle, trailing
-/// icon actions.
+/// Organism. The design-system **Page Header** — the top section of a screen:
+/// a back / menu leading slot, a center block (title, a two-line *search summary*,
+/// or a search input), trailing icon actions, and an optional accessory band
+/// (tabs, a progress line, or a stepper) beneath the bar.
 ///
-/// Chrome is style-driven: set a ``BarStyle`` with `.barStyle(_:)` and the
-/// header hands its back button (leading), title block (content) and icon
-/// actions (trailing) to the style as a `.top`-edge ``BarStyleConfiguration``.
-/// With no style set, the original chrome-less row renders pixel-identically
-/// (the stock `DefaultBarStyle` would add a fill + hairline this header never
-/// had, so the untouched default keeps the legacy layout).
+/// Chrome is **style-driven** — set a ``PageHeaderStyle`` with `.pageHeaderStyle(_:)`:
+///
+/// ```swift
+/// PageHeader("Antalya Hotels")
+///     .onBack { dismiss() }
+///     .searchSummary(caption: "12 – 16 Jul",
+///                    chips: [.init(systemImage: "person", value: "2"),
+///                            .init(systemImage: "bed.double", value: "1")])
+///     .actions([.init(systemImage: "arrow.left.arrow.right") { compare() },
+///               .init(systemImage: "magnifyingglass") { search() }])
+///     .tabs(["Overview", "Rooms", "Reviews"], selected: tab) { tab = $0 }
+///     .pageHeaderStyle(.plain)     // .brand / .onImage
+/// ```
+///
+/// Content + actions live in `init` / provider closures; every appearance knob is
+/// a chainable modifier. All colors, radii, spacing and type resolve from the
+/// active `Theme`, so a preset / dark / brand change re-skins it.
 public struct PageHeader: View {
-    @Environment(\.theme) private var theme
-    @Environment(\.componentDensity) private var density
-    @Environment(\.barStyle) private var barStyle
+    @Environment(\.pageHeaderStyle) private var style
+    @Environment(\.locale) private var locale
 
+    // MARK: Public value types
+
+    /// A trailing icon action.
     public struct Action: Identifiable {
         public let id = UUID()
         let systemImage: String
         let handler: () -> Void
-        public init(systemImage: String, handler: @escaping () -> Void) {
+        let accessibilityLabel: String?
+        public init(systemImage: String, accessibilityLabel: String? = nil, handler: @escaping () -> Void) {
             self.systemImage = systemImage
+            self.accessibilityLabel = accessibilityLabel
             self.handler = handler
         }
     }
 
-    private let title: String
-
-    // Appearance/config — mutated only through the modifiers below (R2).
-    private var subtitle: String?
-    private var onBack: (() -> Void)?
-    private var actions: [Action] = []
-    private var tags: [Tag] = []
-
-    /// A status tag shown next to the title. (Ant PageHeader `tags`.)
+    /// A status tag shown next to the title (Ant PageHeader `tags`).
     public struct Tag: Identifiable {
         public let id = UUID()
         let text: String
@@ -49,136 +58,189 @@ public struct PageHeader: View {
         }
     }
 
-    public init(_ title: String) {   // R1
-        self.title = title
+    /// A brand-soft primary pill in the trailing area (a call-to-action).
+    public struct PrimaryButton {
+        let title: String
+        let systemImage: String?
+        let action: () -> Void
+        public init(_ title: String, systemImage: String? = nil, action: @escaping () -> Void) {
+            self.title = title
+            self.systemImage = systemImage
+            self.action = action
+        }
     }
+
+    /// A center search input bound to the caller's text.
+    public struct SearchField {
+        let text: Binding<String>
+        let placeholder: String
+        let onSubmit: (() -> Void)?
+    }
+
+    /// A filled square button inside the On Map search card (filter / edit).
+    public struct FilterButton {
+        let systemImage: String
+        let accessibilityLabel: String?
+        let action: () -> Void
+    }
+
+    /// A custom leading icon button (menu / hamburger) in place of the back arrow.
+    public struct LeadingIcon {
+        let systemImage: String
+        let handler: () -> Void
+    }
+
+    /// The band under the bar.
+    public enum Accessory {
+        case none
+        /// A row of tabs with a hero underline on the selected index.
+        case tabs(titles: [String], selected: Int, onSelect: (Int) -> Void)
+        /// A hero progress line (0…1) across the bottom of the bar.
+        case progress(Double)
+        /// A segmented stepper: `current` of `total` filled.
+        case stepper(current: Int, total: Int)
+    }
+
+    // MARK: Storage
+
+    private let title: String
+    private var subtitle: String?
+    private var showTitle = true
+    private var tags: [Tag] = []
+    /// Bound ``SearchSummary`` sub-component shown as the center block.
+    private var summary: SearchSummary?
+    private var searchField: SearchField?
+    private var logo: AnyView?
+    private var onBack: (() -> Void)?
+    private var leadingIcon: LeadingIcon?
+    private var actions: [Action] = []
+    private var primaryButton: PrimaryButton?
+    private var filterButton: FilterButton?
+    private var accessory: Accessory = .none
+
+    public init(_ title: String) { self.title = title }   // content only
 
     public var body: some View {
-        if barStyle.isDefault {
-            // No `.barStyle(_:)` set — the original chrome-less header row.
-            legacyRow
-        } else {
-            barStyle.makeBody(configuration: configuration)
-        }
-    }
-
-    // MARK: Legacy (default) layout — unchanged
-
-    private var legacyRow: some View {
-        HStack(spacing: Theme.SpacingKey.sm.value) {
-            if let onBack { backButton(onBack) }
-
-            titleBlock
-
-            Spacer(minLength: Theme.SpacingKey.sm.value)
-
-            actionButtons
-        }
-        .padding(.vertical, Theme.SpacingKey.sm.value)
-    }
-
-    // MARK: BarStyle path
-
-    private var configuration: BarStyleConfiguration {
-        BarStyleConfiguration(leading: onBack.map { AnyView(backButton($0)) },
-                              content: AnyView(styledContent),
-                              trailing: actions.isEmpty ? nil : AnyView(trailingActions),
-                              edge: .top)
-    }
-
-    /// The title block prepared for a style: it reserves the side-slot inset
-    /// wherever an accessory occupies the slot the style overlays, and fills
-    /// the standard bar row height.
-    private var styledContent: some View {
-        titleBlock
-            .padding(.leading, onBack == nil
-                     ? density.scale(Theme.SpacingKey.sm.value)
-                     : BarMetrics.contentInset(density))
-            .padding(.trailing, actions.isEmpty
-                     ? density.scale(Theme.SpacingKey.sm.value)
-                     : BarMetrics.contentInset(density))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .frame(minHeight: BarMetrics.rowHeight)
-    }
-
-    private var trailingActions: some View {
-        HStack(spacing: Theme.SpacingKey.sm.value) { actionButtons }
-    }
-
-    // MARK: Shared pieces
-
-    private var titleBlock: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: Theme.SpacingKey.xs.value) {
-                Text(title)
-                    .textStyle(.headingSm)
-                    .foregroundStyle(theme.text(.textPrimary))
-                ForEach(tags) { tag in
-                    ThemeKit.Tag(tag.text).tagStyle(tag.style)
-                }
-            }
-            if let subtitle {
-                Text(subtitle)
-                    .textStyle(.bodySm400)
-                    .foregroundStyle(theme.text(.textSecondary))
-            }
-        }
-    }
-
-    private func backButton(_ action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Icon(systemName: "chevron.left").size(.md).color(theme.text(.textPrimary))
-                .mirrorsInRTL()
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Back")
-    }
-
-    private var actionButtons: some View {
-        ForEach(actions) { action in
-            Button(action: action.handler) {
-                Icon(systemName: action.systemImage).size(.md).color(theme.text(.textPrimary))
-            }
-            .buttonStyle(.plain)
-        }
+        style.makeBody(configuration: PageHeaderConfiguration(
+            title: title, subtitle: subtitle, showTitle: showTitle, tags: tags, summary: summary,
+            searchField: searchField, logo: logo, onBack: onBack, leadingIcon: leadingIcon,
+            actions: actions, primaryButton: primaryButton, filterButton: filterButton,
+            accessory: accessory, locale: locale
+        ))
     }
 }
 
-// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+// MARK: - Modifiers (copy-on-write · content = init, appearance = modifiers)
 
 public extension PageHeader {
-    /// Secondary line under the title.
+    /// Secondary line under the title (plain-title center only).
     func subtitle(_ text: String?) -> Self { copy { $0.subtitle = text } }
 
-    /// Status tags shown next to the title (Ant PageHeader `tags`).
+    /// Hide the title (per-style `Show Title` toggle).
+    func showTitle(_ show: Bool = true) -> Self { copy { $0.showTitle = show } }
+
+    /// Status tags shown next to the title.
     func tags(_ tags: [Tag]) -> Self { copy { $0.tags = tags } }
+
+    /// Bind a ``SearchSummary`` sub-component as the center block (date/guests,
+    /// optionally with a location title and the boxed pill presentation).
+    func searchSummary(_ summary: SearchSummary) -> Self { copy { $0.summary = summary } }
+
+    /// Replace the center with a bound search input pill.
+    func searchField(text: Binding<String>,
+                     placeholder: String = "",
+                     onSubmit: (() -> Void)? = nil) -> Self {
+        copy { $0.searchField = SearchField(text: text, placeholder: placeholder, onSubmit: onSubmit) }
+    }
+
+    /// Replace the center with a brand logo (any view) — used by `.brand` chrome.
+    func logo(_ view: some View) -> Self { copy { $0.logo = AnyView(view) } }
 
     /// Show a leading back button invoking `action`.
     func onBack(_ action: (() -> Void)?) -> Self { copy { $0.onBack = action } }
 
+    /// A custom leading icon button (menu / hamburger) instead of the back arrow.
+    func leading(systemImage: String, action: @escaping () -> Void) -> Self {
+        copy { $0.leadingIcon = LeadingIcon(systemImage: systemImage, handler: action) }
+    }
+
     /// Trailing icon actions.
     func actions(_ actions: [Action]) -> Self { copy { $0.actions = actions } }
 
-    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+    /// A trailing brand-soft primary pill (call-to-action).
+    func primaryButton(_ title: String, systemImage: String? = nil,
+                       action: @escaping () -> Void) -> Self {
+        copy { $0.primaryButton = PrimaryButton(title, systemImage: systemImage, action: action) }
+    }
+
+    /// A filled square filter/edit button inside the On Map search card
+    /// (`.onImage` chrome + a bound ``SearchSummary``).
+    func mapFilter(systemImage: String, accessibilityLabel: String? = nil,
+                   action: @escaping () -> Void) -> Self {
+        copy { $0.filterButton = FilterButton(systemImage: systemImage,
+                                              accessibilityLabel: accessibilityLabel, action: action) }
+    }
+
+    /// Accessory band: a tab row with a hero underline on `selected`.
+    func tabs(_ titles: [String], selected: Int, onSelect: @escaping (Int) -> Void) -> Self {
+        copy { $0.accessory = .tabs(titles: titles, selected: selected, onSelect: onSelect) }
+    }
+
+    /// Accessory band: a hero progress line across the bottom (0…1).
+    func progress(_ fraction: Double) -> Self { copy { $0.accessory = .progress(fraction) } }
+
+    /// Accessory band: a segmented stepper — `current` of `total` filled.
+    func stepper(current: Int, total: Int) -> Self {
+        copy { $0.accessory = .stepper(current: current, total: total) }
+    }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // single mutation point
         var c = self
         mutate(&c)
         return c
     }
 }
 
-#Preview {
-    VStack(spacing: 16) {
-        PageHeader("Search results")
-            .subtitle("128 hotels")
+// MARK: - Previews
+
+#Preview("Plain — variants") {
+    VStack(spacing: 20) {
+        PageHeader("Antalya Hotels")
             .onBack {}
-            .actions([.init(systemImage: "slider.horizontal.3", handler: {}),
-                      .init(systemImage: "heart", handler: {})])
-        PageHeader("Settings")
-        PageHeader("Floating")
-            .subtitle("BarStyle demo")
+            .searchSummary(SearchSummary(time: "12 – 16 Jul", adults: 2).title("Antalya Hotels").children(1).rooms(1))
+            .actions([.init(systemImage: "square.on.square") {},
+                      .init(systemImage: "magnifyingglass") {}])
+
+        PageHeader("Title")
             .onBack {}
-            .actions([.init(systemImage: "heart", handler: {})])
-            .barStyle(.floating)
+            .tabs(["Tab 1", "Tab 2", "Tab 3", "Tab 4"], selected: 0) { _ in }
+            .actions([.init(systemImage: "magnifyingglass") {}])
+
+        PageHeader("Title").onBack {}.progress(0.4)
+            .actions([.init(systemImage: "magnifyingglass") {}])
+
+        PageHeader("Title").onBack {}.stepper(current: 1, total: 4)
+
+        PageHeader("Title")
+            .primaryButton("Set alert", systemImage: "bell.fill") {}
+            .actions([.init(systemImage: "magnifyingglass") {}])
     }
-    .padding()
+    .padding(.vertical)
+    .environment(Theme.shared)
+}
+
+#Preview("Brand + On-image") {
+    VStack(spacing: 20) {
+        PageHeader("Brand")
+            .logo(Text("etstur").font(.system(size: 22, weight: .heavy)).foregroundStyle(SemanticColor.primary.onSolid))
+            .pageHeaderStyle(.brand)
+
+        PageHeader("Hotel Details")
+            .onBack {}
+            .actions([.init(systemImage: "heart") {}, .init(systemImage: "xmark") {}])
+            .pageHeaderStyle(.onImage)
+            .background(SemanticColor.primary.solid)
+    }
+    .padding(.vertical)
+    .environment(Theme.shared)
 }

--- a/Sources/ThemeKit/Components/Organisms/PageHeaderStyle.swift
+++ b/Sources/ThemeKit/Components/Organisms/PageHeaderStyle.swift
@@ -1,0 +1,541 @@
+//
+//  PageHeaderStyle.swift
+//  ThemeKit
+//
+//  The style system behind ``PageHeader`` — the design-system "Page Header"
+//  organism. One component owns the *data* (title, a bound ``SearchSummary``,
+//  back/leading, trailing actions, a primary pill, an optional tabs/progress/
+//  stepper accessory, a brand logo); a swappable ``PageHeaderStyle`` owns the
+//  *chrome*:
+//
+//      .plain     white bar + soft-blue hairline, dark content, 44pt row
+//      .brand     accent fill (or no-bg) with a centered brand logo
+//      .onImage   transparent overlay — 40pt circular buttons, white content,
+//                 and (when a search summary is set) a floating map card
+//
+//  Every color, radius, spacing and type resolves from the active `Theme`, so a
+//  preset/dark/brand change re-skins the whole header. Pixel-mapped to the Etstur
+//  AppKit "Page Header" variants (Header · Icon Buttons · Tab · Progress ·
+//  Stepper · with Button · With Search Bar · On Image · On Map · brand/-no-bg ·
+//  with search Input).
+//
+
+import SwiftUI
+
+// MARK: - Shared geometry
+
+/// One source of truth for the header's fixed metrics.
+enum PHMetrics {
+    /// Height of the main title/slot row (Figma `header-height`).
+    static let rowHeight: CGFloat = 44
+    /// Square footprint of an inline icon button.
+    static let slot: CGFloat = 32
+    /// Diameter of a circular overlay button (On Image / On Map).
+    static let circle: CGFloat = 40
+    /// Progress / stepper track height.
+    static let track: CGFloat = 6
+    /// Active tab underline height.
+    static let tabBar: CGFloat = 4
+}
+
+// MARK: - Configuration
+
+/// The typed inputs every ``PageHeaderStyle`` lays out. Data only — each chrome
+/// decides its own colors.
+public struct PageHeaderConfiguration {
+    public let title: String
+    public let subtitle: String?
+    public let showTitle: Bool
+    public let tags: [PageHeader.Tag]
+    public let summary: SearchSummary?
+    public let searchField: PageHeader.SearchField?
+    public let logo: AnyView?
+    public let onBack: (() -> Void)?
+    public let leadingIcon: PageHeader.LeadingIcon?
+    public let actions: [PageHeader.Action]
+    public let primaryButton: PageHeader.PrimaryButton?
+    public let filterButton: PageHeader.FilterButton?
+    public let accessory: PageHeader.Accessory
+    public let locale: Locale
+
+    enum Center { case logo, searchField, summary, title }
+    var center: Center {
+        if logo != nil { return .logo }
+        if searchField != nil { return .searchField }
+        if summary != nil { return .summary }
+        return .title
+    }
+
+    var hasLeading: Bool { leadingIcon != nil || onBack != nil }
+    var hasTrailing: Bool { !actions.isEmpty || primaryButton != nil }
+}
+
+// MARK: - Style protocol
+
+/// Defines a header's chrome. Set one with `.pageHeaderStyle(_:)`; default is
+/// ``PlainPageHeaderStyle``.
+public protocol PageHeaderStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: PageHeaderConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks
+
+/// An inline (square, 32pt) or circular (40pt white, shadowed) icon button.
+struct PHIconButton: View {
+    @Environment(\.theme) private var theme
+    let systemImage: String
+    let action: () -> Void
+    var foreground: Color
+    var circular = false
+    var label: String?
+
+    var body: some View {
+        Button(action: action) {
+            Icon(systemName: systemImage)
+                .size(.lg)
+                .colorOverride(circular ? theme.text(.textPrimary) : foreground)
+                .frame(width: circular ? PHMetrics.circle : PHMetrics.slot,
+                       height: circular ? PHMetrics.circle : PHMetrics.slot)
+                .background {
+                    if circular { Circle().fill(theme.background(.bgWhite)).themeShadow(.soft) }
+                }
+                .contentShape(circular ? AnyShape(Circle()) : AnyShape(Rectangle()))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label ?? "")
+    }
+}
+
+/// A filled square action button (the On Map filter / edit).
+struct PHFilterButton: View {
+    @Environment(\.theme) private var theme
+    let systemImage: String
+    let action: () -> Void
+    var label: String?
+
+    var body: some View {
+        Button(action: action) {
+            Icon(systemName: systemImage).size(.sm).colorOverride(SemanticColor.primary.onSolid)
+                .frame(width: PHMetrics.slot, height: PHMetrics.slot)
+                .background(SemanticColor.primary.solid,
+                            in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label ?? "")
+    }
+}
+
+/// The soft-blue primary pill (the "notify me" call-to-action).
+struct PHPrimaryButton: View {
+    @Environment(\.theme) private var theme
+    let button: PageHeader.PrimaryButton
+
+    var body: some View {
+        Button(action: button.action) {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                if let systemImage = button.systemImage {
+                    Icon(systemName: systemImage).size(.sm).colorOverride(theme.text(.textHero))
+                }
+                Text(button.title).textStyle(.labelSm600).foregroundStyle(theme.text(.textHero))
+            }
+            .padding(.horizontal, Theme.SpacingKey.sm.value)
+            .frame(height: PHMetrics.slot)
+            .background(theme.background(.bgElevatorTertiary),
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// The center search input pill — leading magnifier + a bound text field.
+struct PHSearchField: View {
+    @Environment(\.theme) private var theme
+    let field: PageHeader.SearchField
+
+    var body: some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            Icon(systemName: "magnifyingglass").size(.sm).colorOverride(theme.text(.textTertiary))
+            TextField(field.placeholder, text: field.text)
+                .textStyle(.bodyBase400)
+                .foregroundStyle(theme.text(.textPrimary))
+                .submitLabel(.search)
+                .onSubmit { field.onSubmit?() }
+        }
+        .padding(.horizontal, Theme.SpacingKey.md.value)
+        .frame(height: PHMetrics.slot, alignment: .center)
+        .frame(maxWidth: .infinity)
+        .background(theme.background(.bgElevatorPrimary),
+                    in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
+                .strokeBorder(theme.background(.bgElevatorTertiary), lineWidth: 1)
+        )
+    }
+}
+
+/// The shared center block: title / bound search summary / search input.
+struct PHCenter: View {
+    @Environment(\.theme) private var theme
+    let configuration: PageHeaderConfiguration
+    var foreground: Color
+
+    var body: some View {
+        switch configuration.center {
+        case .searchField:
+            if let field = configuration.searchField { PHSearchField(field: field) }
+        case .summary:
+            if let summary = configuration.summary { summary.frame(maxWidth: .infinity) }
+        case .title:
+            if configuration.showTitle { titleText }
+        case .logo:
+            EmptyView()
+        }
+    }
+
+    private var titleText: some View {
+        VStack(alignment: configuration.hasLeading ? .center : .leading, spacing: 2) {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                Text(configuration.title).textStyle(.heading2xs).foregroundStyle(foreground)
+                ForEach(configuration.tags) { tag in ThemeKit.Tag(tag.text).tagStyle(tag.style) }
+            }
+            if let subtitle = configuration.subtitle {
+                Text(subtitle).textStyle(.bodySm400).foregroundStyle(foreground.opacity(0.7))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: configuration.hasLeading ? .center : .leading)
+    }
+}
+
+/// The accessory band under the bar — tabs, a progress line, or a stepper.
+struct PHAccessory: View {
+    @Environment(\.theme) private var theme
+    let accessory: PageHeader.Accessory
+
+    var body: some View {
+        switch accessory {
+        case .none:
+            EmptyView()
+        case let .tabs(titles, selected, onSelect):
+            PHTabsBar(titles: titles, selected: selected, onSelect: onSelect)
+        case let .progress(fraction):
+            progress(fraction)
+        case let .stepper(current, total):
+            stepper(current: current, total: total)
+        }
+    }
+
+    /// A 6pt track with a hero fill of `fraction`, rounded at the leading cap.
+    private func progress(_ fraction: Double) -> some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                theme.background(.bgSecondaryLight)
+                Capsule().fill(theme.foreground(.fgHero))
+                    .frame(width: max(0, geo.size.width * min(max(fraction, 0), 1)))
+            }
+        }
+        .frame(height: PHMetrics.track)
+    }
+
+    /// `total` rounded segments, `current` filled with the deep-hero token.
+    private func stepper(current: Int, total: Int) -> some View {
+        HStack(spacing: Theme.SpacingKey.xs.value) {
+            ForEach(0..<max(total, 1), id: \.self) { index in
+                Capsule()
+                    .fill(index < current ? SemanticColor.primary.active : theme.background(.bgSecondaryLight))
+                    .frame(height: PHMetrics.track)
+            }
+        }
+        .padding(.horizontal, Theme.SpacingKey.md.value)
+    }
+}
+
+/// The tab row: each tab is `Medium` dark when selected with a 4pt hero underline,
+/// `Regular` secondary otherwise, over a shared soft-blue hairline.
+struct PHTabsBar: View {
+    @Environment(\.theme) private var theme
+    let titles: [String]
+    let selected: Int
+    let onSelect: (Int) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 0) {
+                ForEach(Array(titles.enumerated()), id: \.offset) { index, title in
+                    tab(title, index: index)
+                }
+            }
+        }
+        .overlay(alignment: .bottom) {
+            theme.background(.bgElevatorTertiary).frame(height: 1)
+        }
+    }
+
+    private func tab(_ title: String, index: Int) -> some View {
+        let isOn = index == selected
+        return Button { onSelect(index) } label: {
+            VStack(spacing: Theme.SpacingKey.sm.value) {
+                Text(title)
+                    .textStyle(isOn ? .bodyBase500 : .bodyBase400)
+                    .foregroundStyle(isOn ? theme.text(.textPrimary) : theme.text(.textSecondary))
+                    .fixedSize()
+                UnevenRoundedRectangle(topLeadingRadius: Theme.RadiusRole.field.value,
+                                       topTrailingRadius: Theme.RadiusRole.field.value)
+                    .fill(isOn ? theme.foreground(.fgHero) : Color.clear)
+                    .frame(height: PHMetrics.tabBar)
+            }
+            .padding(.leading, index == 0 ? Theme.SpacingKey.md.value : Theme.SpacingKey.sm.value)
+            .padding(.trailing, Theme.SpacingKey.sm.value)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Chrome: the bar row (plain + brand)
+
+/// Lays leading · center · trailing into the 44pt row. Shared by plain + brand.
+struct PHBarRow: View {
+    let configuration: PageHeaderConfiguration
+    var foreground: Color
+
+    var body: some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            leading
+            center
+            trailing
+        }
+        .padding(.horizontal, Theme.SpacingKey.md.value)
+        .frame(height: PHMetrics.rowHeight)
+    }
+
+    @ViewBuilder private var leading: some View {
+        if let leadingIcon = configuration.leadingIcon {
+            PHIconButton(systemImage: leadingIcon.systemImage, action: leadingIcon.handler,
+                         foreground: foreground, label: "Menu")
+        } else if let onBack = configuration.onBack {
+            PHIconButton(systemImage: "arrow.left", action: onBack, foreground: foreground, label: "Back")
+        }
+    }
+
+    @ViewBuilder private var center: some View {
+        if configuration.center == .logo, let logo = configuration.logo {
+            logo.frame(maxWidth: .infinity)
+        } else {
+            PHCenter(configuration: configuration, foreground: foreground)
+        }
+    }
+
+    @ViewBuilder private var trailing: some View {
+        if configuration.hasTrailing {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                if let primary = configuration.primaryButton { PHPrimaryButton(button: primary) }
+                ForEach(configuration.actions) { action in
+                    PHIconButton(systemImage: action.systemImage, action: action.handler,
+                                 foreground: foreground, label: action.accessibilityLabel)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Plain chrome
+
+/// White bar + soft-blue bottom hairline + dark content. Covers Header · Icon
+/// Buttons · Tab · Progress · Stepper · with Button · with search Input.
+public struct PlainPageHeaderStyle: PageHeaderStyle {
+    public init() {}
+    public func makeBody(configuration: PageHeaderConfiguration) -> some View {
+        PlainChrome(configuration: configuration)
+    }
+}
+
+private struct PlainChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: PageHeaderConfiguration
+
+    var body: some View {
+        VStack(spacing: 0) {
+            PHBarRow(configuration: configuration, foreground: theme.text(.textPrimary))
+            accessoryBand
+        }
+        .background(theme.background(.bgWhite))
+        .overlay(alignment: .bottom) {
+            theme.background(.bgElevatorTertiary).frame(height: 1)
+        }
+    }
+
+    @ViewBuilder private var accessoryBand: some View {
+        switch configuration.accessory {
+        case .none:
+            EmptyView()
+        case .tabs:
+            PHAccessory(accessory: configuration.accessory)
+        case .progress, .stepper:
+            PHAccessory(accessory: configuration.accessory)
+                .padding(.bottom, Theme.SpacingKey.sm.value)
+        }
+    }
+}
+
+// MARK: - Brand chrome
+
+/// A centered brand logo on an accent fill (or no background). Covers Brand ·
+/// brand-no bg.
+public struct BrandPageHeaderStyle: PageHeaderStyle {
+    let color: SemanticColor
+    let filled: Bool
+    public init(color: SemanticColor = .primary, filled: Bool = true) {
+        self.color = color
+        self.filled = filled
+    }
+    public func makeBody(configuration: PageHeaderConfiguration) -> some View {
+        BrandChrome(configuration: configuration, color: color, filled: filled)
+    }
+}
+
+private struct BrandChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: PageHeaderConfiguration
+    let color: SemanticColor
+    let filled: Bool
+
+    private var foreground: Color { filled ? color.onSolid : theme.text(.textPrimary) }
+
+    var body: some View {
+        PHBarRow(configuration: configuration, foreground: foreground)
+            .background(filled ? color.solid : theme.background(.bgWhite))
+    }
+}
+
+// MARK: - On-image / On-map chrome
+
+/// A transparent overlay for hero images and maps: 40pt circular white buttons
+/// (dark glyph), white title — or, when a search summary is set, a floating white
+/// map card holding the summary and a filled filter button. Covers On Image ·
+/// With Search Bar_On Image · On Map.
+public struct OnImagePageHeaderStyle: PageHeaderStyle {
+    public init() {}
+    public func makeBody(configuration: PageHeaderConfiguration) -> some View {
+        OnImageChrome(configuration: configuration)
+    }
+}
+
+private struct OnImageChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: PageHeaderConfiguration
+
+    var body: some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            leading
+            if let summary = configuration.summary {
+                if let filter = configuration.filterButton {
+                    mapCard(summary, filter: filter)          // On Map
+                } else {
+                    summary.boxed().frame(maxWidth: .infinity) // With Search Bar · On Image
+                    trailingButtons
+                }
+            } else {
+                title                                          // On Image
+                trailingButtons
+            }
+        }
+        .padding(Theme.SpacingKey.md.value)
+    }
+
+    @ViewBuilder private var leading: some View {
+        if let leadingIcon = configuration.leadingIcon {
+            PHIconButton(systemImage: leadingIcon.systemImage, action: leadingIcon.handler,
+                         foreground: .white, circular: true, label: "Menu")
+        } else if let onBack = configuration.onBack {
+            PHIconButton(systemImage: "arrow.left", action: onBack, foreground: .white, circular: true, label: "Back")
+        }
+    }
+
+    private var title: some View {
+        Group {
+            if configuration.showTitle {
+                Text(configuration.title).textStyle(.heading2xs).foregroundStyle(Color.white)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder private var trailingButtons: some View {
+        if configuration.hasTrailing {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                ForEach(configuration.actions) { action in
+                    PHIconButton(systemImage: action.systemImage, action: action.handler,
+                                 foreground: .white, circular: true, label: action.accessibilityLabel)
+                }
+            }
+        }
+    }
+
+    /// On Map: a white card holding the summary + a filled filter button, floated.
+    private func mapCard(_ summary: SearchSummary, filter: PageHeader.FilterButton) -> some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            summary.frame(maxWidth: .infinity)
+            PHFilterButton(systemImage: filter.systemImage, action: filter.action,
+                           label: filter.accessibilityLabel)
+        }
+        .padding(.leading, Theme.SpacingKey.sm.value)
+        .padding(.trailing, Theme.SpacingKey.xs.value)
+        .padding(.vertical, Theme.SpacingKey.xs.value)
+        .frame(maxWidth: .infinity)
+        .background(theme.background(.bgWhite),
+                    in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+        .themeShadow(.soft)
+    }
+}
+
+// MARK: - Static accessors
+
+public extension PageHeaderStyle where Self == PlainPageHeaderStyle {
+    /// White bar + soft hairline, dark content (the default).
+    static var plain: PlainPageHeaderStyle { PlainPageHeaderStyle() }
+}
+
+public extension PageHeaderStyle where Self == BrandPageHeaderStyle {
+    /// A centered brand logo on an accent fill.
+    static var brand: BrandPageHeaderStyle { BrandPageHeaderStyle() }
+    /// A brand logo with no background fill.
+    static var brandNoBackground: BrandPageHeaderStyle { BrandPageHeaderStyle(filled: false) }
+    /// A brand logo on a custom accent fill.
+    static func brand(_ color: SemanticColor, filled: Bool = true) -> BrandPageHeaderStyle {
+        BrandPageHeaderStyle(color: color, filled: filled)
+    }
+}
+
+public extension PageHeaderStyle where Self == OnImagePageHeaderStyle {
+    /// Transparent overlay with circular buttons + white content, for hero
+    /// images and maps.
+    static var onImage: OnImagePageHeaderStyle { OnImagePageHeaderStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyPageHeaderStyle: PageHeaderStyle {
+    private let _makeBody: @MainActor (PageHeaderConfiguration) -> AnyView
+    init<S: PageHeaderStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: PageHeaderConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct PageHeaderStyleKey: EnvironmentKey {
+    static let defaultValue = AnyPageHeaderStyle(PlainPageHeaderStyle())
+}
+
+extension EnvironmentValues {
+    var pageHeaderStyle: AnyPageHeaderStyle {
+        get { self[PageHeaderStyleKey.self] }
+        set { self[PageHeaderStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``PageHeaderStyle`` for headers in this view and its descendants.
+    func pageHeaderStyle<S: PageHeaderStyle>(_ style: sending S) -> some View {
+        environment(\.pageHeaderStyle, AnyPageHeaderStyle(style))
+    }
+}


### PR DESCRIPTION
Rewrites **PageHeader** as a style-driven organism and adds the reusable **SearchSummary** molecule — pixel-mapped to the Etstur AppKit "Page Header" library.

### PageHeader → `PageHeaderStyle`
Three chromes cover all 13 Figma variants:
- `.plain` — Header · Icon Buttons · Tab · Progress · Stepper · with Button · with search Input
- `.brand` / `.brandNoBackground` — Brand · brand-no bg
- `.onImage` — On Image · With Search Bar_On Image · On Map

Rich, token-fed modifiers: `.searchSummary`, `.searchField`, `.tabs`, `.progress`, `.stepper`, `.primaryButton`, `.mapFilter`, `.logo`, `.leading`, `.showTitle`. Brand-neutral (blue resolves from the theme).

### SearchSummary molecule
Reusable date/guests summary — 4 states (data/prompt × inline/boxed), optional location title, `.onTap`, a11y. Bound as the header's center block.

### Demo
13-style picker exposing each style's full Figma variable panel (Back Nav, First/Sec Action, Show Title, Title, Progress Value, Search summary group).

Verified pixel-accurate in the iOS simulator across all variants. Core builds clean (0 warnings from these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)