### PR TITLE
feat: ResultView Ant parity — icon / content / extra slots

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -1579,6 +1579,7 @@ struct FeedbackDemo: View {
 
 struct ResultDemo: View {
     @State private var status: ResultStatus = .success
+    @State private var customSlots = false
 
     private var copy: (String, String) {
         switch status {
@@ -1594,14 +1595,39 @@ struct ResultDemo: View {
 
     var body: some View {
         ComponentStage("Result", inspector: [("status", status.rawValue), ("code", status.codeText)]) {
-            ResultView(status, title: copy.0)
-                .message(copy.1)
-                .primaryAction("Try again", action: { flash("Result: Try again") })
-                .secondaryAction("Home", action: { flash("Result: Home") })
+            if customSlots {
+                // Ant `icon` / children / `extra` slots.
+                ResultView(status, title: copy.0)
+                    .subtitle(copy.1)
+                    .icon {
+                        Icon(systemName: "gift.fill").size(.xl).accent(.turquoise)
+                            .padding(22).background(SemanticColor.turquoise.soft, in: Circle())
+                    }
+                    .content {
+                        HStack(spacing: 16) {
+                            Text("Order").font(.caption).foregroundStyle(.secondary)
+                            Text("#A-1029").font(.caption.bold())
+                        }
+                        .padding(12).frame(maxWidth: .infinity)
+                        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+                    }
+                    .extra {
+                        HStack(spacing: 8) {
+                            ThemeButton("Buy again") { flash("Buy again") }.color(.primary)
+                            OutlineButton("Invoice") { flash("Invoice") }
+                        }
+                    }
+            } else {
+                ResultView(status, title: copy.0)
+                    .message(copy.1)
+                    .primaryAction("Try again", action: { flash("Result: Try again") })
+                    .secondaryAction("Home", action: { flash("Result: Home") })
+            }
         } knobs: {
             Picker("Status", selection: $status) {
                 ForEach(ResultStatus.allCases, id: \.self) { Text($0.rawValue).tag($0) }
             }
+            Toggle("Custom icon / content / extra slots", isOn: $customSlots)
         }
         .onAppear {
             // Screenshot hook: launch with `-resultStatus notFound|forbidden|serverError|error|…`.

--- a/Sources/ThemeKit/Components/Organisms/ResultView.swift
+++ b/Sources/ThemeKit/Components/Organisms/ResultView.swift
@@ -62,6 +62,9 @@ public struct ResultView: View {
     private var onPrimary: (() -> Void)?
     private var secondaryTitle: String?
     private var onSecondary: (() -> Void)?
+    private var customIcon: AnyView?      // Ant `icon` override
+    private var extraContent: AnyView?    // Ant `extra` (arbitrary actions)
+    private var bodyContent: AnyView?     // Ant children (body between subtitle + extra)
 
     public init(_ status: ResultStatus, title: String) {   // R1
         self.status = status
@@ -85,30 +88,30 @@ public struct ResultView: View {
                 }
             }
 
-            if primaryTitle != nil || secondaryTitle != nil {
-                HStack(spacing: Theme.SpacingKey.sm.value) {
-                    if let secondaryTitle, let onSecondary {
-                        OutlineButton(secondaryTitle, action: onSecondary)
-                    }
-                    if let primaryTitle, let onPrimary {
-                        ThemeButton(primaryTitle, action: onPrimary).color(status.color)
-                    }
-                }
-                .padding(.top, Theme.SpacingKey.xs.value)
-            }
+            if let bodyContent { bodyContent }   // Ant children (e.g. an error-detail box)
+
+            extra
         }
         .frame(maxWidth: .infinity)
         .padding(Theme.SpacingKey.lg.value)
     }
 
-    @ViewBuilder
-    private var emblem: some View {
+    /// The top emblem — a caller-provided icon/illustration or the status default.
+    @ViewBuilder private var emblem: some View {
+        if let customIcon {
+            customIcon
+        } else {
+            statusEmblem
+        }
+    }
+
+    @ViewBuilder private var statusEmblem: some View {
         if let code = status.code {
             Text(code)
                 .font(.system(size: 72, weight: .heavy, design: .rounded))
                 .foregroundStyle(status.color.base)
                 .overlay(alignment: .bottomTrailing) {
-                    Icon(systemName: status.systemImage).size(.md).color(status.color.base)
+                    Icon(systemName: status.systemImage).size(.md).colorOverride(status.color.base)
                         .padding(6)
                         .background(theme.background(.bgWhite), in: Circle())
                         .offset(x: 10, y: 4)
@@ -116,8 +119,25 @@ public struct ResultView: View {
         } else {
             ZStack {
                 Circle().fill(status.color.bg).frame(width: 88, height: 88)
-                Icon(systemName: status.systemImage).size(.xl).color(status.color.base)
+                Icon(systemName: status.systemImage).size(.xl).colorOverride(status.color.base)
             }
+        }
+    }
+
+    /// The actions area — a caller-provided `extra` slot, else the primary/secondary buttons.
+    @ViewBuilder private var extra: some View {
+        if let extraContent {
+            extraContent.padding(.top, Theme.SpacingKey.xs.value)
+        } else if primaryTitle != nil || secondaryTitle != nil {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                if let secondaryTitle, let onSecondary {
+                    OutlineButton(secondaryTitle, action: onSecondary)
+                }
+                if let primaryTitle, let onPrimary {
+                    ThemeButton(primaryTitle, action: onPrimary).color(status.color)
+                }
+            }
+            .padding(.top, Theme.SpacingKey.xs.value)
         }
     }
 }
@@ -127,6 +147,14 @@ public struct ResultView: View {
 public extension ResultView {
     /// Supporting text under the title.
     func message(_ text: String?) -> Self { copy { $0.message = text } }
+    /// Alias for ``message(_:)`` — mirrors Ant's `subTitle`.
+    func subtitle(_ text: String?) -> Self { copy { $0.message = text } }
+    /// Replace the status emblem with a custom icon / illustration (Ant `icon`).
+    func icon(@ViewBuilder _ content: () -> some View) -> Self { copy { $0.customIcon = AnyView(content()) } }
+    /// Arbitrary body content between the subtitle and the actions (Ant children).
+    func content(@ViewBuilder _ content: () -> some View) -> Self { copy { $0.bodyContent = AnyView(content()) } }
+    /// A custom actions area, replacing the primary/secondary buttons (Ant `extra`).
+    func extra(@ViewBuilder _ content: () -> some View) -> Self { copy { $0.extraContent = AnyView(content()) } }
 
     /// Primary (status-tinted) action button — renders when both title and action are set.
     func primaryAction(_ title: String?, action: (() -> Void)? = nil) -> Self {


### PR DESCRIPTION
Extends ResultView beyond the fixed two-button template to match Ant Result's flexibility:

- **`.icon { }`** replaces the status emblem with a custom icon/illustration (Ant `icon`)
- **`.content { }`** inserts arbitrary body content between subtitle and actions (Ant children)
- **`.extra { }`** supplies a custom actions area, replacing the primary/secondary buttons (Ant `extra`)
- **`.subtitle(_)`** alias mirrors Ant's `subTitle`
- fix: Icon color now via `.colorOverride` (drops the deprecated `.color` path)

The Result demo gains a "Custom slots" toggle showcasing all three — verified in the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)