### PR TITLE
feat: Segmented Ant parity + DatePriceStrip strip + RecentSearchRow pill

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -303,35 +303,76 @@ struct RangeSliderDemo: View {
     }
 }
 
+/// Storybook — every Ant Segmented variant at a glance.
 struct SegmentedControlDemo: View {
-    @State private var selection = 0
-    @State private var icons = false
-    @State private var block = true
-    @State private var enabled = true
-    @State private var sizeIdx = 1   // 0 small, 1 medium, 2 large
-    private var size: SegmentedSize { sizeIdx == 0 ? .small : sizeIdx == 2 ? .large : .medium }
+    @State private var basic = 0
+    @State private var round = 1
+    @State private var icons = 0
+    @State private var iconOnly = 0
+    @State private var sS = 0
+    @State private var sM = 1
+    @State private var sL = 2
+    @State private var vert = 0
+    @State private var custom = 0
+    @State private var outline = 2
+    private let period = ["Daily", "Weekly", "Monthly"]
 
     var body: some View {
-        ComponentStage("SegmentedControl", inspector: [("selection", "\(selection)"), ("block", "\(block)"), ("size", sizeIdx == 0 ? "small" : sizeIdx == 2 ? "large" : "medium")]) {
-            if icons {
-                SegmentedControl([SegmentItem("List", systemImage: "list.bullet"),
-                                  SegmentItem("Grid", systemImage: "square.grid.2x2"),
-                                  SegmentItem("Map", systemImage: "map", isEnabled: false)],
-                                 selection: $selection)
-                    .fullWidth(block).size(size)
-                    .disabled(!enabled)
-            } else {
-                SegmentedControl(["Daily", "Weekly", "Monthly"], selection: $selection)
-                    .fullWidth(block).size(size)
-                    .disabled(!enabled)
+        ComponentStage("SegmentedControl") {
+            VStack(alignment: .leading, spacing: 18) {
+                section("Basic") { SegmentedControl(period, selection: $basic) }
+                section("Round shape") { SegmentedControl(period, selection: $round).shape(.round) }
+                section("Sizes — small / medium / large") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        SegmentedControl(period, selection: $sS).size(.small).fullWidth(false)
+                        SegmentedControl(period, selection: $sM).size(.medium).fullWidth(false)
+                        SegmentedControl(period, selection: $sL).size(.large).fullWidth(false)
+                    }
+                }
+                section("Icon + label (Map disabled)") {
+                    SegmentedControl([SegmentItem("List", systemImage: "list.bullet"),
+                                      SegmentItem("Grid", systemImage: "square.grid.2x2"),
+                                      SegmentItem("Map", systemImage: "map", isEnabled: false)], selection: $icons)
+                }
+                section("Icon-only") {
+                    SegmentedControl([SegmentItem(icon: "list.bullet"), SegmentItem(icon: "square.grid.2x2"),
+                                      SegmentItem(icon: "map")], selection: $iconOnly).fullWidth(false)
+                }
+                section("Vertical") {
+                    SegmentedControl(["Recommended", "Price", "Rating"], selection: $vert).vertical().fullWidth(false)
+                }
+                section("Custom content (avatar over name)") {
+                    SegmentedControl([
+                        SegmentItem { avatarTab("A", "Ada") },
+                        SegmentItem { avatarTab("B", "Bo") },
+                        SegmentItem { avatarTab("C", "Cy") },
+                    ], selection: $custom).fullWidth(false)
+                }
+                section("Disabled (whole control)") {
+                    SegmentedControl(period, selection: .constant(0)).disabled(true)
+                }
+                section("selectionStyle .outline — the DatePriceStrip look") {
+                    SegmentedControl(["17 Jul", "18 Jul", "19 Jul", "20 Jul"], selection: $outline)
+                        .selectionStyle(.outline).shape(.round).fullWidth(false)
+                }
             }
-        } knobs: {
-            Stepper("Selection: \(selection)", value: $selection, in: 0...2)
-            Toggle("Icons + disabled option", isOn: $icons)
-            Toggle("Block (full width)", isOn: $block)
-            Toggle("Enabled", isOn: $enabled)
-            Picker("Size", selection: $sizeIdx) { Text("S").tag(0); Text("M").tag(1); Text("L").tag(2) }.pickerStyle(.segmented)
         }
+    }
+
+    @ViewBuilder private func section(_ title: String, @ViewBuilder _ content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            content()
+        }
+    }
+
+    private func avatarTab(_ initial: String, _ name: String) -> some View {
+        VStack(spacing: 4) {
+            Text(initial).font(.system(size: 13, weight: .bold)).foregroundStyle(SemanticColor.primary.onSolid)
+                .frame(width: 28, height: 28).background(Circle().fill(SemanticColor.primary.solid))
+            Text(name).textStyle(.labelSm600)
+        }
+        .padding(.vertical, 2)
     }
 }
 

--- a/Demo/Demo/Gallery/Demos/TravelDemos.swift
+++ b/Demo/Demo/Gallery/Demos/TravelDemos.swift
@@ -1069,32 +1069,45 @@ struct PriceTrendChartDemo: View {
     }
 }
 
+/// Storybook — DatePriceStrip layouts & states.
 struct DatePriceStripDemo: View {
-    @State private var sel = 1
-    @State private var columns = 3.0
-    @State private var cheapest = true
-    @State private var paging = true
+    @State private var s1 = 1
+    @State private var s2 = 2
+    @State private var s3 = 4
+    @State private var s4 = 1
 
     private let items = [
-        DatePriceItem("17 Jul", price: 1_697.99), DatePriceItem("18 Jul", price: 1_767.99),
-        DatePriceItem("19 Jul", price: 1_960.99), DatePriceItem("20 Jul", price: 1_914.99),
-        DatePriceItem("21 Jul", price: 1_474.99), DatePriceItem("22 Jul", price: 1_483.99),
+        DatePriceItem("17 Jul", price: 1_697), DatePriceItem("18 Jul", price: 1_767),
+        DatePriceItem("19 Jul", price: 1_960), DatePriceItem("20 Jul", price: 1_914),
+        DatePriceItem("21 Jul", price: 1_474), DatePriceItem("22 Jul", price: 1_483),
     ]
 
-    private var strip: DatePriceStrip {
-        var s = DatePriceStrip(items, selection: $sel).columns(Int(columns)).currency("TRY").highlightCheapest(cheapest)
-        if paging { s = s.onPage(prev: { flash("Previous dates") }, next: { flash("Next dates") }) }
-        return s
+    var body: some View {
+        ComponentStage("DatePriceStrip") {
+            VStack(alignment: .leading, spacing: 18) {
+                section("Strip (Timeline) — horizontal pills, scrollable, auto-centers") {
+                    DatePriceStrip(items, selection: $s1).strip().currency("TRY").highlightCheapest(false)
+                }
+                section("Strip — cheapest in green") {
+                    DatePriceStrip(items, selection: $s2).strip().currency("TRY").highlightCheapest()
+                }
+                section("Grid (3 columns) — the card layout") {
+                    DatePriceStrip(items, selection: $s3).currency("TRY").highlightCheapest()
+                }
+                section("Grid + paging chevrons (‹ ›)") {
+                    DatePriceStrip(Array(items.prefix(3)), selection: $s4).currency("TRY")
+                        .onPage(prev: { flash("Previous dates") }, next: { flash("Next dates") })
+                }
+                Text("Both layouts share DatePriceCard; the selection model matches SegmentedControl.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
     }
 
-    var body: some View {
-        ComponentStage("DatePriceStrip", inspector: [("selected", items[sel].date)]) {
-            strip.frame(maxWidth: 380)
-        } knobs: {
-            HStack { Text("Columns"); SwiftUI.Slider(value: $columns, in: 2...4, step: 1); Text("\(Int(columns))").font(.caption.monospacedDigit()) }
-            Toggle("Paging chevrons (‹ ›)", isOn: $paging)
-            Toggle("Auto-highlight cheapest (green)", isOn: $cheapest)
-            Text("Cards are the reusable DatePriceCard component.").font(.caption).foregroundStyle(.secondary)
+    @ViewBuilder private func section(_ title: String, @ViewBuilder _ content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+            content()
         }
     }
 }
@@ -1598,8 +1611,17 @@ struct RecentSearchRowDemo: View {
     @State private var round = true
     @State private var remove = false
     @State private var bordered = true
+    @State private var searchPill = false
 
     private var row: RecentSearchRow {
+        if searchPill {
+            // "Mini search bar" — no leading tile, capsule surface, trailing
+            // search button; meant to sit on a brand band (see below).
+            return RecentSearchRow(from: "Istanbul", to: "Antalya") { flash("Edit search") }
+                .icon(nil).dates("14 Jan").passengers("7")
+                .pill().surface(.bgWhite)
+                .onSearch { flash("Search") }
+        }
         var r = RecentSearchRow(from: "IST", to: "AYT") { flash("Re-run search") }
             .roundTrip(round).dates("18 – 27 Jul").passengers("2 adults · Economy").bordered(bordered)
         if remove { r = r.onRemove { flash("Removed") } }
@@ -1608,8 +1630,16 @@ struct RecentSearchRowDemo: View {
 
     var body: some View {
         ComponentStage("RecentSearchRow", inspector: [("trip", round ? "round" : "one-way")]) {
-            row.frame(maxWidth: 360)
+            if searchPill {
+                row.frame(maxWidth: 360)
+                    .padding(Theme.SpacingKey.md.value)
+                    .frame(maxWidth: .infinity)
+                    .background(SemanticColor.primary.solid)
+            } else {
+                row.frame(maxWidth: 360)
+            }
         } knobs: {
+            Toggle("Search pill (mini bar on band)", isOn: $searchPill)
             Toggle("Round trip (⇄ vs →)", isOn: $round)
             Toggle("Remove (✕) instead of chevron", isOn: $remove)
             Toggle("Bordered card", isOn: $bordered)

--- a/Sources/ThemeKit/Components/Molecules/DatePriceStrip.swift
+++ b/Sources/ThemeKit/Components/Molecules/DatePriceStrip.swift
@@ -35,6 +35,7 @@ public struct DatePriceCard: View {
     // Appearance — mutated only through the modifiers below (R2).
     private var currencyCode = "TRY"
     private var isCheapest = false
+    private var pill = false
 
     public init(_ item: DatePriceItem, isSelected: Bool, action: @escaping () -> Void) {   // R1
         self.item = item
@@ -48,20 +49,42 @@ public struct DatePriceCard: View {
 
     public var body: some View {
         Button(action: action) {
-            // The shell (fill, hairline, selected hero frame) is drawn by the
-            // active `CardStyle`; selection flows through `Configuration.isSelected`.
-            // Flat card → `.none` elevation keeps the classic 1pt hairline.
-            cardStyle.makeBody(configuration: CardStyleConfiguration(
-                content: AnyView(cardContent),
-                elevation: .none,
-                isSelected: isSelected,
-                isPressed: false,
-                surfaceKey: .bgElevatorPrimary,
-                radius: .selector))
+            if pill { pillShell } else { cardedShell }
         }
         .buttonStyle(.plain)
         .accessibilityLabel("\(item.date), \(item.price.formatted(.currency(code: currencyCode).precision(.fractionLength(0))))\(isCheapest ? ", lowest fare" : "")")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    /// The default carded shell — drawn by the active `CardStyle` (grid layout).
+    private var cardedShell: some View {
+        // Flat card → `.none` elevation keeps the classic 1pt hairline.
+        cardStyle.makeBody(configuration: CardStyleConfiguration(
+            content: AnyView(cardContent),
+            elevation: .none,
+            isSelected: isSelected,
+            isPressed: false,
+            surfaceKey: .bgElevatorPrimary,
+            radius: .selector))
+    }
+
+    /// The pill shell — the horizontal "Timeline" strip presentation: a rounded
+    /// capsule that turns hero-soft with a 2pt hero border + semibold date when
+    /// selected. Brand color resolves from the theme.
+    private var pillShell: some View {
+        let shape = Capsule(style: .continuous)
+        return VStack(spacing: 2) {
+            Text(item.date)
+                .textStyle(isSelected ? .labelSm600 : .bodySm400)
+                .foregroundStyle(theme.text(.textPrimary))
+            Text(item.price.formatted(.currency(code: currencyCode).precision(.fractionLength(0))))
+                .textStyle(.overline400)
+                .foregroundStyle(isCheapest ? theme.foreground(.systemcolorsFgSuccess) : theme.text(.textTertiary))
+        }
+        .padding(.horizontal, Theme.SpacingKey.base.value)
+        .frame(height: 40)
+        .background(isSelected ? SemanticColor.primary.soft : theme.background(.bgWhite), in: shape)
+        .overlay { if isSelected { shape.strokeBorder(theme.border(.borderHero), lineWidth: 2) } }
     }
 
     /// The card's inner layout — everything inside the shell. The 6% hero wash on
@@ -86,6 +109,8 @@ public extension DatePriceCard {
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
     /// Highlights this as the lowest fare (price shown in success green).
     func cheapest(_ on: Bool = true) -> Self { copy { $0.isCheapest = on } }
+    /// Render as a horizontal-strip pill (rounded capsule) instead of a card.
+    func pill(_ on: Bool = true) -> Self { copy { $0.pill = on } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {
         var c = self
@@ -104,6 +129,7 @@ public struct DatePriceStrip: View {
     private var currencyCode = "TRY"
     private var columns = 3
     private var highlightsCheapest = true
+    private var stripLayout = false
     private var onPrev: (() -> Void)?
     private var onNext: (() -> Void)?
 
@@ -118,7 +144,9 @@ public struct DatePriceStrip: View {
     }
 
     public var body: some View {
-        if onPrev != nil || onNext != nil {
+        if stripLayout {
+            stripView
+        } else if onPrev != nil || onNext != nil {
             HStack(spacing: 8) {
                 pageButton("chevron.left", onPrev)
                 gridView.frame(maxWidth: .infinity)
@@ -126,6 +154,30 @@ public struct DatePriceStrip: View {
             }
         } else {
             gridView
+        }
+    }
+
+    /// The horizontal "Timeline" strip — scrollable pills on a surface, with the
+    /// selected pill auto-centered.
+    private var stripView: some View {
+        let cheapest = cheapestIndex
+        return ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Theme.SpacingKey.xs.value) {
+                    ForEach(Array(items.enumerated()), id: \.offset) { i, item in
+                        DatePriceCard(item, isSelected: i == selection) { selection = i }
+                            .currency(currencyCode)
+                            .cheapest(i == cheapest)
+                            .pill()
+                            .id(i)
+                    }
+                }
+                .padding(density.scale(Theme.SpacingKey.sm.value))
+            }
+            .background(theme.background(.bgElevatorPrimary))
+            .onChange(of: selection) { _, new in
+                withAnimation { proxy.scrollTo(new, anchor: .center) }
+            }
         }
     }
 
@@ -158,8 +210,11 @@ public struct DatePriceStrip: View {
 public extension DatePriceStrip {
     /// Currency code for the prices (default "TRY").
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
-    /// Number of columns (default 3).
+    /// Number of columns for the grid layout (default 3).
     func columns(_ count: Int) -> Self { copy { $0.columns = max(1, count) } }
+    /// Lay the dates out as a horizontal **strip** of scrollable pills (the
+    /// "Timeline" presentation) instead of the multi-column grid.
+    func strip(_ on: Bool = true) -> Self { copy { $0.stripLayout = on } }
     /// Auto-highlight the lowest fare in success green (default on).
     func highlightCheapest(_ on: Bool = true) -> Self { copy { $0.highlightsCheapest = on } }
     /// Adds prev/next paging chevrons flanking the strip.
@@ -180,7 +235,12 @@ public extension DatePriceStrip {
             DatePriceItem("19 Jul", price: 1_960.99), DatePriceItem("20 Jul", price: 1_914.99),
             DatePriceItem("21 Jul", price: 1_474.99), DatePriceItem("22 Jul", price: 1_483.99),
         ]
-        var body: some View { DatePriceStrip(items, selection: $sel).padding() }
+        var body: some View {
+            VStack(spacing: 16) {
+                DatePriceStrip(items, selection: $sel).strip()          // Timeline pills
+                DatePriceStrip(items, selection: $sel).padding()        // grid
+            }
+        }
     }
     return Demo()
 }

--- a/Sources/ThemeKit/Components/Molecules/RecentSearchRow.swift
+++ b/Sources/ThemeKit/Components/Molecules/RecentSearchRow.swift
@@ -25,10 +25,13 @@ public struct RecentSearchRow: View {
     private var roundTrip = false
     private var dates: String?
     private var passengers: String?
-    private var systemImage = "clock.arrow.circlepath"
+    private var systemImage: String? = "clock.arrow.circlepath"
     private var onRemove: (() -> Void)?
+    private var onSearch: (() -> Void)?
+    private var searchAccent: SemanticColor = .neutral
     private var accent: SemanticColor?
     private var bordered = false
+    private var pill = false
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
 
     public init(from: String, to: String, action: @escaping () -> Void = {}) {   // R1
@@ -37,7 +40,11 @@ public struct RecentSearchRow: View {
         self.action = action
     }
 
-    private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous) }
+    private var shape: AnyShape {
+        pill
+            ? AnyShape(Capsule(style: .continuous))
+            : AnyShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+    }
     private var caption: String? {
         [dates, passengers].compactMap { $0 }.joined(separator: " · ").nilIfEmpty
     }
@@ -45,7 +52,7 @@ public struct RecentSearchRow: View {
     public var body: some View {
         Button(action: action) {
             HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-                IconTile(systemImage).size(40).iconSize(16).accent(accent)
+                if let systemImage { IconTile(systemImage).size(40).iconSize(16).accent(accent) }
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 6) {
                         Text(from).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
@@ -59,8 +66,8 @@ public struct RecentSearchRow: View {
             }
             .padding(density.scale(Theme.SpacingKey.sm.value))
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(bordered ? theme.background(surfaceKey) : .clear, in: shape)
-            .overlay { if bordered { shape.stroke(theme.border(.borderPrimary), lineWidth: 1) } }
+            .background((bordered || pill) ? theme.background(surfaceKey) : .clear, in: shape)
+            .overlay { if bordered && !pill { shape.stroke(theme.border(.borderPrimary), lineWidth: 1) } }
             .contentShape(shape)
         }
         .buttonStyle(.plain)
@@ -68,7 +75,14 @@ public struct RecentSearchRow: View {
     }
 
     @ViewBuilder private var trailing: some View {
-        if let onRemove {
+        if let onSearch {
+            ThemeButton(action: onSearch)
+                .icon(leading: "magnifyingglass")
+                .shape(.circle)
+                .color(searchAccent)
+                .size(.small)
+                .accessibilityLabel(String(themeKit: "Search"))
+        } else if let onRemove {
             Button { onRemove() } label: {
                 Image(systemName: "xmark").font(.system(size: 12, weight: .semibold)).foregroundStyle(theme.text(.textTertiary))
                     .frame(width: 44, height: 44).contentShape(Rectangle())
@@ -90,14 +104,24 @@ public extension RecentSearchRow {
     func roundTrip(_ on: Bool = true) -> Self { copy { $0.roundTrip = on } }
     func dates(_ text: String?) -> Self { copy { $0.dates = text } }
     func passengers(_ text: String?) -> Self { copy { $0.passengers = text } }
-    func icon(_ systemName: String) -> Self { copy { $0.systemImage = systemName } }
+    /// Leading icon-tile glyph, or `nil` to drop the tile (e.g. a search pill).
+    func icon(_ systemName: String?) -> Self { copy { $0.systemImage = systemName } }
     /// Adds a trailing remove (✕) button instead of the chevron.
     func onRemove(_ action: @escaping () -> Void) -> Self { copy { $0.onRemove = action } }
+    /// Trailing filled **search** button (magnifier) instead of the chevron/remove —
+    /// turns the row into a "mini search bar" summary that re-runs the search when
+    /// tapped. Takes precedence over ``onRemove(_:)``.
+    func onSearch(_ action: @escaping () -> Void) -> Self { copy { $0.onSearch = action } }
+    /// Fill color of the ``onSearch(_:)`` button (default `.neutral` ink).
+    func searchAccent(_ color: SemanticColor) -> Self { copy { $0.searchAccent = color } }
     /// Brand-tints the leading icon tile (default: neutral tile).
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     /// Wrap in a bordered surface (default off — flush list row).
     func bordered(_ on: Bool = true) -> Self { copy { $0.bordered = on } }
-    /// Surface fill of the bordered variant (background token key, default `.bgBase`).
+    /// Fully-rounded **capsule** surface — a pill that sits on a colored band (the
+    /// search-result mini bar). Fills with ``surface(_:)`` and drops the hairline.
+    func pill(_ on: Bool = true) -> Self { copy { $0.pill = on } }
+    /// Surface fill of the bordered / pill variant (background token key, default `.bgBase`).
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
@@ -113,4 +137,17 @@ public extension RecentSearchRow {
         RecentSearchRow(from: "SAW", to: "ESB") { }.dates("2 Aug").passengers("1 adult").onRemove { }
     }
     .padding()
+}
+
+#Preview("Search summary pill") {
+    // A "mini search bar" — no leading tile, capsule surface on a brand band,
+    // trailing filled search button. Brand color comes from the theme, not here.
+    RecentSearchRow(from: "Istanbul", to: "Antalya") { }
+        .icon(nil)
+        .dates("14 Jan").passengers("7")
+        .pill().surface(.bgWhite)
+        .onSearch { }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(SemanticColor.primary.solid)
 }

--- a/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
+++ b/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
@@ -3,22 +3,50 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
+//  Molecule. Ant Design's **Segmented** — an enclosed single-select control where
+//  the active option is a raised, sliding thumb. Full Ant parity: string / icon /
+//  icon-only / custom-content options, `block` (full width), `size`, `shape`
+//  (default / round), `vertical`, per-item `disabled` + `tooltip`, and hover.
+//
+//  A `selectionStyle` extends Ant: `.thumb` (the white raised card) or `.outline`
+//  (a hero-tinted bordered pill) — the latter lets richer controls like
+//  ``DatePriceStrip`` wrap Segmented while keeping their own selected look.
+//
 
 import SwiftUI
 
+/// One Segmented option. Carries a label + icon, an icon-only glyph, or fully
+/// custom content (Ant's `ReactNode` label — e.g. an avatar over a name).
 public struct SegmentItem {
-    let title: String
+    let title: String?
     let systemImage: String?
     let isEnabled: Bool
-    public init(_ title: String, systemImage: String? = nil, isEnabled: Bool = true) {
-        self.title = title; self.systemImage = systemImage; self.isEnabled = isEnabled
+    let tooltip: String?
+    let content: AnyView?
+
+    /// Label, with an optional leading icon.
+    public init(_ title: String, systemImage: String? = nil, isEnabled: Bool = true, tooltip: String? = nil) {
+        self.title = title; self.systemImage = systemImage
+        self.isEnabled = isEnabled; self.tooltip = tooltip; self.content = nil
     }
+    /// Icon-only option.
+    public init(icon systemImage: String, isEnabled: Bool = true, tooltip: String? = nil) {
+        self.title = nil; self.systemImage = systemImage
+        self.isEnabled = isEnabled; self.tooltip = tooltip; self.content = nil
+    }
+    /// Custom label content (Ant's `ReactNode` label).
+    public init(isEnabled: Bool = true, tooltip: String? = nil, @ViewBuilder content: () -> some View) {
+        self.title = nil; self.systemImage = nil
+        self.isEnabled = isEnabled; self.tooltip = tooltip; self.content = AnyView(content())
+    }
+
+    var accessibilityText: String { title ?? tooltip ?? "" }
+    var isIconOnly: Bool { title == nil && content == nil && systemImage != nil }
 }
 
-/// Vertical sizing of the segments. (Ant Segmented `size`.)
+/// Height of the segments. (Ant Segmented `size`: large 40 / middle 32 / small 24.)
 public enum SegmentedSize {
     case small, medium, large
-
     var verticalPadding: CGFloat {
         switch self {
         case .small: return Theme.SpacingKey.xs.value
@@ -28,20 +56,29 @@ public enum SegmentedSize {
     }
 }
 
-/// Molecule. Enclosed single-select control — the selected segment is a raised
-/// white pill. Options can carry an icon and a disabled state. (Ant Segmented.)
+/// Corner style. (Ant Segmented `shape`.)
+public enum SegmentedShape { case `default`, round }
+
+/// How the active option is drawn. `.thumb` is Ant's raised white card; `.outline`
+/// is a hero-tinted bordered pill (used by wrappers like ``DatePriceStrip``).
+public enum SegmentedSelectionStyle { case thumb, outline }
+
 public struct SegmentedControl: View {
     @Environment(\.theme) private var theme
+    @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
+
+    private let items: [SegmentItem]
+    @Binding private var selection: Int
 
     // Appearance/state — mutated only through the modifiers below (R2).
     private var isFullWidth = true
     private var size: SegmentedSize = .medium
+    private var shape: SegmentedShape = .default
+    private var selectionStyle: SegmentedSelectionStyle = .thumb
+    private var isVertical = false
     private var accessibilityID: String? = nil
 
-    private let items: [SegmentItem]
-    @Binding private var selection: Int
-    @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
-
+    @State private var hovered: Int?
     @Namespace private var pill
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -56,43 +93,87 @@ public struct SegmentedControl: View {
         self.init(items.map { SegmentItem($0) }, selection: selection)
     }
 
+    private var trackShape: AnyShape {
+        shape == .round
+            ? AnyShape(Capsule(style: .continuous))
+            : AnyShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+    }
+    private var thumbShape: AnyShape {
+        shape == .round
+            ? AnyShape(Capsule(style: .continuous))
+            : AnyShape(RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
+    }
+
     public var body: some View {
-        HStack(spacing: 4) {
-            ForEach(Array(items.enumerated()), id: \.offset) { index, item in
-                let isActive = index == selection
-                Button {
-                    withAnimation(motion) { selection = index }
-                } label: {
-                    HStack(spacing: Theme.SpacingKey.xs.value) {
-                        if let icon = item.systemImage {
-                            Image(systemName: icon).font(.system(size: 13, weight: .semibold))
-                        }
-                        Text(item.title).textStyle(isActive ? .labelBase700 : .labelBase600)
-                    }
-                    .foregroundStyle(foreground(isActive: isActive, enabled: item.isEnabled))
-                    .frame(maxWidth: isFullWidth ? .infinity : nil)
-                    .padding(.vertical, size.verticalPadding)
-                    .padding(.horizontal, Theme.SpacingKey.md.value)
-                    .background {
-                        if isActive {
-                            RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous)
-                                .fill(theme.background(.bgWhite))
-                                .themeShadow(.soft)
-                                .matchedGeometryEffect(id: "pill", in: pill)
-                        }
-                    }
-                    .contentShape(Rectangle())
+        segments
+            .padding(4)
+            .background(theme.background(.bgBase), in: trackShape)
+            .opacity(isEnabled ? 1 : 0.5)
+            .a11y(A11yElement.Control.toggle, in: accessibilityID)
+            .accessibilityValue(items.indices.contains(selection) ? items[selection].accessibilityText : "")
+    }
+
+    @ViewBuilder private var segments: some View {
+        if isVertical {
+            VStack(spacing: 4) { ForEach(Array(items.enumerated()), id: \.offset) { segment($0.offset, $0.element) } }
+        } else {
+            HStack(spacing: 4) { ForEach(Array(items.enumerated()), id: \.offset) { segment($0.offset, $0.element) } }
+        }
+    }
+
+    private func segment(_ index: Int, _ item: SegmentItem) -> some View {
+        let isActive = index == selection
+        return Button {
+            withAnimation(motion) { selection = index }
+        } label: {
+            label(item, isActive: isActive)
+                .foregroundStyle(foreground(isActive: isActive, enabled: item.isEnabled))
+                .frame(maxWidth: isFullWidth ? .infinity : nil)
+                .padding(.vertical, size.verticalPadding)
+                .padding(.horizontal, item.isIconOnly ? Theme.SpacingKey.sm.value : Theme.SpacingKey.md.value)
+                .background { hoverFill(index: index, isActive: isActive, enabled: item.isEnabled) }
+                .background { selectionFill(isActive: isActive) }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled || !item.isEnabled)
+        .onHover { hovering in hovered = hovering ? index : (hovered == index ? nil : hovered) }
+        .help(item.tooltip ?? "")
+    }
+
+    @ViewBuilder private func label(_ item: SegmentItem, isActive: Bool) -> some View {
+        if let content = item.content {
+            content
+        } else {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                if let icon = item.systemImage {
+                    Image(systemName: icon).font(.system(size: 13, weight: .semibold))
                 }
-                .buttonStyle(.plain)
-                .disabled(!isEnabled || !item.isEnabled)
+                if let title = item.title {
+                    Text(title).textStyle(isActive ? .labelBase700 : .labelBase600)
+                }
             }
         }
-        .padding(4)
-        .background(theme.background(.bgBase),
-                   in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
-        .opacity(isEnabled ? 1 : 0.5)
-        .a11y(A11yElement.Control.toggle, in: accessibilityID)
-        .accessibilityValue(items.indices.contains(selection) ? items[selection].title : "")
+    }
+
+    @ViewBuilder private func selectionFill(isActive: Bool) -> some View {
+        if isActive {
+            switch selectionStyle {
+            case .thumb:
+                thumbShape.fill(theme.background(.bgWhite)).themeShadow(.soft)
+                    .matchedGeometryEffect(id: "pill", in: pill)
+            case .outline:
+                thumbShape.fill(SemanticColor.primary.soft)
+                    .overlay(thumbShape.stroke(theme.border(.borderHero), lineWidth: 2))
+                    .matchedGeometryEffect(id: "pill", in: pill)
+            }
+        }
+    }
+
+    @ViewBuilder private func hoverFill(index: Int, isActive: Bool, enabled: Bool) -> some View {
+        if hovered == index, !isActive, enabled, isEnabled {
+            thumbShape.fill(theme.text(.textPrimary).opacity(0.06))
+        }
     }
 
     private func foreground(isActive: Bool, enabled: Bool) -> Color {
@@ -101,33 +182,21 @@ public struct SegmentedControl: View {
     }
 }
 
-#Preview {
-    struct Demo: View {
-        @State var sel = 0
-        var body: some View {
-            VStack(spacing: 16) {
-                SegmentedControl(["Daily", "Weekly", "Monthly"], selection: $sel)
-                SegmentedControl([SegmentItem("List", systemImage: "list.bullet"),
-                                  SegmentItem("Grid", systemImage: "square.grid.2x2"),
-                                  SegmentItem("Map", systemImage: "map", isEnabled: false)], selection: $sel)
-            }
-            .padding()
-        }
-    }
-    return Demo()
-}
-
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension SegmentedControl {
     /// Stretch each segment to fill the available width (Ant Segmented `block`).
     func fullWidth(_ on: Bool = true) -> Self { copy { $0.isFullWidth = on } }
-
-    /// Vertical sizing of the segments: small / medium / large.
+    /// Segment height: small / medium / large (Ant Segmented `size`).
     func size(_ s: SegmentedSize) -> Self { copy { $0.size = s } }
-
-    /// Sets the accessibility-identifier namespace for this component (its
-    /// sub-elements get `"<id>.<element>"`). Replaces the `accessibilityID:` init param.
+    /// Corner style — default or a fully-round pill (Ant Segmented `shape`).
+    func shape(_ s: SegmentedShape) -> Self { copy { $0.shape = s } }
+    /// Stack the segments vertically (Ant Segmented `vertical`).
+    func vertical(_ on: Bool = true) -> Self { copy { $0.isVertical = on } }
+    /// How the active option is drawn — the raised white `.thumb` (default) or a
+    /// hero-tinted `.outline` pill (for richer wrappers).
+    func selectionStyle(_ s: SegmentedSelectionStyle) -> Self { copy { $0.selectionStyle = s } }
+    /// Sets the accessibility-identifier namespace for this component.
     func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
@@ -135,4 +204,29 @@ public extension SegmentedControl {
         mutate(&c)
         return c
     }
+}
+
+#Preview {
+    struct Demo: View {
+        @State var a = 0
+        @State var b = 1
+        @State var c = 0
+        @State var d = 2
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    SegmentedControl(["Daily", "Weekly", "Monthly"], selection: $a)
+                    SegmentedControl(["Daily", "Weekly", "Monthly"], selection: $a).shape(.round)
+                    SegmentedControl([SegmentItem("List", systemImage: "list.bullet"),
+                                      SegmentItem("Grid", systemImage: "square.grid.2x2"),
+                                      SegmentItem("Map", systemImage: "map", isEnabled: false)], selection: $b)
+                    SegmentedControl([SegmentItem(icon: "list.bullet"), SegmentItem(icon: "square.grid.2x2"),
+                                      SegmentItem(icon: "map")], selection: $c).fullWidth(false)
+                    SegmentedControl(["A", "B", "C"], selection: $d).vertical().fullWidth(false)
+                }
+                .padding()
+            }
+        }
+    }
+    return Demo()
 }


### PR DESCRIPTION
### SegmentedControl → full Ant Design **Segmented** parity
Adds `shape` (default/round), `vertical`, **icon-only** & **custom-content** options, per-item `tooltip`, hover state, and a `selectionStyle(.thumb / .outline)` extension. Keeps `block`/`size`/`disabled` and the sliding white thumb. Storybook demo covers basic · round · sizes · icon+label · icon-only · vertical · custom avatar · disabled · outline.

### DatePriceStrip → `.strip` pill layout (Figma "Timeline")
Horizontal scrollable pills on a surface — rounded-24, hero-light + 2pt hero border + semibold when selected, 10pt tertiary price, auto-centering scroll. The 3-column grid layout stays for backward-compat. Storybook demo (strip / cheapest / grid / paging). Standalone by design — shares the single-select model with Segmented; keeps its Figma-exact white-pill-on-surface look.

### RecentSearchRow → "mini search bar"
Adds `.onSearch` (trailing filled search button), `.pill` capsule surface, `.searchAccent`, and optional leading-tile hiding.

All token-fed and brand-neutral. Verified in the iOS simulator; core builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)