### PR TITLE
feat: FilterBar circle leading buttons collapse on scroll

### DIFF
--- a/Sources/ThemeKit/Components/Organisms/FilterBar.swift
+++ b/Sources/ThemeKit/Components/Organisms/FilterBar.swift
@@ -74,17 +74,26 @@ public struct FilterBar: View {
     private var accentFg: Color { accentColor.map { $0.onSolid } ?? theme.text(.textSecondaryInverse) }
     private var chipOffText: Color { accentColor.map { $0.base } ?? theme.foreground(.fgHero) }
     private var hasLeading: Bool { onFilter != nil || onSort != nil }
+    /// Circle leading buttons collapse away entirely on scroll (adaptive buttons
+    /// shrink text→icon in place instead).
+    private var hideLeading: Bool { leadingShapeVariant == .circle && collapsed && collapsible && hasLeading }
 
     // MARK: Body
 
     public var body: some View {
-        HStack(spacing: spacing) {
+        HStack(spacing: hideLeading ? 0 : spacing) {
             if hasLeading {
                 HStack(spacing: spacing) {
                     if let onFilter { action(filterIcon, filterTitle, onFilter) }
                     if let onSort { action(sortIcon, sortTitle, onSort) }
                 }
                 .fixedSize()
+                // Adaptive buttons shrink text→icon in place; circle buttons have
+                // nothing to shrink, so they collapse away entirely on scroll and
+                // slide back open once the first chip returns to the leading edge.
+                .frame(width: hideLeading ? 0 : nil, alignment: .leading)
+                .opacity(hideLeading ? 0 : 1)
+                .clipped()
             }
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: spacing) {


### PR DESCRIPTION
The `.adaptive` Filter/Sort buttons already shrink text→icon as the chips scroll off. The `.circle` buttons had nothing to shrink, so they stayed fixed — which is why the flight results screen's filter bar didn't collapse.

Now the circle buttons **collapse away entirely** (width→0, faded) when the first chip scrolls past the leading edge, and **slide back open** once it returns to the start — restoring the collapse/expand interaction of the original bar for the Figma circle style.

`.adaptive` behavior is unchanged. Builds clean; scroll interaction to be felt in the sim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)