### PR TITLE
feat: HeroUI Native audit — 6 new components + gap-analysis document

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -122,6 +122,10 @@ enum ComponentRegistry {
                 CodeLine("Done!", prefix: ">", highlight: .success)
             ]).copyable()
         },
+        .knob("CloseButton", .atoms, demo: CloseButtonDemo(), usage: #"CloseButton { dismiss() }.tint(.error).controlSize(.small)   // .plain() ghost glyph for image overlays"#),
+        .knob("HelperText", .atoms, demo: HelperTextDemo(), usage: #"HelperText("Min. 8 characters, one number.").hasError(invalid).hidesOnError()"#),
+        .knob("Surface", .atoms, demo: SurfaceViewDemo(), usage: #"SurfaceView { content }.level(.secondary).elevation(.soft).radius(.box)   // nestable; or view.surfaceChrome(.secondary)"#),
+        .knob("SkeletonGroup", .atoms, demo: SkeletonGroupDemo(), usage: #"SkeletonGroup { rows.skeleton() }.loading(isLoading)   // .skeletonOnly() collapses when loaded"#),
 
         // MARK: Molecules
         .knob("ColorField", .molecules, demo: ColorFieldDemo(), usage: #"ColorField("Brand color", selection: $color).supportsOpacity()"#),
@@ -232,6 +236,8 @@ enum ComponentRegistry {
             }
             .padding(.horizontal, 24)
         },
+        .knob("ControlRow", .molecules, demo: ControlRowDemo(), usage: #"ControlRow("I agree to the terms", isOn: $accepted).control(.checkbox).description("…").required().hasError(showErrors && !accepted).errorText("This field is required.")"#),
+        .knob("ScrollShadow", .molecules, demo: ScrollShadowDemo(), usage: #"ScrollShadow { ScrollView(.horizontal) { chipRow } }.axis(.horizontal).length(.lg).fadeColor(.bgWhite)   // .visibility(.auto/.start/.end/.both/.none)"#),
 
         // MARK: Organisms
         .knob("Accordion", .organisms, demo: AccordionDemo(), usage: #"Accordion("Title", initiallyExpanded: false) { Text("Body") }"#),

--- a/Demo/Demo/Gallery/Demos/AtomDemos.swift
+++ b/Demo/Demo/Gallery/Demos/AtomDemos.swift
@@ -279,6 +279,192 @@ struct TagDemo: View {
     }
 }
 
+struct CloseButtonDemo: View {
+    @State private var sizeIdx = 2   // 0 mini, 1 small, 2 regular
+    @State private var tintIdx = 0   // 0 muted default, 1 error, 2 primary
+    @State private var plain = false
+    @State private var chevron = false
+    @State private var enabled = true
+    @State private var overlay = false
+    @State private var taps = 0
+
+    private var size: ControlSize { sizeIdx == 0 ? .mini : sizeIdx == 1 ? .small : .regular }
+    private var tint: SemanticColor? { tintIdx == 1 ? .error : tintIdx == 2 ? .primary : nil }
+
+    var body: some View {
+        ComponentStage("CloseButton", inspector: [
+            ("controlSize", sizeIdx == 0 ? "mini" : sizeIdx == 1 ? "small" : "regular"), ("plain", "\(plain)"), ("taps", "\(taps)"),
+        ]) {
+            if overlay {
+                // The .plain() ghost glyph over a media-like surface (photo cards, hero banners).
+                ZStack(alignment: .topTrailing) {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(Theme.shared.background(.bgHero))
+                        .frame(width: 220, height: 132)
+                    CloseButton { taps += 1; flash("Close tapped") }
+                        .plain()
+                        .tint(.neutral)
+                        .controlSize(.small)
+                }
+            } else {
+                CloseButton { taps += 1; flash("Close tapped") }
+                    .tint(tint)
+                    .systemImage(chevron ? "chevron.down" : "xmark")
+                    .plain(plain)
+                    .controlSize(size)
+                    .disabled(!enabled)
+            }
+        } knobs: {
+            Picker("Size", selection: $sizeIdx) { Text("Mini").tag(0); Text("Small").tag(1); Text("Regular").tag(2) }.pickerStyle(.segmented)
+            Picker("Tint", selection: $tintIdx) { Text("Muted").tag(0); Text("Error").tag(1); Text("Primary").tag(2) }.pickerStyle(.segmented)
+            Toggle("Plain (no circle fill)", isOn: $plain)
+            Toggle("Chevron glyph (sheet pull-down)", isOn: $chevron)
+            Toggle("Media overlay (plain, top-trailing)", isOn: $overlay)
+            Toggle("Enabled", isOn: $enabled)
+        }
+    }
+}
+
+struct HelperTextDemo: View {
+    @State private var error = false
+    @State private var hides = false
+    @State private var enabled = true
+
+    var body: some View {
+        ComponentStage("HelperText", inspector: [
+            ("hasError", "\(error)"), ("hidesOnError", "\(hides)"), ("isEnabled", "\(enabled)"),
+        ]) {
+            VStack(alignment: .leading, spacing: 6) {
+                InputLabel("Password").required().hasError(error)
+                Text("••••••••")
+                    .textStyle(.bodyBase400)
+                    .foregroundStyle(Theme.shared.text(.textTertiary))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .background(RoundedRectangle(cornerRadius: 10).stroke(Theme.shared.border(.borderPrimary)))
+                HelperText("Min. 8 characters, one number.")
+                    .hasError(error)
+                    .hidesOnError(hides)
+                    .disabled(!enabled)
+            }
+        } knobs: {
+            Toggle("Error (red helper)", isOn: $error)
+            Toggle("Hide on error (yields to a field-error line)", isOn: $hides)
+            Toggle("Enabled", isOn: $enabled)
+        }
+    }
+}
+
+struct SurfaceViewDemo: View {
+    @State private var levelIdx = 0
+    @State private var elevationIdx = 0   // 0 none, 1 soft, 2 elevated
+    @State private var fieldRadius = false
+    @State private var smallPadding = false
+    @State private var nested = false
+
+    private let levels: [(String, SurfaceLevel)] = [
+        ("Primary", .primary), ("Secondary", .secondary), ("Tertiary", .tertiary), ("Transparent", .transparent),
+    ]
+    private var elevation: CardElevation { elevationIdx == 1 ? .soft : elevationIdx == 2 ? .elevated : .none }
+
+    var body: some View {
+        ComponentStage("Surface", inspector: [
+            ("level", levels[levelIdx].0), ("elevation", elevationIdx == 1 ? "soft" : elevationIdx == 2 ? "elevated" : "none"),
+        ]) {
+            if nested {
+                // Hierarchy from nesting: primary > secondary > tertiary.
+                SurfaceView {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Primary").textStyle(.labelMd600).foregroundStyle(Theme.shared.text(.textPrimary))
+                        SurfaceView {
+                            VStack(alignment: .leading, spacing: 10) {
+                                Text("Secondary").textStyle(.labelMd600).foregroundStyle(Theme.shared.text(.textPrimary))
+                                SurfaceView {
+                                    Text("Tertiary").textStyle(.labelSm600)
+                                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+                                .level(.tertiary)
+                            }
+                        }
+                        .level(.secondary)
+                    }
+                }
+                .elevation(elevation)
+            } else {
+                SurfaceView {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Booking summary").textStyle(.labelMd600).foregroundStyle(Theme.shared.text(.textPrimary))
+                        Text("2 guests · 3 nights").textStyle(.bodySm400).foregroundStyle(Theme.shared.text(.textSecondary))
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .level(levels[levelIdx].1)
+                .elevation(elevation)
+                .radius(fieldRadius ? .field : .box)
+                .contentPadding(smallPadding ? .sm : .md)
+            }
+        } knobs: {
+            Picker("Level", selection: $levelIdx) {
+                ForEach(Array(levels.enumerated()), id: \.offset) { i, l in Text(l.0).tag(i) }
+            }.pickerStyle(.segmented).disabled(nested)
+            Picker("Elevation", selection: $elevationIdx) { Text("None").tag(0); Text("Soft").tag(1); Text("Elevated").tag(2) }.pickerStyle(.segmented)
+            Toggle("Field radius (default .box)", isOn: $fieldRadius)
+            Toggle("Small padding (default .md)", isOn: $smallPadding)
+            Toggle("Nested (primary > secondary > tertiary)", isOn: $nested)
+        }
+    }
+}
+
+struct SkeletonGroupDemo: View {
+    @State private var loading = true
+    @State private var placeholderOnly = false
+
+    var body: some View {
+        ComponentStage("SkeletonGroup", inspector: [("isLoading", "\(loading)"), ("skeletonOnly", "\(placeholderOnly)")]) {
+            if placeholderOnly {
+                // Pure placeholder — the whole group collapses once loading ends.
+                VStack(alignment: .leading, spacing: 14) {
+                    SkeletonGroup {
+                        HStack(spacing: 10) {
+                            Skeleton(.circle).size(width: 48, height: 48)
+                            VStack(alignment: .leading, spacing: 6) {
+                                Skeleton(.capsule).size(width: 150, height: 12)
+                                Skeleton(.capsule).size(width: 100, height: 12)
+                            }
+                        }
+                    }
+                    .skeletonOnly()
+                    .loading(loading)
+                    Text("Content below moves up when the placeholder collapses.")
+                        .textStyle(.bodySm400)
+                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                }
+            } else {
+                SkeletonGroup {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Weekend in Lisbon").textStyle(.headingSm)
+                            .foregroundStyle(Theme.shared.text(.textPrimary))
+                            .skeleton()
+                        Text("Three days of tiles, trams and pastel facades by the river.")
+                            .textStyle(.bodyBase400)
+                            .foregroundStyle(Theme.shared.text(.textSecondary))
+                            .skeleton()
+                        Text("Updated today").textStyle(.labelSm600)
+                            .foregroundStyle(Theme.shared.text(.textTertiary))
+                            .skeleton(shape: .capsule)
+                    }
+                }
+                .loading(loading)
+            }
+        } knobs: {
+            Toggle("Loading", isOn: $loading)
+            Toggle("Skeleton-only (collapses when loaded)", isOn: $placeholderOnly)
+            Text("One .loading() flag drives every zero-argument .skeleton() below the group.").font(.caption).foregroundStyle(.secondary)
+        }
+    }
+}
+
 struct WatermarkDemo: View {
     @Environment(\.theme) private var theme
     @State private var text = "SPECIMEN"

--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -769,3 +769,101 @@ struct ColumnsGridDemo: View {
         }
     }
 }
+
+struct ControlRowDemo: View {
+    @State private var accepted = false
+    @State private var controlIdx = 1   // 0 toggle, 1 checkbox, 2 radio
+    @State private var description = true
+    @State private var required = true
+    @State private var validate = true
+    @State private var custom = false
+    @State private var enabled = true
+
+    private var control: ControlRowControl { controlIdx == 0 ? .toggle : controlIdx == 2 ? .radio : .checkbox }
+    private var error: Bool { validate && !accepted }
+
+    var body: some View {
+        ComponentStage("ControlRow", inspector: [
+            ("isOn", "\(accepted)"), ("control", controlIdx == 0 ? "toggle" : controlIdx == 2 ? "radio" : "checkbox"), ("hasError", "\(error)"),
+        ]) {
+            if custom {
+                // Custom trailing indicator — the whole row still toggles isOn.
+                ControlRow("Star this trip", isOn: $accepted)
+                    .description("Saved trips appear on your profile.")
+                    .indicator {
+                        Image(systemName: accepted ? "star.fill" : "star")
+                            .foregroundStyle(Theme.shared.foreground(.fgHero))
+                    }
+            } else {
+                ControlRow("I agree to the terms", isOn: $accepted)
+                    .control(control)
+                    .description(description ? "By checking this box, you agree to our Terms of Service." : nil)
+                    .required(required)
+                    .hasError(error)
+                    .errorText("This field is required.")
+                    .disabled(!enabled)
+            }
+        } knobs: {
+            Picker("Control", selection: $controlIdx) { Text("Toggle").tag(0); Text("Checkbox").tag(1); Text("Radio").tag(2) }.pickerStyle(.segmented)
+            Toggle("Description", isOn: $description)
+            Toggle("Required asterisk", isOn: $required)
+            Toggle("Validate (error until on)", isOn: $validate)
+            Toggle("Custom indicator (star)", isOn: $custom)
+            Toggle("Enabled", isOn: $enabled)
+        }
+    }
+}
+
+struct ScrollShadowDemo: View {
+    @State private var horizontal = false
+    @State private var visibility: ScrollShadowVisibility = .auto
+    @State private var long = false
+
+    var body: some View {
+        ComponentStage("ScrollShadow", inspector: [
+            ("axis", horizontal ? "horizontal" : "vertical"), ("visibility", visibility.rawValue),
+        ]) {
+            if horizontal {
+                ScrollShadow {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(["Nonstop", "1 stop", "Morning", "Evening", "Refundable", "Baggage included", "Window seat"], id: \.self) { title in
+                                Chip(title, isSelected: .constant(false))
+                            }
+                        }
+                        .padding(.horizontal, 16)
+                    }
+                }
+                .axis(.horizontal)
+                .visibility(visibility)
+                .length(long ? .lg : .md)
+                .fadeColor(.bgWhite)
+            } else {
+                ScrollShadow {
+                    ScrollView(showsIndicators: false) {
+                        VStack(alignment: .leading, spacing: 10) {
+                            ForEach(1..<21) { line in
+                                Text("Terms & conditions, clause \(line)")
+                                    .textStyle(.bodySm400)
+                                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                            }
+                        }
+                        .padding(.vertical, 8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .visibility(visibility)
+                .length(long ? .xl : .lg)
+                .fadeColor(.bgWhite)
+                .frame(height: 200)
+            }
+        } knobs: {
+            Picker("Visibility", selection: $visibility) {
+                ForEach(ScrollShadowVisibility.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+            }.pickerStyle(.segmented)
+            Toggle("Horizontal chip row", isOn: $horizontal)
+            Toggle("Longer fade", isOn: $long)
+            Text(".auto follows the scroll position (iOS 18+); explicit modes are always-on.").font(.caption).foregroundStyle(.secondary)
+        }
+    }
+}

--- a/HEROUI_NATIVE_AUDIT.md
+++ b/HEROUI_NATIVE_AUDIT.md
@@ -1,0 +1,292 @@
+# HeroUI Native → ThemeKit Gap Analysis
+
+This document records an audit of ThemeKit against the full **HeroUI Native** component set (38 components, React Native). Each HeroUI component was compared per-API against the HeroUI Native source/docs and judged **by role, not by name** — a ThemeKit component with a different name counts as coverage if it fills the same role. ThemeKit conventions (atom/molecule/organism tiers, chainable copy-on-write modifiers, theme tokens, MicroMotion gating) follow the `themekit-authoring` skill.
+
+Outcome: **5 covered**, **27 partial** (gap plans below), **6 missing** — all 6 implemented on this branch (see "Newly built in this PR").
+
+## Summary
+
+File paths are relative to `Sources/ThemeKit/`.
+
+| HeroUI component | ThemeKit counterpart | Status |
+|---|---|---|
+| Button | `Components/Molecules/Buttons/ThemeButton.swift`, `ButtonSize.swift`, `Buttons.swift` | Partial |
+| CloseButton | `Components/Atoms/CloseButton.swift` | **Newly built** |
+| LinkButton | `Components/Atoms/TextLink.swift`, `Components/Molecules/Buttons/Buttons.swift` | Covered |
+| PressableFeedback | `Components/Molecules/Buttons/ThemeButton.swift`, `Theme/MicroMotion.swift` | Partial |
+| Chip | `Components/Atoms/Tag.swift`, `Chip.swift`, `ChipStyle.swift`, `Badge.swift` | Partial |
+| Menu | `Components/Molecules/Dropdown.swift`, `Components/Organisms/MenuCard.swift` | Partial |
+| TagGroup | `Components/Atoms/Tag.swift`, `Chip.swift`, `Components/Molecules/Chips.swift`, `FilterGroup.swift` | Partial |
+| Select | `Components/Molecules/Select.swift`, `SelectBox.swift`, `SelectStyle.swift`, `MultiSelect.swift` | Partial |
+| RadioGroup | `Components/Molecules/RadioButton.swift`, `RadioGroup.swift` | Partial |
+| Checkbox | `Components/Molecules/Checkbox.swift`, `CheckboxGroup.swift` | Covered |
+| Switch | `Components/Molecules/ThemeToggle.swift`, `ToggleGroup.swift` | Partial |
+| Slider | `Components/Molecules/Slider.swift`, `RangeSlider.swift` | Partial |
+| ControlField | `Components/Molecules/ControlRow.swift` | **Newly built** |
+| Label | `Components/Atoms/InputLabel.swift` | Partial |
+| Description | `Components/Atoms/HelperText.swift` | **Newly built** |
+| FieldError | `Validation/InfoMessage.swift`, `InfoMessageUI.swift`, `Components/Molecules/ValidationRule.swift` | Partial |
+| Input | `Components/Molecules/TextInput.swift`, `FieldStyle.swift`, `TextInputFormatter.swift` | Partial |
+| InputGroup | `Components/Molecules/TextInput.swift` | Covered |
+| TextField | `Components/Molecules/TextInput.swift`, `Components/Atoms/InputLabel.swift`, `Validation/InfoMessageUI.swift` | Partial |
+| TextArea | `Components/Molecules/MultiLineTextInput.swift`, `FieldStyle.swift` | Covered |
+| SearchField | `Components/Molecules/SearchBar.swift` | Partial |
+| InputOTP | `Components/Molecules/OTPInput.swift` | Partial |
+| Tabs | `Components/Organisms/SegmentedTabBar.swift`, `Components/Molecules/SegmentedControl.swift` | Partial |
+| Accordion | `Components/Organisms/Accordion.swift`, `AccordionGroup.swift` | Partial |
+| BottomSheet | `Components/Organisms/BottomSheet.swift`, `SheetHeader.swift` | Partial |
+| Dialog | `Components/Organisms/Dialog.swift`, `Feedback.swift` | Partial |
+| Popover | `Components/Molecules/Tooltip.swift`, `Components/Organisms/Popconfirm.swift` | Partial |
+| Toast | `Components/Organisms/Toast.swift`, `ToastStyle.swift`, `AlertToast.swift`, `Feedback.swift` | Partial |
+| Alert | `Components/Organisms/InfoBanner.swift`, `Callout.swift`, `AlertToast.swift` | Partial |
+| Skeleton | `Components/Atoms/Skeleton.swift` | Partial |
+| SkeletonGroup | `Components/Atoms/SkeletonGroup.swift` | **Newly built** |
+| Spinner | `Components/Atoms/Spinner.swift` | Partial |
+| ScrollShadow | `Components/Molecules/ScrollShadow.swift` | **Newly built** |
+| ListGroup | `Components/Organisms/ListView.swift`, `ListRow.swift`, `ListRowStyle.swift` | Partial |
+| Card | `Components/Organisms/Card.swift`, `CardStyle.swift` | Partial |
+| Surface | `Components/Atoms/SurfaceView.swift` | **Newly built** |
+| Separator | `Components/Atoms/DividerView.swift` | Covered |
+| Avatar | `Components/Atoms/Avatar.swift` | Partial |
+
+Mapping notes on the "Covered" rows: HeroUI LinkButton = TextLink atom + `LinkButton` preset + `ThemeButton.variant(.link)`; InputGroup is native to TextInput (`.icon(leading:)`/`.trailing{}`/`.clearable()`/`.secure()`/`.addons(before:after:)`); TextArea = MultiLineTextInput; Separator = DividerView (adds dashed and titled variants); Checkbox exceeds HeroUI (indeterminate, box styles, group select-all).
+
+## Gap plans
+
+Each subsection is a follow-up-PR-sized checklist for a partially covered component, prioritized high → low.
+
+### Button
+
+ThemeButton covers HeroUI variants via variant × SemanticColor; loading/disabled/press feedback covered.
+
+- [ ] **[medium]** Custom label slot (Button.Label / arbitrary children) — Add content-slot path in `ThemeButton.swift`: `init(action:@ViewBuilder label:)` storing AnyView replacing the built-in HStack, or a `.label{}`/`.leading{}`/`.trailing{}` slot trio mirroring Chip's AnyView slot pattern; slot content inherits size textStyle + variant token foreground.
+- [ ] **[low]** Per-button press-feedback variant (scale-highlight/scale-ripple/scale/none) — Add chainable `pressFeedback(_ v: ButtonPressFeedback)` enum on ThemeButton routed through `copy(_:)`; ripple tint from the SemanticColor ladder; motion gated by microAnimations + Reduce Motion.
+
+### PressableFeedback
+
+Covered by PressFeedbackStyle/`.microPressScale` + RowPressStyle + the microAnimations gate; missing ripple and hygiene items.
+
+- [ ] **[medium]** RowPressStyle takes a raw cornerRadius CGFloat — Add `init(radius: Theme.RadiusRole)` resolving `.value` internally; deprecate the raw-CGFloat init.
+- [ ] **[low]** No ripple press feedback (PressableFeedback.Ripple) — Add `RipplePressStyle: ButtonStyle` next to PressFeedbackStyle/RowPressStyle; touch-point circle expansion, token tint (default bgElevatorTertiary or SemanticColor `.soft`), Motion token duration, gated by microAnimations + Reduce Motion.
+- [ ] **[low]** No composed scale+highlight style with configurable tint — Expose `SurfacePressStyle(radius: Theme.RadiusRole, tint: SemanticColor?)` ButtonStyle, or add an optional tint to RowPressStyle.
+
+### Chip
+
+HeroUI Chip's role = ThemeKit Tag atom (color × variant axes); ThemeKit's Chip is the selectable filter-chip superset.
+
+- [ ] **[low]** Tag has no size ramp (sm/md/lg) — Add `func size(_ s: ChipSize)` to `Tag.swift` as a copy-on-write extension driving textStyle + SpacingKey paddings; replace the fixed 28pt height with a padding-derived minHeight.
+- [ ] **[low]** Tag lacks arbitrary leading/trailing content slots — Port Chip's slot pattern to `Tag.swift`: leading/trailing @ViewBuilder slots stored as AnyView.
+
+### Menu
+
+Dropdown is the role match (anchored floating action menu). Missing the selection half, richer item anatomy, SubMenu, bottom-sheet presentation, and controlled open state.
+
+- [ ] **[high]** Selection groups with checkmark/dot indicators (Menu.Group + Menu.ItemIndicator) — In `Dropdown.swift` add DropdownSection (optional heading + items) and a selection-aware `DropdownItem(_:isSelected:)` or `Dropdown(sections:selection:)` init binding a Set/optional value; render the leading indicator via Icon checkmark / filled Circle tinted `theme.foreground(.fgHero)`; chainable `indicator(_ v: DropdownIndicator)` enum {checkmark, dot}; `.accessibilityAddTraits(.isSelected)` on selected rows; add a `shouldCloseOnSelect(_:)` modifier.
+- [ ] **[medium]** Section headings (Menu.Label) — Render an optional section title as a non-interactive row: `Text(title).textStyle(.overline400)` in `theme.text(.textTertiary)`, padded SpacingKey.sm, `.isHeader` trait.
+- [ ] **[medium]** Item description line (Menu.ItemDescription) — Add `subtitle: String?` to `DropdownItem.init`; render `.bodySm400` textSecondary under the title in a VStack.
+- [ ] **[medium]** SubMenu (inline expandable nested items) — Add `DropdownItem.submenu(_ title:systemImage:items:)` rendered as a disclosure row with chevron rotation 0→90° via MicroMotion fast, nested rows indented SpacingKey.md; state-aware a11y label.
+- [ ] **[medium]** Bottom-sheet presentation mode — Add chainable `presentation(_ p: DropdownPresentation)` enum {popover, sheet} routing rows into the BottomSheet organism.
+- [ ] **[low]** Controlled open state (isOpen/onOpenChange) — Add init overload `Dropdown(items:isPresented: Binding<Bool>, trigger:)`.
+
+### TagGroup
+
+Covered by the family: ChipGroup (multiple), FilterGroup (single), CheckableTag, `Tag(onRemove:)`.
+
+- [ ] **[high]** Per-option disabled (disabledKeys) — Add an `optionEnabled(_ predicate:)` chainable modifier to ChipGroup (`Chips.swift`) and FilterGroup (`FilterGroup.swift`), matching the RadioGroup/CheckboxGroup/Select convention.
+- [ ] **[medium]** Selection + removal combined — Add `removable(_ onRemove: (Option) -> Void)` to ChipGroup appending a trailing xmark via Chip's `.trailing{}` slot, Icon `.xs`, textTertiary, a11y label "Remove <label>".
+- [ ] **[medium]** Invalid/required state — Add `infoMessages(_:)` to ChipGroup and FilterGroup rendering InfoMessageList under the chips; error-tint the group title when the dominant kind is `.error`.
+- [ ] **[low]** Empty state (renderEmptyState) — Add an `emptyContent(@ViewBuilder)` modifier to ChipGroup shown when `options.isEmpty`.
+
+### Select
+
+Strong coverage across Select/SelectBox/MultiSelect.
+
+- [ ] **[medium]** Bottom-sheet / dialog presentation modes — Add `presentation(_ p: SelectPresentation)` enum {menu, panel, sheet} to `Select.swift`; `.sheet` presents the option list inside the BottomSheet organism.
+- [ ] **[medium]** Option descriptions (Select.ItemDescription) — Add `optionDescription(_ text: (Option) -> String?)` to `Select.swift` and `MultiSelect.swift` rendering a `.bodySm400` textSecondary second line.
+- [ ] **[low]** Custom option row content — Add an `optionLeading(@ViewBuilder (Option) -> V)` slot modifier rendered before the title in panel rows.
+- [ ] **[low]** Controlled open state — Add an init overload with `isExpanded: Binding<Bool>` (panel mode only; document the Menu limitation).
+
+### RadioGroup
+
+Core covered; RadioButtonGroup adds a segmented form HeroUI lacks.
+
+- [ ] **[high]** Per-option description (Label + Description anatomy) — Add `optionDescription(_ description: (Option) -> String?)` to `RadioGroup.swift` (identical to ToggleGroup's) rendering `.bodySm400` textSecondary under the row label, RadioButton top-aligned.
+- [ ] **[medium]** Group-level accent/variant inheritance — Add `accent(_ color: SemanticColor?)` to RadioGroup forwarded to the inner RadioButtons.
+- [ ] **[low]** Horizontal orientation — Add `axis(_ a: Axis)` to RadioGroup (default `.vertical`) switching the container to an HStack spaced SpacingKey.md.
+
+### Switch
+
+ThemeToggle IS the generic switch and covers the core API plus a `.loading()` extra.
+
+- [ ] **[medium]** Track start/end content (Switch.StartContent/EndContent) — Add a `trackSymbols(on: String?, off: String?)` chainable modifier to `ThemeToggle.swift` rendering an SF Symbol via Icon inside a Capsule overlay opposite the thumb, sized off knobSize, textHero on active / textTertiary on inactive, MicroMotion animated. Distinct from `.symbols(on:off:)`, which targets the knob.
+- [ ] **[low]** Custom thumb content slot — Add `thumbContent(@ViewBuilder (Bool) -> C)` storing an AnyView closure rendered inside the knob Circle in place of the symbol/spinner.
+- [ ] **[low]** Press feedback (scale on press) — Replace `.buttonStyle(.plain)` with a private ButtonStyle applying scaleEffect 0.96 when pressed, under MicroMotion/reduceMotion gates.
+
+### Slider
+
+Slider + RangeSlider together cover the role; ThemeKit adds marks and linked inputs.
+
+- [ ] **[medium]** Persistent formatted value output (Slider.Output + formatOptions) — Add `valueLabel(_ format: ((Double) -> String)?)` to `Slider.swift` (mirroring RangeSlider's); render a trailing label row `.labelBase600` textSecondary; reuse the closure for the drag tooltip and accessibilityValue.
+- [ ] **[medium]** Tap-to-set on track — Attach `DragGesture(minimumDistance: 0)` to the full track ZStack via contentShape in `Slider.swift` and `RangeSlider.swift`, snapping to step; RangeSlider moves the nearest thumb.
+- [ ] **[medium]** Semantic accent for fill/thumb — Add `accent(_ color: SemanticColor?)` to both files: fill `accent?.solid ?? bgHero`, thumb ring `accent?.solid ?? borderHero`.
+- [ ] **[low]** Vertical orientation for RangeSlider — Add an `axis(_:height:)` modifier and vertical body to `RangeSlider.swift` reusing Slider's approach.
+- [ ] **[low]** Thumb press feedback — Apply `scaleEffect(dragging ? 0.9 : 1)` to thumbs under microAnimations/reduceMotion gates.
+
+### Label
+
+InputLabel is the direct counterpart (`.required`, `.hasError`, `.hasInfo` extra).
+
+- [ ] **[medium]** Disabled state styling — In `InputLabel.swift` add `@Environment(\.isEnabled)`; resolve text color: hasError → systemcolorsFgError, !isEnabled → textDisabled, else textPrimary; dim the asterisk and info glyph too. No new modifier — native `.disabled` is the API.
+
+### FieldError
+
+HeroUI FieldError maps to `InfoMessage(kind: .error)` + InfoMessageList wired via `.errorText`/`.infoMessages`/`.validate`.
+
+- [ ] **[medium]** Animated appearance/disappearance of field messages — Add `.transition(.opacity.combined(with: .move(edge: .top)))` per message row in `InfoMessageUI.swift` and `.animation(Motion.fast.animation, value: messages)` at InfoMessageList call sites in `TextInput.swift` and `MultiLineTextInput.swift`; optional chainable `messagesAnimated(_:)` opt-out.
+- [ ] **[low]** Custom (non-text) message content slot — Add a chainable `footer(@ViewBuilder)` on TextInput stored as AnyView like the leading/trailing slots, rendered in the message row area.
+
+### Input
+
+TextInput is a superset of HeroUI Input except the "secondary" on-surface variant and invalid-tinted caret.
+
+- [ ] **[medium]** Secondary / on-surface field chrome (variant=secondary) — Add MutedFieldStyle in `FieldStyle.swift`: fill `theme.background(.bgSecondaryLight)`, no shadow, border transparent until focus/error, static accessor `.muted`.
+- [ ] **[low]** Invalid-state caret/selection tint — In `TextInput.swift` change `.tint(theme.foreground(.fgHero))` to `hasError ? systemcolorsFgError : fgHero`; same for the MultiLineTextInput TextEditor.
+
+### TextField
+
+The TextField container role is covered by the monolithic TextInput anatomy; only isRequired is missing.
+
+- [ ] **[high]** Required-field indicator on TextInput — Add `var isRequired` to TextInputModel + chainable `required(_:)` on TextInput; render an asterisk after the floating label in systemcolorsFgError as InputLabel does; append localized ", required" to the accessibilityLabel; mirror on MultiLineTextInput.
+
+### SearchField
+
+HeroUI SearchField maps to ThemeKit SearchBar (ThemeKit's SearchField is a search-form summary card — a different role).
+
+- [ ] **[medium]** Invalid/error state (isInvalid + FieldError) — In `SearchBar.swift` add `errorText(_:)` and `infoMessages(_:)` copy-on-write modifiers; render InfoMessageList below the field; feed dominantKind into FieldStyleConfiguration.hasError/hasWarning.
+- [ ] **[low]** Replaceable leading search icon — Add `leadingIcon(_ systemName:)` (default magnifyingglass) and `leadingIconColor(_ key: Theme.TextColorKey)`.
+- [ ] **[low]** Inline helper/description line — Add a `helperText(_:)` modifier rendering `.bodySm400` textTertiary, suppressed while errorText is active (hideOnInvalid).
+
+### InputOTP
+
+Core covered, including extras (secure masking, resend countdown).
+
+- [ ] **[medium]** Character pattern / input mode — Add `enum OTPCharacterSet {digits, letters, alphanumeric}` + a `characters(_:)` chainable modifier switching the sanitize filter and keyboard traits, keeping `.oneTimeCode`.
+- [ ] **[medium]** Slot grouping with separator — Add `groups(_ sizes: [Int])` validated against digitCount, inserting a separator glyph (Rectangle or dash Text in textTertiary, SpacingKey.sm).
+- [ ] **[low]** Per-slot placeholder characters — Add `placeholder(_ text: String)`; OTPDigitBox renders the per-slot char in textTertiary when empty and not the caret cell.
+- [ ] **[low]** Digit entry micro-animation — Give the digit Text `.contentTransition(.numericText())` or an opacity+scale transition gated by microAnimations + reduceMotion.
+
+### Tabs
+
+SegmentedTabBar covers the strip role; missing the content-panel half and scroll-follow.
+
+- [ ] **[medium]** Tab content panels (Tabs.Content) — Add a generic init overload `init(_ items:selection:@ViewBuilder content: (Int) -> Content)` rendering the selected pane below the bar with `.transition(.opacity)` + `.id(selection)`, MicroMotion/reduceMotion aware.
+- [ ] **[medium]** Auto-scroll selected tab into view — Wrap the bar in ScrollViewReader, tag tabs, scroll on selection change; expose `enum TabScrollAlignment {start, center, end, none}` via `scrollAlign(_:)` (default `.center`).
+- [ ] **[low]** Inter-tab separators — Add `dividers(_:)` (mirroring SegmentedControl's) drawing a 1pt hairline borderPrimary between tabs, hidden when the neighbor is the selection.
+
+### Accordion
+
+Split across Accordion (single row) + AccordionGroup (single/multiple modes, surface chrome).
+
+- [ ] **[high]** Controlled expansion (value/onValueChange) — AccordionGroup: add an init overload with `expanded: Binding<Set<Item.ID>>`; Accordion: an init overload with `isExpanded: Binding<Bool>`; keep initiallyExpanded as the uncontrolled path.
+- [ ] **[medium]** Custom trigger content and indicator in AccordionGroup — Add a generic init overload with `@ViewBuilder header: (Item, Bool) -> Header`; surface the AccordionIndicator enum via chainable `indicator(_:)`.
+- [ ] **[medium]** Variant parity: plain group + hideSeparator — Add `surface(_ on: Bool = true)` and `dividers(_ on: Bool = true)` to AccordionGroup.
+- [ ] **[low]** isCollapsible — Add `collapsible(_ on: Bool = true)`; when false, `toggle()` early-returns so one item stays open in single mode.
+- [ ] **[low]** Per-item disabled — Add `itemDisabled(_ isDisabled: (Item) -> Bool)`; disabled rows get textDisabled + `.disabled(true)`.
+
+### BottomSheet
+
+Covered by `.bottomSheet` + SheetPresenter/`.sheetHost` on the native sheet; SheetHeader for Title/Close.
+
+- [ ] **[medium]** Detached (inset floating card) presentation — Add `detached: Bool = false` to `.bottomSheet` and `SheetPresenter.present`: `.presentationBackground(.clear)` with content wrapped in a card padded SpacingKey.md, bgWhite continuous RoundedRectangle RadiusRole.box.
+- [ ] **[low]** Sheet surface token override — Add `surface: Theme.BackgroundColorKey? = nil` mapping to `.presentationBackground(theme.background(key))`.
+- [ ] **[low]** Corner radius role for the sheet — Add `radius: Theme.RadiusRole? = nil` mapped to `.presentationCornerRadius`.
+
+### Dialog
+
+Role fully covered by the three `.dialog` overloads + `FeedbackPresenter.confirm`.
+
+- [ ] **[medium]** Swipe/drag-to-dismiss gesture on the dialog card — Add `swipeToDismiss: Bool` (default false) to all three `.dialog` overloads; a shared DragGesture offsets the card, fades the scrim proportionally, dismisses past ~1/3 card height, springs back otherwise — gated on microAnimations + reduceMotion (mirror `Feedback.swift` FeedbackToastRow swipe).
+- [ ] **[low]** Scale + fade presentation transition — Change the card transition to `.opacity.combined(with: .scale(scale: 0.96))`; the scrim stays fade-only; MicroMotion gating keeps Reduce Motion a plain fade.
+
+### Popover
+
+Role split across Tooltip (bubble+arrow) and the Popconfirm custom-content overload (generic anchored card).
+
+- [ ] **[high]** Outside-tap dismissal (overlay close-on-press) — Extend PopconfirmPresenter with `dismissOnOutsideTap: Bool = true` (exposed on `.popconfirm` overloads and self-managed `.tooltip`): a transparent full-screen tap-catcher behind the card flipping the binding.
+- [ ] **[medium]** Stock titled popover layout (Title+Description+Close) — Add a `.popover(isPresented:title:message:edge:)` convenience beside `.popconfirm` composing a labelBase600 title, bodySm400 textSecondary message, and the existing xmark close onto PopconfirmSurface.
+- [ ] **[medium]** Alignment along the placement axis (align start/center/end) — Add a PopoverAlign enum + `align:` parameter to `.tooltip`/`.popconfirm`/`.popover` via alignment guides; gap distance from SpacingKey.xs instead of a hardcoded 8pt.
+- [ ] **[low]** Arrow on the popover card — Add `showsArrow: Bool = false` composing TooltipArrow filled bgWhite, stroked borderPrimary.
+- [ ] **[low]** Width strategy for the card — Add PopoverWidth (`.contentFit` → `.fixedSize()`, `.matchTrigger`, `.fixed(CGFloat)` escape) threaded through PopconfirmSurface, defaulting to today's fixed 260pt.
+- [ ] **[low]** Edge-collision avoidance — GeometryReader-based flip in PopconfirmPresenter swapping top↔bottom / leading↔trailing when the card exceeds the safe area; or document caller responsibility.
+
+### Toast
+
+Strong coverage: AlertToast view + `.toast` presenter + FeedbackPresenter/`.feedbackHost` imperative manager.
+
+- [ ] **[low]** Neutral ("default") and accent toast variants — Add a `.neutral` case to AlertToastType (bgTertiary/fgSecondary/bell.fill) and an accent case fed by `SemanticColor.primary.solid`/`.onSolid`; extend the FeedbackKind mapping.
+- [ ] **[low]** Per-toast placement override — Add `position: ToastPosition? = nil` to `FeedbackPresenter.toast` stored on ToastItem; render two anchored stacks in FeedbackHostModifier.
+- [ ] **[low]** Show/hide lifecycle callbacks — Add onShow/onDismiss closures to `FeedbackPresenter.toast`, invoking onDismiss from the single removal point.
+- [ ] **[low]** Stacked depth (peek/scale) animation — Switch toastLayer to a ZStack keyed by index with peek offset + 0.97 scale under `Motion.base.spring`, honoring Reduce Motion.
+
+### Alert
+
+HeroUI Alert maps to InfoBanner (variants, title/message, showsIcon, action, dismiss); Callout is the compact case.
+
+- [ ] **[medium]** Custom leading indicator (icon override + view slot) — Add an `.icon(_ systemName: String?)` override + a `.leading(@ViewBuilder)` copy-on-write slot replacing the stock Icon (e.g. Spinner); apply `.icon(_:)` to `Callout.swift` too.
+- [ ] **[medium]** Trailing accessory slot for real buttons — Add a `.trailing(@ViewBuilder)` modifier rendering after the text block (e.g. small ThemeButton); keep `.action` as the lightweight default.
+- [ ] **[low]** Accent (brand) status variant — Add an `.accent` case to InfoBannerType and CalloutType fed by SemanticColor.primary (`.soft` surface, `.border` hairline, `.base` icon).
+- [ ] **[low]** Alert semantics for assistive tech — Add `.accessibilityElement(children: .combine)` on the root HStack; localized accessibilityLabel on the stock status icon per variant.
+
+### Skeleton
+
+Skeleton atom + `.skeleton(isLoading)` modifier cover the role; shimmer is token-bound and static under Reduce Motion.
+
+- [ ] **[medium]** Pulse animation variant — Add `public enum SkeletonVariant { shimmer, pulse, none }` + copy-on-write `variant(_:)` on Skeleton; thread through SkeletonShimmer; pulse animates fill opacity ~0.5…1.0 easeInOut repeatForever; accept the variant in the `.skeleton(_:)` modifier.
+- [ ] **[medium]** Animated skeleton-to-content reveal — In SkeletonModifier add `.animation(.easeOut, value: isLoading)` and `.transition(.opacity)` on the overlay so the placeholder fades out (skip under reduceMotion).
+- [ ] **[low]** Token-fed corner radius for skeleton shapes — Add `static func rounded(_ role: Theme.RadiusRole)` and a `.skeleton(_:radius:)` overload; deprecate the raw-CGFloat paths.
+- [ ] **[low]** Configurable shimmer highlight — Add `highlight(_ color: SemanticColor?)` (nil = bgWhite default) resolving to `color?.soft` in the shimmer gradient.
+
+### Spinner
+
+Covers and exceeds the core role (5 shapes vs 1).
+
+- [ ] **[medium]** Loading accessibility label — Add `.accessibilityLabel(String(localized: "Loading", bundle: .module))` + a Reduce Motion static 270-degree arc fallback.
+- [ ] **[low]** Custom rotating indicator slot — Add an `indicator(@ViewBuilder)` AnyView slot; the body renders the slot inside the continuous-rotation driver (extract SpinnerRing rotation into a private RotationDriver).
+- [ ] **[low]** Native controlSize support — Read `@Environment(\.controlSize)` deriving diameter/stroke presets (small 16/2, regular 24/3, large 40/4); keep `.size(points)` as the explicit override.
+
+### ListGroup
+
+Role fully present and richer than HeroUI; one meaningful gap.
+
+- [ ] **[medium]** Surface variants on the list container — Add `public enum ListSurfaceVariant { primary, secondary, tertiary, transparent }` + a `surface(_:)` copy-on-write modifier to `ListView.swift` mapping theme.background tokens (`.bgWhite`/`.bgSecondaryLight`/`.bgElevatorTertiary`/`.clear`), stroke only for bordered primary; keep `.bordered(_:)` as an alias; move the container radius from RadiusKey.md to RadiusRole.box.
+
+### Card
+
+Card organism covers the role; exceeds with `.loading` skeleton, `.extraAction`, pressable init.
+
+- [ ] **[high]** Footer slot for bottom-aligned actions — Add a `footer(@ViewBuilder)` copy-on-write slot storing `AnyView?`, rendered in cardContent below the body with `DividerView().size(.small)` above, using the existing contentPadding/SpacingKey.
+- [ ] **[medium]** Custom header content slot — Add `header(@ViewBuilder)` storing a customHeader `AnyView?` replacing the string header when set.
+- [ ] **[medium]** Surface-fill variants (default/secondary/tertiary/transparent) — Add `surface(_ key: Theme.BackgroundColorKey)` threading into `CardStyleConfiguration.surfaceKey` (already modeled, never set); default→`.bgWhite`, secondary→`.bgSecondaryLight`, tertiary→`.bgTertiary`; transparent = `.cardStyle(.outlined)`.
+
+### Avatar
+
+Core covered; adds shape, presence dots, and AvatarGroup beyond HeroUI.
+
+- [ ] **[high]** Remote image with automatic fallback, load fade and delayed fallback — Add `case remote(URL?, fallback: AvatarContent = .icon("person.fill"))` to AvatarContent, rendered via RemoteImage/AsyncImage phases: Skeleton while loading, fade-in via a Motion token on success, fallback via the normal token path on failure with a brief built-in delay.
+- [ ] **[medium]** Soft fill variant — Add `fill(_ v: FillVariant)` (`.solid`/`.soft`; default `.solid`): `.soft` resolves surfaceFill to `SemanticColor.soft` and contentColor to the `.base`/700-step; thread through AvatarGroup.
+- [ ] **[low]** Default accessibility label — Add `.accessibilityElement(children: .ignore)` + a default accessibilityLabel `String(localized: "Avatar")` (initials text when `.initials`); callers override natively.
+
+## Newly built in this PR
+
+The 6 HeroUI components with no ThemeKit counterpart were implemented on this branch:
+
+- **CloseButton** (Atom, `Sources/ThemeKit/Components/Atoms/CloseButton.swift`) — ports HeroUI CloseButton: a circular xmark dismiss button (previously hand-rolled 8+ times across sheets, dialogs and toasts) with token tint/glyph overrides, a plain overlay mode, controlSize-driven icon sizing, a ≥44pt hit target and a localized "Close" accessibility label.
+- **HelperText** (Atom, `Sources/ThemeKit/Components/Atoms/HelperText.swift`) — ports HeroUI Description: a standalone field helper-text atom (`.bodySm400` textSecondary) with `.hasError` recoloring, `.hidesOnError` (hideOnInvalid) and disabled-state dimming via the native environment.
+- **SurfaceView** (Atom, `Sources/ThemeKit/Components/Atoms/SurfaceView.swift`) — ports HeroUI Surface: a brand-neutral nestable themed container with `level` (primary/secondary/tertiary/transparent), `elevation`, token radius and contentPadding modifiers, plus a `surfaceChrome` View extension standing in for asChild.
+- **SkeletonGroup** (Atom, `Sources/ThemeKit/Components/Atoms/SkeletonGroup.swift`) — ports HeroUI SkeletonGroup: coordinates child Skeletons through an environment-provided group state so a card of placeholders shares one loading flag and phase-locked shimmer, with `skeletonOnly` and cross-fade on reveal.
+- **ControlRow** (Molecule, `Sources/ThemeKit/Components/Molecules/ControlRow.swift`) — ports HeroUI ControlField: fuses label + description + a boolean control (toggle/checkbox/radio, or a custom indicator slot) into one pressable row with required/error/errorText validation states and combined accessibility.
+- **ScrollShadow** (Molecule, `Sources/ThemeKit/Components/Molecules/ScrollShadow.swift`) — ports HeroUI ScrollShadow: wraps a caller's scroll view with scroll-aware, token-fed edge fade scrims (auto/start/end/both/none visibility, RTL-safe leading/trailing alignment) using `onScrollGeometryChange` with an iOS 17 fallback.
+
+## Method notes
+
+HeroUI Native's React-isms were translated to ThemeKit idioms rather than ported literally: `className`/Tailwind variant strings became theme tokens and style types; render props and compound sub-components (`Component.Item`, `Component.Label`) became chainable copy-on-write modifiers and `@ViewBuilder` slots; raw animation configs became Motion/MicroMotion tokens gated by the microAnimations setting and Reduce Motion; `isDisabled` props map to native `.disabled`/`@Environment(\.isEnabled)`; and string props with fixed pixel values map to token keys (SpacingKey, RadiusRole, semantic color roles) instead of raw CGFloats.

--- a/Sources/ThemeKit/Components/Atoms/CloseButton.swift
+++ b/Sources/ThemeKit/Components/Atoms/CloseButton.swift
@@ -1,0 +1,146 @@
+//
+//  CloseButton.swift
+//  ThemeKit
+//
+//  Atom. A circular dismiss button — the standard "×" affordance for sheets,
+//  banners, tags and media overlays (HeroUI Native CloseButton parity: a
+//  tertiary icon-only button with a muted glyph and a generous hit slop).
+//  Action-only and token-bound; size rides the native `.controlSize(_:)`
+//  cascade, disabled rides the native `.disabled(_:)` (R3).
+//
+//      CloseButton { dismiss() }
+//          .tint(.error)               // semantic glyph tint
+//          .plain()                    // bare glyph for image overlays
+//          .controlSize(.small)        // native size
+//          .disabled(isBusy)           // native — R3
+//
+
+import SwiftUI
+
+private extension ControlSize {
+    /// Circle diameter for the close button — maps the native control size to
+    /// fixed atom metrics (mini 24 / small 28 / regular+ 32, the reference's
+    /// `h-8` small icon-only button). The tap target stays >= 44pt regardless.
+    var closeButtonDiameter: CGFloat {
+        switch self {
+        case .mini: return 24
+        case .small: return 28
+        default: return 32   // .regular (default) / .large / .extraLarge
+        }
+    }
+}
+
+/// A circular icon-only dismiss button. The glyph (default `xmark`) sits on a
+/// tertiary elevator circle; `.plain()` drops the fill for use over images.
+/// All chroma comes from theme tokens, so the atom re-skins with the theme.
+public struct CloseButton: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.controlSize) private var controlSize
+    @Environment(\.isEnabled) private var isEnabled
+
+    private let action: () -> Void
+    // Appearance — mutated only through the modifiers below (R2).
+    private var tint: SemanticColor?
+    private var systemImage: String = "xmark"
+    private var isPlain: Bool = false
+    private var accessibilityID: String?
+
+    /// Minimum tap side per the HIG; the visual circle floats centered inside it.
+    private static let minimumHitSide: CGFloat = 44
+
+    public init(action: @escaping () -> Void) {   // R1 — action only
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            glyph
+                .frame(width: diameter, height: diameter)
+                .background {
+                    if !isPlain {
+                        Circle().fill(theme.background(.bgElevatorTertiary))
+                    }
+                }
+                .frame(minWidth: Self.minimumHitSide, minHeight: Self.minimumHitSide)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(PressFeedbackStyle())
+        .a11y(A11yElement.Action.close, in: accessibilityID)
+        .accessibilityLabel(String(themeKit: "Close"))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var diameter: CGFloat { controlSize.closeButtonDiameter }
+
+    private var glyph: some View {
+        Image(systemName: systemImage)
+            .font(.system(size: diameter * 0.44, weight: .semibold))
+            .foregroundStyle(glyphColor)
+    }
+
+    /// Disabled always wins; then the semantic tint; else the muted default.
+    private var glyphColor: Color {
+        guard isEnabled else { return theme.text(.textDisabled) }
+        if let tint { return tint.accent }
+        return theme.text(.textTertiary)
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension CloseButton {
+    /// Semantic glyph tint; `nil` (default) uses the muted `textTertiary` token.
+    func tint(_ c: SemanticColor?) -> Self { copy { $0.tint = c } }
+
+    /// Swaps the SF Symbol glyph (default `"xmark"`).
+    func systemImage(_ name: String) -> Self { copy { $0.systemImage = name } }
+
+    /// Drops the circle fill, leaving a bare ghost glyph — for image overlays
+    /// and dense chrome where the elevator surface would be noise.
+    func plain(_ on: Bool = true) -> Self { copy { $0.isPlain = on } }
+
+    /// Stable accessibility-identifier namespace (the button gets `"<id>.close"`).
+    func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+        // Default across the native size cascade.
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            CloseButton {}.controlSize(.mini)
+            CloseButton {}.controlSize(.small)
+            CloseButton {}
+        }
+        // Semantic tint, glyph swap, disabled.
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            CloseButton {}.tint(.error)
+            CloseButton {}.systemImage("chevron.down")
+            CloseButton {}.disabled(true)
+        }
+        // Plain ghost glyph over a hero (image-like) surface.
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            CloseButton {}.plain().tint(.neutral)
+            CloseButton {}.plain().tint(.error)
+        }
+        .padding(Theme.SpacingKey.sm.value)
+        .background(Theme.shared.background(.bgHero),
+                    in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+        // Dark / themed case.
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            CloseButton {}
+            CloseButton {}.tint(.error)
+            CloseButton {}.disabled(true)
+        }
+        .padding(Theme.SpacingKey.sm.value)
+        .environment(\.colorScheme, .dark)
+        .background(Theme.shared.background(.bgTertiary),
+                    in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+    }
+    .padding()
+}

--- a/Sources/ThemeKit/Components/Atoms/HelperText.swift
+++ b/Sources/ThemeKit/Components/Atoms/HelperText.swift
@@ -1,0 +1,105 @@
+//
+//  HelperText.swift
+//  ThemeKit
+//  Created by İsa Mercan on 09.07.2026.
+//
+
+import SwiftUI
+
+/// Atom. A muted helper/description line for form fields — the small print under
+/// an input that explains what to enter (HeroUI Native "Description").
+///
+/// The caller supplies the string; the atom adds no copy of its own. Reads
+/// `.disabled(_:)` from the environment and dims to the disabled text token.
+///
+///     HelperText("We'll never share your email.")
+///     HelperText("Min. 8 characters").hasError(isInvalid)
+///     HelperText("Optional hint").hidesOnError().hasError(isInvalid)
+///
+/// Accessibility: renders as plain text, so VoiceOver reads it naturally in
+/// order. An owning field should either group it with the input via
+/// `.accessibilityElement(children: .combine)` or surface the same string as
+/// an `accessibilityHint` on the field itself.
+public struct HelperText: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
+
+    private let text: String
+    // Appearance/state — mutated only through the modifiers below (R2).
+    private var hasError = false
+    private var hidesOnError = false
+    private var accessibilityID: String? = nil
+
+    public init(_ text: String) {   // R1 — content only
+        self.text = text
+    }
+
+    public var body: some View {
+        Group {
+            if !(hasError && hidesOnError) {   // hidden so a field-error line can take its place
+                Text(text)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(color)
+                    .a11y(A11yElement.Field.message, in: accessibilityID)
+                    .transition(.opacity)
+            }
+        }
+        .animation(motion, value: hasError)
+    }
+
+    private var color: Color {
+        if !isEnabled { return theme.text(.textDisabled) }
+        if hasError { return theme.foreground(.systemcolorsFgError) }
+        return theme.text(.textSecondary)
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension HelperText {
+    /// Render the helper text in the error color (maps HeroUI `isInvalid`).
+    func hasError(_ on: Bool = true) -> Self { copy { $0.hasError = on } }
+
+    /// Remove the helper text entirely while `hasError` is set, so a field-error
+    /// line can take its place (maps HeroUI `hideOnInvalid`).
+    func hidesOnError(_ on: Bool = true) -> Self { copy { $0.hidesOnError = on } }
+
+    /// Namespaced accessibility identifier for UI tests
+    /// (the text gets `"<id>.message"`).
+    func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 12) {
+        HelperText("We'll never share your email.")
+        HelperText("Min. 8 characters, one number.").hasError()
+        HStack(spacing: 4) {
+            Text("(hidden under error →)").textStyle(.bodySm400)
+            HelperText("Optional hint").hidesOnError().hasError()
+        }
+        HelperText("Unavailable while the form is locked.").disabled(true)
+    }
+    .padding()
+}
+
+#Preview("Dark") {
+    let dark = Theme()
+    dark.loadTheme(named: Theme.defaultThemeName, dark: true)
+    return VStack(alignment: .leading, spacing: 12) {
+        HelperText("We'll never share your email.")
+        HelperText("Min. 8 characters, one number.").hasError()
+        HelperText("Unavailable while the form is locked.").disabled(true)
+    }
+    .padding()
+    .background(dark.background(.bgBase))
+    .theme(dark)
+}

--- a/Sources/ThemeKit/Components/Atoms/SkeletonGroup.swift
+++ b/Sources/ThemeKit/Components/Atoms/SkeletonGroup.swift
@@ -4,11 +4,12 @@
 //  Created by İsa Mercan on 09.07.2026.
 //
 //  Coordinates many skeleton placeholders with one loading flag (HeroUI Native
-//  `SkeletonGroup`). The group publishes a small state value into a private
+//  `SkeletonGroup`). The group publishes its loading flag into a private
 //  environment key; the items are the *existing* `Skeleton` atom and the new
 //  zero-argument `.skeleton()` / `.skeleton(shape:)` overloads below, which read
-//  that key and forward to the existing `.skeleton(isLoading:)` modifier. An
-//  explicitly passed `isLoading` always overrides the group.
+//  that key and forward to the existing `.skeleton(isLoading:)` modifier — so
+//  one flag drives every placeholder, while each shimmer animates independently.
+//  An explicitly passed `isLoading` always overrides the group.
 //
 //    SkeletonGroup {
 //        Text(post.title).textStyle(.headingSm).skeleton()   // no flag — group-driven
@@ -26,32 +27,17 @@ import SwiftUI
 
 // MARK: - Group state (private environment plumbing)
 
-/// Shared reference every placeholder under one group sees — a common phase
-/// anchor, so items belonging to the same group share one identity/start point
-/// rather than each acting as an unrelated shimmer.
-fileprivate final class SkeletonGroupPhase {
-    /// The moment this group's placeholders came alive together.
-    let start = Date()
-}
-
-/// What a `SkeletonGroup` publishes to the skeletons below it.
-fileprivate struct SkeletonGroupState: Equatable {
-    var isLoading: Bool
-    var phase: SkeletonGroupPhase
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.isLoading == rhs.isLoading && lhs.phase === rhs.phase
-    }
-}
-
 private struct SkeletonGroupKey: EnvironmentKey {
     /// `nil` — not inside a `SkeletonGroup`; group-driven skeletons render
-    /// their content unchanged.
-    static let defaultValue: SkeletonGroupState? = nil
+    /// their content unchanged. Computed (not `static let`) to match
+    /// `ThemeEnvironmentKey` — Swift 6 strict concurrency house precedent.
+    static var defaultValue: Bool? { nil }
 }
 
 fileprivate extension EnvironmentValues {
-    var skeletonGroup: SkeletonGroupState? {
+    /// The nearest enclosing `SkeletonGroup`'s loading flag, or `nil` outside
+    /// any group.
+    var skeletonGroupIsLoading: Bool? {
         get { self[SkeletonGroupKey.self] }
         set { self[SkeletonGroupKey.self] = newValue }
     }
@@ -60,6 +46,8 @@ fileprivate extension EnvironmentValues {
 // MARK: - SkeletonGroup
 
 /// Drives every group-bound skeleton in `content` from one loading flag.
+/// Each placeholder's shimmer animates independently; the group synchronizes
+/// only *whether* they show, not their sweep.
 ///
 /// Items opt in with the zero-argument `.skeleton()` / `.skeleton(shape:)`
 /// modifiers (group-driven) or compose the standalone `Skeleton` atom inside a
@@ -77,9 +65,6 @@ public struct SkeletonGroup<Content: View>: View {
     private var isLoading = true
     private var isSkeletonOnly = false
 
-    /// One stable reference per group identity, shared by all items below.
-    @State private var phase = SkeletonGroupPhase()
-
     public init(@ViewBuilder content: () -> Content) {   // R1 — content only
         self.content = content()
     }
@@ -90,16 +75,32 @@ public struct SkeletonGroup<Content: View>: View {
             // resolve to nothing at all so layout wrappers collapse.
             if isLoading || !isSkeletonOnly {
                 content
-                    .environment(\.skeletonGroup, SkeletonGroupState(isLoading: isLoading, phase: phase))
-                    // One busy region while loading; ordinary children after.
-                    .accessibilityElement(children: isLoading ? .ignore : .contain)
-                    .accessibilityLabel(isLoading ? String(themeKit: "Loading") : "")
+                    .environment(\.skeletonGroupIsLoading, isLoading)
+                    .modifier(SkeletonGroupAccessibility(isLoading: isLoading))
                     .transition(.opacity)
             }
         }
         // Cross-fade the flip (and the skeleton-only removal), honoring the
         // `microAnimations` switch and Reduce Motion exactly like Skeleton does.
         .animation(MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion), value: isLoading)
+    }
+}
+
+/// One busy region labeled "Loading" while loading; a plain container of
+/// ordinary children — no label — once loaded.
+private struct SkeletonGroupAccessibility: ViewModifier {
+    let isLoading: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if isLoading {
+            content
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(String(themeKit: "Loading"))
+        } else {
+            content
+                .accessibilityElement(children: .contain)
+        }
     }
 }
 
@@ -127,10 +128,10 @@ public extension SkeletonGroup {
 /// Forwards the group's flag to the existing `.skeleton(isLoading:shape:)`
 /// modifier; outside a group it renders the content unchanged.
 private struct GroupSkeletonModifier: ViewModifier {
-    @Environment(\.skeletonGroup) private var group
+    @Environment(\.skeletonGroupIsLoading) private var groupIsLoading
 
     let shape: SkeletonShape
-    private var isLoading: Bool { group?.isLoading ?? false }
+    private var isLoading: Bool { groupIsLoading ?? false }
 
     func body(content: Content) -> some View {
         content

--- a/Sources/ThemeKit/Components/Atoms/SkeletonGroup.swift
+++ b/Sources/ThemeKit/Components/Atoms/SkeletonGroup.swift
@@ -1,0 +1,259 @@
+//
+//  SkeletonGroup.swift
+//  ThemeKit
+//  Created by İsa Mercan on 09.07.2026.
+//
+//  Coordinates many skeleton placeholders with one loading flag (HeroUI Native
+//  `SkeletonGroup`). The group publishes a small state value into a private
+//  environment key; the items are the *existing* `Skeleton` atom and the new
+//  zero-argument `.skeleton()` / `.skeleton(shape:)` overloads below, which read
+//  that key and forward to the existing `.skeleton(isLoading:)` modifier. An
+//  explicitly passed `isLoading` always overrides the group.
+//
+//    SkeletonGroup {
+//        Text(post.title).textStyle(.headingSm).skeleton()   // no flag — group-driven
+//        Text(post.body).skeleton()
+//    }
+//    .loading(isLoading)
+//
+//  `.skeletonOnly()` marks a layout-only placeholder group (HeroUI
+//  `isSkeletonOnly`): when loading ends the whole group renders `EmptyView`,
+//  so wrapper stacks that exist purely to lay out `Skeleton` blocks collapse
+//  instead of leaving empty space behind.
+//
+
+import SwiftUI
+
+// MARK: - Group state (private environment plumbing)
+
+/// Shared reference every placeholder under one group sees — a common phase
+/// anchor, so items belonging to the same group share one identity/start point
+/// rather than each acting as an unrelated shimmer.
+fileprivate final class SkeletonGroupPhase {
+    /// The moment this group's placeholders came alive together.
+    let start = Date()
+}
+
+/// What a `SkeletonGroup` publishes to the skeletons below it.
+fileprivate struct SkeletonGroupState: Equatable {
+    var isLoading: Bool
+    var phase: SkeletonGroupPhase
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.isLoading == rhs.isLoading && lhs.phase === rhs.phase
+    }
+}
+
+private struct SkeletonGroupKey: EnvironmentKey {
+    /// `nil` — not inside a `SkeletonGroup`; group-driven skeletons render
+    /// their content unchanged.
+    static let defaultValue: SkeletonGroupState? = nil
+}
+
+fileprivate extension EnvironmentValues {
+    var skeletonGroup: SkeletonGroupState? {
+        get { self[SkeletonGroupKey.self] }
+        set { self[SkeletonGroupKey.self] = newValue }
+    }
+}
+
+// MARK: - SkeletonGroup
+
+/// Drives every group-bound skeleton in `content` from one loading flag.
+///
+/// Items opt in with the zero-argument `.skeleton()` / `.skeleton(shape:)`
+/// modifiers (group-driven) or compose the standalone `Skeleton` atom inside a
+/// `.skeletonOnly()` group. Passing an explicit flag — `.skeleton(true)` —
+/// bypasses the group entirely.
+///
+/// While loading, the group reads to assistive technology as a single busy
+/// region labeled "Loading" instead of N meaningless shimmers.
+public struct SkeletonGroup<Content: View>: View {
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let content: Content
+    // Appearance/config — mutated only through the modifiers below (R2).
+    private var isLoading = true
+    private var isSkeletonOnly = false
+
+    /// One stable reference per group identity, shared by all items below.
+    @State private var phase = SkeletonGroupPhase()
+
+    public init(@ViewBuilder content: () -> Content) {   // R1 — content only
+        self.content = content()
+    }
+
+    public var body: some View {
+        Group {
+            // A skeleton-only group has nothing to show once loading ends —
+            // resolve to nothing at all so layout wrappers collapse.
+            if isLoading || !isSkeletonOnly {
+                content
+                    .environment(\.skeletonGroup, SkeletonGroupState(isLoading: isLoading, phase: phase))
+                    // One busy region while loading; ordinary children after.
+                    .accessibilityElement(children: isLoading ? .ignore : .contain)
+                    .accessibilityLabel(isLoading ? String(themeKit: "Loading") : "")
+                    .transition(.opacity)
+            }
+        }
+        // Cross-fade the flip (and the skeleton-only removal), honoring the
+        // `microAnimations` switch and Reduce Motion exactly like Skeleton does.
+        .animation(MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion), value: isLoading)
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension SkeletonGroup {
+    /// Drive every group-bound skeleton below from this one flag
+    /// (same verb as `ListView.loading()` / `Card.loading()`).
+    func loading(_ on: Bool = true) -> Self { copy { $0.isLoading = on } }
+
+    /// Mark the group as a pure placeholder (HeroUI `isSkeletonOnly`): its
+    /// content exists only to lay out skeleton blocks, so when loading ends the
+    /// whole group renders `EmptyView` and its layout wrappers collapse.
+    func skeletonOnly(_ on: Bool = true) -> Self { copy { $0.isSkeletonOnly = on } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+// MARK: - Group-driven items
+
+/// Forwards the group's flag to the existing `.skeleton(isLoading:shape:)`
+/// modifier; outside a group it renders the content unchanged.
+private struct GroupSkeletonModifier: ViewModifier {
+    @Environment(\.skeletonGroup) private var group
+
+    let shape: SkeletonShape
+    private var isLoading: Bool { group?.isLoading ?? false }
+
+    func body(content: Content) -> some View {
+        content
+            .skeleton(isLoading, shape: shape)
+            // The placeholder region carries no information of its own — the
+            // group announces a single "Loading" element instead.
+            .accessibilityHidden(isLoading)
+    }
+}
+
+public extension View {
+    /// Replaces the view with a shimmering rounded skeleton while the nearest
+    /// enclosing `SkeletonGroup` is loading. Outside a group the view renders
+    /// unchanged; pass an explicit flag — `.skeleton(true)` — to override the group.
+    func skeleton(cornerRadius: CGFloat = 8) -> some View {
+        modifier(GroupSkeletonModifier(shape: .rounded(cornerRadius)))
+    }
+
+    /// Group-driven skeleton with a custom outline (see `skeleton(cornerRadius:)`).
+    func skeleton(shape: SkeletonShape) -> some View {
+        modifier(GroupSkeletonModifier(shape: shape))
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Group loading toggle") {
+    @Previewable @State var isLoading = true
+    @Previewable @Environment(\.theme) var theme
+
+    VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+        Toggle("Loading", isOn: $isLoading)
+
+        SkeletonGroup {
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                Text("Weekend in Lisbon").textStyle(.headingSm)
+                    .foregroundStyle(theme.text(.textPrimary))
+                    .skeleton()
+                Text("Three days of tiles, trams and pastel facades by the river.")
+                    .textStyle(.bodyBase400)
+                    .foregroundStyle(theme.text(.textSecondary))
+                    .skeleton()
+                Text("Updated today").textStyle(.labelSm600)
+                    .foregroundStyle(theme.text(.textTertiary))
+                    .skeleton(shape: .capsule)
+            }
+        }
+        .loading(isLoading)
+    }
+    .padding(Theme.SpacingKey.md.value)
+}
+
+#Preview("Skeleton-only card") {
+    @Previewable @State var isLoading = true
+
+    VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+        Toggle("Loading", isOn: $isLoading)
+
+        // Pure placeholder: the HStack/VStack exist only for layout, so the
+        // whole group collapses to nothing once loading ends.
+        SkeletonGroup {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                Skeleton(.circle).size(width: 48, height: 48)
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
+                    Skeleton(.capsule).size(width: 160, height: 12)
+                    Skeleton(.capsule).size(width: 100, height: 12)
+                }
+            }
+        }
+        .skeletonOnly()
+        .loading(isLoading)
+
+        Text("Content below moves up when the placeholder collapses.")
+            .textStyle(.bodySm400)
+    }
+    .padding(Theme.SpacingKey.md.value)
+}
+
+#Preview("Per-item explicit override") {
+    @Previewable @Environment(\.theme) var theme
+
+    // The group has finished loading, but one item pins itself with an
+    // explicit flag — explicit `isLoading` always beats the group.
+    SkeletonGroup {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+            Text("Follows the group (loaded)").textStyle(.bodyBase400)
+                .foregroundStyle(theme.text(.textPrimary))
+                .skeleton()
+            Text("Explicit .skeleton(true) — still shimmering").textStyle(.bodyBase400)
+                .skeleton(true)
+        }
+    }
+    .loading(false)
+    .padding(Theme.SpacingKey.md.value)
+}
+
+#Preview("Dark theme") {
+    let dark = Theme()
+    dark.loadTheme(named: Theme.defaultThemeName, dark: true)
+
+    return VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+        SkeletonGroup {
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                Text("Loading on a dark surface").textStyle(.headingSm).skeleton()
+                Text("Skeleton tokens adapt to the dark theme automatically.")
+                    .textStyle(.bodyBase400)
+                    .skeleton()
+            }
+        }
+        .loading(true)
+
+        SkeletonGroup {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                Skeleton(.circle).size(width: 40, height: 40)
+                Skeleton(.capsule).size(width: 140, height: 12)
+            }
+        }
+        .skeletonOnly()
+        .loading(true)
+    }
+    .padding(Theme.SpacingKey.md.value)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(dark.background(.bgBase))
+    .theme(dark)
+    .preferredColorScheme(.dark)
+}

--- a/Sources/ThemeKit/Components/Atoms/SurfaceView.swift
+++ b/Sources/ThemeKit/Components/Atoms/SurfaceView.swift
@@ -1,0 +1,216 @@
+//
+//  SurfaceView.swift
+//  ThemeKit
+//
+
+import SwiftUI
+
+/// Semantic surface level → background token. Visual hierarchy comes from
+/// nesting levels (primary > secondary > tertiary), not from bespoke colors.
+/// `transparent` renders no fill and suppresses any shadow.
+public enum SurfaceLevel: CaseIterable {
+    case primary, secondary, tertiary, transparent
+
+    func background(_ theme: Theme) -> Color {
+        switch self {
+        case .primary: return theme.background(.bgWhite)
+        case .secondary: return theme.background(.bgSecondaryLight)
+        case .tertiary: return theme.background(.bgTertiary)
+        case .transparent: return .clear
+        }
+    }
+}
+
+/// Atom. A brand-neutral, nestable themed container primitive — the surface
+/// `Card` and other boxed organisms sit on. It draws only chrome (token fill,
+/// continuous corner, optional token shadow) around arbitrary content; it has
+/// no header, no interaction and no state. (HeroUI Native `Surface` parity.)
+///
+///     SurfaceView {
+///         Text("Nested")
+///     }
+///     .level(.secondary)
+///     .elevation(.soft)
+///
+/// Decorative by construction: it adds no accessibility label or traits and
+/// does not force an accessibility element, so children read naturally.
+public struct SurfaceView<Content: View>: View {
+    @Environment(\.theme) private var theme
+
+    private let content: () -> Content
+
+    // Appearance — mutated only through the modifiers below (R2).
+    private var level: SurfaceLevel = .primary
+    private var elevation: CardElevation = .none
+    private var radius: Theme.RadiusRole = .box
+    private var padding: Theme.SpacingKey = .md
+
+    public init(@ViewBuilder content: @escaping () -> Content) {   // R1 — content only
+        self.content = content
+    }
+
+    public var body: some View {
+        content()
+            .padding(padding.value)
+            .background(level.background(theme), in: shape)
+            .clipShape(shape)   // keeps edge-to-edge children inside the corner
+            .modifier(CardShadow(elevation: effectiveElevation))
+    }
+
+    /// Continuous corner used for both the fill and the clip.
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: radius.value, style: .continuous)
+    }
+
+    /// A transparent surface casts no shadow, whatever the requested elevation.
+    private var effectiveElevation: CardElevation {
+        level == .transparent ? .none : elevation
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension SurfaceView {
+    /// Surface level: primary / secondary / tertiary background token, or
+    /// transparent (no fill, no shadow). Nest levels for visual hierarchy.
+    func level(_ l: SurfaceLevel) -> Self { copy { $0.level = l } }
+
+    /// Token shadow: none (default) / soft / elevated. Ignored while transparent.
+    func elevation(_ e: CardElevation) -> Self { copy { $0.elevation = e } }
+
+    /// Radius role for the container corner (default `.box`).
+    func radius(_ role: Theme.RadiusRole) -> Self { copy { $0.radius = role } }
+
+    /// Inner content padding by spacing token (default `.md`); named so it
+    /// doesn't shadow the native `.padding`.
+    func contentPadding(_ key: Theme.SpacingKey) -> Self { copy { $0.padding = key } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+// MARK: - surfaceChrome (asChild companion)
+
+public extension View {
+    /// Applies surface chrome — the level's background token filled and clipped
+    /// with the same continuous-corner shape — to an arbitrary view, without
+    /// wrapping it in a `SurfaceView` (SwiftUI equivalent of HeroUI `asChild`).
+    /// Adds no padding, shadow, interaction or accessibility traits.
+    func surfaceChrome(_ level: SurfaceLevel, radius: Theme.RadiusRole = .box) -> some View {
+        modifier(SurfaceChrome(level: level, radius: radius))
+    }
+}
+
+private struct SurfaceChrome: ViewModifier {
+    @Environment(\.theme) private var theme
+    let level: SurfaceLevel
+    let radius: Theme.RadiusRole
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: radius.value, style: .continuous)
+        content
+            .background(level.background(theme), in: shape)
+            .clipShape(shape)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Levels + nesting") {
+    @Previewable @Environment(\.theme) var theme
+    ScrollView {
+        VStack(spacing: Theme.SpacingKey.md.value) {
+            // Every level
+            ForEach(SurfaceLevel.allCases, id: \.self) { level in
+                SurfaceView {
+                    Text(String(describing: level))
+                        .textStyle(.labelMd600)
+                        .foregroundStyle(theme.text(.textPrimary))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .level(level)
+            }
+
+            // Elevation + radius + padding knobs
+            SurfaceView {
+                Text("Elevated · field radius · sm padding")
+                    .textStyle(.labelSm600)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+            .elevation(.elevated)
+            .radius(.field)
+            .contentPadding(.sm)
+
+            // Nested hierarchy: primary > secondary > tertiary
+            SurfaceView {
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                    Text("Primary").textStyle(.headingSm)
+                        .foregroundStyle(theme.text(.textPrimary))
+                    SurfaceView {
+                        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                            Text("Secondary").textStyle(.labelMd600)
+                                .foregroundStyle(theme.text(.textPrimary))
+                            SurfaceView {
+                                Text("Tertiary").textStyle(.labelSm600)
+                                    .foregroundStyle(theme.text(.textSecondary))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .level(.tertiary)
+                        }
+                    }
+                    .level(.secondary)
+                }
+            }
+            .elevation(.soft)
+
+            // asChild companion: chrome on an arbitrary view
+            Text("surfaceChrome on a plain Text")
+                .textStyle(.bodyBase400)
+                .foregroundStyle(theme.text(.textSecondary))
+                .padding(Theme.SpacingKey.md.value)
+                .surfaceChrome(.secondary, radius: .field)
+        }
+        .padding()
+    }
+    .background(theme.background(.bgBase))
+}
+
+#Preview("Dark theme") {
+    let darkTheme: Theme = {
+        let t = Theme()
+        t.loadTheme(named: Theme.defaultThemeName, dark: true)
+        return t
+    }()
+    return ScrollView {
+        VStack(spacing: Theme.SpacingKey.md.value) {
+            ForEach(SurfaceLevel.allCases, id: \.self) { level in
+                SurfaceView {
+                    Text(String(describing: level))
+                        .textStyle(.labelMd600)
+                        .foregroundStyle(darkTheme.text(.textPrimary))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .level(level)
+            }
+            SurfaceView {
+                SurfaceView {
+                    SurfaceView {
+                        Text("Primary > Secondary > Tertiary")
+                            .textStyle(.labelSm600)
+                            .foregroundStyle(darkTheme.text(.textSecondary))
+                    }
+                    .level(.tertiary)
+                }
+                .level(.secondary)
+            }
+            .elevation(.soft)
+        }
+        .padding()
+    }
+    .background(darkTheme.background(.bgBase))
+    .theme(darkTheme)
+    .preferredColorScheme(.dark)
+}

--- a/Sources/ThemeKit/Components/Molecules/ControlRow.swift
+++ b/Sources/ThemeKit/Components/Molecules/ControlRow.swift
@@ -1,0 +1,241 @@
+//
+//  ControlRow.swift
+//  ThemeKit
+//  Created by İsa Mercan on 09.07.2026.
+//
+
+import SwiftUI
+
+/// Boolean control archetype rendered in a `ControlRow`'s trailing slot.
+/// (Reference ControlField.Indicator `variant` parity.)
+public enum ControlRowControl: Equatable {
+    /// A `ThemeToggle` switch (the default).
+    case toggle
+    /// A `Checkbox` box.
+    case checkbox
+    /// A `RadioButton` dot.
+    case radio
+}
+
+/// Molecule. A single form field fusing an `InputLabel`, optional supporting
+/// text and a boolean control (toggle / checkbox / radio) into one pressable
+/// row with validation. (Reference ControlField parity.) Per the modifier-based
+/// architecture (COMPONENT_REFACTOR_RULES R1–R7) the init takes only its title
+/// and the `isOn` binding; every appearance/validation axis is a chainable,
+/// order-free modifier. `disabled` is native (`@Environment(\.isEnabled)`, R3);
+/// the indicator inherits the native `.controlSize(_:)` cascade.
+///
+///     ControlRow("I agree to the terms", isOn: $accepted)
+///         .control(.checkbox)
+///         .description("By checking this box, you agree to our Terms of Service.")
+///         .required()
+///         .hasError(showErrors && !accepted)
+///         .errorText("This field is required.")
+///         .disabled(!editable)            // native — R3
+public struct ControlRow: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
+
+    @Binding private var isOn: Bool
+    private let title: String
+
+    // Appearance/validation — mutated only through the modifiers below (R2).
+    private var description: String?
+    private var control: ControlRowControl = .toggle
+    private var customIndicator: AnyView?
+    private var isRequired = false
+    private var hasError = false
+    private var errorText: String?
+    private var accessibilityID: String?
+
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
+
+    public init(_ title: String, isOn: Binding<Bool>) {   // R1 — content + binding
+        self.title = title
+        self._isOn = isOn
+    }
+
+    /// The error line renders only while `hasError` is on (the recolor axis
+    /// gates the message, TextInput `errorText` convention).
+    private var showsError: Bool { hasError && errorText != nil }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
+            Button {
+                withAnimation(motion) { isOn.toggle() }
+            } label: {
+                HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
+                    VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
+                        InputLabel(title)
+                            .required(isRequired)
+                            .hasError(hasError)
+                        if let description {
+                            Text(description)
+                                .textStyle(.bodySm400)
+                                .foregroundStyle(descriptionColor)
+                        }
+                    }
+                    Spacer(minLength: Theme.SpacingKey.sm.value)
+                    indicator
+                        .accessibilityHidden(true)   // the row is the single a11y element
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(PressFeedbackStyle())   // subtle press scale, gated by microAnimations + Reduce Motion
+            .disabled(!isEnabled)
+            .opacity(isEnabled ? 1 : 0.6)
+            .a11y(controlElement, in: accessibilityID)
+            .accessibilityLabel(title)
+            .accessibilityValue(isOn ? String(themeKit: "on") : String(themeKit: "off"))
+            .accessibilityHint(accessibilityHint)
+            .accessibilityAddTraits(isOn ? .isSelected : [])
+
+            if showsError, let errorText {
+                Text(errorText)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(theme.foreground(.systemcolorsFgError))
+                    .transition(.opacity)
+                    .a11y(A11yElement.Field.message, in: accessibilityID)
+            }
+        }
+        .animation(motion, value: showsError)
+    }
+
+    /// Trailing boolean control: the custom slot when set, else the archetype
+    /// from `control(_:)` — all driven by the same `isOn` binding, so a tap on
+    /// the indicator and a tap on the row stay in sync.
+    @ViewBuilder
+    private var indicator: some View {
+        if let customIndicator {
+            customIndicator
+        } else {
+            switch control {
+            case .toggle: ThemeToggle(isOn: $isOn)
+            case .checkbox: Checkbox(isChecked: $isOn)
+            case .radio: RadioButton(isSelected: $isOn)
+            }
+        }
+    }
+
+    private var descriptionColor: Color {
+        if hasError { return theme.foreground(.systemcolorsFgError) }
+        return theme.text(isEnabled ? .textSecondary : .textDisabled)
+    }
+
+    private var controlElement: A11yElement.Control {
+        switch control {
+        case .toggle: return .toggle
+        case .checkbox: return .checkbox
+        case .radio: return .radio
+        }
+    }
+
+    /// Description + (while errored) the error text, so VoiceOver reads the
+    /// supporting copy and the validation message on the single row element.
+    private var accessibilityHint: String {
+        var parts: [String] = []
+        if let description { parts.append(description) }
+        if showsError, let errorText { parts.append(errorText) }
+        return parts.joined(separator: ". ")
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension ControlRow {
+    /// Supporting text rendered under the label.
+    func description(_ text: String?) -> Self { copy { $0.description = text } }
+
+    /// Which boolean control renders in the trailing slot: `.toggle` (default),
+    /// `.checkbox`, or `.radio`. Ignored when a custom `indicator` is set.
+    func control(_ kind: ControlRowControl) -> Self { copy { $0.control = kind } }
+
+    /// Replaces the built-in control with a custom trailing indicator view.
+    /// The row press still toggles `isOn`; keep the slot purely visual.
+    func indicator(@ViewBuilder _ content: () -> some View) -> Self {
+        copy { $0.customIndicator = AnyView(content()) }
+    }
+
+    /// Append a required asterisk after the label text (via `InputLabel`).
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
+
+    /// Render the label + description in the error color and unlock the
+    /// `errorText(_:)` line.
+    func hasError(_ on: Bool = true) -> Self { copy { $0.hasError = on } }
+
+    /// Validation message rendered under the row — shown only while `hasError`.
+    func errorText(_ text: String?) -> Self { copy { $0.errorText = text } }
+
+    /// Sets the accessibility-identifier namespace for this component (its
+    /// sub-elements get `"<id>.<element>"`).
+    func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+#Preview("States") {
+    struct Demo: View {
+        @State var notifications = true
+        @State var terms = false
+        @State var remember = true
+        @State var marketing = false
+        @State var starred = true
+        var body: some View {
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                ControlRow("Enable notifications", isOn: $notifications)
+                    .description("Receive push notifications about your account activity.")
+                ControlRow("I agree to the terms", isOn: $terms)
+                    .control(.checkbox)
+                    .description("By checking this box, you agree to our Terms of Service.")
+                    .required()
+                    .hasError(!terms)
+                    .errorText("This field is required.")
+                    .a11yID("terms")
+                ControlRow("Remember me", isOn: $remember)
+                    .control(.radio)
+                ControlRow("Marketing emails", isOn: $marketing)
+                    .description("Occasional product updates and offers.")
+                    .disabled(true)
+                ControlRow("Star this item", isOn: $starred)
+                    .indicator {
+                        Image(systemName: starred ? "star.fill" : "star")
+                            .foregroundStyle(Theme.shared.foreground(.fgHero))
+                    }
+            }
+            .padding()
+        }
+    }
+    return Demo().environment(Theme.shared)
+}
+
+#Preview("Dark / themed") {
+    struct Demo: View {
+        @State var notifications = true
+        @State var terms = false
+        var body: some View {
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                ControlRow("Enable notifications", isOn: $notifications)
+                    .description("Receive push notifications about your account activity.")
+                ControlRow("I agree to the terms", isOn: $terms)
+                    .control(.checkbox)
+                    .required()
+                    .hasError(!terms)
+                    .errorText("This field is required.")
+                ControlRow("Small control", isOn: $notifications)
+                    .controlSize(.small)
+            }
+            .padding()
+        }
+    }
+    let dark = Theme()
+    dark.loadTheme(named: Theme.defaultThemeName, dark: true)
+    return Demo()
+        .background(dark.background(.bgBase))
+        .theme(dark)
+}

--- a/Sources/ThemeKit/Components/Molecules/ControlRow.swift
+++ b/Sources/ThemeKit/Components/Molecules/ControlRow.swift
@@ -33,7 +33,6 @@ public enum ControlRowControl: Equatable {
 ///         .errorText("This field is required.")
 ///         .disabled(!editable)            // native — R3
 public struct ControlRow: View {
-    @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
 
     @Binding private var isOn: Bool
@@ -72,9 +71,8 @@ public struct ControlRow: View {
                             .required(isRequired)
                             .hasError(hasError)
                         if let description {
-                            Text(description)
-                                .textStyle(.bodySm400)
-                                .foregroundStyle(descriptionColor)
+                            HelperText(description)
+                                .hasError(hasError)
                         }
                     }
                     Spacer(minLength: Theme.SpacingKey.sm.value)
@@ -87,15 +85,13 @@ public struct ControlRow: View {
             .disabled(!isEnabled)
             .opacity(isEnabled ? 1 : 0.6)
             .a11y(controlElement, in: accessibilityID)
-            .accessibilityLabel(title)
+            .accessibilityLabel(isRequired ? title + ", " + String(themeKit: "required") : title)
             .accessibilityValue(isOn ? String(themeKit: "on") : String(themeKit: "off"))
             .accessibilityHint(accessibilityHint)
             .accessibilityAddTraits(isOn ? .isSelected : [])
 
             if showsError, let errorText {
-                Text(errorText)
-                    .textStyle(.bodySm400)
-                    .foregroundStyle(theme.foreground(.systemcolorsFgError))
+                InfoMessageList([InfoMessage(errorText, kind: .error)])
                     .transition(.opacity)
                     .a11y(A11yElement.Field.message, in: accessibilityID)
             }
@@ -117,11 +113,6 @@ public struct ControlRow: View {
             case .radio: RadioButton(isSelected: $isOn)
             }
         }
-    }
-
-    private var descriptionColor: Color {
-        if hasError { return theme.foreground(.systemcolorsFgError) }
-        return theme.text(isEnabled ? .textSecondary : .textDisabled)
     }
 
     private var controlElement: A11yElement.Control {

--- a/Sources/ThemeKit/Components/Molecules/ScrollShadow.swift
+++ b/Sources/ThemeKit/Components/Molecules/ScrollShadow.swift
@@ -1,0 +1,304 @@
+//
+//  ScrollShadow.swift
+//  ThemeKit
+//  Created by İsa Mercan on 09.07.2026.
+//
+//  Molecule. HeroUI Native's **ScrollShadow** — wraps a caller-provided scroll
+//  view and fades its clipped edges with token-fed gradient scrims that react to
+//  the scroll position, hinting that more content lies beyond the fold.
+//
+//  The content is *the caller's* `ScrollView`/`List`; ScrollShadow never creates
+//  its own. Because SwiftUI cannot introspect the child's scroll axis, set it
+//  explicitly with `.axis(.horizontal)` when wrapping a horizontal scroller.
+//
+//  Scroll detection: on iOS 18 / macOS 15+ the component observes the wrapped
+//  scroll view with `onScrollGeometryChange`, so `.auto` shows the start scrim
+//  once the content is scrolled away from its start (offset > 0) and the end
+//  scrim while more content remains (offset + viewport < content size). On the
+//  package's minimum OSes (iOS 17 / macOS 14) that observation API does not
+//  exist, so `.auto` degrades to always-on scrims at both edges (`.both`
+//  behavior); the explicit `.start` / `.end` / `.both` / `.none` modes are
+//  position-independent and behave identically on every supported OS.
+//
+
+import SwiftUI
+
+/// Which edge scrims a ``ScrollShadow`` shows. Start/end vocabulary (rather than
+/// top/bottom/left/right) keeps the API RTL-safe: for a vertical axis *start* is
+/// the top edge and *end* the bottom; for a horizontal axis *start* is the
+/// leading edge and *end* the trailing edge, mirroring automatically under
+/// right-to-left layouts. (HeroUI's separate `isEnabled` flag collapses into
+/// `.none` here — disabling is just another visibility.)
+public enum ScrollShadowVisibility: String, CaseIterable, Sendable {
+    /// Scrims follow the scroll position (iOS 18 / macOS 15+); on older OSes
+    /// this degrades to `.both`. The default.
+    case auto
+    /// Only the start (top / leading) scrim, always on.
+    case start
+    /// Only the end (bottom / trailing) scrim, always on.
+    case end
+    /// Both scrims, always on.
+    case both
+    /// No scrims — the effect is disabled.
+    case none
+}
+
+/// Fades the clipped edges of a wrapped scroll view with theme-fed gradient
+/// scrims — ThemeKit's port of HeroUI Native's `ScrollShadow`.
+///
+/// ```swift
+/// ScrollShadow {
+///     ScrollView { articleBody }
+/// }
+///
+/// ScrollShadow {
+///     ScrollView(.horizontal) { chipRow }
+/// }
+/// .axis(.horizontal)
+/// .length(.lg)
+/// .fadeColor(.bgWhite)
+/// ```
+///
+/// The scrims are purely decorative: they never intercept touches and are
+/// hidden from assistive technologies. Their opacity animates with the theme's
+/// fast motion token when a threshold crosses, and snaps instantly when the
+/// system Reduce Motion setting (or `.microAnimations(false)`) is active.
+public struct ScrollShadow<Content: View>: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let content: Content
+
+    // Appearance — mutated only through the modifiers below (R2).
+    private var axis: Axis = .vertical
+    private var visibility: ScrollShadowVisibility = .auto
+    private var lengthKey: Theme.SpacingKey = .xl          // 40pt ≈ HeroUI's 50px default
+    private var fadeKey: Theme.BackgroundColorKey = .bgBase
+
+    // Scroll metrics (iOS 18 / macOS 15+ only) — local UI state, nothing more.
+    @State private var isScrolledFromStart = false
+    @State private var hasTrailingOverflow = false
+
+    /// Wraps `content` — the caller's `ScrollView`/`List` — with edge scrims.
+    public init(@ViewBuilder content: () -> Content) {   // R1: content only
+        self.content = content()
+    }
+
+    public var body: some View {
+        if #available(iOS 18.0, macOS 15.0, *) {
+            observed.modifier(scrims(
+                start: showsStart(auto: isScrolledFromStart),
+                end: showsEnd(auto: hasTrailingOverflow)))
+        } else {
+            // No scroll observation below iOS 18 / macOS 15: `.auto` → `.both`.
+            content.modifier(scrims(
+                start: showsStart(auto: true),
+                end: showsEnd(auto: true)))
+        }
+    }
+
+    // MARK: Scroll observation (iOS 18 / macOS 15+)
+
+    @available(iOS 18.0, macOS 15.0, *)
+    private var observed: some View {
+        let axis = axis   // capture the value, not the view struct
+        return content.onScrollGeometryChange(for: ScrollShadowEdgeState.self) { geometry in
+            ScrollShadowEdgeState(geometry: geometry, axis: axis)
+        } action: { _, state in
+            isScrolledFromStart = state.isScrolledFromStart
+            hasTrailingOverflow = state.hasTrailingOverflow
+        }
+    }
+
+    // MARK: Visibility resolution
+
+    private func showsStart(auto: Bool) -> Bool {
+        switch visibility {
+        case .auto: return auto
+        case .start, .both: return true
+        case .end, .none: return false
+        }
+    }
+
+    private func showsEnd(auto: Bool) -> Bool {
+        switch visibility {
+        case .auto: return auto
+        case .end, .both: return true
+        case .start, .none: return false
+        }
+    }
+
+    // MARK: Scrim chrome
+
+    private func scrims(start: Bool, end: Bool) -> ScrollShadowScrims {
+        ScrollShadowScrims(
+            axis: axis,
+            showsStart: start,
+            showsEnd: end,
+            length: theme.spacing(lengthKey),
+            fill: theme.background(fadeKey),
+            motion: MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion))
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · single mutation point)
+
+public extension ScrollShadow {
+    /// The scroll axis of the wrapped content (default `.vertical`). Explicit
+    /// because SwiftUI cannot introspect the child scroll view's axis.
+    func axis(_ axis: Axis) -> Self { copy { $0.axis = axis } }
+    /// Which edge scrims to show (default `.auto`). See ``ScrollShadowVisibility``.
+    func visibility(_ v: ScrollShadowVisibility) -> Self { copy { $0.visibility = v } }
+    /// Scrim depth along the scroll axis, as a spacing token (default `.xl`).
+    func length(_ key: Theme.SpacingKey) -> Self { copy { $0.lengthKey = key } }
+    /// The surface the scrims fade from (default `.bgBase`) — match it to the
+    /// background the scroll view sits on so the fade reads as depth, not tint.
+    func fadeColor(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.fadeKey = key } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+// MARK: - Private chrome
+
+/// Overlays the two edge scrims. Alignments and gradient anchors use
+/// leading/trailing `UnitPoint`s only, so horizontal scrims mirror under RTL.
+private struct ScrollShadowScrims: ViewModifier {
+    let axis: Axis
+    let showsStart: Bool
+    let showsEnd: Bool
+    let length: CGFloat
+    let fill: Color
+    let motion: Animation?
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: axis == .vertical ? .top : .leading) {
+                scrim(visible: showsStart,
+                      from: axis == .vertical ? .top : .leading,
+                      to: axis == .vertical ? .bottom : .trailing)
+            }
+            .overlay(alignment: axis == .vertical ? .bottom : .trailing) {
+                scrim(visible: showsEnd,
+                      from: axis == .vertical ? .bottom : .trailing,
+                      to: axis == .vertical ? .top : .leading)
+            }
+    }
+
+    private func scrim(visible: Bool, from: UnitPoint, to: UnitPoint) -> some View {
+        LinearGradient(colors: [fill, fill.opacity(0)], startPoint: from, endPoint: to)
+            .frame(width: axis == .horizontal ? length : nil,
+                   height: axis == .vertical ? length : nil)
+            .opacity(visible ? 1 : 0)
+            .animation(motion, value: visible)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Scroll metrics (iOS 18 / macOS 15+)
+
+@available(iOS 18.0, macOS 15.0, *)
+private struct ScrollShadowEdgeState: Equatable {
+    var isScrolledFromStart: Bool
+    var hasTrailingOverflow: Bool
+
+    init(geometry: ScrollGeometry, axis: Axis) {
+        let epsilon: CGFloat = 1   // sub-point jitter shouldn't flicker the scrims
+        let offset: CGFloat
+        let viewport: CGFloat
+        let contentLength: CGFloat
+        switch axis {
+        case .vertical:
+            offset = geometry.contentOffset.y + geometry.contentInsets.top
+            viewport = geometry.containerSize.height
+            contentLength = geometry.contentSize.height
+        case .horizontal:
+            offset = geometry.contentOffset.x + geometry.contentInsets.leading
+            viewport = geometry.containerSize.width
+            contentLength = geometry.contentSize.width
+        }
+        isScrolledFromStart = offset > epsilon
+        hasTrailingOverflow = offset + viewport < contentLength - epsilon
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Vertical · visibility modes") {
+    HStack(alignment: .top, spacing: Theme.SpacingKey.md.value) {
+        ForEach(ScrollShadowVisibility.allCases, id: \.self) { mode in
+            VStack(spacing: Theme.SpacingKey.xs.value) {
+                Text(mode.rawValue)
+                    .textStyle(.labelSm600)
+                    .foregroundStyle(Theme.shared.text(.textSecondary))
+                ScrollShadow {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                            ForEach(1..<21) { line in
+                                Text("Line \(line)")
+                                    .textStyle(.bodySm400)
+                                    .foregroundStyle(Theme.shared.text(.textPrimary))
+                            }
+                        }
+                        .padding(Theme.SpacingKey.sm.value)
+                    }
+                }
+                .visibility(mode)
+                .length(.lg)
+                .frame(height: 180)
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+    .padding()
+    .background(Theme.shared.background(.bgBase))
+}
+
+#Preview("Horizontal · chip row") {
+    VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+        Text("Filters")
+            .textStyle(.headingSm)
+            .foregroundStyle(Theme.shared.text(.textPrimary))
+        ScrollShadow {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    ForEach(["Nonstop", "1 stop", "Morning", "Evening",
+                             "Refundable", "Baggage included", "Window seat"], id: \.self) { title in
+                        Chip(title, isSelected: .constant(false))
+                    }
+                }
+                .padding(.horizontal, Theme.SpacingKey.md.value)
+            }
+        }
+        .axis(.horizontal)
+        .length(.md)
+    }
+    .padding(.vertical)
+    .background(Theme.shared.background(.bgBase))
+}
+
+#Preview("Themed fade · dark") {
+    ScrollShadow {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                ForEach(1..<26) { line in
+                    Text("Terms & conditions, clause \(line)")
+                        .textStyle(.bodyBase400)
+                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                }
+            }
+            .padding(Theme.SpacingKey.md.value)
+        }
+    }
+    .visibility(.both)
+    .fadeColor(.bgSecondaryLight)
+    .frame(height: 260)
+    .background(Theme.shared.background(.bgSecondaryLight))
+    .padding()
+    .preferredColorScheme(.dark)
+}

--- a/Sources/ThemeKit/Components/Molecules/ScrollShadow.swift
+++ b/Sources/ThemeKit/Components/Molecules/ScrollShadow.swift
@@ -14,8 +14,12 @@
 //  Scroll detection: on iOS 18 / macOS 15+ the component observes the wrapped
 //  scroll view with `onScrollGeometryChange`, so `.auto` shows the start scrim
 //  once the content is scrolled away from its start (offset > 0) and the end
-//  scrim while more content remains (offset + viewport < content size). On the
-//  package's minimum OSes (iOS 17 / macOS 14) that observation API does not
+//  scrim while more content remains (offset + viewport < content size). For a
+//  horizontal axis the physical offset is normalized to logical-start
+//  coordinates under right-to-left layout, so "start" always means the leading
+//  edge — the visual right in RTL.
+//
+//  On the package's minimum OSes (iOS 17 / macOS 14) that observation API does not
 //  exist, so `.auto` degrades to always-on scrims at both edges (`.both`
 //  behavior); the explicit `.start` / `.end` / `.both` / `.none` modes are
 //  position-independent and behave identically on every supported OS.
@@ -65,6 +69,7 @@ public enum ScrollShadowVisibility: String, CaseIterable, Sendable {
 /// system Reduce Motion setting (or `.microAnimations(false)`) is active.
 public struct ScrollShadow<Content: View>: View {
     @Environment(\.theme) private var theme
+    @Environment(\.layoutDirection) private var layoutDirection
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -102,9 +107,10 @@ public struct ScrollShadow<Content: View>: View {
 
     @available(iOS 18.0, macOS 15.0, *)
     private var observed: some View {
-        let axis = axis   // capture the value, not the view struct
+        let axis = axis                         // capture the values, not the view struct
+        let layoutDirection = layoutDirection
         return content.onScrollGeometryChange(for: ScrollShadowEdgeState.self) { geometry in
-            ScrollShadowEdgeState(geometry: geometry, axis: axis)
+            ScrollShadowEdgeState(geometry: geometry, axis: axis, layoutDirection: layoutDirection)
         } action: { _, state in
             isScrolledFromStart = state.isScrolledFromStart
             hasTrailingOverflow = state.hasTrailingOverflow
@@ -207,7 +213,7 @@ private struct ScrollShadowEdgeState: Equatable {
     var isScrolledFromStart: Bool
     var hasTrailingOverflow: Bool
 
-    init(geometry: ScrollGeometry, axis: Axis) {
+    init(geometry: ScrollGeometry, axis: Axis, layoutDirection: LayoutDirection) {
         let epsilon: CGFloat = 1   // sub-point jitter shouldn't flicker the scrims
         let offset: CGFloat
         let viewport: CGFloat
@@ -218,9 +224,18 @@ private struct ScrollShadowEdgeState: Equatable {
             viewport = geometry.containerSize.height
             contentLength = geometry.contentSize.height
         case .horizontal:
-            offset = geometry.contentOffset.x + geometry.contentInsets.leading
             viewport = geometry.containerSize.width
             contentLength = geometry.contentSize.width
+            if layoutDirection == .rightToLeft {
+                // `contentOffset` is physical: a right-to-left horizontal
+                // scroller *rests* at its maximum x (content starts at the
+                // visual right), so normalize to logical-start coordinates —
+                // distance scrolled away from the leading (right) edge.
+                offset = contentLength + geometry.contentInsets.leading
+                    - viewport - geometry.contentOffset.x
+            } else {
+                offset = geometry.contentOffset.x + geometry.contentInsets.leading
+            }
         }
         isScrolledFromStart = offset > epsilon
         hasTrailingOverflow = offset + viewport < contentLength - epsilon

--- a/Sources/ThemeKit/Resources/Localizable.xcstrings
+++ b/Sources/ThemeKit/Resources/Localizable.xcstrings
@@ -1282,6 +1282,17 @@
         }
       }
     },
+    "required" : {
+      "comment" : "Accessibility suffix announced for a required form field.",
+      "localizations" : {
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zorunlu"
+          }
+        }
+      }
+    },
     "selected" : {
       "comment" : "Checkbox / radio accessibility value: selected.",
       "localizations" : {


### PR DESCRIPTION
## Summary

Audited ThemeKit against the full **HeroUI Native** component set (38 components), judged by role rather than name. Outcome: 5 fully covered, 27 partial (prioritized gap plans documented), 6 missing — all 6 built on this branch following the `themekit-authoring` conventions (stateless value-type views, chainable copy-on-write modifiers, token-fed styling, a11y/localization/RTL by construction).

### New components

| Component | Tier | Ports | File |
|---|---|---|---|
| `CloseButton` | Atom | close-button | `Sources/ThemeKit/Components/Atoms/CloseButton.swift` |
| `HelperText` | Atom | description | `Sources/ThemeKit/Components/Atoms/HelperText.swift` |
| `SurfaceView` | Atom | surface | `Sources/ThemeKit/Components/Atoms/SurfaceView.swift` |
| `SkeletonGroup` | Atom | skeleton-group | `Sources/ThemeKit/Components/Atoms/SkeletonGroup.swift` |
| `ControlRow` | Molecule | control-field | `Sources/ThemeKit/Components/Molecules/ControlRow.swift` |
| `ScrollShadow` | Molecule | scroll-shadow | `Sources/ThemeKit/Components/Molecules/ScrollShadow.swift` |

### Also in this PR

- **`HEROUI_NATIVE_AUDIT.md`** — coverage map for all 38 HeroUI components and actionable, prioritized gap plans for the 27 partial ones (each executable as a follow-up PR).
- **Demo gallery registration** — all six components registered in `ComponentRegistry` with interactive demos in `AtomDemos`/`MoleculeDemos` (additive edits only).
- **Review fixes** — the diff was reviewed through three lenses (house-rules, Swift/SwiftUI correctness, a11y/l10n/RTL); 7 findings fixed, including a Swift 6 strict-concurrency issue in `SkeletonGroup`'s EnvironmentKey, RTL-inverted edge detection in `ScrollShadow`, and `ControlRow` now composing `InfoMessageList`/`HelperText` like sibling field molecules.
- `Localizable.xcstrings`: new `required` key (VoiceOver suffix for required fields).

### Notes

- HeroUI React-isms (className, render props, raw animation knobs) were translated to ThemeKit idioms (token keys, style enums, MicroMotion/Reduce Motion gates) rather than ported literally.
- No existing component files were modified; all changes are additive.
- No Swift toolchain exists in the authoring environment — every token/API reference was cross-checked against its real declaration, but a local Xcode build + snapshot run is recommended before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NurTVFpssqcMiR3BBb2H24

---
_Generated by [Claude Code](https://claude.ai/code/session_01NurTVFpssqcMiR3BBb2H24)_