### PR TITLE
feat: Tag Ant parity — .color palette, .bordered, CheckableTag

### DIFF
--- a/Demo/Demo/Gallery/Demos/AtomDemos.swift
+++ b/Demo/Demo/Gallery/Demos/AtomDemos.swift
@@ -233,17 +233,37 @@ struct TagDemo: View {
     @State private var icon = false
     @State private var styleIdx = 0   // 0 = neutral (no style)
     @State private var variant: FillVariant = .soft
+    @State private var bordered = false
+    @State private var checkA = true
+    @State private var checkB = false
 
     private let styles: [(String, BadgeStyle?)] = [
         ("Neutral", nil), ("Success", .success), ("Warning", .warning), ("Error", .error), ("Info", .info),
     ]
+    private let palette: [(String, SemanticColor)] = [
+        ("turquoise", .turquoise), ("orange", .orange), ("purple", .purple), ("pink", .pink), ("info", .info),
+    ]
 
     var body: some View {
         ComponentStage("Tag", inspector: [("style", styles[styleIdx].0), ("variant", "\(variant)")]) {
-            Tag(text, onRemove: removable ? { flash("Tag removed") } : nil)
-                .icon(icon ? "mappin" : nil)
-                .tagStyle(styles[styleIdx].1)
-                .variant(variant)
+            VStack(spacing: 18) {
+                Tag(text, onRemove: removable ? { flash("Tag removed") } : nil)
+                    .icon(icon ? "mappin" : nil)
+                    .tagStyle(styles[styleIdx].1)
+                    .variant(variant)
+                    .bordered(bordered)
+
+                // .color(_) — the broader Ant palette
+                FlowLayout(spacing: 6, lineSpacing: 6) {
+                    ForEach(palette, id: \.0) { name, c in Tag(name).color(c) }
+                }
+
+                // CheckableTag
+                HStack(spacing: 8) {
+                    CheckableTag("Nonstop", isChecked: $checkA)
+                    CheckableTag("Morning", isChecked: $checkB).icon("sunrise")
+                }
+            }
         } knobs: {
             TextField("Text", text: $text).textFieldStyle(.roundedBorder)
             Picker("Style", selection: $styleIdx) {
@@ -254,6 +274,7 @@ struct TagDemo: View {
             }.pickerStyle(.segmented)
             Toggle("Removable", isOn: $removable)
             Toggle("Leading icon", isOn: $icon)
+            Toggle("Bordered", isOn: $bordered)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Atoms/Tag.swift
+++ b/Sources/ThemeKit/Components/Atoms/Tag.swift
@@ -18,7 +18,9 @@ public struct Tag: View {
     // Appearance — mutated only through the modifiers below (R2).
     private var leadingSystemImage: String?
     private var style: BadgeStyle?
+    private var semantic: SemanticColor?   // .color(_) — the broader Ant palette
     private var variant: FillVariant = .soft
+    private var bordered = false
 
     @Environment(\.theme) private var theme
 
@@ -49,6 +51,12 @@ public struct Tag: View {
     }
 
     private var foreground: Color {
+        if let semantic {
+            switch variant {
+            case .soft, .outline, .ghost: return semantic.accent
+            case .solid: return semantic.onSolid
+            }
+        }
         guard let style else { return theme.text(.textHero) }
         switch variant {
         case .soft: return style.foreground(theme)
@@ -58,6 +66,13 @@ public struct Tag: View {
     }
 
     private var background: Color {
+        if let semantic {
+            switch variant {
+            case .soft: return semantic.soft
+            case .solid: return semantic.solid
+            case .outline, .ghost: return .clear
+            }
+        }
         guard let style else { return theme.background(.bgElevatorTertiary) }
         switch variant {
         case .soft: return style.background(theme)
@@ -66,9 +81,12 @@ public struct Tag: View {
         }
     }
 
+    /// Outline is always bordered; `.bordered()` opts soft/solid tags into a hairline too (Ant `bordered`).
     private var border: Color {
-        guard let style, variant == .outline else { return .clear }
-        return style.semantic.border
+        let hue = semantic ?? style?.semantic
+        guard let hue else { return bordered ? theme.border(.borderPrimary) : .clear }
+        if variant == .outline { return hue.border }
+        return bordered ? hue.border : .clear
     }
 }
 
@@ -83,6 +101,63 @@ public extension Tag {
 
     /// Fill variant: soft / solid / outline / ghost.
     func variant(_ v: FillVariant) -> Self { copy { $0.variant = v } }
+
+    /// Color the tag from the full semantic palette (Ant Tag `color`) — reaches hues
+    /// beyond ``tagStyle(_:)``'s status set (e.g. `.turquoise`, `.purple`, `.pink`).
+    /// Takes precedence over ``tagStyle(_:)``.
+    func color(_ color: SemanticColor) -> Self { copy { $0.semantic = color } }
+
+    /// Add a hairline border to a soft/solid tag (Ant `bordered`). Outline is always bordered.
+    func bordered(_ on: Bool = true) -> Self { copy { $0.bordered = on } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+/// Ant's **CheckableTag** — a tag that toggles a bound boolean, like a lightweight
+/// selectable filter. Unchecked is a neutral pill; checked fills with `.color` (hero
+/// by default). For rich multi-select filters prefer `Chip`; this mirrors Ant 1:1.
+public struct CheckableTag: View {
+    @Environment(\.theme) private var theme
+
+    private let text: String
+    @Binding private var isChecked: Bool
+    // Appearance — mutated only through the modifiers below (R2).
+    private var leadingSystemImage: String?
+    private var color: SemanticColor = .primary
+
+    public init(_ text: String, isChecked: Binding<Bool>) {   // R1
+        self.text = text
+        self._isChecked = isChecked
+    }
+
+    public var body: some View {
+        Button { isChecked.toggle() } label: {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                if let leadingSystemImage {
+                    Image(systemName: leadingSystemImage).font(.system(size: 12))
+                }
+                Text(text).textStyle(.labelSm600)
+            }
+            .foregroundStyle(isChecked ? color.onSolid : theme.text(.textSecondary))
+            .padding(.horizontal, Theme.SpacingKey.sm.value)
+            .frame(height: 28)
+            .background(isChecked ? color.solid : theme.background(.bgElevatorTertiary), in: Capsule())
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isChecked ? .isSelected : [])
+    }
+}
+
+public extension CheckableTag {
+    /// Leading SF Symbol.
+    func icon(_ systemImage: String?) -> Self { copy { $0.leadingSystemImage = systemImage } }
+    /// Fill color when checked (Ant CheckableTag stays hero; override per brand).
+    func color(_ color: SemanticColor) -> Self { copy { $0.color = color } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -104,8 +179,25 @@ public extension Tag {
             Tag("Error").tagStyle(.error).variant(.solid)
             Tag("Info").tagStyle(.info).variant(.outline)
         }
+        HStack {
+            Tag("Turquoise").color(.turquoise)
+            Tag("Purple").color(.purple).bordered()
+            Tag("Pink").color(.pink).variant(.solid)
+        }
+        CheckableTagRow()
     }
     .padding()
+}
+
+private struct CheckableTagRow: View {
+    @State private var a = true
+    @State private var b = false
+    var body: some View {
+        HStack {
+            CheckableTag("Nonstop", isChecked: $a)
+            CheckableTag("Morning", isChecked: $b).icon("sunrise")
+        }
+    }
 }
 
 #Preview("States") {


### PR DESCRIPTION
Brings the Tag atom to Ant Tag parity (it already had closable/icon/variants/status colors):

- **`.color(_ SemanticColor)`** — color a Tag from the full semantic palette (Ant Tag `color`), reaching hues beyond `.tagStyle`'s status set (turquoise / orange / purple / pink / …). Takes precedence over `.tagStyle`.
- **`.bordered(_)`** — add a hairline to a soft/solid tag (Ant `bordered`); outline stays always-bordered.
- **`CheckableTag`** — Ant's checkable tag: toggles a bound `Bool`, neutral when off and `.color`-filled when on. Mirrors Ant 1:1; `Chip` remains the richer multi-select filter.

Tag demo shows the palette, a bordered toggle, and two CheckableTags — verified in the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)