### PR TITLE
fix: revert FilterBar circle-collapse; native collapse + polished flight results

### DIFF
--- a/Demo/Demo/Examples/FlightResultsView.swift
+++ b/Demo/Demo/Examples/FlightResultsView.swift
@@ -18,17 +18,34 @@ private struct SampleFlight: Identifiable {
     let to: String
     let departure: Date
     let arrival: Date
+    var stops: Int = 0
+    var layover: String? = nil
+    var cabin: String = "Economy"
+    var carryOn: String? = "8 kg"
+    var checked: String? = nil
     let price: Decimal
+    var original: Decimal? = nil
+    var badge: String? = nil
+    var deal: String? = nil
+    var dealTone: SemanticColor = .warning
 
+    /// Deliberately varied so each `.tray` card exercises different knobs —
+    /// stops, baggage, cabin, a strikethrough discount, a badge, a deal note.
     static let all: [SampleFlight] = {
         let base = Calendar.current.date(from: DateComponents(year: 2026, month: 5, day: 3, hour: 7)) ?? Date(timeIntervalSince1970: 0)
         func at(_ h: Int, _ m: Int = 0) -> Date { base.addingTimeInterval(TimeInterval(h * 3600 + m * 60)) }
         return [
-            .init(airline: "Skyline Air", from: "SAW", to: "AYT", departure: at(0), arrival: at(3, 15), price: 12_700),
-            .init(airline: "Skyline Air", from: "SAW", to: "AYT", departure: at(2), arrival: at(5, 15), price: 12_700),
-            .init(airline: "Aegean Jet", from: "IST", to: "AYT", departure: at(4), arrival: at(6, 5), price: 13_450),
-            .init(airline: "Skyline Air", from: "SAW", to: "AYT", departure: at(6), arrival: at(9, 15), price: 12_700),
-            .init(airline: "Blue Wings", from: "IST", to: "AYT", departure: at(8), arrival: at(10, 20), price: 11_980),
+            .init(airline: "Skyline Air", from: "SAW", to: "AYT", departure: at(0), arrival: at(3, 15),
+                  checked: "20 kg", price: 12_700, original: 22_700, badge: "Best value"),
+            .init(airline: "Aegean Jet", from: "IST", to: "AYT", departure: at(2), arrival: at(6),
+                  stops: 1, layover: "SAW", carryOn: "Hand baggage", price: 13_450),
+            .init(airline: "Blue Wings", from: "IST", to: "AYT", departure: at(1), arrival: at(3, 20),
+                  price: 11_980, badge: "Cheapest"),
+            .init(airline: "Skyline Air", from: "SAW", to: "AYT", departure: at(5), arrival: at(8, 15),
+                  cabin: "Economy Plus", checked: "30 kg", price: 14_200, original: 16_000),
+            .init(airline: "Aegean Jet", from: "IST", to: "AYT", departure: at(11), arrival: at(13, 5),
+                  stops: 1, layover: "ESB", carryOn: "Hand baggage", price: 12_100,
+                  deal: "Last 2 seats", dealTone: .warning),
         ]
     }()
 }
@@ -84,10 +101,16 @@ struct FlightResultsView: View {
 
                 filterSection
 
-                ForEach(flights) { flight in
-                    FlightListItem(airline: flight.airline, from: flight.from, to: flight.to,
-                                   departure: flight.departure, arrival: flight.arrival)
-                        .price(flight.price, currencyCode: "TRY")
+                ForEach(flights) { f in
+                    FlightListItem(legs: [FlightLeg(airline: f.airline, from: f.from, to: f.to,
+                                                    departure: f.departure, arrival: f.arrival,
+                                                    stops: f.stops, layover: f.layover)])
+                        .cabin(f.cabin)
+                        .baggage(f.carryOn, checked: f.checked)
+                        .price(f.price, currencyCode: "TRY")
+                        .original(f.original)
+                        .badge(f.badge)
+                        .deal(f.deal, tone: f.dealTone)
                         .onSelect("Details") {}
                         .flightListItemStyle(.tray)
                         .padding(.horizontal, Theme.SpacingKey.md.value)
@@ -101,9 +124,11 @@ struct FlightResultsView: View {
     /// link and a chart/grid view toggle.
     private var filterSection: some View {
         VStack(spacing: Theme.SpacingKey.sm.value) {
+            // FilterBar's native behaviour: icon + label Filter/Sort buttons that
+            // collapse to icons as the chips scroll left, and expand back at the start.
             FilterBar([QuickFilter("Cheapest", id: "cheapest"), QuickFilter("Fastest"),
                        QuickFilter("Fast & Cheap"), QuickFilter("Direct")], selection: $filters)
-                .chipStyle(.outlined).leadingShape(.circle).size(.small)
+                .chipStyle(.outlined).size(.small)
                 .onFilter {}.onSort {}
 
             HStack {

--- a/Demo/Demo/Examples/FlightResultsView.swift
+++ b/Demo/Demo/Examples/FlightResultsView.swift
@@ -102,23 +102,53 @@ struct FlightResultsView: View {
                 filterSection
 
                 ForEach(flights) { f in
-                    FlightListItem(legs: [FlightLeg(airline: f.airline, from: f.from, to: f.to,
-                                                    departure: f.departure, arrival: f.arrival,
-                                                    stops: f.stops, layover: f.layover)])
-                        .cabin(f.cabin)
-                        .baggage(f.carryOn, checked: f.checked)
-                        .price(f.price, currencyCode: "TRY", caption: "from")
-                        .original(f.original)
-                        .badge(f.badge)
-                        .deal(f.deal, tone: f.dealTone)
-                        .onDetails {}
-                        .onSelect {}
-                        .flightListItemStyle(.tray)
+                    flightCard(f).flightListItemStyle(.tray)
                         .padding(.horizontal, Theme.SpacingKey.md.value)
                 }
+
+                variantsSection
             }
             .padding(.vertical, Theme.SpacingKey.sm.value)
         }
+    }
+
+    /// The shared card data — the same flight, rendered by any FlightListItem style.
+    private func flightCard(_ f: SampleFlight) -> FlightListItem {
+        FlightListItem(legs: [FlightLeg(airline: f.airline, from: f.from, to: f.to,
+                                        departure: f.departure, arrival: f.arrival,
+                                        stops: f.stops, layover: f.layover)])
+            .cabin(f.cabin)
+            .baggage(f.carryOn, checked: f.checked)
+            .price(f.price, currencyCode: "TRY", caption: "from")
+            .original(f.original)
+            .badge(f.badge)
+            .deal(f.deal, tone: f.dealTone)
+            .onDetails {}
+            .onSelect {}
+    }
+
+    /// A few other FlightListItem styles rendering the same flight — swap with
+    /// `.flightListItemStyle(_:)`.
+    private var variantsSection: some View {
+        let f = flights[0]
+        return VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
+            Text("Other list styles")
+                .textStyle(.labelBase700).foregroundStyle(theme.text(.textSecondary))
+                .padding(.horizontal, Theme.SpacingKey.md.value)
+                .padding(.top, Theme.SpacingKey.md.value)
+            styleLabel("Timeline")
+            flightCard(f).flightListItemStyle(.timeline).padding(.horizontal, Theme.SpacingKey.md.value)
+            styleLabel("Compact")
+            flightCard(f).flightListItemStyle(.compact).padding(.horizontal, Theme.SpacingKey.md.value)
+            styleLabel("Deal")
+            flightCard(f).flightListItemStyle(.deal).padding(.horizontal, Theme.SpacingKey.md.value)
+        }
+    }
+
+    private func styleLabel(_ text: String) -> some View {
+        Text(text).textStyle(.labelSm600).foregroundStyle(theme.text(.textTertiary))
+            .padding(.horizontal, Theme.SpacingKey.md.value)
+            .padding(.top, Theme.SpacingKey.sm.value)
     }
 
     /// The Figma "Filter Section": outlined chips + circle buttons, then an info

--- a/Demo/Demo/Examples/FlightResultsView.swift
+++ b/Demo/Demo/Examples/FlightResultsView.swift
@@ -107,11 +107,12 @@ struct FlightResultsView: View {
                                                     stops: f.stops, layover: f.layover)])
                         .cabin(f.cabin)
                         .baggage(f.carryOn, checked: f.checked)
-                        .price(f.price, currencyCode: "TRY")
+                        .price(f.price, currencyCode: "TRY", caption: "from")
                         .original(f.original)
                         .badge(f.badge)
                         .deal(f.deal, tone: f.dealTone)
-                        .onSelect("Details") {}
+                        .onDetails {}
+                        .onSelect {}
                         .flightListItemStyle(.tray)
                         .padding(.horizontal, Theme.SpacingKey.md.value)
                 }

--- a/Sources/ThemeKit/Components/Molecules/RecentSearchRow.swift
+++ b/Sources/ThemeKit/Components/Molecules/RecentSearchRow.swift
@@ -64,7 +64,13 @@ public struct RecentSearchRow: View {
                 Spacer(minLength: 6)
                 trailing
             }
-            .padding(density.scale(Theme.SpacingKey.sm.value))
+            // Uniform tap padding, except the pill "mini search bar" (no leading
+            // tile) insets its content from the left (Figma pl-24 · pr-8 · py-8).
+            .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
+            .padding(.trailing, density.scale(Theme.SpacingKey.sm.value))
+            .padding(.leading, density.scale(pill && systemImage == nil
+                                             ? Theme.SpacingKey.base.value
+                                             : Theme.SpacingKey.sm.value))
             .frame(maxWidth: .infinity, alignment: .leading)
             .background((bordered || pill) ? theme.background(surfaceKey) : .clear, in: shape)
             .overlay { if bordered && !pill { shape.stroke(theme.border(.borderPrimary), lineWidth: 1) } }

--- a/Sources/ThemeKit/Components/Organisms/FilterBar.swift
+++ b/Sources/ThemeKit/Components/Organisms/FilterBar.swift
@@ -74,26 +74,17 @@ public struct FilterBar: View {
     private var accentFg: Color { accentColor.map { $0.onSolid } ?? theme.text(.textSecondaryInverse) }
     private var chipOffText: Color { accentColor.map { $0.base } ?? theme.foreground(.fgHero) }
     private var hasLeading: Bool { onFilter != nil || onSort != nil }
-    /// Circle leading buttons collapse away entirely on scroll (adaptive buttons
-    /// shrink text→icon in place instead).
-    private var hideLeading: Bool { leadingShapeVariant == .circle && collapsed && collapsible && hasLeading }
 
     // MARK: Body
 
     public var body: some View {
-        HStack(spacing: hideLeading ? 0 : spacing) {
+        HStack(spacing: spacing) {
             if hasLeading {
                 HStack(spacing: spacing) {
                     if let onFilter { action(filterIcon, filterTitle, onFilter) }
                     if let onSort { action(sortIcon, sortTitle, onSort) }
                 }
                 .fixedSize()
-                // Adaptive buttons shrink text→icon in place; circle buttons have
-                // nothing to shrink, so they collapse away entirely on scroll and
-                // slide back open once the first chip returns to the leading edge.
-                .frame(width: hideLeading ? 0 : nil, alignment: .leading)
-                .opacity(hideLeading ? 0 : 1)
-                .clipped()
             }
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: spacing) {


### PR DESCRIPTION
Addresses feedback on the flight results screen and the filter bar.

- **Revert** the FilterBar circle-collapse (#200) — circle buttons no longer hide on scroll.
- **Flight results filter** now uses FilterBar's **native** Filter/Sort buttons (icon + label that collapse to icons as the chips scroll, expand back at the start) instead of fixed circles — that collapse interaction is what FilterBar is for.
- **RecentSearchRow** pill "mini search bar" insets its content 24pt from the left (Figma `pl-24 · pr-8 · py-8`) so the route no longer hugs the edge.
- **`.tray` cards** use the full footer — a **Details** link + a **"from"** price prefix with the strikethrough original — and are fed **varied** data (stops, baggage, cabin, discounts, badges, a deal note).
- Adds an **"Other list styles"** section at the bottom rendering the same flight via `.timeline` / `.compact` / `.deal`.

Verified in the iOS simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)