### PR TITLE
fix(a11y): accessibility labels for icon-only controls

### DIFF
--- a/Sources/ThemeKit/Components/Molecules/CalendarView.swift
+++ b/Sources/ThemeKit/Components/Molecules/CalendarView.swift
@@ -50,17 +50,17 @@ public struct CalendarView: View {
 
     private var header: some View {
         HStack {
-            navButton("chevron.left", months: -1)
+            navButton("chevron.left", label: String(themeKit: "Previous month"), months: -1)
             Spacer()
             Text(displayed.formatted(.dateTime.month(.wide).year().locale(locale)))
                 .textStyle(.labelMd700)
                 .foregroundStyle(theme.text(.textPrimary))
             Spacer()
-            navButton("chevron.right", months: 1)
+            navButton("chevron.right", label: String(themeKit: "Next month"), months: 1)
         }
     }
 
-    private func navButton(_ name: String, months: Int) -> some View {
+    private func navButton(_ name: String, label: String, months: Int) -> some View {
         Button {
             if let d = calendar.date(byAdding: .month, value: months, to: monthStart) {
                 withAnimation(Motion.fast.animation) { displayed = d }
@@ -71,6 +71,7 @@ public struct CalendarView: View {
                 .mirrorsInRTL()
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(label)
     }
 
     private var weekdayRow: some View {

--- a/Sources/ThemeKit/Components/Molecules/ColorField.swift
+++ b/Sources/ThemeKit/Components/Molecules/ColorField.swift
@@ -51,6 +51,7 @@ public struct ColorField: View {
             Spacer(minLength: 0)
             ColorPicker("", selection: $selection, supportsOpacity: supportsOpacity)
                 .labelsHidden()
+                .accessibilityLabel(label)
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
         .frame(height: 52)

--- a/Sources/ThemeKit/Components/Molecules/Transfer.swift
+++ b/Sources/ThemeKit/Components/Molecules/Transfer.swift
@@ -46,8 +46,8 @@ public struct Transfer: View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
             listBox(titles.0, items: source)
             VStack(spacing: Theme.SpacingKey.sm.value) {
-                arrow("chevron.right", enabled: checkedInSource, action: moveToTarget)
-                arrow("chevron.left", enabled: checkedInTarget, action: moveToSource)
+                arrow("chevron.right", label: String(themeKit: "Move to \(titles.1)"), enabled: checkedInSource, action: moveToTarget)
+                arrow("chevron.left", label: String(themeKit: "Move to \(titles.0)"), enabled: checkedInTarget, action: moveToSource)
             }
             listBox(titles.1, items: targeted)
         }
@@ -100,7 +100,7 @@ public struct Transfer: View {
         .buttonStyle(.plain)
     }
 
-    private func arrow(_ systemImage: String, enabled: Bool, action: @escaping () -> Void) -> some View {
+    private func arrow(_ systemImage: String, label: String, enabled: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: systemImage)
                 .font(.system(size: 13, weight: .semibold))
@@ -111,6 +111,7 @@ public struct Transfer: View {
         }
         .buttonStyle(.plain)
         .disabled(!enabled)
+        .accessibilityLabel(label)
     }
 
     private func moveToTarget() {

--- a/Sources/ThemeKit/Components/Organisms/Carousel.swift
+++ b/Sources/ThemeKit/Components/Organisms/Carousel.swift
@@ -97,9 +97,9 @@ public struct Carousel<Item: Identifiable, Content: View>: View {
 
                 if showsArrows && count > 1 {
                     HStack {
-                        arrow("chevron.left") { advance(-1) }
+                        arrow("chevron.left", label: String(themeKit: "Previous")) { advance(-1) }
                         Spacer()
-                        arrow("chevron.right") { advance(1) }
+                        arrow("chevron.right", label: String(themeKit: "Next")) { advance(1) }
                     }
                     .padding(.horizontal, Theme.SpacingKey.sm.value)
                 }
@@ -170,7 +170,7 @@ public struct Carousel<Item: Identifiable, Content: View>: View {
         }
     }
 
-    private func arrow(_ systemName: String, action: @escaping () -> Void) -> some View {
+    private func arrow(_ systemName: String, label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Icon(systemName: systemName).size(.sm).color(theme.foreground(.fgSecondary))
                 .frame(width: 32, height: 32)
@@ -178,6 +178,7 @@ public struct Carousel<Item: Identifiable, Content: View>: View {
                 .background(theme.background(.bgTertiary).opacity(0.5), in: Circle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(label)
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/FloatingActionButton.swift
+++ b/Sources/ThemeKit/Components/Organisms/FloatingActionButton.swift
@@ -67,7 +67,7 @@ public struct FloatingActionButton: View {
                                 .background(theme.background(.bgWhite), in: Capsule())
                                 .themeShadow(.soft)
                         }
-                        miniButton(item.systemImage) { item.action(); expanded = false }
+                        miniButton(item.systemImage, label: item.label ?? item.systemImage) { item.action(); expanded = false }
                     }
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
@@ -86,10 +86,13 @@ public struct FloatingActionButton: View {
                     .countBadge(badge ?? 0)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel(actions.isEmpty
+                ? String(themeKit: "Action")
+                : (expanded ? String(themeKit: "Collapse actions") : String(themeKit: "Expand actions")))
         }
     }
 
-    private func miniButton(_ name: String, action: @escaping () -> Void) -> some View {
+    private func miniButton(_ name: String, label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: name)
                 .font(.system(size: 16, weight: .semibold))
@@ -99,6 +102,7 @@ public struct FloatingActionButton: View {
                 .themeShadow(.soft)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(label)
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/VideoPlayerView.swift
+++ b/Sources/ThemeKit/Components/Organisms/VideoPlayerView.swift
@@ -145,6 +145,8 @@ private struct InlineVideo: View {
                     .onTapGesture {
                         if let onTap { onTap() } else { toggle() }
                     }
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel(isPlaying ? String(themeKit: "Pause") : String(themeKit: "Play"))
                 if !isPlaying {
                     Image(systemName: "play.circle.fill")
                         .font(.system(size: 56))
@@ -172,6 +174,7 @@ private struct InlineVideo: View {
                                 .background(.black.opacity(0.4), in: Circle())
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel(isMuted ? String(themeKit: "Unmute") : String(themeKit: "Mute"))
                         .padding(Theme.SpacingKey.md.value)
                     }
                 }
@@ -263,3 +266,17 @@ private struct SimpleVideoPlayer: NSViewRepresentable {
     func updateNSView(_ view: AVPlayerView, context: Context) {}
 }
 #endif
+
+#Preview {
+    // No bundled sample asset — the nil-URL placeholder stands in for the player
+    // (a live AVPlayer can't render in a static preview anyway).
+    VStack(spacing: 16) {
+        VideoPlayerView(nil)
+            .frame(width: 320, height: 180)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+        VideoPlayerView(nil).muteToggle().tapToToggle()
+            .frame(width: 320, height: 180)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+    .padding()
+}


### PR DESCRIPTION
Audit follow-up — adds VoiceOver labels to icon-only interactive controls flagged by the component audit (state-aware where relevant, localized via `String(themeKit:)`):

- **FloatingActionButton** — main button (Expand/Collapse actions) + speed-dial mini buttons
- **ColorField** — the `ColorPicker` well (was `labelsHidden` with no a11y label)
- **Transfer** — the move-across arrows (Move to <box>)
- **VideoPlayerView** — mute toggle (Mute/Unmute) + tap-to-toggle overlay (Play/Pause); also adds the missing `#Preview`
- **CalendarView** — month prev/next nav buttons
- **Carousel** — prev/next arrows

Remaining audit candidates (Tree*/DataTable/pickers) mostly announce readable text content already; a follow-up pass can add labels to their chevrons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)