### PR TITLE
feat: HeroUI gap wave 1 — form-field parity (TextInput, SearchBar, OTPInput, InputLabel)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/InputLabel.swift
+++ b/Sources/ThemeKit/Components/Atoms/InputLabel.swift
@@ -70,6 +70,9 @@ public extension InputLabel {
         InputLabel("Email")
         InputLabel("Password").required().hasInfo()
         InputLabel("Invalid").hasError()
+        InputLabel("Disabled").disabled(true)
+        InputLabel("Disabled required").required().hasInfo().disabled(true)
+        InputLabel("Disabled error").hasError().disabled(true)
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Atoms/InputLabel.swift
+++ b/Sources/ThemeKit/Components/Atoms/InputLabel.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// glyph. Shared by the input components.
 public struct InputLabel: View {
     @Environment(\.theme) private var theme
+    @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)` (R5)
 
     // Appearance/state — mutated only through the modifiers below (R2).
     private var isRequired = false
@@ -26,14 +27,22 @@ public struct InputLabel: View {
         HStack(spacing: 4) {
             Text(text)
                 .textStyle(.labelSm600)
-                .foregroundStyle(hasError ? theme.foreground(.systemcolorsFgError) : theme.text(.textPrimary))
+                .foregroundStyle(textColor)
             if isRequired {
-                Text("*").textStyle(.labelSm600).foregroundStyle(theme.foreground(.systemcolorsFgError))
+                Text("*").textStyle(.labelSm600)
+                    .foregroundStyle(isEnabled ? theme.foreground(.systemcolorsFgError) : theme.text(.textDisabled))
             }
             if hasInfo {
-                Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(theme.text(.textTertiary))
+                Image(systemName: "info.circle").font(.system(size: 11))
+                    .foregroundStyle(isEnabled ? theme.text(.textTertiary) : theme.text(.textDisabled))
             }
         }
+    }
+
+    private var textColor: Color {
+        if hasError { return theme.foreground(.systemcolorsFgError) }
+        if !isEnabled { return theme.text(.textDisabled) }
+        return theme.text(.textPrimary)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/FieldStyle.swift
+++ b/Sources/ThemeKit/Components/Molecules/FieldStyle.swift
@@ -124,7 +124,7 @@ private struct MutedFieldChrome: View {
 
     var body: some View {
         configuration.content
-            .background(theme.background(.bgSecondaryLight),
+            .background(theme.background(configuration.isEnabled ? .bgSecondaryLight : .bgSecondary),
                         in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
             .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
             .overlay(

--- a/Sources/ThemeKit/Components/Molecules/FieldStyle.swift
+++ b/Sources/ThemeKit/Components/Molecules/FieldStyle.swift
@@ -4,8 +4,8 @@
 //
 //  The `ButtonStyle`-shaped styling hook for `TextInput`'s field. The field's
 //  *chrome* (fill, border, shape) lives in a `FieldStyle` you set with
-//  `.fieldStyle(_:)`, so the field can be reskinned — bordered, underlined —
-//  without editing `TextInput`. The interactive content (floating label, editor,
+//  `.fieldStyle(_:)`, so the field can be reskinned — bordered, underlined,
+//  muted — without editing `TextInput`. The interactive content (floating label, editor,
 //  icons/addons/clear/reveal and custom slots) stays in `TextInput` and arrives
 //  composed; the style only wraps it. Helper/error text and the character counter
 //  render *below* the field and are not part of the style. The default reproduces
@@ -99,9 +99,50 @@ private struct UnderlinedFieldChrome: View {
     }
 }
 
+/// A muted, on-surface field (HeroUI Input `variant="secondary"`): secondary-light
+/// fill, no shadow, and a border that stays transparent until it has something to
+/// say — hero on focus, error/warning tokens on validation. For fields sitting on
+/// a white card where the stock white fill + resting border would disappear.
+public struct MutedFieldStyle: FieldStyle {
+    public init() {}
+    public func makeBody(configuration: FieldStyleConfiguration) -> some View {
+        MutedFieldChrome(configuration: configuration)
+    }
+}
+
+private struct MutedFieldChrome: View {
+    let configuration: FieldStyleConfiguration
+    @Environment(\.theme) private var theme
+
+    /// Transparent at rest; recolors only for focus / validation.
+    private var borderColor: Color {
+        if configuration.hasError { return theme.border(.systemcolorsBorderError) }
+        if configuration.hasWarning { return theme.border(.systemcolorsBorderWarning) }
+        if configuration.isFocused { return theme.border(.borderHero) }
+        return .clear
+    }
+
+    var body: some View {
+        configuration.content
+            .background(theme.background(.bgSecondaryLight),
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
+                    .strokeBorder(borderColor,
+                                  lineWidth: configuration.isFocused || configuration.hasError || configuration.hasWarning ? 1.5 : 1)
+            )
+    }
+}
+
 public extension FieldStyle where Self == DefaultFieldStyle {
     /// The stock bordered field (white fill + state-driven border).
     static var `default`: DefaultFieldStyle { DefaultFieldStyle() }
+}
+
+public extension FieldStyle where Self == MutedFieldStyle {
+    /// A muted on-surface field: secondary-light fill, border only on focus / validation.
+    static var muted: MutedFieldStyle { MutedFieldStyle() }
 }
 
 public extension FieldStyle where Self == UnderlinedFieldStyle {

--- a/Sources/ThemeKit/Components/Molecules/MultiLineTextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiLineTextInput.swift
@@ -26,6 +26,8 @@ public struct MultiLineTextInput: View {
     @Binding private var text: String
     private let label: String
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Appearance / validation — mutated only through the modifiers below (R2).
     private var placeholder: String = ""
@@ -36,6 +38,10 @@ public struct MultiLineTextInput: View {
     private var minHeightOverride: CGFloat?
     private var countStyle: TextInputCountStyle = .count
     private var accessibilityID: String?
+
+    /// Marks the editor as required: asterisk after the header label + ", required"
+    /// appended to the accessibility label (HeroUI `isRequired`, TextInput parity).
+    private var isRequired = false
 
     @FocusState private var isFocused: Bool
 
@@ -69,10 +75,18 @@ public struct MultiLineTextInput: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
-            Text(label)
-                .textStyle(.labelSm600)
-                .foregroundStyle(labelColor)
-                .a11y(A11yElement.Field.label, in: accessibilityID)
+            HStack(spacing: 4) {   // matches the `InputLabel` atom's asterisk gap
+                Text(label)
+                    .foregroundStyle(labelColor)
+                if isRequired {
+                    // Same treatment as `InputLabel.required()` — error-token asterisk.
+                    Text(verbatim: "*")
+                        .foregroundStyle(theme.foreground(.systemcolorsFgError))
+                        .accessibilityHidden(true)   // spoken via the editor's label suffix
+                }
+            }
+            .textStyle(.labelSm600)
+            .a11y(A11yElement.Field.label, in: accessibilityID)
 
             editorBox
 
@@ -87,6 +101,9 @@ public struct MultiLineTextInput: View {
                 }
             }
         }
+        // Animate message rows in/out (their `.transition` lives in
+        // `InfoMessageList`); gated by `microAnimations` + Reduce Motion.
+        .animation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion), value: messages)
     }
 
     /// The editor + placeholder overlay, sized to `minHeight` — everything the
@@ -98,12 +115,13 @@ public struct MultiLineTextInput: View {
                 .focused($isFocused)
                 .textStyle(.bodyBase400)
                 .foregroundStyle(isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
-                .tint(theme.foreground(.fgHero))
+                // Caret / selection tint follows the validation state (HeroUI invalid caret).
+                .tint(theme.foreground(hasError ? .systemcolorsFgError : .fgHero))
                 .scrollContentBackground(.hidden)
                 .padding(8)
                 .disabled(!isEnabled)
                 .a11y(A11yElement.Field.field, in: accessibilityID)
-                .accessibilityLabel(label)
+                .accessibilityLabel(isRequired ? label + ", " + String(themeKit: "required") : label)
                 .accessibilityValue(text)
 
             if text.isEmpty {
@@ -173,6 +191,11 @@ public extension MultiLineTextInput {
     /// 120). An explicit `minHeight(_:)` wins regardless of order.
     func size(_ s: TextInputSize) -> Self { copy { $0.size = s } }
 
+    /// Marks the editor as required: renders an error-token asterisk after the
+    /// header label (the `InputLabel` treatment) and appends ", required" to the
+    /// editor's accessibility label (HeroUI `isRequired`, TextInput parity).
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
+
     /// Convenience error message appended as an `.error` `InfoMessage`.
     func errorText(_ text: String?) -> Self { copy { $0.errorText = text } }
 
@@ -196,6 +219,8 @@ public extension MultiLineTextInput {
 #Preview {
     struct Demo: View {
         @State var text = ""
+        @State var feedback = ""
+        @State var showError = false
         var body: some View {
             VStack(spacing: 16) {
                 MultiLineTextInput("Notes", text: $text)
@@ -206,6 +231,14 @@ public extension MultiLineTextInput {
                 MultiLineTextInput("Underlined", text: $text)
                     .placeholder("No border, just a rule")
                     .fieldStyle(.underlined)
+                // Required header + muted on-surface chrome, with an animated
+                // error toggle (message rows fade + slide in/out).
+                MultiLineTextInput("Feedback", text: $feedback)
+                    .placeholder("Required, on-surface")
+                    .required()
+                    .errorText(showError ? "This field is required." : nil)
+                    .fieldStyle(.muted)
+                Button(showError ? "Hide error" : "Show error") { showError.toggle() }
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/OTPInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/OTPInput.swift
@@ -6,6 +6,24 @@
 
 import SwiftUI
 
+/// The characters an ``OTPInput`` accepts. Mirrors HeroUI's
+/// `REGEXP_ONLY_DIGITS` / `REGEXP_ONLY_CHARS` / `REGEXP_ONLY_DIGITS_AND_CHARS`
+/// patterns; letters keep the case the user typed (HeroUI does not capitalize).
+public enum OTPCharacterSet: CaseIterable, Sendable {
+    case digits
+    case letters
+    case alphanumeric
+
+    /// Whether `character` is permitted by this set.
+    func allows(_ character: Character) -> Bool {
+        switch self {
+        case .digits: character.isNumber
+        case .letters: character.isLetter
+        case .alphanumeric: character.isNumber || character.isLetter
+        }
+    }
+}
+
 /// Improved, token-bound rewrite of the reference OTPInputView. A row of digit
 /// boxes backed by a single hidden field, with focus caret + error state.
 public struct OTPInput: View {
@@ -15,6 +33,9 @@ public struct OTPInput: View {
 
     // Appearance/content/state — mutated only through the modifiers below (R2).
     private var digitCount: Int = 6
+    private var characterSet: OTPCharacterSet = .digits
+    private var groupSizes: [Int]?
+    private var placeholderText: String?
     private var isSecure = false
     private var errorText: String?
     private var infoMessages: [InfoMessage] = []
@@ -45,24 +66,48 @@ public struct OTPInput: View {
     private var hasError: Bool { messages.dominantKind == .error }
     private var hasWarning: Bool { messages.dominantKind == .warning }
 
-    /// Keeps only digits and caps the length (extracted for testing).
-    static func sanitize(_ raw: String, digitCount: Int) -> String {
-        String(raw.filter(\.isNumber).prefix(digitCount))
+    /// Keeps only the characters allowed by `characters` (digits by default)
+    /// and caps the length (extracted for testing).
+    static func sanitize(_ raw: String, digitCount: Int, characters: OTPCharacterSet = .digits) -> String {
+        String(raw.filter(characters.allows).prefix(digitCount))
+    }
+
+    /// Slot indices split into visual groups. Falls back to a single group when
+    /// no `groups(_:)` were set — or when the sizes are invalid (non-positive
+    /// entries, or a sum that doesn't match `digitCount`).
+    private var resolvedGroups: [Range<Int>] {
+        guard let groupSizes, !groupSizes.isEmpty,
+              groupSizes.allSatisfy({ $0 > 0 }),
+              groupSizes.reduce(0, +) == digitCount
+        else { return [0..<digitCount] }
+        var ranges: [Range<Int>] = []
+        var start = 0
+        for size in groupSizes {
+            ranges.append(start..<(start + size))
+            start += size
+        }
+        return ranges
     }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             ZStack {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
-                    ForEach(0..<digitCount, id: \.self) { index in
-                        OTPDigitBox(
-                            digit: digit(at: index),
-                            isActive: isFocused && code.count == index,
-                            hasError: hasError,
-                            hasWarning: hasWarning,
-                            isEnabled: isEnabled,
-                            isSecure: isSecure
-                        )
+                    ForEach(Array(resolvedGroups.enumerated()), id: \.offset) { groupIndex, range in
+                        // HeroUI Group/Separator anatomy: a decorative dash
+                        // between groups, spaced by the row's `sm` gap.
+                        if groupIndex > 0 { OTPGroupSeparator() }
+                        ForEach(range, id: \.self) { index in
+                            OTPDigitBox(
+                                digit: digit(at: index),
+                                placeholder: placeholderChar(at: index),
+                                isActive: isFocused && code.count == index,
+                                hasError: hasError,
+                                hasWarning: hasWarning,
+                                isEnabled: isEnabled,
+                                isSecure: isSecure
+                            )
+                        }
                     }
                 }
                 .contentShape(Rectangle())
@@ -77,12 +122,12 @@ public struct OTPInput: View {
 
                 TextField("", text: $code)
                     .focused($isFocused)
-                    .otpKeyboard()
+                    .otpKeyboard(for: characterSet)
                     .opacity(0.001)
                     .frame(width: 1, height: 1)
                     .disabled(!isEnabled)
                     .onChange(of: code) { _, newValue in
-                        let sanitized = Self.sanitize(newValue, digitCount: digitCount)
+                        let sanitized = Self.sanitize(newValue, digitCount: digitCount, characters: characterSet)
                         if sanitized != code { code = sanitized }
                         if sanitized.count == digitCount {
                             // Fire once per completion; re-arms after an edit.
@@ -147,17 +192,46 @@ public struct OTPInput: View {
         guard index < code.count else { return "" }
         return String(Array(code)[index])
     }
+
+    /// The placeholder glyph for the cell at `index` — one character of the
+    /// `placeholder(_:)` string per slot position ("" past its end).
+    private func placeholderChar(at index: Int) -> String {
+        guard let placeholderText else { return "" }
+        let characters = Array(placeholderText)
+        guard index < characters.count else { return "" }
+        return String(characters[index])
+    }
 }
 
 private extension View {
-    /// Applies numeric / one-time-code keyboard traits (iOS only).
+    /// Applies keyboard + one-time-code traits for the character set (iOS only):
+    /// digits get the number pad; letters/alphanumeric get an ASCII keyboard
+    /// with capitalization and autocorrection off (matching HeroUI, which keeps
+    /// letters as typed).
     @ViewBuilder
-    func otpKeyboard() -> some View {
+    func otpKeyboard(for characters: OTPCharacterSet) -> some View {
         #if os(iOS)
-        self.keyboardType(.numberPad).textContentType(.oneTimeCode)
+        self.keyboardType(characters == .digits ? .numberPad : .asciiCapable)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .textContentType(.oneTimeCode)
         #else
         self
         #endif
+    }
+}
+
+/// The dash between slot groups — HeroUI's `InputOTP.Separator` (a short
+/// rounded bar in a muted tone). Purely decorative; the surrounding `HStack`'s
+/// `sm` spacing provides the gap on both sides.
+private struct OTPGroupSeparator: View {
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Capsule()
+            .fill(theme.text(.textTertiary))
+            .frame(width: 8, height: 2)
+            .accessibilityHidden(true)
     }
 }
 
@@ -172,6 +246,7 @@ private struct OTPDigitBox: View {
     @Environment(\.fieldStyle) private var fieldStyle
 
     let digit: String
+    let placeholder: String
     let isActive: Bool
     let hasError: Bool
     let hasWarning: Bool
@@ -180,6 +255,11 @@ private struct OTPDigitBox: View {
 
     @State private var caretOn = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.microAnimations) private var micro
+
+    /// Digit-entry motion plays only when the library switch is on *and*
+    /// Reduce Motion is off — same gate the caret blink uses.
+    private var motionOn: Bool { micro && !reduceMotion }
 
     var body: some View {
         fieldStyle.makeBody(configuration: FieldStyleConfiguration(
@@ -207,13 +287,24 @@ private struct OTPDigitBox: View {
                             guard !reduceMotion else { return }
                             withAnimation(Motion.slower.animation.repeatForever()) { caretOn = true }
                         }
+                } else if !placeholder.isEmpty {
+                    // HeroUI SlotPlaceholder: shown only while the cell is
+                    // empty and not the caret cell, in the muted text tone.
+                    Text(placeholder)
+                        .textStyle(.headingBase)
+                        .foregroundStyle(theme.text(.textTertiary))
                 }
             } else {
                 Text(isSecure ? "●" : digit)
                     .textStyle(.headingBase)
                     .foregroundStyle(textColor)
+                    // Entry pop (HeroUI SlotValue): scale+fade in; edits to an
+                    // already-filled cell roll via the numeric transition.
+                    .transition(motionOn ? .scale(scale: 0.8).combined(with: .opacity) : .identity)
+                    .contentTransition(motionOn ? .numericText() : .identity)
             }
         }
+        .animation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion), value: digit)
         // Fixed height: the box is a square cell in a fixed-width grid;
         // Dynamic Type is capped at the container via dynamicTypeClamp().
         .frame(height: 56)
@@ -230,6 +321,8 @@ private struct OTPDigitBox: View {
 #Preview {
     struct Demo: View {
         @State var code = "123"
+        @State var grouped = "12"
+        @State var alpha = "A1"
         @State var lastComplete = "—"
         var body: some View {
             VStack(spacing: 24) {
@@ -239,6 +332,12 @@ private struct OTPDigitBox: View {
                 OTPInput(code: .constant("12")).digitCount(4).errorText("Invalid code")
                 // Swapped chrome: every digit cell picks up the underlined style.
                 OTPInput(code: .constant("98")).digitCount(4).fieldStyle(.underlined)
+                // HeroUI Group/Separator anatomy: 3 + 3 with a dash between.
+                OTPInput(code: $grouped).groups([3, 3])
+                // Letters + digits: ASCII keyboard, `.oneTimeCode` kept.
+                OTPInput(code: $alpha).characters(.alphanumeric)
+                // Per-slot placeholder in the tertiary text tone.
+                OTPInput(code: .constant("7")).digitCount(4).placeholder("0000")
             }
             .padding()
         }
@@ -251,6 +350,21 @@ private struct OTPDigitBox: View {
 public extension OTPInput {
     /// Number of digit boxes (default 6).
     func digitCount(_ n: Int) -> Self { copy { $0.digitCount = n } }
+
+    /// Which characters the field accepts (default `.digits`). Also switches
+    /// the iOS keyboard: number pad for digits, ASCII keyboard otherwise —
+    /// `.oneTimeCode` autofill stays on either way.
+    func characters(_ set: OTPCharacterSet) -> Self { copy { $0.characterSet = set } }
+
+    /// Splits the boxes into visual groups separated by a small dash, e.g.
+    /// `.groups([3, 3])` for `123 - 456`. Sizes must be positive and sum to
+    /// `digitCount`; invalid sizes are ignored (single group). The separator is
+    /// decorative only — entry still flows through one field.
+    func groups(_ sizes: [Int]) -> Self { copy { $0.groupSizes = sizes } }
+
+    /// Per-slot placeholder: each empty, non-caret box shows the character at
+    /// its position (e.g. `"------"` or `"000000"`) in the tertiary text tone.
+    func placeholder(_ text: String) -> Self { copy { $0.placeholderText = text } }
 
     /// Mask the entered digits (password-style dots) instead of showing them.
     func secure(_ on: Bool = true) -> Self { copy { $0.isSecure = on } }

--- a/Sources/ThemeKit/Components/Molecules/OTPInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/OTPInput.swift
@@ -14,12 +14,15 @@ public enum OTPCharacterSet: CaseIterable, Sendable {
     case letters
     case alphanumeric
 
-    /// Whether `character` is permitted by this set.
+    /// Whether `character` is permitted by this set. ASCII-only, mirroring
+    /// HeroUI's REGEXP_ONLY_DIGITS / _CHARS patterns ([0-9] / [a-zA-Z]) —
+    /// pasted non-ASCII numerals/letters must not reach `onComplete`.
     func allows(_ character: Character) -> Bool {
+        guard character.isASCII else { return false }
         switch self {
-        case .digits: character.isNumber
-        case .letters: character.isLetter
-        case .alphanumeric: character.isNumber || character.isLetter
+        case .digits: return character.isNumber
+        case .letters: return character.isLetter
+        case .alphanumeric: return character.isNumber || character.isLetter
         }
     }
 }
@@ -30,6 +33,8 @@ public struct OTPInput: View {
     @Environment(\.theme) private var theme
 
     @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Appearance/content/state — mutated only through the modifiers below (R2).
     private var digitCount: Int = 6
@@ -156,6 +161,9 @@ public struct OTPInput: View {
                 resendRow(interval: resendInterval, onResend: onResend)
             }
         }
+        // Message rows carry the HeroUI FieldError transition; key it here so
+        // it plays (and snaps under `microAnimations(false)` / Reduce Motion).
+        .animation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion), value: messages)
     }
 
     @ViewBuilder

--- a/Sources/ThemeKit/Components/Molecules/SearchBar.swift
+++ b/Sources/ThemeKit/Components/Molecules/SearchBar.swift
@@ -4,7 +4,13 @@
 //  Created by İsa Mercan on 23.06.2026.
 //
 //  Improved, token-bound rewrite of the reference SearchView. Magnifying-glass
-//  leading icon, clear button, optional back / trailing actions.
+//  leading icon (replaceable via `.leadingIcon(_:)` / `.leadingIconColor(_:)`),
+//  clear button, optional back / trailing actions.
+//
+//  Validation, like `TextInput`: `.errorText(_:)`, `.infoMessages(_:)` and
+//  `.helperText(_:)` render an `InfoMessageList` under the field; the dominant
+//  severity drives the ambient `FieldStyle`'s error / warning border, and the
+//  helper hides while the field is invalid (hideOnInvalid).
 //
 //  Optional typeahead: pass a static `.suggestions(_:)` list or an async
 //  `suggest` provider (init) to get a results dropdown (debounced, with a
@@ -169,19 +175,19 @@ public struct SearchBar: View {
 
     /// The field row wrapped in the active ``FieldStyle`` chrome (fill + border).
     /// Configuration mapping: `isFocused` ← the field's `@FocusState`;
-    /// `isEnabled` ← `\.isEnabled`; `hasError` / `hasWarning` are `false`
-    /// (SearchBar has no validation concept); `size` is `.small` — SearchBar has
-    /// no `TextInputSize` axis, but its fixed 44pt control height (kept in the
-    /// content) exactly matches `TextInputSize.small`, so size-keyed styles see
-    /// the truthful preset.
+    /// `isEnabled` ← `\.isEnabled`; `hasError` / `hasWarning` ← the dominant
+    /// severity of the merged message list (same derivation as `TextInput`);
+    /// `size` is `.small` — SearchBar has no `TextInputSize` axis, but its fixed
+    /// 44pt control height (kept in the content) exactly matches
+    /// `TextInputSize.small`, so size-keyed styles see the truthful preset.
     @ViewBuilder
     private var fieldBox: some View {
         fieldStyle.makeBody(configuration: FieldStyleConfiguration(
             content: AnyView(fieldCore),
             isFocused: isFocused,
             isEnabled: isEnabled,
-            hasError: false,
-            hasWarning: false,
+            hasError: hasError,
+            hasWarning: hasWarning,
             size: .small
         ))
     }
@@ -425,6 +431,25 @@ public extension SearchBar {
         copy { $0.trailingSystemImage = systemName; $0.onTrailing = action }
     }
 
+    /// Replaces the leading SF Symbol (defaults to `"magnifyingglass"`).
+    func leadingIcon(_ systemName: String) -> Self { copy { $0.leadingSystemImage = systemName } }
+
+    /// Token key for the leading icon's color (defaults to `.textTertiary`).
+    func leadingIconColor(_ key: Theme.TextColorKey) -> Self { copy { $0.leadingIconColorKey = key } }
+
+    /// Convenience hint rendered under the field as an `.info` `InfoMessage`;
+    /// hidden while the field is invalid (an `errorText` or an error-severity
+    /// `infoMessages` entry is active).
+    func helperText(_ text: String?) -> Self { copy { $0.helperText = text } }
+
+    /// Convenience error appended to the message list as an `.error`
+    /// `InfoMessage`; also flips the ambient `FieldStyle` into its error border.
+    func errorText(_ text: String?) -> Self { copy { $0.errorText = text } }
+
+    /// Validation / info messages rendered under the field (their dominant
+    /// severity drives the `FieldStyle` error / warning border, as in `TextInput`).
+    func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }
+
     /// Debounce interval for typeahead / `onSearch` (async init defaults to 0.3s).
     func debounce(_ interval: TimeInterval) -> Self { copy { $0.debounce = interval } }
 
@@ -453,6 +478,36 @@ public extension SearchBar {
                 SearchBar(text: $b).backButton()
                 // Same bar, underlined chrome via the ambient FieldStyle.
                 SearchBar(text: $c).fieldStyle(.underlined)
+            }
+            .padding()
+        }
+    }
+    return Demo()
+}
+
+#Preview("Validation + custom icon") {
+    struct Demo: View {
+        @State var a = "b@d query"
+        @State var b = ""
+        @State var c = ""
+        @State var d = "coffee"
+        var body: some View {
+            VStack(spacing: 16) {
+                // Error message flips the ambient FieldStyle into its error border.
+                SearchBar(text: $a)
+                    .errorText("Query contains unsupported characters")
+                // Helper line (an .info InfoMessage, like TextInput's helperText)…
+                SearchBar(text: $b)
+                    .helperText("Search by name, code or city")
+                // …suppressed while an error is active (hideOnInvalid).
+                SearchBar(text: $c)
+                    .helperText("Search by name, code or city")
+                    .errorText("Something went wrong")
+                // Structured messages + a replaceable, token-colored leading icon.
+                SearchBar(text: $d)
+                    .leadingIcon("location.magnifyingglass")
+                    .leadingIconColor(.textHero)
+                    .infoMessages([InfoMessage("Searching nearby only", kind: .warning)])
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/SearchBar.swift
+++ b/Sources/ThemeKit/Components/Molecules/SearchBar.swift
@@ -64,6 +64,15 @@ public struct SearchBar: View {
     private var debounce: TimeInterval = 0
     private var maxResults: Int = 6
     private var accessibilityID: String? = nil
+    private var leadingSystemImage: String = "magnifyingglass"
+    private var leadingIconColorKey: Theme.TextColorKey = .textTertiary
+
+    // Convenience helper/error strings + structured messages — merged into the
+    // rendered message list at render time (see `messages`), mirroring
+    // `TextInput`; the dominant severity drives the `FieldStyle` border.
+    private var helperText: String?
+    private var errorText: String?
+    private var infoMessages: [InfoMessage] = []
 
     @FocusState private var isFocused: Bool
     @State private var results: [String] = []
@@ -88,6 +97,24 @@ public struct SearchBar: View {
         self.debounce = 0.3   // async baseline; `.debounce(_:)` overrides
     }
 
+    /// `infoMessages` plus the helper/error conveniences (computed merge, same
+    /// idiom as `TextInput`). The helper hides while the field is invalid
+    /// (hideOnInvalid, as in the HeroUI reference) so the error replaces it.
+    private var messages: [InfoMessage] {
+        var messages = infoMessages
+        if let errorText { messages.append(InfoMessage(errorText, kind: .error)) }
+        if let helperText, !isInvalid { messages.append(InfoMessage(helperText, kind: .info)) }
+        return messages
+    }
+    /// Whether the field is in an error state (an `errorText` or an
+    /// error-severity `InfoMessage`) — gates the helper line.
+    private var isInvalid: Bool {
+        errorText != nil || infoMessages.contains { $0.kind == .error }
+    }
+    private var dominant: InfoMessage.Kind? { messages.dominantKind }
+    private var hasError: Bool { dominant == .error }
+    private var hasWarning: Bool { dominant == .warning }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
             HStack(spacing: Theme.SpacingKey.sm.value) {
@@ -100,6 +127,11 @@ public struct SearchBar: View {
                 }
 
                 fieldBox
+            }
+
+            if !messages.isEmpty {
+                InfoMessageList(messages)
+                    .a11y(A11yElement.Field.message, in: accessibilityID)
             }
 
             dropdown
@@ -116,7 +148,7 @@ public struct SearchBar: View {
     /// The fixed 44pt control height is layout, not chrome, so it stays here.
     private var fieldCore: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
-            Icon(systemName: "magnifyingglass").size(.sm).color(theme.text(.textTertiary))
+            Icon(systemName: leadingSystemImage).size(.sm).color(theme.text(leadingIconColorKey))
 
             TextField(placeholder, text: $text)
                 .textStyle(.bodyBase400)

--- a/Sources/ThemeKit/Components/Molecules/SearchBar.swift
+++ b/Sources/ThemeKit/Components/Molecules/SearchBar.swift
@@ -52,6 +52,8 @@ public struct SearchBar: View {
 
     @Binding private var text: String
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Appearance/config — mutated only through the modifiers below (R2); the
     // async init seeds a 0.3s debounce baseline, which `.debounce(_:)` can
@@ -142,6 +144,9 @@ public struct SearchBar: View {
 
             dropdown
         }
+        // Message rows carry the HeroUI FieldError transition; key it here so
+        // it plays (and snaps under `microAnimations(false)` / Reduce Motion).
+        .animation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion), value: messages)
         .onAppear { update(for: text) }
         .onDebouncedChange(of: text, for: effectiveDebounce) { value in
             update(for: value)

--- a/Sources/ThemeKit/Components/Molecules/TextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInput.swift
@@ -655,6 +655,16 @@ private extension TextInputCapitalization {
                     .trailing { Text("USD").textStyle(.labelSm600) }
                     .keyboard(.decimalPad)
                     .fieldStyle(.underlined)
+                // Required indicator on a muted, on-surface field.
+                TextInput("Full name", text: $name)
+                    .required()
+                    .fieldStyle(.muted)
+                // Required + error, with an animated message toggle
+                // (rows fade + slide via the MicroMotion-gated animation).
+                TextInput("Nickname", text: $nickname)
+                    .required()
+                    .errorText(showError ? "This field is required." : nil)
+                Button(showError ? "Hide error" : "Show error") { showError.toggle() }
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/TextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInput.swift
@@ -142,7 +142,13 @@ public struct TextInput: View {
     /// Optional external focus (e.g. driven by `FormValidator.focusBinding`).
     private var externalFocus: Binding<Bool>?
     @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private var accessibilityID: String? = nil
+
+    /// Marks the field as required: asterisk after the label + ", required"
+    /// appended to the accessibility label (HeroUI `isRequired`).
+    private var isRequired = false
 
     // Custom slot views placed in the field row, before / after the text.
     // Additive to `icon` / `addons` — those APIs are untouched.
@@ -241,11 +247,19 @@ public struct TextInput: View {
             if let leadingContent { leadingContent }
 
             ZStack(alignment: .leading) {
-                Text(model.label)
-                    .textStyle(floating ? .labelSm600 : .bodyBase400)
-                    .foregroundStyle(labelColor)
-                    .offset(y: floating ? -11 : 0)
-                    .a11y(A11yElement.Field.label, in: accessibilityID)
+                HStack(spacing: 4) {   // matches the `InputLabel` atom's asterisk gap
+                    Text(model.label)
+                        .foregroundStyle(labelColor)
+                    if isRequired {
+                        // Same treatment as `InputLabel.required()` — error-token asterisk.
+                        Text(verbatim: "*")
+                            .foregroundStyle(theme.foreground(.systemcolorsFgError))
+                            .accessibilityHidden(true)   // spoken via the field's label suffix
+                    }
+                }
+                .textStyle(floating ? .labelSm600 : .bodyBase400)
+                .offset(y: floating ? -11 : 0)
+                .a11y(A11yElement.Field.label, in: accessibilityID)
 
                 field
                     .opacity(floating ? 1 : 0)
@@ -330,6 +344,9 @@ public struct TextInput: View {
                 }
             }
         }
+        // Animate message rows in/out (their `.transition` lives in
+        // `InfoMessageList`); gated by `microAnimations` + Reduce Motion.
+        .animation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion), value: messages)
         .onChange(of: text) { _, newValue in
             var v = newValue
             if let formatter = model.formatter { v = formatter(v) }
@@ -362,7 +379,8 @@ public struct TextInput: View {
         .focused($isFocused)
         .textStyle(.bodyBase400)
         .foregroundStyle(isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
-        .tint(theme.foreground(.fgHero))
+        // Caret / selection tint follows the validation state (HeroUI invalid caret).
+        .tint(theme.foreground(hasError ? .systemcolorsFgError : .fgHero))
         .disabled(!isEnabled)
         .submitLabel(model.submitLabel)
         .autocorrectionDisabled(model.autocorrectionDisabled)
@@ -373,7 +391,7 @@ public struct TextInput: View {
             runValidation(text)   // submit is the strongest trigger — always validate
             model.onSubmit?()
         }
-        .accessibilityLabel(model.label)
+        .accessibilityLabel(isRequired ? model.label + ", " + String(themeKit: "required") : model.label)
         .accessibilityValue(model.isSecure ? "" : text)
     }
 
@@ -439,6 +457,11 @@ public extension TextInput {
     func trailing<V: View>(@ViewBuilder _ content: () -> V) -> Self {
         copy { $0.trailingContent = AnyView(content()) }
     }
+
+    /// Marks the field as required: renders an error-token asterisk after the
+    /// label (the `InputLabel` treatment) and appends ", required" to the
+    /// field's accessibility label (HeroUI `isRequired`).
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
 
     /// Masks input as a password field with a reveal toggle.
     func secure(_ on: Bool = true) -> Self { copy { $0.model.isSecure = on } }
@@ -603,6 +626,9 @@ private extension TextInputCapitalization {
         @State var pass = ""
         @State var bio = ""
         @State var amount = ""
+        @State var name = ""
+        @State var nickname = ""
+        @State var showError = false
         private var emailMessages: [InfoMessage] {
             Validator.validate(email, [.required(), .email()])
         }

--- a/Sources/ThemeKit/Validation/InfoMessage.swift
+++ b/Sources/ThemeKit/Validation/InfoMessage.swift
@@ -45,6 +45,11 @@ public struct InfoMessage: Identifiable, Equatable {
     /// The icon to render: the custom override if set, else the kind's default.
     var resolvedSystemImage: String? { systemImage ?? kind.systemImage }
 
+    /// Content-derived identity for list diffing: stable across re-created
+    /// instances of the same message (unlike `id`), so transitions play only
+    /// for rows whose content actually changed.
+    var diffIdentity: String { "\(kind.rawValue)|\(text)" }
+
     public static func == (a: InfoMessage, b: InfoMessage) -> Bool { a.text == b.text && a.kind == b.kind }
 }
 

--- a/Sources/ThemeKit/Validation/InfoMessageUI.swift
+++ b/Sources/ThemeKit/Validation/InfoMessageUI.swift
@@ -40,6 +40,11 @@ public struct InfoMessageList: View {
                         InlineText(message.text, links: message.links).color(message.kind.color)
                     }
                 }
+                // Animated appearance/disappearance (HeroUI FieldError parity).
+                // Plays only when the owning field animates the change — fields
+                // key a `MicroMotion`-gated animation on their message list, so
+                // `microAnimations(false)` / Reduce Motion snap instantly.
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
     }

--- a/Sources/ThemeKit/Validation/InfoMessageUI.swift
+++ b/Sources/ThemeKit/Validation/InfoMessageUI.swift
@@ -29,7 +29,11 @@ public struct InfoMessageList: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            ForEach(messages) { message in
+            // Keyed on content (kind + text), not the per-instance UUID id:
+            // fields rebuild convenience messages every render, and a fresh
+            // UUID would make ForEach remove+insert unchanged rows, replaying
+            // the transition on lines that didn't change.
+            ForEach(messages, id: \.diffIdentity) { message in
                 HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.xs.value) {
                     if let icon = message.resolvedSystemImage {
                         Image(systemName: icon).font(.system(size: 11)).foregroundStyle(message.kind.color)


### PR DESCRIPTION
## Summary

First wave of the gap plans from `HEROUI_NATIVE_AUDIT.md` (#216): closes every audited form-field gap vs HeroUI Native. All changes are additive — no existing public signature changed.

### TextInput + MultiLineTextInput (text-field / input / field-error parity)
- `.required(_:)` — asterisk on the floating/header label (InputLabel treatment) + VoiceOver announces a localized "required" suffix.
- Field messages (`InfoMessageList`) animate in/out (opacity + top slide) via the MicroMotion gate; snaps under `microAnimations(false)` / Reduce Motion.
- `MutedFieldStyle` (`.fieldStyle(.muted)`) — flat on-surface secondary variant: `bgSecondaryLight` fill (stepping to `bgSecondary` when disabled), border transparent until focus/error.
- Caret/selection tint switches to the error foreground while invalid.

### SearchBar (search-field parity)
- `.errorText(_:)` / `.infoMessages(_:)` drive the ambient FieldStyle error/warning border and render an `InfoMessageList` (TextInput conventions, incl. a11y wiring).
- `.helperText(_:)` — info-kind helper line, suppressed while invalid (hideOnInvalid).
- `.leadingIcon(_:)` / `.leadingIconColor(_:)` replace the hardcoded magnifyingglass.

### OTPInput (input-otp parity)
- `.characters(.digits/.letters/.alphanumeric)` — ASCII-only sanitize filter + matching keyboard traits, `.oneTimeCode` kept.
- `.groups([3, 3])` — decorative capsule separators between slot groups.
- `.placeholder(_:)` — per-slot hint characters on empty, non-caret cells.
- Digit entry animates (scale+opacity, `.numericText()` content transition) under the MicroMotion/Reduce Motion gates.

### InputLabel (label parity)
- Native `.disabled(_:)` now mutes label, required asterisk and info glyph (`textDisabled`).

### Review
Diff was reviewed by two adversarial lenses (compile-correctness; house-rules + a11y/l10n/RTL); 6 findings fixed, notably a content-derived `ForEach` identity for `InfoMessageList` rows so message transitions only play for rows that actually changed.

Previews extended for every new state. No Swift toolchain in the authoring environment — all token/API references cross-checked against real declarations; a local build + snapshot run is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NurTVFpssqcMiR3BBb2H24

---
_Generated by [Claude Code](https://claude.ai/code/session_01NurTVFpssqcMiR3BBb2H24)_