### PR TITLE
fix: FilterBar outlined chip border clipped at pill curves

### DIFF
--- a/Sources/ThemeKit/Components/Organisms/FilterBar.swift
+++ b/Sources/ThemeKit/Components/Organisms/FilterBar.swift
@@ -143,8 +143,11 @@ public struct FilterBar: View {
                 .padding(.horizontal, chipHPad)
                 .frame(minHeight: controlHeight)
                 .background(chipFill(isOn: isOn, outlined: outlined), in: Capsule())
-                .overlay(Capsule().stroke(chipBorderColor(isOn: isOn, outlined: outlined),
-                                          lineWidth: outlined && isOn ? 2 : 1))
+                // strokeBorder (not stroke) insets the line fully inside the pill,
+                // so the 2pt selected border isn't clipped at the tight top/bottom
+                // curves — a centered stroke would bleed outside and look distorted.
+                .overlay(Capsule().strokeBorder(chipBorderColor(isOn: isOn, outlined: outlined),
+                                                lineWidth: outlined && isOn ? 2 : 1))
                 .fixedSize()
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
The selected **outlined** chip drew its 2pt border with `Capsule().stroke`, which centers the line on the path — half the width bleeds outside the fill and gets clipped by the chip's bounds at the tight top/bottom curves, so the border looked distorted (reported on "Free cancellation").

Fix: `strokeBorder` insets the line fully inside the pill → clean, uniform 2pt border. Verified in the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)