### PR TITLE
feat(demo): full-screen paged Showcase hero for screen recording

### DIFF
--- a/Demo/Demo/DemoApp.swift
+++ b/Demo/Demo/DemoApp.swift
@@ -16,7 +16,7 @@ struct DemoApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ShowcaseView()
                 .microAnimations(microAnimations)
                 .environmentObject(themeStore)
                 .feedbackHost()       // installs the shared FeedbackPresenter + overlays

--- a/Demo/Demo/DemoApp.swift
+++ b/Demo/Demo/DemoApp.swift
@@ -5,6 +5,7 @@
 //
 
 import SwiftUI
+import UIKit
 import ThemeKit
 
 @main
@@ -16,7 +17,7 @@ struct DemoApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ShowcaseView()
+            rootView
                 .microAnimations(microAnimations)
                 .environmentObject(themeStore)
                 .feedbackHost()       // installs the shared FeedbackPresenter + overlays
@@ -25,6 +26,16 @@ struct DemoApp: App {
                 // env-only (no root rebuild) so the in-session Configurator sheet
                 // isn't torn down mid-edit; screens observe Theme via @ThemeContext.
                 .themeKit(reactToRuntimeChanges: false)
+        }
+    }
+
+    /// The Showcase collage is a wide-canvas (iPad) experience; on iPhone the Demo
+    /// keeps its original tabbed catalog (``ContentView``).
+    @ViewBuilder private var rootView: some View {
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            ShowcaseView()
+        } else {
+            ContentView()
         }
     }
 }

--- a/Demo/Demo/Gallery/Showcase/RichComponentsBrowser.swift
+++ b/Demo/Demo/Gallery/Showcase/RichComponentsBrowser.swift
@@ -17,11 +17,18 @@ import ThemeKit
 
 struct RichComponentsBrowser: View {
     @Environment(\.dismiss) private var dismiss
-    @EnvironmentObject private var themeStore: DemoThemeStore
+
+    // Shares the Showcase's isolated theme — the same instance, never Theme.shared.
+    let theme: Theme
+    @Binding var preset: DemoTheme
+    @Binding var isDark: Bool
 
     @State private var selected: ComponentEntry?
     @State private var autoCycle = false
     private let ticker = Timer.publish(every: 4.5, on: .main, in: .common).autoconnect()
+
+    /// Load the selected preset into the shared Showcase theme.
+    private func applyTheme() { theme.loadTheme(named: preset.resourceName, dark: isDark) }
 
     private enum ShelfItem: Identifiable {
         case marker(ComponentCategory, Int)
@@ -51,7 +58,7 @@ struct RichComponentsBrowser: View {
             let cardW = min(max(geo.size.width * 0.32, 360), 480)
 
             ZStack(alignment: .top) {
-                Theme.shared.background(.bgBase).ignoresSafeArea()
+                theme.background(.bgBase).ignoresSafeArea()
 
                 VStack(spacing: 0) {
                     header
@@ -66,6 +73,8 @@ struct RichComponentsBrowser: View {
         .environment(\.locale, Locale(identifier: "en_US"))
         .statusBarHidden(true)
         .persistentSystemOverlays(.hidden)
+        .onChange(of: preset) { _, _ in applyTheme() }
+        .onChange(of: isDark) { _, _ in applyTheme() }
         .onReceive(ticker) { _ in if autoCycle { advanceTheme() } }
         .sheet(item: $selected) { entry in
             NavigationStack {
@@ -87,11 +96,11 @@ struct RichComponentsBrowser: View {
     private var header: some View {
         HStack(spacing: 16) {
             Spacer()
-            ThemePresetRow(autoCycle: $autoCycle)
+            ThemePresetRow(theme: theme, preset: $preset, isDark: $isDark, autoCycle: $autoCycle)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 9)
-                .background(Theme.shared.background(.bgWhite), in: Capsule())
-                .overlay(Capsule().stroke(Theme.shared.border(.borderPrimary), lineWidth: 0.5))
+                .background(theme.background(.bgWhite), in: Capsule())
+                .overlay(Capsule().stroke(theme.border(.borderPrimary), lineWidth: 0.5))
             Button { dismiss() } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.system(size: 26))
@@ -140,16 +149,17 @@ struct RichComponentsBrowser: View {
 
     private func advanceTheme() {
         let cases = DemoTheme.allCases
-        guard let idx = cases.firstIndex(of: themeStore.current) else { return }
+        guard let idx = cases.firstIndex(of: preset) else { return }
         let next = (idx + 1) % cases.count
-        themeStore.select(cases[next])
-        if next == 0 { themeStore.setDark(!themeStore.isDark) }
+        preset = cases[next]                 // onChange(of:) applies it to the shared theme
+        if next == 0 { isDark.toggle() }
     }
 }
 
 // MARK: - One big shelf card: clean live preview on top, info + code below
 
 private struct ShelfCard: View {
+    @Environment(\.theme) private var theme
     let entry: ComponentEntry
     let width: CGFloat
     let height: CGFloat
@@ -160,7 +170,7 @@ private struct ShelfCard: View {
     // component fully inside the card (no cropping / overflow), while the theme
     // bar / properties below stay clipped off.
     private let previewHeight: CGFloat = 224
-    private var accent: Color { Theme.shared.foreground(.systemcolorsFgInfo) }
+    private var accent: Color { theme.foreground(.systemcolorsFgInfo) }
 
     var body: some View {
         Button(action: onTap) {
@@ -172,13 +182,13 @@ private struct ShelfCard: View {
 
                 infoFooter
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                    .background(Theme.shared.background(.bgWhite))
+                    .background(theme.background(.bgWhite))
             }
             .frame(width: width, height: height)
             .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .stroke(Theme.shared.border(.borderPrimary), lineWidth: 0.5)
+                    .stroke(theme.border(.borderPrimary), lineWidth: 0.5)
             )
         }
         .buttonStyle(.plain)
@@ -220,6 +230,7 @@ private struct ShelfCard: View {
 // MARK: - Slim in-row category marker
 
 private struct CategoryMarker: View {
+    @Environment(\.theme) private var theme
     let category: ComponentCategory
     let count: Int
     let height: CGFloat
@@ -229,7 +240,7 @@ private struct CategoryMarker: View {
             Spacer()
             Text("\(count)")
                 .font(.system(size: 44, weight: .bold, design: .rounded))
-                .foregroundStyle(Theme.shared.foreground(.systemcolorsFgInfo))
+                .foregroundStyle(theme.foreground(.systemcolorsFgInfo))
             Text(category.rawValue.uppercased())
                 .font(.headline)
                 .foregroundStyle(.secondary)

--- a/Demo/Demo/Gallery/Showcase/RichComponentsBrowser.swift
+++ b/Demo/Demo/Gallery/Showcase/RichComponentsBrowser.swift
@@ -1,0 +1,241 @@
+//
+//  RichComponentsBrowser.swift
+//  Demo
+//  Created by İsa Mercan.
+//
+//  The "Rich components" shelf — every entry in the ComponentRegistry rendered
+//  live in ONE horizontal row of large cards (each ~half the screen tall), like
+//  Ant Design's "Rich components" section. Swipe the row to browse all 198
+//  components & organisms; tap a card to open its full interactive demo.
+//  Auto theme-cycle is off by default (tap a swatch / play to change the theme).
+//
+
+import SwiftUI
+import Combine
+import UIKit
+import ThemeKit
+
+struct RichComponentsBrowser: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var themeStore: DemoThemeStore
+
+    @State private var selected: ComponentEntry?
+    @State private var autoCycle = false
+    private let ticker = Timer.publish(every: 4.5, on: .main, in: .common).autoconnect()
+
+    private enum ShelfItem: Identifiable {
+        case marker(ComponentCategory, Int)
+        case component(ComponentEntry)
+        var id: String {
+            switch self {
+            case let .marker(category, _): return "marker-\(category.rawValue)"
+            case let .component(entry): return "comp-\(entry.id)"
+            }
+        }
+    }
+
+    // All components in one ordered row, with a slim marker before each category.
+    private var shelfItems: [ShelfItem] {
+        var items: [ShelfItem] = []
+        for category in ComponentCategory.allCases {
+            let entries = ComponentRegistry.entries(in: category)
+            items.append(.marker(category, entries.count))
+            items.append(contentsOf: entries.map { .component($0) })
+        }
+        return items
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let cardH = geo.size.height * 0.5
+            let cardW = min(max(geo.size.width * 0.32, 360), 480)
+
+            ZStack(alignment: .top) {
+                Theme.shared.background(.bgBase).ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    header
+                    Spacer(minLength: 0)
+                    titleBlock
+                    Spacer().frame(height: 28)
+                    shelf(cardW: cardW, cardH: cardH)
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .environment(\.locale, Locale(identifier: "en_US"))
+        .statusBarHidden(true)
+        .persistentSystemOverlays(.hidden)
+        .onReceive(ticker) { _ in if autoCycle { advanceTheme() } }
+        .sheet(item: $selected) { entry in
+            NavigationStack {
+                entry.make()
+                    .environment(\.componentUsage, entry.usage)
+                    .navigationTitle(entry.name)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") { selected = nil }
+                        }
+                    }
+            }
+        }
+    }
+
+    // MARK: - Header (theme row + close)
+
+    private var header: some View {
+        HStack(spacing: 16) {
+            Spacer()
+            ThemePresetRow(autoCycle: $autoCycle)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 9)
+                .background(Theme.shared.background(.bgWhite), in: Capsule())
+                .overlay(Capsule().stroke(Theme.shared.border(.borderPrimary), lineWidth: 0.5))
+            Button { dismiss() } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 26))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+        .padding(.horizontal, 28)
+        .padding(.top, 18)
+    }
+
+    private var titleBlock: some View {
+        VStack(spacing: 8) {
+            Text("Rich components")
+                .font(.system(size: 40, weight: .bold, design: .rounded))
+            Text("\(ComponentRegistry.all.count) live components & organisms — practical, flexible, and yours to theme.")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 24)
+    }
+
+    // MARK: - The single horizontal row
+
+    private func shelf(cardW: CGFloat, cardH: CGFloat) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: 18) {
+                ForEach(shelfItems) { item in
+                    switch item {
+                    case let .marker(category, count):
+                        CategoryMarker(category: category, count: count, height: cardH)
+                    case let .component(entry):
+                        ShelfCard(entry: entry, width: cardW, height: cardH) { selected = entry }
+                    }
+                }
+            }
+            .padding(.horizontal, 40)
+        }
+        .frame(height: cardH)
+    }
+
+    // MARK: - Auto theme-cycle (off unless the user turns it on)
+
+    private func advanceTheme() {
+        let cases = DemoTheme.allCases
+        guard let idx = cases.firstIndex(of: themeStore.current) else { return }
+        let next = (idx + 1) % cases.count
+        themeStore.select(cases[next])
+        if next == 0 { themeStore.setDark(!themeStore.isDark) }
+    }
+}
+
+// MARK: - One big shelf card: clean live preview on top, info + code below
+
+private struct ShelfCard: View {
+    let entry: ComponentEntry
+    let width: CGFloat
+    let height: CGFloat
+    let onTap: () -> Void
+
+    // The demo's canvas (its live preview) sits in the top ~220pt of
+    // `entry.make()`; rendering it at the card's real width keeps every
+    // component fully inside the card (no cropping / overflow), while the theme
+    // bar / properties below stay clipped off.
+    private let previewHeight: CGFloat = 224
+    private var accent: Color { Theme.shared.foreground(.systemcolorsFgInfo) }
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 0) {
+                entry.make()
+                    .frame(width: width, height: previewHeight, alignment: .top)
+                    .clipped()
+                    .allowsHitTesting(false)
+
+                infoFooter
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .background(Theme.shared.background(.bgWhite))
+            }
+            .frame(width: width, height: height)
+            .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .stroke(Theme.shared.border(.borderPrimary), lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var infoFooter: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(entry.category.rawValue.uppercased())
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(accent)
+            Text(entry.name)
+                .font(.title3.weight(.bold))
+                .lineLimit(1)
+
+            if let usage = entry.usage, !usage.isEmpty {
+                Text(usage)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(4)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(10)
+                    .background(Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 10))
+            }
+
+            Spacer(minLength: 4)
+
+            HStack(spacing: 6) {
+                Text("Open in playground")
+                Image(systemName: "arrow.up.right")
+            }
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(accent)
+        }
+        .padding(16)
+    }
+}
+
+// MARK: - Slim in-row category marker
+
+private struct CategoryMarker: View {
+    let category: ComponentCategory
+    let count: Int
+    let height: CGFloat
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Spacer()
+            Text("\(count)")
+                .font(.system(size: 44, weight: .bold, design: .rounded))
+                .foregroundStyle(Theme.shared.foreground(.systemcolorsFgInfo))
+            Text(category.rawValue.uppercased())
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(width: 130, height: height, alignment: .leading)
+        .padding(.horizontal, 16)
+    }
+}

--- a/Demo/Demo/Gallery/Showcase/ShowcaseView.swift
+++ b/Demo/Demo/Gallery/Showcase/ShowcaseView.swift
@@ -20,6 +20,15 @@ import ThemeKit
 struct ShowcaseView: View {
     @EnvironmentObject private var themeStore: DemoThemeStore
 
+    // The Showcase owns an ISOLATED theme instance: the global theme (themeStore /
+    // Theme.shared) never changes the wall, and the wall's preset row never changes
+    // the global. It re-skins only when the user taps the top-right row (or auto-cycle).
+    @State private var localTheme: Theme = {
+        let t = Theme(); t.loadTheme(named: DemoTheme.default.resourceName, dark: false); return t
+    }()
+    @State private var preset: DemoTheme = .default
+    @State private var isDark = false
+
     @State private var page = UserDefaults.standard.integer(forKey: "startPage")
     @State private var autoCycle = false
     @State private var showBrowser = UserDefaults.standard.bool(forKey: "openBrowser")
@@ -27,7 +36,7 @@ struct ShowcaseView: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            Theme.shared.background(.bgBase).ignoresSafeArea()
+            localTheme.background(.bgBase).ignoresSafeArea()
 
             TabView(selection: $page) {
                 OverviewPage().tag(0)
@@ -40,17 +49,26 @@ struct ShowcaseView: View {
 
             topBar
         }
+        .theme(localTheme)   // isolate the whole wall on the Showcase's own theme
         .environment(\.locale, Locale(identifier: "en_US"))
         .statusBarHidden(true)
         .persistentSystemOverlays(.hidden)
+        .onChange(of: preset) { _, _ in applyTheme() }
+        .onChange(of: isDark) { _, _ in applyTheme() }
         .onReceive(ticker) { _ in if autoCycle { advanceTheme() } }
         .fullScreenCover(isPresented: $showBrowser) {
-            RichComponentsBrowser()
+            RichComponentsBrowser(theme: localTheme, preset: $preset, isDark: $isDark)
+                .theme(localTheme)
                 .environmentObject(themeStore)
                 .feedbackHost()
                 .sheetHost()
                 .drawerHost()
         }
+    }
+
+    /// Load the selected preset into the Showcase's own theme (never `Theme.shared`).
+    private func applyTheme() {
+        localTheme.loadTheme(named: preset.resourceName, dark: isDark)
     }
 
     private var topBar: some View {
@@ -62,18 +80,18 @@ struct ShowcaseView: View {
                     .font(.subheadline.weight(.semibold))
                     .padding(.horizontal, 14)
                     .padding(.vertical, 9)
-                    .background(Theme.shared.background(.bgWhite), in: Capsule())
-                    .overlay(Capsule().stroke(Theme.shared.border(.borderPrimary), lineWidth: 0.5))
+                    .background(localTheme.background(.bgWhite), in: Capsule())
+                    .overlay(Capsule().stroke(localTheme.border(.borderPrimary), lineWidth: 0.5))
             }
             .buttonStyle(.plain)
 
             Spacer()
 
-            ThemePresetRow(autoCycle: $autoCycle)
+            ThemePresetRow(theme: localTheme, preset: $preset, isDark: $isDark, autoCycle: $autoCycle)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 9)
-                .background(Theme.shared.background(.bgWhite), in: Capsule())
-                .overlay(Capsule().stroke(Theme.shared.border(.borderPrimary), lineWidth: 0.5))
+                .background(localTheme.background(.bgWhite), in: Capsule())
+                .overlay(Capsule().stroke(localTheme.border(.borderPrimary), lineWidth: 0.5))
         }
         .padding(.horizontal, 24)
         .padding(.top, 14)
@@ -81,10 +99,10 @@ struct ShowcaseView: View {
 
     private func advanceTheme() {
         let cases = DemoTheme.allCases
-        guard let idx = cases.firstIndex(of: themeStore.current) else { return }
+        guard let idx = cases.firstIndex(of: preset) else { return }
         let next = (idx + 1) % cases.count
-        themeStore.select(cases[next])
-        if next == 0 { themeStore.setDark(!themeStore.isDark) }
+        preset = cases[next]                 // onChange(of:) applies it to localTheme
+        if next == 0 { isDark.toggle() }
     }
 }
 
@@ -726,6 +744,7 @@ private struct PageScaffold<Content: View>: View {
 // MARK: - Titled collage container (Ant-style rounded card)
 
 struct CollageCard<Content: View>: View {
+    @Environment(\.theme) private var theme
     private let title: String?
     @ViewBuilder private let content: () -> Content
 
@@ -743,10 +762,10 @@ struct CollageCard<Content: View>: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(Theme.shared.border(.borderPrimary), lineWidth: 0.5)
+                .stroke(theme.border(.borderPrimary), lineWidth: 0.5)
         )
     }
 }
@@ -754,27 +773,29 @@ struct CollageCard<Content: View>: View {
 // MARK: - Theme preset row (swatches + dark toggle + auto-cycle)
 
 struct ThemePresetRow: View {
-    @EnvironmentObject private var themeStore: DemoThemeStore
+    let theme: Theme                 // the Showcase's own theme (for chrome tint)
+    @Binding var preset: DemoTheme   // drives the local theme via the parent's onChange
+    @Binding var isDark: Bool
     @Binding var autoCycle: Bool
 
     var body: some View {
         HStack(spacing: 12) {
-            ForEach(DemoTheme.allCases) { theme in
-                Button { themeStore.select(theme) } label: {
+            ForEach(DemoTheme.allCases) { p in
+                Button { preset = p } label: {
                     Circle()
-                        .fill(swatch(theme))
+                        .fill(swatch(p))
                         .frame(width: 22, height: 22)
-                        .overlay(Circle().stroke(Color.primary.opacity(themeStore.current == theme ? 0.9 : 0), lineWidth: 2))
+                        .overlay(Circle().stroke(Color.primary.opacity(preset == p ? 0.9 : 0), lineWidth: 2))
                         .overlay(Circle().stroke(.white.opacity(0.5), lineWidth: 1))
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(theme.label)
+                .accessibilityLabel(p.label)
             }
 
             Divider().frame(height: 18)
 
-            Button { themeStore.setDark(!themeStore.isDark) } label: {
-                Image(systemName: themeStore.isDark ? "moon.fill" : "sun.max.fill")
+            Button { isDark.toggle() } label: {
+                Image(systemName: isDark ? "moon.fill" : "sun.max.fill")
                     .font(.system(size: 15, weight: .semibold))
             }
             .buttonStyle(.plain)
@@ -783,7 +804,7 @@ struct ThemePresetRow: View {
             Button { autoCycle.toggle() } label: {
                 Image(systemName: autoCycle ? "pause.circle.fill" : "play.circle.fill")
                     .font(.system(size: 19, weight: .semibold))
-                    .foregroundStyle(Theme.shared.foreground(.systemcolorsFgInfo))
+                    .foregroundStyle(theme.foreground(.systemcolorsFgInfo))
             }
             .buttonStyle(.plain)
             .accessibilityLabel(autoCycle ? "Pause auto theme cycle" : "Start auto theme cycle")

--- a/Demo/Demo/Gallery/Showcase/ShowcaseView.swift
+++ b/Demo/Demo/Gallery/Showcase/ShowcaseView.swift
@@ -43,6 +43,7 @@ struct ShowcaseView: View {
                 TravelPage().tag(1)
                 ContentPage().tag(2)
                 DashboardPage().tag(3)
+                FormsPage().tag(4)
             }
             .tabViewStyle(.page(indexDisplayMode: .always))
             .indexViewStyle(.page(backgroundDisplayMode: .always))
@@ -713,6 +714,78 @@ private struct DashboardPage: View {
         VStack(alignment: .leading, spacing: 5) {
             Text(label).font(.caption).foregroundStyle(.secondary)
             ProgressBar(value: v).showsPercentage().status(status)
+        }
+    }
+}
+
+// MARK: - Page 4 · FORMS & LISTS (grouped inputs · multi-select · passenger rows)
+
+private struct FormsPage: View {
+    @State private var email = ""
+    @State private var newsletter = true
+    @State private var interests: Set<String> = ["Design", "Code"]
+    @State private var cities: Set<String> = ["Istanbul", "Rome"]
+
+    var body: some View {
+        PageScaffold(title: "Forms & lists",
+                     subtitle: "Grouped inputs, multi-select, amenities and passenger rows — all live.") {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(spacing: 16) { fieldsetCard; checkboxGroupCard }
+                VStack(spacing: 16) { multiSelectCard; amenitiesCard }
+                VStack(spacing: 16) { passengersCard }
+            }
+        }
+    }
+
+    private var fieldsetCard: some View {
+        CollageCard("Fieldset") {
+            Fieldset("Contact") {
+                VStack(alignment: .leading, spacing: 12) {
+                    TextInput("Email", text: $email).placeholder("antd@email.com").icon(leading: "envelope")
+                    Checkbox("Subscribe to the newsletter", isChecked: $newsletter)
+                }
+            }
+            .helper("We'll only email booking updates.")
+        }
+    }
+
+    private var checkboxGroupCard: some View {
+        CollageCard("CheckboxGroup") {
+            CheckboxGroup(title: "Interests",
+                          options: ["Design", "Code", "Travel", "Music"],
+                          selection: $interests) { $0 }
+        }
+    }
+
+    private var multiSelectCard: some View {
+        CollageCard("MultiSelect") {
+            MultiSelect("Cities",
+                        options: ["Istanbul", "Rome", "Paris", "Tokyo", "Berlin"],
+                        selection: $cities) { $0 }
+                .placeholder("Select")
+        }
+    }
+
+    private var amenitiesCard: some View {
+        CollageCard("Amenities") {
+            AmenityGrid([
+                ThemeKit.Amenity("Free Wi-Fi", systemImage: "wifi"),
+                ThemeKit.Amenity("Breakfast", systemImage: "cup.and.saucer.fill"),
+                ThemeKit.Amenity("Pool", systemImage: "figure.pool.swim"),
+                ThemeKit.Amenity("Parking", systemImage: "parkingsign"),
+            ])
+            .columns(2)
+            .highlighted(["Free Wi-Fi"])
+        }
+    }
+
+    private var passengersCard: some View {
+        CollageCard("Passengers") {
+            VStack(spacing: 8) {
+                PassengerRow("İsa Mercan").type("Adult").subtitle("Passport · TR12345").seat("14C").status("Checked in").onEdit { }
+                PassengerRow("Ada Lovelace").type("Adult").subtitle("Passport · UK88231").seat("14D").onEdit { }
+                PassengerRow("Kid Mercan").type("Child").subtitle("12 years").seat("14E").onEdit { }
+            }
         }
     }
 }

--- a/Demo/Demo/Gallery/Showcase/ShowcaseView.swift
+++ b/Demo/Demo/Gallery/Showcase/ShowcaseView.swift
@@ -1,0 +1,806 @@
+//
+//  ShowcaseView.swift
+//  Demo
+//  Created by İsa Mercan.
+//
+//  The app's opening experience — a full-screen, tab-bar-free, non-scrolling
+//  paged showcase built for screen recording. It opens on an Ant-Design-homepage
+//  style collage, then swipes through curated, densely-packed pages (Overview ·
+//  Travel · Content · Dashboard) with page dots at the bottom. Each page fills
+//  the screen with the richest components in the library. A theme-preset row
+//  (top-right) re-skins the whole wall; "All components" opens the Rich
+//  components shelf. Auto theme-cycle is OFF by default. Wide-canvas first
+//  (iPad landscape / Mac Catalyst).
+//
+
+import SwiftUI
+import Combine
+import ThemeKit
+
+struct ShowcaseView: View {
+    @EnvironmentObject private var themeStore: DemoThemeStore
+
+    @State private var page = UserDefaults.standard.integer(forKey: "startPage")
+    @State private var autoCycle = false
+    @State private var showBrowser = UserDefaults.standard.bool(forKey: "openBrowser")
+    private let ticker = Timer.publish(every: 4.5, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            Theme.shared.background(.bgBase).ignoresSafeArea()
+
+            TabView(selection: $page) {
+                OverviewPage().tag(0)
+                TravelPage().tag(1)
+                ContentPage().tag(2)
+                DashboardPage().tag(3)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .indexViewStyle(.page(backgroundDisplayMode: .always))
+
+            topBar
+        }
+        .environment(\.locale, Locale(identifier: "en_US"))
+        .statusBarHidden(true)
+        .persistentSystemOverlays(.hidden)
+        .onReceive(ticker) { _ in if autoCycle { advanceTheme() } }
+        .fullScreenCover(isPresented: $showBrowser) {
+            RichComponentsBrowser()
+                .environmentObject(themeStore)
+                .feedbackHost()
+                .sheetHost()
+                .drawerHost()
+        }
+    }
+
+    private var topBar: some View {
+        HStack(spacing: 12) {
+            Button {
+                showBrowser = true
+            } label: {
+                Label("All components", systemImage: "square.grid.2x2.fill")
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 9)
+                    .background(Theme.shared.background(.bgWhite), in: Capsule())
+                    .overlay(Capsule().stroke(Theme.shared.border(.borderPrimary), lineWidth: 0.5))
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            ThemePresetRow(autoCycle: $autoCycle)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 9)
+                .background(Theme.shared.background(.bgWhite), in: Capsule())
+                .overlay(Capsule().stroke(Theme.shared.border(.borderPrimary), lineWidth: 0.5))
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 14)
+    }
+
+    private func advanceTheme() {
+        let cases = DemoTheme.allCases
+        guard let idx = cases.firstIndex(of: themeStore.current) else { return }
+        let next = (idx + 1) % cases.count
+        themeStore.select(cases[next])
+        if next == 0 { themeStore.setDark(!themeStore.isDark) }
+    }
+}
+
+// MARK: - Page 0 · OVERVIEW (Ant-Design-homepage-style opening)
+
+private struct OverviewPage: View {
+    @State private var email = ""
+    @State private var fruits: Set<String> = ["Apple", "Banana"]
+    @State private var brandColor = Color(red: 0.086, green: 0.463, blue: 1.0)
+    @State private var pickedDate: Date? = nil
+    @State private var checkApple = true
+    @State private var checkPear = false
+    @State private var radioApple = true
+    @State private var radioPear = false
+    @State private var switchOn = true
+    @State private var rangeTab = 0
+    @State private var otp = "4320"
+    @State private var calDate: Date? = nil
+
+    var body: some View {
+        PageScaffold(
+            title: "ThemeKit",
+            subtitle: "\(ComponentRegistry.all.count) native SwiftUI components · one theme, infinite skins."
+        ) {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(spacing: 16) { inputsCard; choicesCard; calendarCard }
+                VStack(spacing: 16) { verifyCard; buttonsCard; loyaltyCard }
+                VStack(spacing: 16) { accountCard; dataCard; menuCard }
+            }
+        }
+    }
+
+    private var inputsCard: some View {
+        CollageCard("Inputs") {
+            VStack(spacing: 12) {
+                TextInput("Email", text: $email).placeholder("antd@email.com").icon(leading: "envelope")
+                MultiSelect("Fruits", options: ["Apple", "Banana", "Cherry", "Pear"], selection: $fruits) { $0 }
+                    .placeholder("Select")
+                HStack(spacing: 10) {
+                    ColorField("Color", selection: $brandColor)
+                    DateField(date: $pickedDate).placeholder("Date")
+                }
+            }
+        }
+    }
+
+    private var choicesCard: some View {
+        CollageCard("Choices") {
+            HStack(alignment: .top, spacing: 20) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Checkbox("Apple", isChecked: $checkApple)
+                    Checkbox("Pear", isChecked: $checkPear)
+                }
+                VStack(alignment: .leading, spacing: 10) {
+                    RadioButton("Apple", isSelected: $radioApple)
+                    RadioButton("Pear", isSelected: $radioPear)
+                }
+                VStack(alignment: .leading, spacing: 12) {
+                    ThemeToggle(isOn: $switchOn)
+                    Spinner().style(.ring).size(20)
+                }
+            }
+        }
+    }
+
+    private var calendarCard: some View {
+        CollageCard("Calendar") {
+            CalendarView(selection: $calDate)
+        }
+    }
+
+    private var verifyCard: some View {
+        CollageCard {
+            VStack(spacing: 10) {
+                AvatarGroup([
+                    .initials("İM"), .icon("person.fill"), .initials("EK"),
+                    .icon("person.crop.circle.fill"), .initials("AY"), .initials("MB"), .initials("SD"),
+                ])
+                .maxVisible(5).size(.sm)
+                Text("Verify account").font(.headline)
+                Text("Code sent to a****@gmail.com").font(.caption).foregroundStyle(.secondary)
+                OTPInput(code: $otp).digitCount(6)
+                HStack(spacing: 4) {
+                    Text("Didn't get it?").font(.caption).foregroundStyle(.secondary)
+                    TextLink("Resend") { }.accent(.primary)
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    private var buttonsCard: some View {
+        CollageCard("Buttons") {
+            VStack(spacing: 10) {
+                HStack(spacing: 10) {
+                    PrimaryButton("Primary") { }.fullWidth()
+                    ThemeButton("Danger") { }.color(.error).fullWidth()
+                }
+                HStack(spacing: 10) {
+                    ThemeButton("Outlined") { }.variant(.outline).fullWidth()
+                    ThemeButton("Round") { }.variant(.outline).color(.error).shape(.pill).fullWidth()
+                }
+                SegmentedControl(["1D", "7D", "1M", "1Y", "All"], selection: $rangeTab).fullWidth()
+            }
+        }
+    }
+
+    private var loyaltyCard: some View {
+        LoyaltyCard(tier: "Gold", points: 8_430)
+            .memberName("İsa Mercan")
+            .progress(0.62, toNextTier: "Platinum")
+            .flippable()
+    }
+
+    private var accountCard: some View {
+        CollageCard {
+            VStack(spacing: 12) {
+                Avatar(.icon("person.crop.circle.fill")).size(.lg).accent(.primary)
+                VStack(spacing: 3) {
+                    Text("Create an account").font(.headline)
+                    Text("Start your free 7-day trial. No credit card required.")
+                        .font(.caption).foregroundStyle(.secondary).multilineTextAlignment(.center)
+                }
+                PrimaryButton("Get Started") { }.fullWidth()
+                DividerView("OR")
+                ThemeButton("Continue with Google") { }.variant(.outline).fullWidth().icon(leading: "g.circle.fill")
+                ThemeButton("Continue with Apple") { }.variant(.outline).fullWidth().icon(leading: "apple.logo")
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .borderBeam(cornerRadius: 18, lineWidth: 2)
+    }
+
+    private var dataCard: some View {
+        CollageCard("Data & actions") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 14) {
+                    QRCode("https://themekit.dev").size(72)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Rating(value: 3).maxValue(5).starSize(16)
+                        Spinner().style(.dots).size(18)
+                    }
+                }
+                Flex {
+                    Tag("Twitter").icon("at").color(.info).variant(.outline)
+                    Tag("YouTube").icon("play.rectangle.fill").color(.error).variant(.outline)
+                    Tag("Facebook").icon("f.square.fill").color(.primary).variant(.outline)
+                }
+            }
+        }
+    }
+
+    private var menuCard: some View {
+        MenuCard(items: [
+            .init(title: "Reservations", subtitle: "3 upcoming", systemImage: "calendar"),
+            .init(title: "Payment methods", systemImage: "creditcard"),
+            .init(title: "Settings", systemImage: "gearshape"),
+        ])
+    }
+}
+
+// MARK: - Page 1 · TRAVEL (flight & booking component suite)
+
+private struct TravelPage: View {
+    @State private var flightFilters: Set<String> = ["cheapest"]
+    @State private var viewMode = 0
+    @State private var trendDay = 3
+    @State private var sortSel = 0
+    @State private var histLow = 800.0
+    @State private var histHigh = 3_200.0
+
+    private let departure = Calendar.current.date(from: DateComponents(year: 2026, month: 5, day: 3, hour: 7))
+        ?? Date(timeIntervalSince1970: 0)
+    private var arrival: Date { departure.addingTimeInterval(3 * 3600 + 15 * 60) }
+    private let trendPoints: [PriceTrendPoint] = [
+        PriceTrendPoint("Mon", price: 1_450), PriceTrendPoint("Tue", price: 1_320),
+        PriceTrendPoint("Wed", price: 1_680), PriceTrendPoint("Thu", price: 1_290),
+        PriceTrendPoint("Fri", price: 1_540), PriceTrendPoint("Sat", price: 1_210),
+        PriceTrendPoint("Sun", price: 1_760),
+    ]
+    private let sortOptions = [
+        SortOption("Best", value: "₺2.777", subtitle: "1h 07m", icon: "star.fill"),
+        SortOption("Cheapest", value: "₺2.178", subtitle: "6h 45m", icon: "tag.fill"),
+        SortOption("Fastest", value: "₺3.410", subtitle: "1h 05m", icon: "bolt.fill"),
+    ]
+
+    var body: some View {
+        PageScaffold(title: "Travel", subtitle: "A full flight-booking flow, assembled from ThemeKit.") {
+            VStack(spacing: 16) {
+                filterCard
+                HStack(alignment: .top, spacing: 16) {
+                    VStack(spacing: 16) { flightTrayCard; hotelCard }
+                    VStack(spacing: 16) { priceTrendCard; sortSummaryCard; priceHistogramCard }
+                    VStack(spacing: 16) { boardingPassCard; fareFamilyCard }
+                }
+            }
+        }
+    }
+
+    private var filterCard: some View {
+        CollageCard("Flight filters") {
+            VStack(spacing: 12) {
+                FilterBar([
+                    QuickFilter("Cheapest", id: "cheapest"),
+                    QuickFilter("Fastest"),
+                    QuickFilter("Fast & Cheap"),
+                    QuickFilter("Direct"),
+                ], selection: $flightFilters)
+                    .chipStyle(.outlined).size(.small)
+                    .onFilter { }.onSort { }
+                HStack {
+                    TextLink("About prices & deals") { }
+                    Spacer()
+                    SegmentedControl([
+                        SegmentItem(icon: "chart.bar.fill"),
+                        SegmentItem(icon: "square.grid.2x2.fill"),
+                    ], selection: $viewMode)
+                        .tinted().dividers().shape(.round).fullWidth(false).size(.small)
+                        .fixedSize()
+                }
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var flightTrayCard: some View {
+        FlightListItem(legs: [
+            FlightLeg(airline: "Skyline Air", from: "SAW", to: "AYT",
+                      departure: departure, arrival: arrival, stops: 0, layover: nil),
+        ])
+        .cabin("Economy")
+        .baggage("8 kg", checked: "20 kg")
+        .price(12_700, currencyCode: "TRY", caption: "from")
+        .original(22_700)
+        .badge("Best value")
+        .onDetails { }
+        .onSelect { }
+        .flightListItemStyle(.tray)
+    }
+
+    private var hotelCard: some View {
+        HotelResultCard(name: "Mirage Park Resort")
+            .location("Kemer, Antalya")
+            .score(8.9, reviews: 1_284)
+            .price(9_600)
+            .media {
+                LinearGradient(colors: [SemanticColor.info.base, SemanticColor.turquoise.base],
+                               startPoint: .topLeading, endPoint: .bottomTrailing)
+                    .frame(height: 130)
+            }
+    }
+
+    private var priceTrendCard: some View {
+        CollageCard("Price trend") {
+            PriceTrendChart(trendPoints, selection: $trendDay).title("This week")
+        }
+    }
+
+    private var sortSummaryCard: some View {
+        CollageCard("Sort by") {
+            SortSummaryBar(sortOptions, selection: $sortSel).onMore { }
+        }
+    }
+
+    private var priceHistogramCard: some View {
+        CollageCard("Price distribution") {
+            PriceHistogram(bins: [2, 5, 9, 14, 18, 22, 19, 12, 8, 5, 3, 2],
+                           lowerValue: $histLow, upperValue: $histHigh, in: 0...5_000)
+                .barHeight(48).currency("TRY").showsBounds(true).resultCount(119)
+        }
+    }
+
+    private var boardingPassCard: some View {
+        BoardingPass(passenger: "İsa Mercan", from: "SAW", to: "BER")
+            .airline("Pegasus")
+            .flightNo("PC 1234")
+            .times(departure: "13:15", arrival: "16:05")
+            .gate("A12", seat: "14C", boarding: "12:45")
+            .barcode("PC1234SAWBER14C")
+    }
+
+    private var fareFamilyCard: some View {
+        FareFamilyCard("Super Eco", price: 1_871.99)
+            .accent(.success)
+            .currency("TRY")
+            .features([
+                FareFeature("Cabin bag", systemImage: "handbag", status: .included),
+                FareFeature("Checked bag 20 kg", systemImage: "suitcase", status: .included),
+                FareFeature("Non-changeable", systemImage: "nosign", status: .excluded),
+            ])
+            .onSelect { }
+    }
+}
+
+// MARK: - Page 2 · CONTENT (messaging, offers, feedback, reviews)
+
+private struct ContentPage: View {
+    @State private var dismissedTip = false
+    @State private var saleDeadline = Date.now.addingTimeInterval(45 * 60)
+    private let paletteColors: [SemanticColor] = [.primary, .success, .warning, .error, .info, .purple]
+
+    var body: some View {
+        PageScaffold(title: "Content & feedback", subtitle: "Messaging, offers, reviews, status and timelines.") {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(spacing: 16) { chatCard; reviewCard }
+                VStack(spacing: 16) { feedbackCard; accordionCard; tagsCard }
+                VStack(spacing: 16) { couponCard; countdownCard; alertToastCard; paletteCard }
+                VStack(spacing: 16) { timelineCard; ratingCard; alertCard }
+            }
+        }
+    }
+
+    private var tagsCard: some View {
+        CollageCard("Tags") {
+            Flex {
+                Tag("Beachfront").color(.turquoise).variant(.soft)
+                Tag("Free cancel").color(.success).variant(.soft)
+                Tag("Breakfast").color(.info).variant(.soft)
+                Tag("Pool").color(.primary).variant(.outline)
+                Tag("Sold out", onRemove: { }).color(.error).variant(.solid)
+            }
+        }
+    }
+
+    private var countdownCard: some View {
+        CollageCard("Flash sale") {
+            VStack(spacing: 8) {
+                Text("Ends soon — book now").font(.caption).foregroundStyle(.secondary)
+                CountdownTimer(until: saleDeadline).style(.urgent).format(.boxed).size(.large).showsDays(false)
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    private var alertToastCard: some View {
+        CollageCard("Alerts") {
+            VStack(spacing: 8) {
+                AlertToast("Saved successfully").variant(.success)
+                AlertToast("Check your details").variant(.warning)
+            }
+        }
+    }
+
+    private var paletteCard: some View {
+        CollageCard("Color palette") {
+            VStack(spacing: 6) {
+                ForEach(Array(paletteColors.enumerated()), id: \.offset) { _, color in
+                    HStack(spacing: 4) {
+                        ForEach(SemanticColor.Shade.allCases, id: \.rawValue) { shade in
+                            RoundedRectangle(cornerRadius: 3).fill(color.shade(shade)).frame(height: 16)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var chatCard: some View {
+        CollageCard("Chat") {
+            VStack(alignment: .leading, spacing: 8) {
+                ChatBubble("Hey! Is the flight confirmed?", time: "09:24").side(.incoming)
+                ChatBubble("Yes — boarding at 12:45 ✈️", time: "09:25").side(.outgoing).accent(.success)
+                ChatBubble("Perfect, see you there!", time: "09:26").side(.incoming)
+            }
+        }
+    }
+
+    private var couponCard: some View {
+        CollageCard("Coupon") {
+            Coupon(code: "THEMEKIT20", onCopy: { })
+                .couponStyle(.outlined)
+                .discount("20% OFF")
+                .expiry("Valid until Dec 31")
+        }
+    }
+
+    private var reviewCard: some View {
+        ReviewCard(author: "Elif Kaya", score: 9.2,
+                   text: "Absolutely loved the stay — spotless rooms, friendly staff and an unbeatable seafront location. Would book again in a heartbeat.")
+            .verified(true).stars(true).title("Would absolutely stay again").date(.now)
+    }
+
+    private var feedbackCard: some View {
+        CollageCard("Feedback") {
+            VStack(alignment: .leading, spacing: 14) {
+                Steps([
+                    Steps.Step("Finished", state: .done),
+                    Steps.Step("In Process", state: .error),
+                    Steps.Step("Waiting", state: .todo),
+                ])
+                ProgressBar(value: 0.5).showsPercentage()
+                Flex {
+                    StatusDot(.online, label: "Success")
+                    StatusDot(.busy, label: "Error")
+                    StatusDot(.away, label: "Warning")
+                }
+            }
+        }
+    }
+
+    private var ratingCard: some View {
+        CollageCard("Reviews") {
+            RatingSummary(score: 9.0).label("Excellent").reviews(count: 1_284)
+        }
+    }
+
+    private var accordionCard: some View {
+        CollageCard("FAQ") {
+            VStack(spacing: 8) {
+                Accordion("Can I cancel?", initiallyExpanded: true) {
+                    Text("Free cancellation up to 24 hours before departure.")
+                        .font(.footnote).foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                Accordion("What are the payment options?") {
+                    Text("All major cards, Apple Pay and up to 12 installments.")
+                        .font(.footnote).foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    private var timelineCard: some View {
+        CollageCard("Order timeline") {
+            Timeline([
+                Timeline.Item(title: "Order placed", time: "09:24", state: .done),
+                Timeline.Item(title: "Packed", time: "10:10", state: .done),
+                Timeline.Item(title: "Shipped", time: "12:00", state: .active),
+                Timeline.Item(title: "Delivered", state: .todo),
+            ])
+            .pending("Awaiting courier…")
+        }
+    }
+
+    private var alertCard: some View {
+        Group {
+            if !dismissedTip {
+                NotificationCard(title: "ThemeKit") {
+                    HStack(spacing: 8) {
+                        ThemeButton("Cancel") { dismissedTip = true }.variant(.ghost).size(.small)
+                        PrimaryButton("OK") { dismissedTip = true }.size(.small)
+                    }
+                }
+                .message("Token-driven theming — swap one theme, restyle every component instantly.")
+                .onClose { dismissedTip = true }
+            }
+        }
+    }
+}
+
+// MARK: - Page 3 · DASHBOARD (product screen)
+
+private struct DashboardPage: View {
+    @State private var page = 1
+    @State private var histLow = 900.0
+    @State private var histHigh = 3_400.0
+    @State private var installments = 1
+
+    private struct Booking: Identifiable {
+        let id: Int; let hotel: String; let nights: Int; let total: String
+    }
+    private let bookings: [Booking] = [
+        Booking(id: 1, hotel: "Mirage Park Resort", nights: 4, total: "₺190,960"),
+        Booking(id: 2, hotel: "Blue Lagoon Suites", nights: 2, total: "₺84,300"),
+        Booking(id: 3, hotel: "Skyline Grand", nights: 3, total: "₺121,500"),
+        Booking(id: 4, hotel: "Harbor View Hotel", nights: 5, total: "₺210,000"),
+    ]
+
+    var body: some View {
+        PageScaffold(title: "Dashboard", subtitle: "The same components, composed into a product screen.") {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(spacing: 16) { statsCard; gaugesCard; seatMapCard }
+                VStack(spacing: 16) { histogramCard; installmentCard; roomCard }
+                VStack(spacing: 16) { tableCard; amenityCard; summaryCard }
+                VStack(spacing: 16) { timelineCard; goalsCard }
+            }
+        }
+    }
+
+    private var seatMapCard: some View {
+        CollageCard("Seat layouts") {
+            SeatMap(columns: "AB CDE FG", rows: [1, 2, 3, 4], selection: .constant(["1A", "2C", "3F"])) { id, _, _ in
+                SeatInfo(available: id != "2D")
+            }
+            .legend()
+        }
+    }
+
+    private var installmentCard: some View {
+        CollageCard("Installments") {
+            InstallmentPicker([
+                InstallmentOption(count: 1, total: 9_600),
+                InstallmentOption(count: 3, total: 9_900, monthly: 3_300),
+                InstallmentOption(count: 6, total: 10_200, monthly: 1_700),
+            ], selection: $installments).currency("TRY")
+        }
+    }
+
+    private var roomCard: some View {
+        RoomCard(name: "Deluxe Room, Sea View")
+            .board("All-inclusive").occupancy("2 adults, 1 child")
+            .features([
+                FareFeature("Free cancellation", systemImage: "checkmark.circle", status: .included),
+                FareFeature("Breakfast included", systemImage: "cup.and.saucer", status: .included),
+            ])
+            .original(12_000).discountBadge("-20%").price(9_600).unit("/ night")
+            .badge("Last 2").onSelect { }
+    }
+
+    private var amenityCard: some View {
+        CollageCard("Amenities") {
+            AmenityGrid([
+                ThemeKit.Amenity("Free Wi-Fi", systemImage: "wifi"),
+                ThemeKit.Amenity("Pool", systemImage: "figure.pool.swim"),
+                ThemeKit.Amenity("Breakfast", systemImage: "cup.and.saucer"),
+                ThemeKit.Amenity("Parking", systemImage: "car.fill"),
+                ThemeKit.Amenity("Gym", systemImage: "dumbbell.fill"),
+                ThemeKit.Amenity("Spa", systemImage: "sparkles"),
+            ]).columns(2).size(.medium)
+        }
+    }
+
+    private var statsCard: some View {
+        CollageCard {
+            VStack(spacing: 14) {
+                Stat(title: "Bookings", value: 1_284).icon("ticket").trend(.up("+12%")).description("this month")
+                Divider()
+                Stat(title: "Revenue", value: 486).prefix("₺").suffix("K").icon("creditcard").trend(.up("+8%")).description("this month")
+            }
+        }
+    }
+
+    private var gaugesCard: some View {
+        CollageCard("Utilization") {
+            HStack(spacing: 18) {
+                gauge(0.72, "CPU", .primary)
+                gauge(0.54, "Memory", .purple)
+                gauge(0.88, "Disk", .success)
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    private func gauge(_ v: Double, _ label: String, _ accent: SemanticColor) -> some View {
+        VStack(spacing: 6) {
+            RadialProgress(v).size(76).showsLabel().accent(accent)
+            Text(label).font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    private var histogramCard: some View {
+        CollageCard("Spend distribution") {
+            PriceHistogram(bins: [3, 7, 12, 18, 24, 20, 15, 10, 6, 4, 2, 1],
+                           lowerValue: $histLow, upperValue: $histHigh, in: 0...5_000)
+                .barHeight(44).currency("TRY").showsBounds(true)
+        }
+    }
+
+    private var tableCard: some View {
+        CollageCard("Recent bookings") {
+            VStack(spacing: 12) {
+                DataTable<Booking>(columns: [
+                    DataTable<Booking>.Column("Hotel", align: .leading, value: { $0.hotel }),
+                    DataTable<Booking>.Column("Nights", align: .center, value: { "\($0.nights)" }),
+                    DataTable<Booking>.Column("Total", align: .trailing, value: { $0.total }),
+                ], rows: bookings)
+                    .striped()
+                Pagination(current: $page, total: 12).simple()
+            }
+        }
+    }
+
+    private var summaryCard: some View {
+        KeyValueTable(rows: [
+            KeyValueTable.Row("Gross revenue", value: "₺486,000"),
+            KeyValueTable.Row("Refunds", value: "−₺12,400"),
+            KeyValueTable.Row("Fees", value: "−₺8,900"),
+            KeyValueTable.Row("Net", value: "₺464,700"),
+        ])
+        .title("Revenue breakdown")
+        .bordered()
+    }
+
+    private var timelineCard: some View {
+        CollageCard("Order timeline") {
+            Timeline([
+                Timeline.Item(title: "Order placed", time: "09:24", state: .done),
+                Timeline.Item(title: "Packed", time: "10:10", state: .done),
+                Timeline.Item(title: "Shipped", time: "12:00", state: .active),
+                Timeline.Item(title: "Delivered", state: .todo),
+            ])
+            .pending("Awaiting courier…")
+        }
+    }
+
+    private var goalsCard: some View {
+        CollageCard("Goals") {
+            VStack(alignment: .leading, spacing: 12) {
+                goal("New users", 0.68, .active)
+                goal("Revenue target", 0.42, .normal)
+                goal("Retention", 0.91, .success)
+            }
+        }
+    }
+
+    private func goal(_ label: String, _ v: Double, _ status: ProgressStatus) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(label).font(.caption).foregroundStyle(.secondary)
+            ProgressBar(value: v).showsPercentage().status(status)
+        }
+    }
+}
+
+// MARK: - Shared page scaffold (title + centered, fit-to-screen body)
+
+private struct PageScaffold<Content: View>: View {
+    let title: String
+    let subtitle: String
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(spacing: 16) {
+            VStack(spacing: 6) {
+                Text(title).font(.system(size: 34, weight: .bold, design: .rounded))
+                Text(subtitle).font(.subheadline).foregroundStyle(.secondary)
+            }
+            content()
+                .frame(maxWidth: 1300)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 28)
+        .padding(.top, 78)
+        .padding(.bottom, 52)
+    }
+}
+
+// MARK: - Titled collage container (Ant-style rounded card)
+
+struct CollageCard<Content: View>: View {
+    private let title: String?
+    @ViewBuilder private let content: () -> Content
+
+    init(_ title: String? = nil, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let title {
+                Text(title).font(.footnote.weight(.semibold)).foregroundStyle(.secondary)
+            }
+            content()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.shared.background(.bgWhite), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Theme.shared.border(.borderPrimary), lineWidth: 0.5)
+        )
+    }
+}
+
+// MARK: - Theme preset row (swatches + dark toggle + auto-cycle)
+
+struct ThemePresetRow: View {
+    @EnvironmentObject private var themeStore: DemoThemeStore
+    @Binding var autoCycle: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ForEach(DemoTheme.allCases) { theme in
+                Button { themeStore.select(theme) } label: {
+                    Circle()
+                        .fill(swatch(theme))
+                        .frame(width: 22, height: 22)
+                        .overlay(Circle().stroke(Color.primary.opacity(themeStore.current == theme ? 0.9 : 0), lineWidth: 2))
+                        .overlay(Circle().stroke(.white.opacity(0.5), lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(theme.label)
+            }
+
+            Divider().frame(height: 18)
+
+            Button { themeStore.setDark(!themeStore.isDark) } label: {
+                Image(systemName: themeStore.isDark ? "moon.fill" : "sun.max.fill")
+                    .font(.system(size: 15, weight: .semibold))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Toggle dark mode")
+
+            Button { autoCycle.toggle() } label: {
+                Image(systemName: autoCycle ? "pause.circle.fill" : "play.circle.fill")
+                    .font(.system(size: 19, weight: .semibold))
+                    .foregroundStyle(Theme.shared.foreground(.systemcolorsFgInfo))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(autoCycle ? "Pause auto theme cycle" : "Start auto theme cycle")
+        }
+    }
+
+    private func swatch(_ theme: DemoTheme) -> Color {
+        switch theme {
+        case .default: return Color(red: 0.086, green: 0.463, blue: 1.0)
+        case .ocean: return Color(red: 0.0, green: 0.60, blue: 0.65)
+        case .sunset: return Color(red: 1.0, green: 0.48, blue: 0.20)
+        }
+    }
+}
+
+#Preview {
+    ShowcaseView()
+        .environment(Theme.shared)
+        .environmentObject(DemoThemeStore())
+}


### PR DESCRIPTION
## What

A full-screen, tab-bar-free, **non-scrolling paged Showcase** as the Demo app's opening experience — built for recording a promo video. It replaces `ContentView` as the app root.

Swipe horizontally between four curated pages (page dots at the bottom), each fitting the screen and packed with the richest ThemeKit components:

| Page | Highlights |
|------|-----------|
| **Overview** (Ant-homepage style) | Inputs, MultiSelect, ColorField, Checkbox/Radio/Toggle, OTP verify, Buttons, **CalendarView**, **LoyaltyCard**, Create-account (BorderBeam), **MenuCard** |
| **Travel** | **FilterBar** + view toggle, **FlightListItem `.tray`**, **PriceTrendChart**, **SortSummaryBar**, **PriceHistogram**, **HotelResultCard**, **BoardingPass**, **FareFamilyCard** |
| **Content** | **ChatBubble**, **Coupon**, **ReviewCard**, Steps/ProgressBar/StatusDot, **Accordion** FAQ, **Tag**, **CountdownTimer**, **AlertToast**, **Color palette**, Timeline, RatingSummary, NotificationCard |
| **Dashboard** | Stat, RadialProgress gauges, **SeatMap** (seat layouts), **InstallmentPicker**, **RoomCard**, DataTable, **AmenityGrid**, **KeyValueTable**, Timeline, Goals |

A fixed top bar hosts a **theme-preset row** (swatches + dark toggle + auto-cycle play/pause) that re-skins the whole wall live, and an **All components** button that opens the **Rich components shelf** — every one of the **198 components & organisms** rendered live in horizontal rails; tap a card to open its full interactive demo.

## Notes
- Auto theme-cycle is **off by default** (opt-in via the ▶ button) so recordings stay steady.
- `en_US` locale is forced on the showcase for clean number/percent formatting.
- Status bar + home indicator hidden for an immersive, chrome-free capture.
- Designed for a wide canvas (iPad landscape / Mac Catalyst); collapses gracefully on narrower widths.
- Screenshot deep-links: `-startPage <0-3>`, `-openBrowser YES`.

## Scope
Demo target only — no changes to the `ThemeKit` library. Every component is used via its public API (verified against the existing demos), and the Demo builds clean for the iPad Pro 13" simulator.

## Files
- `Demo/Demo/Gallery/Showcase/ShowcaseView.swift` (new) — paged root + 4 pages + shared helpers
- `Demo/Demo/Gallery/Showcase/RichComponentsBrowser.swift` (new) — the all-components shelf
- `Demo/Demo/DemoApp.swift` — root now launches `ShowcaseView`

🤖 Generated with [Claude Code](https://claude.com/claude-code)