### PR TITLE
fix(a11y): sort/disclosure/selected traits (audit round 2)

### DIFF
--- a/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
@@ -186,6 +186,7 @@ public struct MultiSelect<Option: Hashable>: View {
                     .buttonStyle(RowPressStyle())
                     .disabled(!enabled)
                     .opacity(enabled ? 1 : 0.4)
+                    .accessibilityAddTraits(selection.contains(opt) ? .isSelected : [])
                     if opt != filtered.last { DividerView().size(.small).padding(.leading, Theme.SpacingKey.md.value) }
                 }
             }

--- a/Sources/ThemeKit/Components/Molecules/Transfer.swift
+++ b/Sources/ThemeKit/Components/Molecules/Transfer.swift
@@ -98,6 +98,7 @@ public struct Transfer: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityAddTraits(isOn ? .isSelected : [])
     }
 
     private func arrow(_ systemImage: String, label: String, enabled: Bool, action: @escaping () -> Void) -> some View {

--- a/Sources/ThemeKit/Components/Molecules/TreeSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/TreeSelect.swift
@@ -175,6 +175,7 @@ public struct TreeSelect: View {
                         .mirrorsInRTL()
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(expanded.contains(node.id) ? String(themeKit: "Collapse") : String(themeKit: "Expand"))
             }
             Button { toggleSelect(node) } label: {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
@@ -193,6 +194,7 @@ public struct TreeSelect: View {
             .buttonStyle(RowPressStyle())
             .disabled(!enabled)
             .opacity(enabled ? 1 : 0.4)
+            .accessibilityAddTraits(checkState(node) == .on ? .isSelected : [])
         }
         .padding(.leading, CGFloat(depth) * 18 + Theme.SpacingKey.md.value)
         .padding(.trailing, Theme.SpacingKey.md.value)

--- a/Sources/ThemeKit/Components/Molecules/TreeView.swift
+++ b/Sources/ThemeKit/Components/Molecules/TreeView.swift
@@ -54,6 +54,7 @@ public struct TreeView: View {
             }
             .buttonStyle(.plain)
             .disabled(!hasChildren)
+            .accessibilityLabel(expanded.contains(node.id) ? String(themeKit: "Collapse") : String(themeKit: "Expand"))
 
             // Row body (checkbox + icon + title)
             Button { checkable ? toggleChecked(node) : toggleExpanded(node) } label: {
@@ -74,6 +75,7 @@ public struct TreeView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityAddTraits(checkable && isOn ? .isSelected : [])
         }
         .padding(.vertical, 5)
         .padding(.leading, CGFloat(depth) * Theme.SpacingKey.md.value)

--- a/Sources/ThemeKit/Components/Organisms/DataTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/DataTable.swift
@@ -188,6 +188,11 @@ public struct DataTable<Row: Identifiable>: View {
         if column.sortKey != nil {
             Button { toggleSort(index) } label: { title }
                 .buttonStyle(.plain)
+                .accessibilityLabel(column.title)
+                .accessibilityValue(sortColumn == index
+                    ? (sortAscending ? String(themeKit: "sorted ascending") : String(themeKit: "sorted descending"))
+                    : String(themeKit: "not sorted"))
+                .accessibilityHint(String(themeKit: "Double-tap to sort"))
         } else {
             title
         }


### PR DESCRIPTION
The top-value slice of the second a11y pass — announces **role + state** on controls that previously read only their text label:

- **DataTable** sort headers → `accessibilityValue` ("sorted ascending / descending / not sorted") + a "Double-tap to sort" hint
- **TreeView / TreeSelect** disclosure chevrons → "Expand" / "Collapse" labels
- **Selectable rows** → `.isSelected` trait: TreeView, TreeSelect, Transfer, MultiSelect option rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)