### PR TITLE
feat: Ant Anchor (AnchorNav) + Splitter

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -130,6 +130,8 @@ enum ComponentRegistry {
         .knob("ButtonGroup", .molecules, demo: ButtonGroupDemo(), usage: #"ButtonGroup { PrimaryButton("OK") { } }"#),
         .knob("Space", .molecules, demo: SpaceDemo(), usage: #"Space { Button("Save"){}; Button("Cancel"){} }.size(.large).wrap()"#),
         .knob("Flex", .molecules, demo: FlexDemo(), usage: #"Flex { Tag("A"); Tag("B"); Tag("C") }.justify(.spaceBetween).align(.center)"#),
+        .knob("Anchor", .molecules, demo: AnchorNavDemo(), usage: #"AnchorNav(sections, active: $current).onSelect { proxy.scrollTo($0, anchor: .top) }"#),
+        .knob("Splitter", .molecules, demo: SplitterDemo(), usage: #"Splitter(.horizontal) { Sidebar() } second: { Detail() }.bounds(min: 0.2, max: 0.8)"#),
         .knob("Affix", .molecules, demo: AffixDemo(), usage: #"ScrollView { Affix(offsetTop: 0) { Toolbar() }.onChange { affixed = $0 }; … }"#),
         .knob("ThemeButton", .molecules, demo: ThemeButtonDemo(), usage: #"ThemeButton("Save") { }.color(.success).variant(.soft).size(.medium).shape(.pill)"#),
         .knob("Checkbox", .molecules, demo: CheckboxDemo(), usage: #"Checkbox("Accept terms", isChecked: $on).accent(.success).infoMessages(error ? [.init("Required", kind: .error)] : [])"#),

--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -557,3 +557,84 @@ struct FlexDemo: View {
         }
     }
 }
+
+private struct AnchorSectionYKey: PreferenceKey {
+    static let defaultValue: [String: CGFloat] = [:]
+    static func reduce(value: inout [String: CGFloat], nextValue: () -> [String: CGFloat]) {
+        value.merge(nextValue()) { _, new in new }
+    }
+}
+
+struct AnchorNavDemo: View {
+    @Environment(\.theme) private var theme
+    @State private var active = "s0"
+    private let sections = (0..<5).map { AnchorItem("s\($0)", title: "Section \($0)") }
+
+    var body: some View {
+        ComponentStage("Anchor", inspector: [("active", active)]) {
+            ScrollViewReader { proxy in
+                HStack(alignment: .top, spacing: 16) {
+                    AnchorNav(sections, active: $active)
+                        .onSelect { id in withAnimation { proxy.scrollTo(id, anchor: .top) } }
+                        .frame(width: 110)
+
+                    ScrollView {
+                        VStack(spacing: 12) {
+                            ForEach(sections) { s in
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text(s.title).textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
+                                    Text("Body content for \(s.title.lowercased()).").textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                                }
+                                .frame(maxWidth: .infinity, minHeight: 120, alignment: .topLeading)
+                                .padding(12)
+                                .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: 12))
+                                .id(s.id)
+                                .background(GeometryReader { g in
+                                    Color.clear.preference(key: AnchorSectionYKey.self,
+                                                           value: [s.id: g.frame(in: .named("anchorScroll")).minY])
+                                })
+                            }
+                        }
+                        .padding(.trailing, 4)
+                    }
+                    .coordinateSpace(name: "anchorScroll")
+                    .frame(height: 300)
+                    .onPreferenceChange(AnchorSectionYKey.self) { ys in
+                        let current = sections.last { (ys[$0.id] ?? .infinity) <= 40 } ?? sections.first
+                        if let current, current.id != active { active = current.id }
+                    }
+                }
+            }
+        } knobs: {
+            Text("Tap a link to scroll; scrolling updates the active link (scroll-spy).").font(.caption).foregroundStyle(.secondary)
+        }
+    }
+}
+
+struct SplitterDemo: View {
+    @Environment(\.theme) private var theme
+    @State private var vertical = false
+
+    var body: some View {
+        ComponentStage("Splitter", inspector: [("axis", vertical ? "vertical" : "horizontal")]) {
+            Splitter(vertical ? .vertical : .horizontal, initialFraction: 0.4) {
+                pane("Pane A", .bgElevatorPrimary)
+            } second: {
+                pane("Pane B", .bgWhite)
+            }
+            .frame(height: 320)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .overlay(RoundedRectangle(cornerRadius: 16).stroke(theme.border(.borderPrimary), lineWidth: 1))
+        } knobs: {
+            Toggle("Vertical", isOn: $vertical)
+            Text("Drag the divider to resize the panes.").font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    private func pane(_ title: String, _ bg: Theme.BackgroundColorKey) -> some View {
+        Text(title)
+            .textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(theme.background(bg))
+    }
+}

--- a/Sources/ThemeKit/Components/Molecules/AnchorNav.swift
+++ b/Sources/ThemeKit/Components/Molecules/AnchorNav.swift
@@ -1,0 +1,122 @@
+//
+//  AnchorNav.swift
+//  ThemeKit
+//
+//  Molecule. Ant Design's **Anchor** — a scroll-spy link rail. Each link jumps to
+//  a section (via `onSelect`, wired to a `ScrollViewReader`), and the active link
+//  is highlighted with a moving hero indicator as the reader reports the current
+//  section. Vertical (default) or horizontal. Named `AnchorNav` because SwiftUI
+//  already defines a generic `Anchor<Value>` for anchor preferences.
+//
+//      ScrollViewReader { proxy in
+//          AnchorNav(sections, active: $current).onSelect { proxy.scrollTo($0, anchor: .top) }
+//      }
+//
+//  Pair with ``Affix`` on the enclosing view to pin the rail while scrolling.
+//
+
+import SwiftUI
+
+/// One entry in an ``AnchorNav`` rail. `level` indents nested links (Ant sub-anchors).
+public struct AnchorItem: Identifiable, Sendable {
+    public let id: String
+    public let title: String
+    public var level: Int
+    public init(_ id: String, title: String, level: Int = 0) {
+        self.id = id
+        self.title = title
+        self.level = level
+    }
+}
+
+public struct AnchorNav: View {
+    @Environment(\.theme) private var theme
+    @Namespace private var indicator
+
+    private let items: [AnchorItem]
+    @Binding private var active: String
+    // Appearance — mutated only through the modifiers below.
+    private var axis: Axis = .vertical
+    private var onSelect: ((String) -> Void)?
+
+    public init(_ items: [AnchorItem], active: Binding<String>) {   // R1
+        self.items = items
+        self._active = active
+    }
+
+    public var body: some View {
+        let layout = axis == .vertical
+            ? AnyLayout(VStackLayout(alignment: .leading, spacing: 2))
+            : AnyLayout(HStackLayout(spacing: Theme.SpacingKey.sm.value))
+        layout {
+            ForEach(items) { item in link(item) }
+        }
+        .animation(.snappy(duration: 0.25), value: active)
+    }
+
+    private func link(_ item: AnchorItem) -> some View {
+        let isActive = item.id == active
+        return Button {
+            active = item.id
+            onSelect?(item.id)
+        } label: {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                if axis == .vertical { rail(isActive: isActive) }
+                Text(item.title)
+                    .textStyle(isActive ? .labelBase700 : .bodyBase400)
+                    .foregroundStyle(isActive ? theme.text(.textHero) : theme.text(.textSecondary))
+                    .padding(.leading, axis == .vertical ? CGFloat(item.level) * Theme.SpacingKey.md.value : 0)
+            }
+            .padding(.vertical, axis == .vertical ? 4 : 6)
+            .padding(.horizontal, axis == .horizontal ? Theme.SpacingKey.sm.value : 0)
+            .overlay(alignment: .bottom) {
+                if axis == .horizontal, isActive {
+                    Rectangle().fill(theme.border(.borderHero)).frame(height: 2)
+                        .matchedGeometryEffect(id: "bar", in: indicator)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder private func rail(isActive: Bool) -> some View {
+        ZStack {
+            Capsule().fill(theme.background(.bgElevatorTertiary)).frame(width: 2)
+            if isActive {
+                Capsule().fill(theme.border(.borderHero)).frame(width: 2)
+                    .matchedGeometryEffect(id: "bar", in: indicator)
+            }
+        }
+        .frame(width: 2)
+    }
+}
+
+// MARK: - Modifiers (copy-on-write · single mutation point)
+
+public extension AnchorNav {
+    /// Called when a link is tapped — wire to `proxy.scrollTo(id, anchor: .top)`.
+    func onSelect(_ action: @escaping (String) -> Void) -> Self { copy { $0.onSelect = action } }
+    /// Lay the rail out horizontally (Ant Anchor `direction`).
+    func direction(_ axis: Axis) -> Self { copy { $0.axis = axis } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    struct Demo: View {
+        @State private var active = "intro"
+        let items = [AnchorItem("intro", title: "Introduction"),
+                     AnchorItem("install", title: "Installation"),
+                     AnchorItem("usage", title: "Usage", level: 1),
+                     AnchorItem("api", title: "API")]
+        var body: some View {
+            AnchorNav(items, active: $active).padding()
+        }
+    }
+    return Demo().environment(Theme.shared)
+}

--- a/Sources/ThemeKit/Components/Molecules/Splitter.swift
+++ b/Sources/ThemeKit/Components/Molecules/Splitter.swift
@@ -1,0 +1,122 @@
+//
+//  Splitter.swift
+//  ThemeKit
+//
+//  Molecule. Ant Design's **Splitter** — two panes separated by a draggable
+//  divider that resizes them. Horizontal (side-by-side) or vertical (stacked); the
+//  split is clamped to a min/max fraction.
+//
+//      Splitter(.horizontal) { Sidebar() } second: { Detail() }
+//      Splitter(.vertical, initialFraction: 0.35) { Map() } second: { List() }
+//          .bounds(min: 0.2, max: 0.8)
+//
+
+import SwiftUI
+
+public struct Splitter<First: View, Second: View>: View {
+    @Environment(\.theme) private var theme
+
+    private let axis: Axis
+    private let first: First
+    private let second: Second
+    // Appearance — mutated only through the modifiers below.
+    private var minFraction: CGFloat = 0.15
+    private var maxFraction: CGFloat = 0.85
+
+    @State private var fraction: CGFloat
+    @State private var dragAnchor: CGFloat?
+
+    public init(
+        _ axis: Axis = .horizontal,
+        initialFraction: CGFloat = 0.5,
+        @ViewBuilder first: () -> First,
+        @ViewBuilder second: () -> Second
+    ) {   // R1
+        self.axis = axis
+        self.first = first()
+        self.second = second()
+        self._fraction = State(initialValue: initialFraction)
+    }
+
+    private let handle: CGFloat = 12
+
+    public var body: some View {
+        GeometryReader { geo in
+            let total = axis == .horizontal ? geo.size.width : geo.size.height
+            let usable = max(1, total - handle)
+            let firstMain = usable * fraction
+            let secondMain = usable * (1 - fraction)
+            let stack = axis == .horizontal
+                ? AnyLayout(HStackLayout(spacing: 0))
+                : AnyLayout(VStackLayout(spacing: 0))
+            stack {
+                pane(first, main: firstMain, geo: geo.size)
+                divider(usable: usable)
+                pane(second, main: secondMain, geo: geo.size)
+            }
+        }
+    }
+
+    private func pane(_ content: some View, main: CGFloat, geo: CGSize) -> some View {
+        content
+            .frame(width: axis == .horizontal ? max(0, main) : geo.width,
+                   height: axis == .vertical ? max(0, main) : geo.height)
+            .clipped()
+    }
+
+    private func divider(usable: CGFloat) -> some View {
+        ZStack {
+            theme.background(.bgBase)
+            // Grip — a short capsule perpendicular to the drag axis.
+            Capsule().fill(theme.text(.textTertiary).opacity(0.5))
+                .frame(width: axis == .horizontal ? 3 : 28, height: axis == .horizontal ? 28 : 3)
+            Rectangle().fill(theme.border(.borderPrimary))
+                .frame(width: axis == .horizontal ? 1 : nil, height: axis == .vertical ? 1 : nil)
+                .frame(maxWidth: axis == .vertical ? .infinity : nil, maxHeight: axis == .horizontal ? .infinity : nil)
+        }
+        .frame(width: axis == .horizontal ? handle : nil, height: axis == .vertical ? handle : nil)
+        .frame(maxWidth: axis == .vertical ? .infinity : nil, maxHeight: axis == .horizontal ? .infinity : nil)
+        .contentShape(Rectangle())
+        .gesture(
+            DragGesture()
+                .onChanged { value in
+                    if dragAnchor == nil { dragAnchor = fraction }
+                    let base = dragAnchor ?? fraction
+                    let delta = axis == .horizontal ? value.translation.width : value.translation.height
+                    fraction = min(maxFraction, max(minFraction, base + delta / usable))
+                }
+                .onEnded { _ in dragAnchor = nil }
+        )
+        #if os(iOS)
+        .hoverEffect(.highlight)
+        #endif
+    }
+}
+
+// MARK: - Modifiers (copy-on-write · single mutation point)
+
+public extension Splitter {
+    /// Clamp the split fraction (Ant Panel `min` / `max`).
+    func bounds(min: CGFloat, max: CGFloat) -> Self {
+        copy { $0.minFraction = Swift.max(0, min); $0.maxFraction = Swift.min(1, max) }
+    }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    @Previewable @Environment(\.theme) var theme
+    Splitter(.horizontal) {
+        Text("Sidebar").frame(maxWidth: .infinity, maxHeight: .infinity).background(theme.background(.bgElevatorPrimary))
+    } second: {
+        Text("Detail").frame(maxWidth: .infinity, maxHeight: .infinity).background(theme.background(.bgWhite))
+    }
+    .frame(height: 240)
+    .clipShape(RoundedRectangle(cornerRadius: 16))
+    .padding()
+    .environment(Theme.shared)
+}


### PR DESCRIPTION
Two Ant-parity navigation/layout components, token-fed & gallery-registered.

**AnchorNav** (molecule) — Ant's Anchor scroll-spy link rail: vertical/horizontal, a moving hero indicator marks the active section, `.onSelect` wires to a `ScrollViewReader`. Named `AnchorNav` to avoid SwiftUI's generic `Anchor<Value>`. Demo shows tap-to-scroll + preference-based scroll-spy.

**Splitter** (molecule) — two panes with a draggable divider (horizontal/vertical), clamped via `.bounds(min:max:)` (Ant Panel min/max); the drag anchors on the start fraction so it tracks 1:1.

Verified in the simulator (active rail indicator; 0.4/0.6 split with grip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)