### PR TITLE
feat: Ant Design Space + Affix layout components

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -127,6 +127,8 @@ enum ComponentRegistry {
         .knob("Autocomplete", .molecules, demo: AutocompleteDemo(), usage: #"Autocomplete("Destination", text: $text, suggestions: items)\n// async: Autocomplete(text: $text, suggest: { await api.search($0) })"#),
         .knob("Button", .molecules, demo: ButtonDemo(), usage: #"PrimaryButton("Continue") { }"#),
         .knob("ButtonGroup", .molecules, demo: ButtonGroupDemo(), usage: #"ButtonGroup { PrimaryButton("OK") { } }"#),
+        .knob("Space", .molecules, demo: SpaceDemo(), usage: #"Space { Button("Save"){}; Button("Cancel"){} }.size(.large).wrap()"#),
+        .knob("Affix", .molecules, demo: AffixDemo(), usage: #"ScrollView { Affix(offsetTop: 0) { Toolbar() }.onChange { affixed = $0 }; … }"#),
         .knob("ThemeButton", .molecules, demo: ThemeButtonDemo(), usage: #"ThemeButton("Save") { }.color(.success).variant(.soft).size(.medium).shape(.pill)"#),
         .knob("Checkbox", .molecules, demo: CheckboxDemo(), usage: #"Checkbox("Accept terms", isChecked: $on).accent(.success).infoMessages(error ? [.init("Required", kind: .error)] : [])"#),
         .knob("CheckboxGroup", .molecules, demo: CheckboxGroupDemo(), usage: #"CheckboxGroup(options: items, selection: $set) { $0 }"#),

--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -457,3 +457,65 @@ struct PaginationDemo: View {
         }
     }
 }
+
+struct SpaceDemo: View {
+    @State private var vertical = false
+    @State private var sizeIdx = 0
+    @State private var wrap = false
+    @State private var alignIdx = 1
+    private var size: SpaceSize { [.small, .medium, .large][sizeIdx] }
+    private var align: SpaceAlign { [.start, .center, .end, .baseline][alignIdx] }
+
+    var body: some View {
+        ComponentStage("Space", inspector: [("dir", vertical ? "vertical" : "horizontal")]) {
+            Space {
+                ForEach(0..<6) { Tag("Item \($0)") }
+            }
+            .vertical(vertical).size(size).wrap(wrap).align(align)
+            .frame(maxWidth: wrap ? 280 : nil, alignment: .leading)
+        } knobs: {
+            Toggle("Vertical", isOn: $vertical)
+            Picker("Size", selection: $sizeIdx) { Text("S").tag(0); Text("M").tag(1); Text("L").tag(2) }.pickerStyle(.segmented)
+            Toggle("Wrap (horizontal)", isOn: $wrap)
+            Picker("Align", selection: $alignIdx) { Text("start").tag(0); Text("center").tag(1); Text("end").tag(2); Text("base").tag(3) }.pickerStyle(.segmented)
+            Text("Even spacing between children — direction, size, wrap, cross-align.").font(.caption).foregroundStyle(.secondary)
+        }
+    }
+}
+
+struct AffixDemo: View {
+    @Environment(\.theme) private var theme
+    @State private var affixed = false
+
+    var body: some View {
+        ComponentStage("Affix", inspector: [("affixed", "\(affixed)")]) {
+            ScrollView {
+                VStack(spacing: 10) {
+                    Affix(offsetTop: 0) {
+                        HStack {
+                            Text("Pinned toolbar").textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+                            Spacer()
+                            if affixed { Tag("affixed").tagStyle(.info) }
+                        }
+                        .padding(10)
+                        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: 12))
+                        .themeShadow(.soft)
+                    }
+                    .target("affixDemo")
+                    .onChange { affixed = $0 }
+                    ForEach(0..<20) { i in
+                        Text("Row \(i)").frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(12)
+                            .background(theme.background(.bgElevatorPrimary), in: RoundedRectangle(cornerRadius: 8))
+                    }
+                }
+                .padding(10)
+            }
+            .coordinateSpace(name: "affixDemo")
+            .frame(height: 300)
+            .background(theme.background(.bgBase), in: RoundedRectangle(cornerRadius: 16))
+        } knobs: {
+            Text("Scroll the inner list → the toolbar pins to the top and 'affixed' flips.").font(.caption).foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Sources/ThemeKit/Components/Molecules/Affix.swift
+++ b/Sources/ThemeKit/Components/Molecules/Affix.swift
@@ -1,0 +1,140 @@
+//
+//  Affix.swift
+//  ThemeKit
+//
+//  Molecule. Ant Design's **Affix** — pins its content to the top (or bottom) of
+//  the viewport once it would scroll past a given offset, then releases it when it
+//  scrolls back. A placeholder holds the content's slot in the scroll flow, and
+//  the content is offset to stay fixed. Best used inside a vertical `ScrollView`.
+//
+//      ScrollView {
+//          Affix(offsetTop: 0) { Toolbar() }     // sticks to the top on scroll
+//          … long content …
+//      }
+//
+//  `.onChange { affixed in … }` fires when the pinned state flips.
+//
+
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+public struct Affix<Content: View>: View {
+    private let content: Content
+    // One of the two offsets is set by the initializer.
+    private var offsetTop: CGFloat?
+    private var offsetBottom: CGFloat?
+    private var spaceName: String?
+    private var onChange: ((Bool) -> Void)?
+
+    @State private var pinOffset: CGFloat = 0
+    @State private var affixed = false
+    @State private var contentSize: CGSize = .zero
+
+    /// Pin to the top once the content scrolls within `offsetTop` of the viewport top.
+    public init(offsetTop: CGFloat = 0, @ViewBuilder content: () -> Content) {
+        self.offsetTop = offsetTop
+        self.content = content()
+    }
+
+    /// Pin to the bottom once the content scrolls within `offsetBottom` of the viewport bottom.
+    public init(offsetBottom: CGFloat, @ViewBuilder content: () -> Content) {
+        self.offsetBottom = offsetBottom
+        self.content = content()
+    }
+
+    /// The space the offset is measured in — a named scroll container (Ant `target`)
+    /// or the whole screen.
+    private var coordinateSpace: CoordinateSpace {
+        spaceName.map { CoordinateSpace.named($0) } ?? .global
+    }
+
+    public var body: some View {
+        // The placeholder reserves the content's slot in the scroll flow and is
+        // measured (in-flow, so no feedback loop with the offset content).
+        Color.clear
+            .frame(width: contentSize.width, height: contentSize.height)
+            .background(alignment: .topLeading) {
+                GeometryReader { geo in
+                    Color.clear.preference(key: AffixMinYKey.self, value: geo.frame(in: coordinateSpace).minY)
+                }
+            }
+            .overlay(alignment: .topLeading) {
+                content
+                    .background(GeometryReader { geo in
+                        Color.clear
+                            .onAppear { contentSize = geo.size }
+                            .onChange(of: geo.size) { contentSize = $1 }
+                    })
+                    .offset(y: pinOffset)
+            }
+            .onPreferenceChange(AffixMinYKey.self) { minY in update(placeholderMinY: minY) }
+    }
+
+    private func update(placeholderMinY minY: CGFloat) {
+        var offset: CGFloat = 0
+        if let offsetTop {
+            offset = minY < offsetTop ? (offsetTop - minY) : 0
+        } else if let offsetBottom {
+            let placeholderMaxY = minY + contentSize.height
+            let threshold = AffixMetrics.viewportHeight - offsetBottom
+            offset = placeholderMaxY > threshold ? (threshold - placeholderMaxY) : 0
+        }
+        if offset != pinOffset { pinOffset = offset }
+        let isAffixed = offset != 0
+        if isAffixed != affixed {
+            affixed = isAffixed
+            onChange?(isAffixed)
+        }
+    }
+}
+
+// MARK: - Modifiers
+
+public extension Affix {
+    /// Fires when the pinned state changes (Ant Affix `onChange`).
+    func onChange(_ action: @escaping (Bool) -> Void) -> Self {
+        var c = self; c.onChange = action; return c
+    }
+    /// Measure the offset within a named scroll container instead of the screen
+    /// (Ant Affix `target`) — set the same name via `.coordinateSpace(name:)` on
+    /// the enclosing `ScrollView`.
+    func target(_ name: String) -> Self {
+        var c = self; c.spaceName = name; return c
+    }
+}
+
+// MARK: - Support
+
+private struct AffixMinYKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
+
+private enum AffixMetrics {
+    /// Best-effort viewport height for bottom-affix (full-screen contexts).
+    static var viewportHeight: CGFloat {
+        #if canImport(UIKit)
+        return UIScreen.main.bounds.height
+        #else
+        return 800
+        #endif
+    }
+}
+
+#Preview {
+    ScrollView {
+        VStack(spacing: 12) {
+            Affix(offsetTop: 8) {
+                HStack { ThemeButton("Pinned toolbar") {}; Spacer() }
+                    .padding(8)
+                    .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: 12))
+                    .themeShadow(.soft)
+            }
+            ForEach(0..<40) { Text("Row \($0)").frame(maxWidth: .infinity).padding().background(Theme.shared.background(.bgElevatorPrimary), in: RoundedRectangle(cornerRadius: 8)) }
+        }
+        .padding()
+    }
+    .environment(Theme.shared)
+}

--- a/Sources/ThemeKit/Components/Molecules/Space.swift
+++ b/Sources/ThemeKit/Components/Molecules/Space.swift
@@ -1,0 +1,103 @@
+//
+//  Space.swift
+//  ThemeKit
+//
+//  Molecule. Ant Design's **Space** — sets a consistent gap between inline or
+//  stacked children, so a row/column of controls is evenly spaced without hand-
+//  tuned padding. Horizontal or vertical, a preset or custom size, cross-axis
+//  alignment, and optional wrapping (horizontal).
+//
+//      Space { Button("Save"){}; Button("Cancel"){} }            // 8pt row
+//      Space { Tag("A"); Tag("B"); Tag("C") }.size(.large).wrap()
+//      Space { title; subtitle }.vertical().align(.start)
+//
+
+import SwiftUI
+
+/// Gap between ``Space`` children. (Ant Space `size` — small 8 / middle 16 / large 24.)
+public enum SpaceSize: Sendable {
+    case small, medium, large
+    var value: CGFloat {
+        switch self {
+        case .small: return Theme.SpacingKey.sm.value      // 8
+        case .medium: return Theme.SpacingKey.md.value     // 16
+        case .large: return Theme.SpacingKey.base.value    // 24
+        }
+    }
+}
+
+/// Cross-axis alignment of ``Space`` children. (Ant Space `align`.)
+public enum SpaceAlign: Sendable { case start, center, end, baseline }
+
+public struct Space<Content: View>: View {
+    private let content: Content
+    // Appearance — mutated only through the modifiers below.
+    private var axis: Axis = .horizontal
+    private var spacing: CGFloat = Theme.SpacingKey.sm.value   // Ant default: small
+    private var alignment: SpaceAlign = .center
+    private var wraps = false
+
+    public init(@ViewBuilder content: () -> Content) { self.content = content() }
+
+    public var body: some View {
+        if axis == .horizontal, wraps {
+            FlowLayout(spacing: spacing, lineSpacing: spacing, alignment: horizontal) { content }
+        } else if axis == .horizontal {
+            HStack(alignment: vertical, spacing: spacing) { content }
+        } else {
+            VStack(alignment: horizontal, spacing: spacing) { content }
+        }
+    }
+
+    private var vertical: VerticalAlignment {
+        switch alignment {
+        case .start: return .top
+        case .center: return .center
+        case .end: return .bottom
+        case .baseline: return .firstTextBaseline
+        }
+    }
+    private var horizontal: HorizontalAlignment {
+        switch alignment {
+        case .start, .baseline: return .leading
+        case .center: return .center
+        case .end: return .trailing
+        }
+    }
+}
+
+// MARK: - Modifiers (copy-on-write · single mutation point)
+
+public extension Space {
+    /// Layout direction (Ant Space `direction`/`orientation`). Default `.horizontal`.
+    func direction(_ axis: Axis) -> Self { copy { $0.axis = axis } }
+    /// Stack the children vertically.
+    func vertical(_ on: Bool = true) -> Self { copy { $0.axis = on ? .vertical : .horizontal } }
+    /// Gap from a preset size (small / medium / large).
+    func size(_ size: SpaceSize) -> Self { copy { $0.spacing = size.value } }
+    /// Gap from a theme spacing token.
+    func size(_ key: Theme.SpacingKey) -> Self { copy { $0.spacing = key.value } }
+    /// Gap from a raw point value.
+    func size(_ value: CGFloat) -> Self { copy { $0.spacing = max(0, value) } }
+    /// Cross-axis alignment (start / center / end / baseline).
+    func align(_ alignment: SpaceAlign) -> Self { copy { $0.alignment = alignment } }
+    /// Wrap onto multiple lines when horizontal (Ant Space `wrap`).
+    func wrap(_ on: Bool = true) -> Self { copy { $0.wraps = on } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 24) {
+        Space { ForEach(0..<3) { Tag("Tag \($0)") } }
+        Space { ForEach(0..<8) { Tag("Item \($0)") } }.size(.medium).wrap().frame(width: 260)
+        Space { Text("Title").textStyle(.headingSm); Text("Subtitle").textStyle(.bodySm400) }
+            .vertical().align(.start)
+    }
+    .padding()
+    .environment(Theme.shared)
+}


### PR DESCRIPTION
Two new Ant-parity components (molecules), token-fed & brand-neutral, registered in the gallery.

**Space** — even spacing between inline/stacked children: `direction` (horizontal/vertical), `size` (small/medium/large + token/raw), `align` (start/center/end/baseline), `wrap` (via FlowLayout).

**Affix** — pins content to the top (`offsetTop`) or bottom (`offsetBottom`) of the viewport, or a named scroll container via `.target(_:)` (Ant `target`), once it scrolls past the offset; `.onChange { affixed in … }`. A placeholder holds the slot; the content is offset to stay fixed.

Verified: Space renders in the gallery; Affix pins within its scroll container (scroll to feel it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)