### PR TITLE
feat: HeroUI gap wave 2 — selection & control parity (Dropdown, Select, Tag, sliders…)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/Tag.swift
+++ b/Sources/ThemeKit/Components/Atoms/Tag.swift
@@ -10,7 +10,9 @@ import SwiftUI
 /// Chip (selectable): Tag represents an applied keyword/filter.
 /// An optional semantic `.tagStyle` + `.variant` colors the tag (Ant Tag colors),
 /// reusing Badge's `BadgeStyle` / `FillVariant`. With no style it keeps the
-/// original neutral keyword look.
+/// original neutral keyword look. `.size(.small/.large)` shares Chip's ramp,
+/// and `.leading { } / .trailing { }` inject custom content around the text
+/// (HeroUI Chip start/end slots).
 public struct Tag: View {
     private let text: String
     private let onRemove: (() -> Void)?
@@ -21,6 +23,9 @@ public struct Tag: View {
     private var semantic: SemanticColor?   // .color(_) — the broader Ant palette
     private var variant: FillVariant = .soft
     private var bordered = false
+    private var size: ChipSize = .small
+    private var leadingSlot: AnyView?
+    private var trailingSlot: AnyView?
 
     @Environment(\.theme) private var theme
 
@@ -31,24 +36,46 @@ public struct Tag: View {
 
     public var body: some View {
         HStack(spacing: Theme.SpacingKey.xs.value) {
-            if let leadingSystemImage {
-                Image(systemName: leadingSystemImage).font(.system(size: 12))
+            if let leadingSlot {
+                leadingSlot
+            } else if let leadingSystemImage {
+                Image(systemName: leadingSystemImage).font(.system(size: iconGlyphSize))
             }
-            Text(text).textStyle(.labelSm600)
+            Text(text).textStyle(labelStyle)
+            if let trailingSlot {
+                trailingSlot
+            }
             if let onRemove {
                 Button(action: onRemove) {
-                    Image(systemName: "xmark").font(.system(size: 10, weight: .semibold))
+                    Image(systemName: "xmark").font(.system(size: removeGlyphSize, weight: .semibold))
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(String(themeKit: "Remove \(text)"))
             }
         }
         .foregroundStyle(foreground)
-        .padding(.horizontal, Theme.SpacingKey.sm.value)
-        .frame(height: 28)
+        .padding(.horizontal, horizontalPadding)
+        .padding(.vertical, verticalPadding)
         .background(background, in: Capsule())
         .overlay(Capsule().strokeBorder(border, lineWidth: border == .clear ? 0 : 1))
     }
+
+    // MARK: Size ramp — reuses Chip's `ChipSize`. Paddings derive from spacing
+    // tokens (no fixed height), so Dynamic Type grows the capsule instead of
+    // clipping the label.
+
+    private var labelStyle: TextStyle {
+        size == .small ? .labelSm600 : .labelBase600
+    }
+    private var horizontalPadding: CGFloat {
+        size == .small ? Theme.SpacingKey.sm.value : Theme.SpacingKey.md.value
+    }
+    private var verticalPadding: CGFloat {
+        size == .small ? Theme.SpacingKey.xs.value : Theme.SpacingKey.sm.value
+    }
+    // Fixed glyph constants for the icon/remove shorthands (no semantic token).
+    private var iconGlyphSize: CGFloat { size == .small ? 12 : 14 }
+    private var removeGlyphSize: CGFloat { size == .small ? 10 : 12 }
 
     private var foreground: Color {
         if let semantic {
@@ -93,8 +120,25 @@ public struct Tag: View {
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension Tag {
+    /// Control size: small / large (shares Chip's ``ChipSize`` ramp) — drives
+    /// the text style and token-derived paddings.
+    func size(_ s: ChipSize) -> Self { copy { $0.size = s } }
+
     /// Leading SF Symbol.
     func icon(_ systemImage: String?) -> Self { copy { $0.leadingSystemImage = systemImage } }
+
+    /// A custom leading view before the text; when set, it replaces the
+    /// `icon` shorthand.
+    func leading<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        let view = AnyView(content())
+        return copy { $0.leadingSlot = view }
+    }
+
+    /// A custom trailing view after the text, before the built-in remove button.
+    func trailing<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        let view = AnyView(content())
+        return copy { $0.trailingSlot = view }
+    }
 
     /// Semantic color treatment (Ant Tag colors). `nil` keeps the neutral keyword look.
     func tagStyle(_ s: BadgeStyle?) -> Self { copy { $0.style = s } }
@@ -144,7 +188,7 @@ public struct CheckableTag: View {
             }
             .foregroundStyle(isChecked ? color.onSolid : theme.text(.textSecondary))
             .padding(.horizontal, Theme.SpacingKey.sm.value)
-            .frame(height: 28)
+            .padding(.vertical, Theme.SpacingKey.xs.value)   // padding-derived height — Dynamic Type never clips
             .background(isChecked ? color.solid : theme.background(.bgElevatorTertiary), in: Capsule())
             .contentShape(Capsule())
         }

--- a/Sources/ThemeKit/Components/Atoms/Tag.swift
+++ b/Sources/ThemeKit/Components/Atoms/Tag.swift
@@ -228,6 +228,19 @@ public extension CheckableTag {
             Tag("Purple").color(.purple).bordered()
             Tag("Pink").color(.pink).variant(.solid)
         }
+        // Size ramp (shares Chip's ChipSize).
+        HStack {
+            Tag("Small").icon("tag")
+            Tag("Large").icon("tag").size(.large)
+            Tag("Large removable", onRemove: {}).size(.large).tagStyle(.success)
+        }
+        // Slots: leading replaces the icon shorthand; trailing renders before
+        // the remove button.
+        HStack {
+            Tag("Online").leading { StatusDot(.online) }
+            Tag("Boosted").leading { Image(systemName: "sparkles").font(.system(size: 12)) }
+            Tag("Deploys", onRemove: {}).trailing { Text("12").textStyle(.labelSm700) }
+        }
         CheckableTagRow()
     }
     .padding()
@@ -250,6 +263,9 @@ private struct CheckableTagRow: View {
         PreviewCase("Removable") { Tag("Filter", onRemove: {}) }
         PreviewCase("With icon") { Tag("Beach").icon("beach.umbrella") }
         PreviewCase("Semantic")  { Tag("Error").tagStyle(.error).variant(.solid) }
+        PreviewCase("Large")     { Tag("Filter", onRemove: {}).size(.large) }
+        PreviewCase("Leading slot")  { Tag("Online").leading { StatusDot(.online) } }
+        PreviewCase("Trailing slot") { Tag("Deploys", onRemove: {}).trailing { Text("12").textStyle(.labelSm700) } }
         PreviewCase("Long text") { Tag("a-very-long-keyword-value-here") }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Chips.swift
+++ b/Sources/ThemeKit/Components/Molecules/Chips.swift
@@ -559,6 +559,7 @@ public extension ChipGroup {
     struct Demo: View {
         @State var a = true; @State var b = false; @State var c = true
         @State var multi: Set<String> = ["Wifi"]
+        @State var removableOptions = ["Wifi", "Pool", "Spa"]
         var body: some View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
@@ -573,6 +574,18 @@ public extension ChipGroup {
                         FilterChip("4+ stars") {}.shape(.square)
                     }
                     ChipGroup(title: "Amenities", options: ["Wifi", "Pool", "Spa", "Parking"], selection: $multi) { $0 }
+                    // Per-option disabled: "Spa" renders dimmed + non-interactive.
+                    ChipGroup(title: "Per-option disabled", options: ["Wifi", "Pool", "Spa", "Parking"], selection: $multi) { $0 }
+                        .optionEnabled { $0 != "Spa" }
+                    // Removable: every chip gets a trailing xmark that mutates the caller's array.
+                    ChipGroup(title: "Removable", options: removableOptions, selection: $multi) { $0 }
+                        .removable { option in removableOptions.removeAll { $0 == option } }
+                    // Invalid state: messages under the chips + error-tinted title.
+                    ChipGroup(title: "With error", options: ["Wifi", "Pool"], selection: $multi) { $0 }
+                        .infoMessages([InfoMessage("Pick at least one amenity", kind: .error)])
+                    // Empty state: custom placeholder while the options collection is empty.
+                    ChipGroup(title: "Empty", options: [String](), selection: $multi) { $0 }
+                        .emptyContent { Text("No amenities available").textStyle(.bodySm400) }
                     // Custom ChipStyle via the environment: `.chipStyle(.solid)`
                     // on the container is non-default, so these molecules route
                     // through `SolidChipStyle.makeBody` (capsule chroma) instead

--- a/Sources/ThemeKit/Components/Molecules/Chips.swift
+++ b/Sources/ThemeKit/Components/Molecules/Chips.swift
@@ -433,14 +433,21 @@ public extension FilterChip {
 /// A horizontally-scrolling, multi-select chip group backed by a `Set` binding.
 public struct ChipGroup<Option: Hashable>: View {
     @Environment(\.theme) private var theme
+    @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let title: String?
     private let options: [Option]
     @Binding private var selection: Set<Option>
     private let label: (Option) -> String
 
-    // Appearance — mutated only through the modifiers below (R2).
+    // Appearance/config — mutated only through the modifiers below (R2).
     private var selectionStyle: ChipSelectionStyle = .tonal
+    private var isOptionEnabled: ((Option) -> Bool)?
+    private var onRemove: ((Option) -> Void)?
+    private var infoMessages: [InfoMessage] = []
+    private var emptyContent: AnyView? = nil
 
     public init(   // R1
         title: String? = nil,
@@ -454,23 +461,65 @@ public struct ChipGroup<Option: Hashable>: View {
         self.label = label
     }
 
+    private func optionEnabled(_ option: Option) -> Bool { isEnabled && (isOptionEnabled?(option) ?? true) }
+
+    /// The most severe message tints the group title (RadioGroup convention).
+    private var titleColor: Color {
+        switch infoMessages.dominantKind {
+        case .error: return theme.foreground(.systemcolorsFgError)
+        case .warning: return theme.foreground(.systemcolorsFgWarning)
+        default: return theme.text(.textPrimary)
+        }
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             if let title {
-                Text(title).textStyle(.labelMd600).foregroundStyle(theme.text(.textPrimary))
+                Text(title).textStyle(.labelMd600).foregroundStyle(titleColor)
             }
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.SpacingKey.sm.value) {
-                    ForEach(options, id: \.self) { option in
-                        Chip(label(option),
-                             isSelected: Binding(
-                                get: { selection.contains(option) },
-                                set: { isOn in if isOn { selection.insert(option) } else { selection.remove(option) } }
-                             ))
-                            .chipStyle(selectionStyle)
+            if options.isEmpty, let emptyContent {
+                emptyContent
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: Theme.SpacingKey.sm.value) {
+                        ForEach(options, id: \.self) { option in
+                            let enabled = optionEnabled(option)
+                            chip(for: option)
+                                .disabled(!enabled)
+                                .opacity(enabled ? 1 : 0.4)
+                        }
                     }
                 }
             }
+            if !infoMessages.isEmpty {
+                InfoMessageList(infoMessages)
+            }
+        }
+        // Animate message rows in/out (their `.transition` lives in
+        // `InfoMessageList`); gated by `microAnimations` + Reduce Motion.
+        .animation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion), value: infoMessages)
+    }
+
+    /// One selectable chip; `removable` appends a trailing remove affordance
+    /// via `Chip`'s trailing slot (HeroUI TagGroup.ItemRemoveButton parity).
+    @ViewBuilder private func chip(for option: Option) -> some View {
+        let base = Chip(label(option),
+                        isSelected: Binding(
+                           get: { selection.contains(option) },
+                           set: { isOn in if isOn { selection.insert(option) } else { selection.remove(option) } }
+                        ))
+            .chipStyle(selectionStyle)
+        if let onRemove {
+            base.trailing {
+                Button { onRemove(option) } label: {
+                    Image(systemName: "xmark").font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(theme.text(.textTertiary))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(themeKit: "Remove \(label(option))"))
+            }
+        } else {
+            base
         }
     }
 }
@@ -480,6 +529,24 @@ public struct ChipGroup<Option: Hashable>: View {
 public extension ChipGroup {
     /// Visual style applied to every chip (matches `Chip.chipStyle`).
     func chipStyle(_ style: ChipSelectionStyle) -> Self { copy { $0.selectionStyle = style } }
+
+    /// Per-option enablement predicate (nil enables every option).
+    func optionEnabled(_ predicate: ((Option) -> Bool)?) -> Self { copy { $0.isOptionEnabled = predicate } }
+
+    /// Appends a trailing remove button to every chip; the callback receives
+    /// the option to remove (HeroUI TagGroup `onRemove`). The caller owns the
+    /// options array, so removal mutates it there.
+    func removable(_ onRemove: @escaping (Option) -> Void) -> Self { copy { $0.onRemove = onRemove } }
+
+    /// Validation / info messages rendered under the chips (drive the title color).
+    func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }
+
+    /// Custom view shown instead of the chip row while `options` is empty
+    /// (HeroUI TagGroup `renderEmptyState`).
+    func emptyContent<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        let view = AnyView(content())
+        return copy { $0.emptyContent = view }
+    }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self

--- a/Sources/ThemeKit/Components/Molecules/Dropdown.swift
+++ b/Sources/ThemeKit/Components/Molecules/Dropdown.swift
@@ -7,14 +7,17 @@
 //  trigger and a themed floating panel of actions opens beside it; tap an item
 //  (or anywhere outside) to dismiss. The token-bound `Menu` replacement: unlike
 //  ``Select`` it binds to no selection, and unlike ``MenuCard`` it floats over
-//  content instead of sitting in the layout. (daisyUI Dropdown.)
+//  content instead of sitting in the layout. Items can carry a subtitle and a
+//  selected state, group into headed ``DropdownSection``s, and nest one inline
+//  submenu tier. (daisyUI Dropdown + HeroUI Menu.)
 //
 
 import SwiftUI
 
 // MARK: - Item
 
-/// One entry of a ``Dropdown`` menu — an action row, or a divider line.
+/// One entry of a ``Dropdown`` menu — an action row, a divider line, or an
+/// inline expandable submenu.
 public struct DropdownItem: Identifiable {
     /// Visual intent of an action row. (daisyUI Dropdown menu item.)
     public enum Role: Sendable {
@@ -26,38 +29,109 @@ public struct DropdownItem: Identifiable {
 
     public let id = UUID()
     let title: String
+    let subtitle: String?
     let systemImage: String?
     let role: Role
     let isDisabled: Bool
+    let isSelected: Bool
     let action: () -> Void
     let isDivider: Bool
+    /// Non-`nil` marks this item as a submenu trigger row (one tier deep).
+    let submenuItems: [DropdownItem]?
 
     public init(
         _ title: String,
+        subtitle: String? = nil,
         systemImage: String? = nil,
         role: Role = .normal,
         disabled: Bool = false,
+        isSelected: Bool = false,
         action: @escaping () -> Void = {}
     ) {
         self.title = title
+        self.subtitle = subtitle
         self.systemImage = systemImage
         self.role = role
         self.isDisabled = disabled
+        self.isSelected = isSelected
         self.action = action
         self.isDivider = false
+        self.submenuItems = nil
     }
 
     private init(divider: Bool) {
         self.title = ""
+        self.subtitle = nil
         self.systemImage = nil
         self.role = .normal
         self.isDisabled = false
+        self.isSelected = false
         self.action = {}
         self.isDivider = divider
+        self.submenuItems = nil
+    }
+
+    private init(submenu title: String, systemImage: String?, disabled: Bool, items: [DropdownItem]) {
+        self.title = title
+        self.subtitle = nil
+        self.systemImage = systemImage
+        self.role = .normal
+        self.isDisabled = disabled
+        self.isSelected = false
+        self.action = {}
+        self.isDivider = false
+        self.submenuItems = items
     }
 
     /// A thin separator line between groups of actions.
     public static var divider: DropdownItem { DropdownItem(divider: true) }
+
+    /// An inline expandable nested tier — tapping the row discloses `items`
+    /// indented beneath it instead of running an action. One level deep:
+    /// submenus nested inside a submenu render as plain rows. (HeroUI SubMenu.)
+    public static func submenu(
+        _ title: String,
+        systemImage: String? = nil,
+        disabled: Bool = false,
+        items: [DropdownItem]
+    ) -> DropdownItem {
+        DropdownItem(submenu: title, systemImage: systemImage, disabled: disabled, items: items)
+    }
+}
+
+// MARK: - Section
+
+/// A group of ``DropdownItem`` rows with an optional non-interactive heading.
+/// Consecutive sections are separated by a divider line automatically.
+/// (HeroUI Menu.Group + Menu.Label.)
+public struct DropdownSection: Identifiable {
+    public let id = UUID()
+    let heading: String?
+    let items: [DropdownItem]
+
+    public init(_ heading: String? = nil, items: [DropdownItem]) {
+        self.heading = heading
+        self.items = items
+    }
+}
+
+// MARK: - Indicator
+
+/// The leading mark drawn on selected rows. (HeroUI Menu.ItemIndicator.)
+public enum DropdownIndicator: Sendable {
+    /// A small checkmark glyph.
+    case checkmark
+    /// A small filled circle.
+    case dot
+}
+
+/// Fixed indicator geometry — genuine dimensions with no semantic token.
+private enum DropdownMetrics {
+    /// Width of the leading indicator slot; reserved on every row of a section
+    /// that contains a selection so titles stay aligned.
+    static let indicatorSlot: CGFloat = IconSize.xs.value
+    /// Diameter of the `.dot` indicator mark.
+    static let dotDiameter: CGFloat = 6
 }
 
 // MARK: - Placement
@@ -109,7 +183,8 @@ private struct DropdownPlacement: ViewModifier {
 
 /// Molecule. A lightweight action menu anchored to any trigger view — tapping
 /// the trigger presents a themed floating panel of ``DropdownItem`` actions;
-/// tapping an item or anywhere outside dismisses it. (daisyUI Dropdown.)
+/// tapping an item or anywhere outside dismisses it. (daisyUI Dropdown +
+/// HeroUI Menu.)
 ///
 /// ```swift
 /// Dropdown(items: [
@@ -121,32 +196,80 @@ private struct DropdownPlacement: ViewModifier {
 /// }
 /// .edge(.bottomTrailing)
 /// ```
+///
+/// Selection menus group items into headed ``DropdownSection``s, mark rows
+/// with `isSelected:`, and can stay open across taps:
+///
+/// ```swift
+/// Dropdown(sections: [
+///     DropdownSection("Sort by", items: [
+///         .init("Name", isSelected: sort == .name) { sort = .name },
+///         .init("Date", isSelected: sort == .date) { sort = .date },
+///     ]),
+/// ]) { trigger }
+/// .indicator(.checkmark)
+/// .shouldCloseOnSelect(false)
+/// ```
 public struct Dropdown<Trigger: View>: View {
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    private let items: [DropdownItem]
+    private let sections: [DropdownSection]
     private let trigger: Trigger
+    /// Caller-owned open state; `nil` falls back to the internal `@State`.
+    private let externalOpen: Binding<Bool>?
 
     // Appearance/config — mutated only through the modifiers below (R2).
     private var edge: DropdownEdge = .bottomLeading
     private var accentColor: SemanticColor = .neutral
     private var menuWidth: CGFloat? = nil
+    private var indicatorStyle: DropdownIndicator = .checkmark
+    private var closesOnSelect = true
 
-    @State private var open = false
+    @State private var internalOpen = false
+    @State private var expandedSubmenus: Set<UUID> = []
 
-    public init(items: [DropdownItem], @ViewBuilder trigger: () -> Trigger) {   // R1
-        self.items = items
+    /// A flat menu of items. Pass `isPresented:` to own the open state
+    /// (controlled); omit it for the self-managing convenience.
+    public init(
+        items: [DropdownItem],
+        isPresented: Binding<Bool>? = nil,
+        @ViewBuilder trigger: () -> Trigger
+    ) {   // R1
+        self.sections = [DropdownSection(items: items)]
+        self.externalOpen = isPresented
+        self.trigger = trigger()
+    }
+
+    /// A sectioned menu — each ``DropdownSection`` renders its optional heading
+    /// and rows, divided from the next section by a separator line.
+    public init(
+        sections: [DropdownSection],
+        isPresented: Binding<Bool>? = nil,
+        @ViewBuilder trigger: () -> Trigger
+    ) {   // R1
+        self.sections = sections
+        self.externalOpen = isPresented
         self.trigger = trigger()
     }
 
     private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
 
+    private var open: Bool { externalOpen?.wrappedValue ?? internalOpen }
+
+    private func setOpen(_ newValue: Bool) {
+        if let externalOpen {
+            externalOpen.wrappedValue = newValue
+        } else {
+            internalOpen = newValue
+        }
+    }
+
     public var body: some View {
         Button {
-            open.toggle()
+            setOpen(!open)
         } label: {
             trigger.contentShape(Rectangle())
         }
@@ -159,7 +282,7 @@ public struct Dropdown<Trigger: View>: View {
                 Color.clear
                     .contentShape(Rectangle())
                     .frame(width: 10_000, height: 10_000)
-                    .onTapGesture { open = false }
+                    .onTapGesture { setOpen(false) }
                     .accessibilityHidden(true)
             }
         }
@@ -172,9 +295,12 @@ public struct Dropdown<Trigger: View>: View {
         }
         .zIndex(open ? 1 : 0)   // float over later siblings while open (Tooltip-style)
         .animation(motion, value: open)
+        .onChange(of: open) { _, isOpen in
+            if !isOpen { expandedSubmenus = [] }   // fresh submenu state on reopen
+        }
         .accessibilityAddTraits(.isButton)
         .accessibilityValue(open ? Text(String(themeKit: "Expanded")) : Text(String(themeKit: "Collapsed")))
-        .accessibilityAction(.escape) { open = false }
+        .accessibilityAction(.escape) { setOpen(false) }
     }
 
     // MARK: Panel
@@ -185,13 +311,12 @@ public struct Dropdown<Trigger: View>: View {
 
     private var panel: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ForEach(items) { item in
-                if item.isDivider {
+            ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
+                if index > 0 {
                     DividerView().size(.small)
                         .padding(.vertical, Theme.SpacingKey.xs.value)
-                } else {
-                    row(item)
                 }
+                sectionRows(section)
             }
         }
         .padding(Theme.SpacingKey.xs.value)
@@ -200,28 +325,75 @@ public struct Dropdown<Trigger: View>: View {
         .background(theme.background(.bgWhite), in: panelShape)
         .overlay(panelShape.stroke(theme.border(.borderPrimary), lineWidth: 1))
         .themeShadow(.soft)
+        .animation(motion, value: expandedSubmenus)
         .zIndex(1)
     }
 
-    private func row(_ item: DropdownItem) -> some View {
+    // MARK: Section
+
+    @ViewBuilder
+    private func sectionRows(_ section: DropdownSection) -> some View {
+        if let heading = section.heading {
+            headingRow(heading)
+        }
+        // Reserve the indicator slot across the whole section when any row is
+        // selected, so titles stay aligned. (HeroUI ItemIndicator forceMount.)
+        let reservesIndicator = section.items.contains { $0.isSelected }
+        ForEach(section.items) { item in
+            if item.isDivider {
+                DividerView().size(.small)
+                    .padding(.vertical, Theme.SpacingKey.xs.value)
+            } else if let children = item.submenuItems {
+                submenuRows(item, children: children, reservesIndicator: reservesIndicator)
+            } else {
+                row(item, reservesIndicator: reservesIndicator)
+            }
+        }
+    }
+
+    /// Non-interactive section heading. (HeroUI Menu.Label.)
+    private func headingRow(_ heading: String) -> some View {
+        Text(heading)
+            .textStyle(.overline500)
+            .foregroundStyle(theme.text(.textTertiary))
+            .padding(.horizontal, Theme.SpacingKey.sm.value)
+            .padding(.vertical, Theme.SpacingKey.xs.value)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    // MARK: Rows
+
+    private func row(_ item: DropdownItem, reservesIndicator: Bool, indented: Bool = false) -> some View {
         let destructive = item.role == .destructive
         let titleColor = destructive ? SemanticColor.error.accent : theme.text(.textPrimary)
         let iconColor = destructive ? SemanticColor.error.accent : theme.text(.textSecondary)
 
         return Button {
-            open = false
+            if closesOnSelect { setOpen(false) }
             item.action()
         } label: {
             HStack(spacing: Theme.SpacingKey.sm.value) {
-                if let systemImage = item.systemImage {
-                    Icon(systemName: systemImage).size(.sm).color(iconColor)
+                if reservesIndicator {
+                    indicatorMark(selected: item.isSelected)
                 }
-                Text(item.title)
-                    .textStyle(.bodyBase400)
-                    .foregroundStyle(titleColor)
-                    .lineLimit(1)
+                if let systemImage = item.systemImage {
+                    Icon(systemName: systemImage).size(.sm).colorOverride(iconColor)
+                }
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(item.title)
+                        .textStyle(.bodyBase400)
+                        .foregroundStyle(titleColor)
+                        .lineLimit(1)
+                    if let subtitle = item.subtitle {
+                        Text(subtitle)
+                            .textStyle(.bodySm400)
+                            .foregroundStyle(theme.text(.textSecondary))
+                            .lineLimit(2)
+                    }
+                }
                 Spacer(minLength: Theme.SpacingKey.md.value)
             }
+            .padding(.leading, indented ? Theme.SpacingKey.md.value : 0)
             .padding(.horizontal, Theme.SpacingKey.sm.value)
             .padding(.vertical, Theme.SpacingKey.sm.value)
             .contentShape(Rectangle())
@@ -229,6 +401,79 @@ public struct Dropdown<Trigger: View>: View {
         .buttonStyle(DropdownRowPressStyle(tint: destructive ? SemanticColor.error.soft : accentColor.soft))
         .disabled(item.isDisabled)
         .opacity(item.isDisabled ? 0.4 : 1)
+        .accessibilityAddTraits(item.isSelected ? .isSelected : [])
+    }
+
+    /// Inline expandable submenu — a disclosure row plus, when expanded, its
+    /// children indented beneath it. (HeroUI SubMenu.)
+    @ViewBuilder
+    private func submenuRows(_ item: DropdownItem, children: [DropdownItem], reservesIndicator: Bool) -> some View {
+        let expanded = expandedSubmenus.contains(item.id)
+
+        Button {
+            if expanded {
+                expandedSubmenus.remove(item.id)
+            } else {
+                expandedSubmenus.insert(item.id)
+            }
+        } label: {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                if reservesIndicator {
+                    indicatorMark(selected: false)
+                }
+                if let systemImage = item.systemImage {
+                    Icon(systemName: systemImage).size(.sm).colorOverride(theme.text(.textSecondary))
+                }
+                Text(item.title)
+                    .textStyle(.bodyBase400)
+                    .foregroundStyle(theme.text(.textPrimary))
+                    .lineLimit(1)
+                Spacer(minLength: Theme.SpacingKey.md.value)
+                Icon(systemName: "chevron.forward").size(.xs).colorOverride(theme.text(.textTertiary))
+                    .rotationEffect(.degrees(expanded ? 90 : 0))
+            }
+            .padding(.horizontal, Theme.SpacingKey.sm.value)
+            .padding(.vertical, Theme.SpacingKey.sm.value)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(DropdownRowPressStyle(tint: accentColor.soft))
+        .disabled(item.isDisabled)
+        .opacity(item.isDisabled ? 0.4 : 1)
+        .accessibilityValue(expanded ? Text(String(themeKit: "Expanded")) : Text(String(themeKit: "Collapsed")))
+
+        if expanded {
+            let childReservesIndicator = children.contains { $0.isSelected }
+            ForEach(children) { child in
+                if child.isDivider {
+                    DividerView().size(.small)
+                        .padding(.vertical, Theme.SpacingKey.xs.value)
+                } else {
+                    // One tier deep: a nested `.submenu` renders as a plain row.
+                    row(child, reservesIndicator: childReservesIndicator, indented: true)
+                }
+            }
+        }
+    }
+
+    /// Fixed-width leading slot holding the selection mark; clear when the row
+    /// is unselected so titles align across the section.
+    private func indicatorMark(selected: Bool) -> some View {
+        Group {
+            if selected {
+                switch indicatorStyle {
+                case .checkmark:
+                    Icon(systemName: "checkmark").size(.xs).colorOverride(theme.foreground(.fgHero))
+                case .dot:
+                    Circle()
+                        .fill(theme.foreground(.fgHero))
+                        .frame(width: DropdownMetrics.dotDiameter, height: DropdownMetrics.dotDiameter)
+                }
+            } else {
+                Color.clear
+            }
+        }
+        .frame(width: DropdownMetrics.indicatorSlot, height: DropdownMetrics.indicatorSlot)
+        .accessibilityHidden(true)
     }
 }
 
@@ -262,6 +507,13 @@ public extension Dropdown {
     /// Fixed panel width in points; `nil` (default) fits the widest item.
     func menuWidth(_ points: CGFloat?) -> Self { copy { $0.menuWidth = points } }
 
+    /// The leading mark drawn on selected rows (default `.checkmark`).
+    func indicator(_ v: DropdownIndicator) -> Self { copy { $0.indicatorStyle = v } }
+
+    /// Whether tapping an action row dismisses the menu (default `true`).
+    /// Pass `false` for selection menus that should stay open across taps.
+    func shouldCloseOnSelect(_ on: Bool = true) -> Self { copy { $0.closesOnSelect = on } }
+
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
         mutate(&c)
@@ -273,39 +525,82 @@ public extension Dropdown {
     struct Demo: View {
         @Environment(\.theme) private var theme
 
+        @State private var sortBy = "Name"
+        @State private var layout = "List"
+        @State private var controlledOpen = false
+
         var items: [DropdownItem] {
             [
                 .init("Rename", systemImage: "pencil"),
-                .init("Duplicate", systemImage: "plus.square.on.square"),
+                .init("Duplicate", subtitle: "Copies into the same folder", systemImage: "plus.square.on.square"),
                 .init("Share", systemImage: "square.and.arrow.up", disabled: true),
+                .submenu("Export", systemImage: "arrow.up.doc", items: [
+                    .init("PDF", systemImage: "doc.richtext"),
+                    .init("PNG", systemImage: "photo"),
+                    .divider,
+                    .init("Plain text", systemImage: "doc.plaintext"),
+                ]),
                 .divider,
                 .init("Delete", systemImage: "trash", role: .destructive),
             ]
         }
 
+        var selectionSections: [DropdownSection] {
+            [
+                DropdownSection("Sort by", items: ["Name", "Date", "Size"].map { option in
+                    DropdownItem(option, isSelected: sortBy == option) { sortBy = option }
+                }),
+                DropdownSection("Layout", items: ["List", "Grid"].map { option in
+                    DropdownItem(option, isSelected: layout == option) { layout = option }
+                }),
+            ]
+        }
+
+        func triggerLabel(_ title: String) -> some View {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                Text(title).textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary))
+                Icon(systemName: "chevron.down").size(.xs).colorOverride(theme.text(.textTertiary))
+            }
+            .padding(.horizontal, Theme.SpacingKey.md.value)
+            .padding(.vertical, Theme.SpacingKey.sm.value)
+            .background(theme.background(.bgSecondaryLight),
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+        }
+
         var body: some View {
             VStack(spacing: 160) {
                 HStack(spacing: 120) {
+                    // Actions with subtitle + inline submenu.
                     Dropdown(items: items) {
-                        HStack(spacing: Theme.SpacingKey.xs.value) {
-                            Text("Options").textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary))
-                            Icon(systemName: "chevron.down").size(.xs).color(theme.text(.textTertiary))
-                        }
-                        .padding(.horizontal, Theme.SpacingKey.md.value)
-                        .padding(.vertical, Theme.SpacingKey.sm.value)
-                        .background(theme.background(.bgSecondaryLight),
-                                    in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+                        triggerLabel("Options")
                     }
 
                     Dropdown(items: items) {
-                        Icon(systemName: "ellipsis.circle").size(.md).color(theme.foreground(.fgHero))
+                        Icon(systemName: "ellipsis.circle").size(.md).colorOverride(theme.foreground(.fgHero))
                     }
                     .edge(.bottomTrailing)
                     .accent(.primary)
                 }
 
-                Dropdown(items: items) {
-                    Icon(systemName: "square.grid.2x2").size(.md).color(theme.foreground(.fgHero))
+                HStack(spacing: 120) {
+                    // Sectioned selection — checkmark indicator, stays open.
+                    Dropdown(sections: selectionSections) {
+                        triggerLabel(sortBy)
+                    }
+                    .shouldCloseOnSelect(false)
+
+                    // Dot indicator variant.
+                    Dropdown(sections: selectionSections) {
+                        triggerLabel(layout)
+                    }
+                    .edge(.bottomTrailing)
+                    .indicator(.dot)
+                    .shouldCloseOnSelect(false)
+                }
+
+                // Controlled open state via `isPresented:`.
+                Dropdown(items: items, isPresented: $controlledOpen) {
+                    triggerLabel(controlledOpen ? "Close" : "Open")
                 }
                 .edge(.topLeading)
                 .menuWidth(220)

--- a/Sources/ThemeKit/Components/Molecules/Dropdown.swift
+++ b/Sources/ThemeKit/Components/Molecules/Dropdown.swift
@@ -39,6 +39,12 @@ public struct DropdownItem: Identifiable {
     /// Non-`nil` marks this item as a submenu trigger row (one tier deep).
     let submenuItems: [DropdownItem]?
 
+    /// Content-stable identity for state that must survive item-array
+    /// rebuilds (e.g. submenu expansion): `id` is minted per instance, so a
+    /// parent re-render (selection change with `shouldCloseOnSelect(false)`)
+    /// would otherwise orphan any state keyed on it.
+    var diffIdentity: String { "\(title)|\(systemImage ?? "")" }
+
     public init(
         _ title: String,
         subtitle: String? = nil,
@@ -229,7 +235,7 @@ public struct Dropdown<Trigger: View>: View {
     private var closesOnSelect = true
 
     @State private var internalOpen = false
-    @State private var expandedSubmenus: Set<UUID> = []
+    @State private var expandedSubmenus: Set<String> = []
 
     /// A flat menu of items. Pass `isPresented:` to own the open state
     /// (controlled); omit it for the self-managing convenience.
@@ -408,13 +414,13 @@ public struct Dropdown<Trigger: View>: View {
     /// children indented beneath it. (HeroUI SubMenu.)
     @ViewBuilder
     private func submenuRows(_ item: DropdownItem, children: [DropdownItem], reservesIndicator: Bool) -> some View {
-        let expanded = expandedSubmenus.contains(item.id)
+        let expanded = expandedSubmenus.contains(item.diffIdentity)
 
         Button {
             if expanded {
-                expandedSubmenus.remove(item.id)
+                expandedSubmenus.remove(item.diffIdentity)
             } else {
-                expandedSubmenus.insert(item.id)
+                expandedSubmenus.insert(item.diffIdentity)
             }
         } label: {
             HStack(spacing: Theme.SpacingKey.sm.value) {
@@ -429,8 +435,9 @@ public struct Dropdown<Trigger: View>: View {
                     .foregroundStyle(theme.text(.textPrimary))
                     .lineLimit(1)
                 Spacer(minLength: Theme.SpacingKey.md.value)
-                Icon(systemName: "chevron.forward").size(.xs).colorOverride(theme.text(.textTertiary))
+                Icon(systemName: "chevron.right").size(.xs).colorOverride(theme.text(.textTertiary))
                     .rotationEffect(.degrees(expanded ? 90 : 0))
+                    .mirrorsInRTL()
             }
             .padding(.horizontal, Theme.SpacingKey.sm.value)
             .padding(.vertical, Theme.SpacingKey.sm.value)

--- a/Sources/ThemeKit/Components/Molecules/FilterGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/FilterGroup.swift
@@ -9,16 +9,21 @@ import SwiftUI
 /// Molecule. A single-select chip filter with a reset control. (daisyUI "Filter".)
 public struct FilterGroup<Option: Hashable>: View {
     @Environment(\.theme) private var theme
+    @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let title: String?
     private let options: [Option]
     @Binding private var selection: Option?
     private let label: (Option) -> String
 
-    // Appearance — mutated only through the modifiers below (R2).
+    // Appearance/config — mutated only through the modifiers below (R2).
     private var chipSize: ChipSize = .small
     private var selectionStyle: ChipSelectionStyle = .solid
     private var fillsWidth = false
+    private var isOptionEnabled: ((Option) -> Bool)?
+    private var infoMessages: [InfoMessage] = []
 
     public init(title: String? = nil, options: [Option], selection: Binding<Option?>, label: @escaping (Option) -> String) {
         self.title = title
@@ -27,17 +32,34 @@ public struct FilterGroup<Option: Hashable>: View {
         self.label = label
     }
 
+    private func optionEnabled(_ option: Option) -> Bool { isEnabled && (isOptionEnabled?(option) ?? true) }
+
+    /// The most severe message tints the group title (RadioGroup convention).
+    private var titleColor: Color {
+        switch infoMessages.dominantKind {
+        case .error: return theme.foreground(.systemcolorsFgError)
+        case .warning: return theme.foreground(.systemcolorsFgWarning)
+        default: return theme.text(.textPrimary)
+        }
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             if let title {
-                Text(title).textStyle(.labelMd600).foregroundStyle(theme.text(.textPrimary))
+                Text(title).textStyle(.labelMd600).foregroundStyle(titleColor)
             }
             if fillsWidth {
                 chips
             } else {
                 ScrollView(.horizontal, showsIndicators: false) { chips }
             }
+            if !infoMessages.isEmpty {
+                InfoMessageList(infoMessages)
+            }
         }
+        // Animate message rows in/out (their `.transition` lives in
+        // `InfoMessageList`); gated by `microAnimations` + Reduce Motion.
+        .animation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion), value: infoMessages)
     }
 
     private var chips: some View {
@@ -54,11 +76,14 @@ public struct FilterGroup<Option: Hashable>: View {
                 .buttonStyle(.plain)
             }
             ForEach(options, id: \.self) { option in
+                let enabled = optionEnabled(option)
                 Chip(label(option),
                      isSelected: Binding(get: { selection == option }, set: { isOn in selection = isOn ? option : nil }))
                     .chipStyle(selectionStyle)
                     .size(chipSize)
                     .expands(fillsWidth)
+                    .disabled(!enabled)
+                    .opacity(enabled ? 1 : 0.4)
             }
         }
     }
@@ -74,6 +99,10 @@ public extension FilterGroup {
     /// Stretch the chips edge-to-edge instead of scrolling horizontally —
     /// for option sets known to fit the row.
     func fullWidth(_ on: Bool = true) -> Self { copy { $0.fillsWidth = on } }
+    /// Per-option enablement predicate (nil enables every option).
+    func optionEnabled(_ predicate: ((Option) -> Bool)?) -> Self { copy { $0.isOptionEnabled = predicate } }
+    /// Validation / info messages rendered under the chips (drive the title color).
+    func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -92,6 +121,12 @@ public extension FilterGroup {
                 FilterGroup(title: "Stops", options: ["Direct", "1 stop", "2+"], selection: $stops) { $0 }
                     .chipStyle(.tonal)
                     .fullWidth()
+                // Per-option disabled: "Cars" renders dimmed + non-interactive.
+                FilterGroup(title: "Per-option disabled", options: ["Hotels", "Flights", "Cars", "Tours"], selection: $sel) { $0 }
+                    .optionEnabled { $0 != "Cars" }
+                // Invalid state: messages under the chips + error-tinted title.
+                FilterGroup(title: "With error", options: ["Direct", "1 stop", "2+"], selection: .constant(nil)) { $0 }
+                    .infoMessages([InfoMessage("Choose a stop filter", kind: .error)])
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
@@ -25,6 +25,8 @@ public struct MultiSelect<Option: Hashable>: View {
     private var placeholder: String = String(themeKit: "Select")
     private var infoMessages: [InfoMessage] = []
     private var isOptionEnabled: ((Option) -> Bool)? = nil
+    private var describeOption: ((Option) -> String?)? = nil
+    private var leadingContent: ((Option) -> AnyView)? = nil
     private var searchable: Bool = true
     private var allowClear: Bool = true
     private var maxTagCount: Int? = nil
@@ -34,17 +36,30 @@ public struct MultiSelect<Option: Hashable>: View {
 
     @State private var open = false
     @State private var query = ""
+    /// Caller-owned open state (R1 — bindings belong in `init`). When supplied,
+    /// the dropdown panel's visibility is controlled/observable from outside;
+    /// when `nil`, the private `open` state is used. MultiSelect is always
+    /// panel-presented, so the binding applies unconditionally.
+    private var externalExpanded: Binding<Bool>? = nil
 
     public init(   // R1
         _ label: String? = nil,
         options: [Option],
         selection: Binding<Set<Option>>,
+        isExpanded: Binding<Bool>? = nil,
         optionTitle: @escaping (Option) -> String
     ) {
         self.label = label
         self.options = options
         self._selection = selection
+        self.externalExpanded = isExpanded
         self.optionTitle = optionTitle
+    }
+
+    /// Resolved open state — the external binding wins when one was injected.
+    private var isOpen: Bool { externalExpanded?.wrappedValue ?? open }
+    private func setOpen(_ value: Bool) {
+        if let externalExpanded { externalExpanded.wrappedValue = value } else { open = value }
     }
 
     private var hasError: Bool { infoMessages.dominantKind == .error }
@@ -73,9 +88,9 @@ public struct MultiSelect<Option: Hashable>: View {
             if !infoMessages.isEmpty {
                 InfoMessageList(infoMessages).a11y(A11yElement.Field.message, in: accessibilityID)
             }
-            if open { panel }
+            if isOpen { panel }
         }
-        .animation(Motion.fast.animation, value: open)
+        .animation(Motion.fast.animation, value: isOpen)
     }
 
     /// The trigger wrapped in the active ``FieldStyle`` chrome. Configuration
@@ -85,11 +100,11 @@ public struct MultiSelect<Option: Hashable>: View {
     /// field's own 56pt min-height, which stays in the content).
     private var field: some View {
         Button {
-            if isEnabled { open.toggle() }
+            if isEnabled { setOpen(!isOpen) }
         } label: {
             fieldStyle.makeBody(configuration: FieldStyleConfiguration(
                 content: AnyView(fieldContent),
-                isFocused: open,
+                isFocused: isOpen,
                 isEnabled: isEnabled,
                 hasError: hasError,
                 hasWarning: hasWarning,
@@ -133,7 +148,7 @@ public struct MultiSelect<Option: Hashable>: View {
             if isLoading {
                 Spinner().size(IconSize.sm.value).lineWidth(2)
             } else {
-                Icon(systemName: open ? "chevron.up" : "chevron.down").size(.sm).color(theme.text(.textTertiary))
+                Icon(systemName: isOpen ? "chevron.up" : "chevron.down").size(.sm).color(theme.text(.textTertiary))
             }
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
@@ -174,9 +189,17 @@ public struct MultiSelect<Option: Hashable>: View {
                             Checkbox(isChecked: .constant(selection.contains(opt)))
                                 .controlSize(.small)
                                 .allowsHitTesting(false)
-                            Text(optionTitle(opt))
-                                .textStyle(.bodyBase400)
-                                .foregroundStyle(theme.text(.textPrimary))
+                            if let leadingContent { leadingContent(opt) }
+                            VStack(alignment: .leading, spacing: 0) {
+                                Text(optionTitle(opt))
+                                    .textStyle(.bodyBase400)
+                                    .foregroundStyle(theme.text(.textPrimary))
+                                if let description = describeOption?(opt) {
+                                    Text(description)
+                                        .textStyle(.bodySm400)
+                                        .foregroundStyle(theme.text(.textSecondary))
+                                }
+                            }
                             Spacer()
                         }
                         .padding(.horizontal, Theme.SpacingKey.md.value)

--- a/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
@@ -239,6 +239,17 @@ public extension MultiSelect {
     /// Per-option enable predicate; disabled rows are shown greyed and unselectable.
     func optionEnabled(_ predicate: ((Option) -> Bool)?) -> Self { copy { $0.isOptionEnabled = predicate } }
 
+    /// Second line rendered under each option title in the dropdown rows
+    /// (HeroUI `Select.ItemDescription`) — `.bodySm400` in the secondary text
+    /// token. Return `nil` for options without one.
+    func optionDescription(_ text: @escaping (Option) -> String?) -> Self { copy { $0.describeOption = text } }
+
+    /// Custom leading content rendered between the checkbox and the title in
+    /// each dropdown row (e.g. a `StatusDot` or `Icon`).
+    func optionLeading<V: View>(@ViewBuilder _ content: @escaping (Option) -> V) -> Self {
+        copy { $0.leadingContent = { AnyView(content($0)) } }
+    }
+
     /// Whether the dropdown shows a search field (default true).
     func searchable(_ on: Bool = true) -> Self { copy { $0.searchable = on } }
 
@@ -265,10 +276,23 @@ public extension MultiSelect {
 #Preview {
     struct Demo: View {
         @State var picks: Set<String> = ["Istanbul"]
+        @State var channels: Set<String> = []
+        @State var channelsOpen = false
         let cities = ["Istanbul", "Ankara", "Izmir", "Antalya", "Bursa", "Adana"]
+        let channelDetails = [
+            "Email": "Daily digest to your inbox",
+            "Push": "Instant alerts on your device",
+            "SMS": "Text messages for urgent updates",
+        ]
         var body: some View {
             VStack(spacing: 16) {
                 MultiSelect("Cities", options: cities, selection: $picks) { $0 }
+                // Descriptions + custom leading content, driven by a
+                // controlled isExpanded binding.
+                MultiSelect("Channels", options: ["Email", "Push", "SMS"], selection: $channels, isExpanded: $channelsOpen) { $0 }
+                    .optionDescription { channelDetails[$0] }
+                    .optionLeading { StatusDot($0 == "SMS" ? .busy : .online) }
+                Button(channelsOpen ? "Close channels" : "Open channels") { channelsOpen.toggle() }
                 // Chrome via the shared FieldStyle axis.
                 MultiSelect("Underlined", options: cities, selection: $picks) { $0 }
                     .fieldStyle(.underlined)

--- a/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
@@ -148,7 +148,7 @@ public struct MultiSelect<Option: Hashable>: View {
             if isLoading {
                 Spinner().size(IconSize.sm.value).lineWidth(2)
             } else {
-                Icon(systemName: isOpen ? "chevron.up" : "chevron.down").size(.sm).color(theme.text(.textTertiary))
+                Icon(systemName: isOpen ? "chevron.up" : "chevron.down").size(.sm).colorOverride(theme.text(.textTertiary))
             }
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)

--- a/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
@@ -20,6 +20,9 @@ public struct RadioGroup<Option: Hashable>: View {
     // Appearance/config — mutated only through the modifiers below (R2).
     private var infoMessages: [InfoMessage] = []
     private var isOptionEnabled: ((Option) -> Bool)?
+    private var description: (Option) -> String? = { _ in nil }
+    private var accent: SemanticColor?
+    private var axis: Axis = .vertical
     private var accessibilityID: String? = nil
 
     public init(
@@ -49,30 +52,54 @@ public struct RadioGroup<Option: Hashable>: View {
             if let title {
                 Text(title).textStyle(.labelMd600).foregroundStyle(titleColor)
             }
-            ForEach(Array(options.enumerated()), id: \.element) { index, option in
-                let enabled = optionEnabled(option)
-                Button {
-                    selection = option
-                } label: {
-                    HStack(spacing: Theme.SpacingKey.sm.value) {
-                        RadioButton(isSelected: .constant(selection == option))
-                        Text(label(option))
-                            .textStyle(.bodyBase400)
-                            .foregroundStyle(theme.text(.textPrimary))
-                        Spacer()
-                    }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(!enabled)
-                .opacity(enabled ? 1 : 0.4)
-                .a11y("option.\(index)", in: accessibilityID)
-                .accessibilityLabel(label(option))
-                .accessibilityAddTraits(selection == option ? .isSelected : [])
-            }
+            optionsContainer
             if !infoMessages.isEmpty {
                 InfoMessageList(infoMessages).a11y(A11yElement.Field.message, in: accessibilityID)
             }
+        }
+    }
+
+    /// Lays the option rows out along `axis` (HStack/VStack mirror for RTL automatically).
+    @ViewBuilder private var optionsContainer: some View {
+        switch axis {
+        case .horizontal:
+            HStack(alignment: .top, spacing: Theme.SpacingKey.md.value) { optionRows }
+        case .vertical:
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) { optionRows }
+        }
+    }
+
+    private var optionRows: some View {
+        ForEach(Array(options.enumerated()), id: \.element) { index, option in
+            let enabled = optionEnabled(option)
+            let description = description(option)
+            Button {
+                selection = option
+            } label: {
+                // Top-align the radio against the label block when supporting text is present.
+                HStack(alignment: description == nil ? .center : .top, spacing: Theme.SpacingKey.sm.value) {
+                    RadioButton(isSelected: .constant(selection == option))
+                        .accent(accent)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(label(option))
+                            .textStyle(.bodyBase400)
+                            .foregroundStyle(theme.text(.textPrimary))
+                        if let description {
+                            Text(description)
+                                .textStyle(.bodySm400)
+                                .foregroundStyle(theme.text(.textSecondary))
+                        }
+                    }
+                    if axis == .vertical { Spacer() }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!enabled)
+            .opacity(enabled ? 1 : 0.4)
+            .a11y("option.\(index)", in: accessibilityID)
+            .accessibilityLabel(label(option))
+            .accessibilityAddTraits(selection == option ? .isSelected : [])
         }
     }
 }
@@ -168,6 +195,14 @@ public struct RadioButtonGroup<Option: Hashable>: View {
         var body: some View {
             VStack(spacing: 24) {
                 RadioGroup(title: "Class", options: ["Economy", "Business", "First"], selection: $sel) { $0 }
+                RadioGroup(title: "Class + descriptions", options: ["Economy", "Business", "First"], selection: $sel) { $0 }
+                    .optionDescription {
+                        ["Economy": "Standard seat and cabin baggage.",
+                         "Business": "Priority boarding, lounge access and flat bed."][$0]
+                    }
+                    .accent(.success)
+                RadioGroup(title: "Horizontal", options: ["Economy", "Business", "First"], selection: $sel) { $0 }
+                    .axis(.horizontal)
                 RadioButtonGroup(options: ["Day", "Week", "Month"], selection: $seg) { $0 }
                 RadioButtonGroup(options: ["Day", "Week", "Month"], selection: $seg) { $0 }
                     .groupStyle(.outline).fullWidth()
@@ -186,6 +221,17 @@ public extension RadioGroup {
 
     /// Per-option enablement predicate (nil enables every option).
     func optionEnabled(_ predicate: ((Option) -> Bool)?) -> Self { copy { $0.isOptionEnabled = predicate } }
+
+    /// Supporting text rendered under each row's label (return nil for none).
+    func optionDescription(_ description: @escaping (Option) -> String?) -> Self { copy { $0.description = description } }
+
+    /// Semantic tint forwarded to every radio's selected fill/border; `nil`
+    /// (default) uses the hero tokens. (HeroUI item variant / daisyUI `radio-{color}`.)
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+
+    /// Layout axis of the option rows: `.vertical` (default) or `.horizontal`.
+    /// (HeroUI RadioGroup `orientation`.)
+    func axis(_ a: Axis) -> Self { copy { $0.axis = a } }
 
     /// Sets the accessibility-identifier namespace for this component (its
     /// sub-elements get `"<id>.<element>"`). Replaces the `accessibilityID:` init param.

--- a/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
+++ b/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
@@ -366,12 +366,24 @@ public struct RangeSlider: View {
     struct Demo: View {
         @State var lo: Double = 200
         @State var hi: Double = 800
+        @State var vLo: Double = 2
+        @State var vHi: Double = 6
         var body: some View {
-            RangeSlider(lowerValue: $lo, upperValue: $hi, in: 0...1000)
-                .step(50)
-                .marks([0, 250, 500, 750, 1000])
-                .valueLabel { "\(Int($0)) $" }
-                .padding()
+            // Tap-to-set: tapping anywhere on a track moves the nearest thumb.
+            VStack(spacing: 32) {
+                RangeSlider(lowerValue: $lo, upperValue: $hi, in: 0...1000)
+                    .step(50)
+                    .marks([0, 250, 500, 750, 1000])
+                    .valueLabel { "\(Int($0)) $" }
+                RangeSlider(lowerValue: $lo, upperValue: $hi, in: 0...1000)
+                    .step(50)
+                    .accent(.success)
+                    .valueLabel { "$\(Int($0))" }   // currency-style readout
+                RangeSlider(lowerValue: $vLo, upperValue: $vHi, in: 0...8)
+                    .axis(.vertical, height: 140)
+                    .valueLabel { "\(Int($0))" }
+            }
+            .padding()
         }
     }
     return Demo()
@@ -384,8 +396,15 @@ public extension RangeSlider {
 
     /// Snap increment for dragging, typed input and VoiceOver adjustments (default 1).
     func step(_ step: Double) -> Self { copy { $0.step = step } }
-    /// Labeled tick marks at the given values.
+    /// Labeled tick marks at the given values (horizontal axis only).
     func marks(_ marks: [Double]) -> Self { copy { $0.marks = marks } }
+    /// Lays the slider out vertically with the given track height (default 160).
+    func axis(_ axis: Axis, height: CGFloat = 160) -> Self {
+        copy { $0.axis = axis; $0.verticalHeight = height }
+    }
+    /// Semantic tint for the range fill and thumb rings; `nil` (default) keeps
+    /// the hero tokens.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     /// Shows linked numeric min/max input fields above the track.
     func inputs(_ on: Bool = true, titles: (min: String, max: String) = (String(themeKit: "Min"), String(themeKit: "Max"))) -> Self {
         copy { $0.showInputs = on; $0.inputTitles = titles }

--- a/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
+++ b/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
@@ -9,9 +9,11 @@ import SwiftUI
 /// Improved, token-bound rewrite of the reference RangeSliderView — a
 /// self-contained dual-thumb slider over a numeric range (decoupled from the
 /// reference's text-field wiring).
-/// Reference: Ant Design `Slider` (range) / MUI `Slider` — optional `marks`
-/// (labeled ticks), a disabled state, an `onChangeEnd` commit callback (fire the
-/// search on release, not on every drag tick), and VoiceOver-adjustable thumbs.
+/// Reference: Ant Design `Slider` (range) / MUI `Slider` / HeroUI `Slider` —
+/// optional `marks` (labeled ticks), a disabled state, an `onChangeEnd` commit
+/// callback (fire the search on release, not on every drag tick), tap-to-set on
+/// the track (moves the nearest thumb), a vertical axis, a semantic accent, and
+/// VoiceOver-adjustable thumbs.
 public struct RangeSlider: View {
     @Environment(\.theme) private var theme
 
@@ -23,6 +25,9 @@ public struct RangeSlider: View {
     // Opt-in presentation — set via chainable modifiers.
     private var step: Double = 1
     private var marks: [Double] = []
+    private var axis: Axis = .horizontal
+    private var verticalHeight: CGFloat = 160
+    private var accent: SemanticColor? = nil
     private var valueLabel: ((Double) -> String)? = nil
     private var onChangeEnd: ((Double, Double) -> Void)? = nil
     private var showInputs: Bool = false
@@ -32,9 +37,16 @@ public struct RangeSlider: View {
     @State private var upperText = ""
     @FocusState private var focusedField: Field?
     private enum Field { case lower, upper }
+    /// Which thumb the current track gesture is moving — chosen once at gesture
+    /// start (nearest to the touch) and kept for the rest of the drag.
+    @State private var activeThumb: Field? = nil
 
     private let thumbSize: CGFloat = 24
     private let trackHeight: CGFloat = 4
+    /// Extra tappable slop around the track so tap-to-set is easy to hit.
+    private let hitSlop: CGFloat = 8
+    /// HeroUI-style press feedback: the active thumb scales down while dragging.
+    private let pressScale: CGFloat = 0.9
 
     public init(   // R1
         lowerValue: Binding<Double>,

--- a/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
+++ b/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
@@ -63,43 +63,28 @@ public struct RangeSlider: View {
             if showInputs {
                 inputFields
             } else if let valueLabel {
-                HStack {
-                    Text(valueLabel(lowerValue))
-                    Spacer()
-                    Text(valueLabel(upperValue))
+                if axis == .vertical {
+                    HStack(spacing: Theme.SpacingKey.xs.value) {
+                        Text(valueLabel(lowerValue))
+                        Text(verbatim: "–")
+                        Text(valueLabel(upperValue))
+                    }
+                    .textStyle(.labelBase600)
+                    .foregroundStyle(theme.text(.textPrimary))
+                } else {
+                    HStack {
+                        Text(valueLabel(lowerValue))
+                        Spacer()
+                        Text(valueLabel(upperValue))
+                    }
+                    .textStyle(.labelBase600)
+                    .foregroundStyle(theme.text(.textPrimary))
                 }
-                .textStyle(.labelBase600)
-                .foregroundStyle(theme.text(.textPrimary))
             }
 
-            GeometryReader { geo in
-                let usable = max(geo.size.width - thumbSize, 1)
-                let span = bounds.upperBound - bounds.lowerBound
-                let lowerX = CGFloat((lowerValue - bounds.lowerBound) / span) * usable
-                let upperX = CGFloat((upperValue - bounds.lowerBound) / span) * usable
+            if axis == .vertical { verticalTrack } else { horizontalTrack }
 
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(theme.border(.borderPrimary))
-                        .frame(height: trackHeight)
-                    Capsule()
-                        .fill(theme.background(isEnabled ? .bgHero : .bgSecondaryLight))
-                        .frame(width: max(upperX - lowerX, 0), height: trackHeight)
-                        .offset(x: lowerX + thumbSize / 2)
-
-                    thumb(value: lowerValue, title: inputTitles.min, isLower: true)
-                        .offset(x: lowerX)
-                        .gesture(drag(usable: usable, span: span, isLower: true))
-                    thumb(value: upperValue, title: inputTitles.max, isLower: false)
-                        .offset(x: upperX)
-                        .gesture(drag(usable: usable, span: span, isLower: false))
-                }
-                .frame(height: thumbSize)
-            }
-            .frame(height: thumbSize)
-            .opacity(isEnabled ? 1 : 0.6)
-
-            if !marks.isEmpty {
+            if axis == .horizontal, !marks.isEmpty {
                 GeometryReader { geo in
                     marksRow(usable: max(geo.size.width - thumbSize, 1),
                              span: bounds.upperBound - bounds.lowerBound)
@@ -117,6 +102,86 @@ public struct RangeSlider: View {
             if new != .lower { commitLower() }
             if new != .upper { commitUpper() }
         }
+    }
+
+    // MARK: Track
+
+    private var horizontalTrack: some View {
+        GeometryReader { geo in
+            let usable = max(geo.size.width - thumbSize, 1)
+            let span = bounds.upperBound - bounds.lowerBound
+            let lowerX = CGFloat((lowerValue - bounds.lowerBound) / span) * usable
+            let upperX = CGFloat((upperValue - bounds.lowerBound) / span) * usable
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(theme.border(.borderPrimary))
+                    .frame(height: trackHeight)
+                Capsule()
+                    .fill(fillColor)
+                    .frame(width: max(upperX - lowerX, 0), height: trackHeight)
+                    .offset(x: lowerX + thumbSize / 2)
+
+                thumb(value: lowerValue, title: inputTitles.min, isLower: true)
+                    .offset(x: lowerX)
+                thumb(value: upperValue, title: inputTitles.max, isLower: false)
+                    .offset(x: upperX)
+            }
+            .frame(height: thumbSize)
+            // Tap-to-set: the whole (slop-enlarged) track accepts the drag and
+            // moves the thumb nearest to the touch.
+            .contentShape(Rectangle().inset(by: -hitSlop))
+            .gesture(drag(usable: usable, span: span))
+        }
+        .frame(height: thumbSize)
+        .opacity(isEnabled ? 1 : 0.6)
+    }
+
+    /// Vertical layout — same approach as `Slider.axis(.vertical)`: a fixed-height
+    /// bottom-aligned track whose gesture maps the absolute touch location to a
+    /// value (up = increase).
+    private var verticalTrack: some View {
+        GeometryReader { geo in
+            let usable = max(geo.size.height - thumbSize, 1)
+            let span = bounds.upperBound - bounds.lowerBound
+            let lowerY = CGFloat((lowerValue - bounds.lowerBound) / span) * usable
+            let upperY = CGFloat((upperValue - bounds.lowerBound) / span) * usable
+
+            ZStack(alignment: .bottom) {
+                Capsule()
+                    .fill(theme.border(.borderPrimary))
+                    .frame(width: trackHeight)
+                Capsule()
+                    .fill(fillColor)
+                    .frame(width: trackHeight, height: max(upperY - lowerY, 0))
+                    .offset(y: -(lowerY + thumbSize / 2))
+
+                thumb(value: lowerValue, title: inputTitles.min, isLower: true)
+                    .offset(y: -lowerY)
+                thumb(value: upperValue, title: inputTitles.max, isLower: false)
+                    .offset(y: -upperY)
+            }
+            .frame(maxWidth: .infinity)
+            // Tap-to-set, vertical flavor — see `horizontalTrack`.
+            .contentShape(Rectangle().inset(by: -hitSlop))
+            .gesture(verticalDrag(usable: usable, span: span))
+        }
+        .frame(width: thumbSize, height: verticalHeight)
+        .opacity(isEnabled ? 1 : 0.6)
+    }
+
+    // MARK: Colors
+
+    /// Track-fill shade — the accent's solid shade when set, else the hero token.
+    private var fillColor: Color {
+        guard isEnabled else { return theme.background(.bgSecondaryLight) }
+        return accent?.solid ?? theme.background(.bgHero)
+    }
+
+    /// Thumb-ring shade — the accent's solid shade when set, else the hero border.
+    private var thumbRingColor: Color {
+        guard isEnabled else { return theme.border(.borderPrimary) }
+        return accent?.solid ?? theme.border(.borderHero)
     }
 
     // MARK: Marks
@@ -204,12 +269,11 @@ public struct RangeSlider: View {
     private func thumb(value: Double, title: String, isLower: Bool) -> some View {
         Circle()
             .fill(theme.background(.bgWhite))
-            .overlay(
-                Circle().strokeBorder(isEnabled ? theme.border(.borderHero)
-                                                : theme.border(.borderPrimary), lineWidth: 2)
-            )
+            .overlay(Circle().strokeBorder(thumbRingColor, lineWidth: 2))
             .frame(width: thumbSize, height: thumbSize)
             .themeShadow(.soft)
+            // Press feedback while dragging — gated on microAnimations + Reduce Motion.
+            .microPressScale(activeThumb == (isLower ? .lower : .upper), scale: pressScale)
             .accessibilityElement()
             .accessibilityLabel(title)
             .accessibilityValue(markLabel(value))

--- a/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
+++ b/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
@@ -293,22 +293,59 @@ public struct RangeSlider: View {
         onChangeEnd?(lowerValue, upperValue)
     }
 
-    private func drag(usable: CGFloat, span: Double, isLower: Bool) -> some Gesture {
-        DragGesture()
+    /// Attached to the whole track (minimumDistance 0), so a tap anywhere moves
+    /// the nearest thumb to that value and a drag keeps moving the same thumb;
+    /// the change-end callback fires on release either way.
+    private func drag(usable: CGFloat, span: Double) -> some Gesture {
+        DragGesture(minimumDistance: 0)
             .onChanged { gesture in
                 guard isEnabled else { return }
                 let ratio = Double(min(max(gesture.location.x - thumbSize / 2, 0), usable) / usable)
-                let stepped = Self.snap(bounds.lowerBound + ratio * span, step: step)
-                if isLower {
-                    lowerValue = min(max(bounds.lowerBound, stepped), upperValue)
-                } else {
-                    upperValue = max(min(bounds.upperBound, stepped), lowerValue)
-                }
+                move(toward: bounds.lowerBound + ratio * span)
             }
             .onEnded { _ in
+                activeThumb = nil
                 guard isEnabled else { return }
                 onChangeEnd?(lowerValue, upperValue)
             }
+    }
+
+    /// Vertical variant of the track gesture (up = increase).
+    private func verticalDrag(usable: CGFloat, span: Double) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { gesture in
+                guard isEnabled else { return }
+                let fromBottom = usable + thumbSize / 2 - gesture.location.y
+                let ratio = Double(min(max(fromBottom, 0), usable) / usable)
+                move(toward: bounds.lowerBound + ratio * span)
+            }
+            .onEnded { _ in
+                activeThumb = nil
+                guard isEnabled else { return }
+                onChangeEnd?(lowerValue, upperValue)
+            }
+    }
+
+    /// Moves the gesture's thumb — chosen once per gesture as the one nearest to
+    /// the touched value — keeping the pair ordered (lower never crosses upper).
+    private func move(toward raw: Double) {
+        let stepped = Self.snap(raw, step: step)
+        let target = activeThumb ?? nearestThumb(to: stepped)
+        activeThumb = target
+        if target == .lower {
+            lowerValue = min(max(bounds.lowerBound, stepped), upperValue)
+        } else {
+            upperValue = max(min(bounds.upperBound, stepped), lowerValue)
+        }
+    }
+
+    private func nearestThumb(to value: Double) -> Field {
+        let lowerDistance = abs(value - lowerValue)
+        let upperDistance = abs(value - upperValue)
+        // Tie (including coincident thumbs): move lower when the touch is below
+        // it, upper otherwise, so a stacked pair can always be pulled apart.
+        if lowerDistance == upperDistance { return value < lowerValue ? .lower : .upper }
+        return lowerDistance < upperDistance ? .lower : .upper
     }
 
     // MARK: - Pure helpers (extracted for testing)

--- a/Sources/ThemeKit/Components/Molecules/Select.swift
+++ b/Sources/ThemeKit/Components/Molecules/Select.swift
@@ -288,6 +288,7 @@ public struct Select<Option: Hashable>: View {
                             .buttonStyle(RowPressStyle())
                             .disabled(!enabled)
                             .opacity(enabled ? 1 : 0.4)
+                            .accessibilityAddTraits(selection == option ? .isSelected : [])
                         }
                     }
                 }

--- a/Sources/ThemeKit/Components/Molecules/Select.swift
+++ b/Sources/ThemeKit/Components/Molecules/Select.swift
@@ -39,6 +39,8 @@ public struct Select<Option: Hashable>: View {
     private var infoMessages: [InfoMessage] = []
     private var isLoading: Bool = false
     private var isOptionEnabled: ((Option) -> Bool)? = nil
+    private var describeOption: ((Option) -> String?)? = nil
+    private var leadingContent: ((Option) -> AnyView)? = nil
     private var accessibilityID: String? = nil
     @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
 
@@ -50,26 +52,41 @@ public struct Select<Option: Hashable>: View {
 
     @State private var open = false
     @State private var query = ""
+    /// Caller-owned open state (R1 — bindings belong in `init`). When supplied,
+    /// the searchable panel's visibility is controlled/observable from outside;
+    /// when `nil`, the private `open` state is used. Native-`Menu` mode manages
+    /// its own presentation (SwiftUI exposes no `isPresented` for `Menu`), so
+    /// the binding is honored only together with `.searchable()`.
+    private var externalExpanded: Binding<Bool>? = nil
 
     public init(   // R1
         _ label: String,
         options: [Option],
         selection: Binding<Option?>,
+        isExpanded: Binding<Bool>? = nil,
         optionTitle: @escaping (Option) -> String
     ) {
-        self.init(label, sections: [Section(nil, options)], selection: selection, optionTitle: optionTitle)
+        self.init(label, sections: [Section(nil, options)], selection: selection, isExpanded: isExpanded, optionTitle: optionTitle)
     }
 
     public init(   // R1
         _ label: String,
         sections: [Section],
         selection: Binding<Option?>,
+        isExpanded: Binding<Bool>? = nil,
         optionTitle: @escaping (Option) -> String
     ) {
         self.label = label
         self.sections = sections
         self._selection = selection
+        self.externalExpanded = isExpanded
         self.optionTitle = optionTitle
+    }
+
+    /// Resolved open state — the external binding wins when one was injected.
+    private var isOpen: Bool { externalExpanded?.wrappedValue ?? open }
+    private func setOpen(_ value: Bool) {
+        if let externalExpanded { externalExpanded.wrappedValue = value } else { open = value }
     }
 
     private var hasValue: Bool { selection != nil }
@@ -81,7 +98,7 @@ public struct Select<Option: Hashable>: View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
             ZStack(alignment: .trailing) {
                 if searchable {
-                    Button { if isEnabled { open.toggle() } } label: { field }
+                    Button { if isEnabled { setOpen(!isOpen) } } label: { field }
                         .buttonStyle(.plain)
                         .disabled(!isEnabled)
                 } else {
@@ -94,12 +111,12 @@ public struct Select<Option: Hashable>: View {
             .accessibilityLabel(label)
             .accessibilityValue(selection.map(optionTitle) ?? "")
 
-            if searchable && open { panel }
+            if searchable && isOpen { panel }
             if !infoMessages.isEmpty {
                 InfoMessageList(infoMessages).a11y(A11yElement.Field.message, in: accessibilityID)
             }
         }
-        .animation(Motion.fast.animation, value: open)
+        .animation(Motion.fast.animation, value: isOpen)
     }
 
     // MARK: Trigger field
@@ -122,7 +139,7 @@ public struct Select<Option: Hashable>: View {
             if isLoading {
                 Spinner().size(IconSize.sm.value).lineWidth(2)
             } else {
-                Icon(systemName: open ? "chevron.up" : "chevron.down")
+                Icon(systemName: isOpen ? "chevron.up" : "chevron.down")
                     .size(.sm)
                     .color(showsClear ? .clear : theme.text(.textTertiary))
             }
@@ -144,7 +161,7 @@ public struct Select<Option: Hashable>: View {
         if selectStyle.isDefault {
             fieldStyle.makeBody(configuration: FieldStyleConfiguration(
                 content: AnyView(fieldContent),
-                isFocused: open,
+                isFocused: isOpen,
                 isEnabled: isEnabled,
                 hasError: infoMessages.dominantKind == .error,
                 hasWarning: infoMessages.dominantKind == .warning,
@@ -153,7 +170,7 @@ public struct Select<Option: Hashable>: View {
         } else {
             selectStyle.makeBody(configuration: SelectStyleConfiguration(
                 content: AnyView(fieldContent),
-                isOpen: open,
+                isOpen: isOpen,
                 isEnabled: isEnabled,
                 hasError: infoMessages.dominantKind == .error,
                 hasWarning: infoMessages.dominantKind == .warning
@@ -185,14 +202,24 @@ public struct Select<Option: Hashable>: View {
         }
     }
 
+    /// Native menu rows. A second `Text` in a menu button's label renders as the
+    /// system subtitle line — that's how `optionDescription` reaches this mode.
+    /// The system styles menu rows itself (theme tokens can't apply inside a
+    /// native `Menu`); `optionLeading` views are likewise stripped by the menu,
+    /// so custom leading content appears only in the searchable panel.
     @ViewBuilder
     private func rows(_ options: [Option]) -> some View {
         ForEach(options, id: \.self) { option in
             Button {
                 selection = option
             } label: {
-                if selection == option { Label(optionTitle(option), systemImage: "checkmark") }
-                else { Text(optionTitle(option)) }
+                Text(optionTitle(option))
+                if let description = describeOption?(option) {
+                    Text(description)
+                }
+                if selection == option {
+                    Image(systemName: "checkmark")
+                }
             }
             .disabled(!optionEnabled(option))
         }
@@ -241,9 +268,15 @@ public struct Select<Option: Hashable>: View {
                         }
                         ForEach(opts, id: \.self) { option in
                             let enabled = optionEnabled(option)
-                            Button { selection = option; open = false; query = "" } label: {
-                                HStack {
-                                    Text(optionTitle(option)).textStyle(.bodyBase400).foregroundStyle(theme.text(.textPrimary))
+                            Button { selection = option; setOpen(false); query = "" } label: {
+                                HStack(spacing: Theme.SpacingKey.sm.value) {
+                                    if let leadingContent { leadingContent(option) }
+                                    VStack(alignment: .leading, spacing: 0) {
+                                        Text(optionTitle(option)).textStyle(.bodyBase400).foregroundStyle(theme.text(.textPrimary))
+                                        if let description = describeOption?(option) {
+                                            Text(description).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                                        }
+                                    }
                                     Spacer()
                                     if selection == option {
                                         Icon(systemName: "checkmark").size(.sm).color(theme.foreground(.fgHero))

--- a/Sources/ThemeKit/Components/Molecules/Select.swift
+++ b/Sources/ThemeKit/Components/Molecules/Select.swift
@@ -326,6 +326,19 @@ public extension Select {
     /// Per-option enable predicate; disabled rows are shown greyed and unselectable.
     func optionEnabled(_ predicate: ((Option) -> Bool)?) -> Self { copy { $0.isOptionEnabled = predicate } }
 
+    /// Second line rendered under each option title (HeroUI `Select.ItemDescription`).
+    /// Return `nil` for options without one. In the searchable panel it renders
+    /// `.bodySm400` in the secondary text token; in native-`Menu` mode it becomes
+    /// the system-styled menu subtitle (tokens can't apply inside a native menu).
+    func optionDescription(_ text: @escaping (Option) -> String?) -> Self { copy { $0.describeOption = text } }
+
+    /// Custom leading content rendered before each option title in the
+    /// **searchable panel** rows (e.g. a `StatusDot` or `Icon`). Native `Menu`
+    /// rows strip custom views, so this has no effect without `.searchable()`.
+    func optionLeading<V: View>(@ViewBuilder _ content: @escaping (Option) -> V) -> Self {
+        copy { $0.leadingContent = { AnyView(content($0)) } }
+    }
+
     /// Sets the accessibility-identifier namespace for this component (its
     /// sub-elements get `"<id>.<element>"`).
     func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
@@ -340,6 +353,13 @@ public extension Select {
 #Preview {
     struct Demo: View {
         @State var city: String?
+        @State var plan: String?
+        @State var planPanelOpen = false
+        let planDetails = [
+            "Basic": "Essential features for personal use",
+            "Pro": "Advanced tools for power users",
+            "Team": "Collaboration for organizations",
+        ]
         var body: some View {
             VStack(spacing: 16) {
                 Select("City", options: ["Istanbul", "Ankara", "Izmir"], selection: $city) { $0 }
@@ -347,6 +367,16 @@ public extension Select {
                 Select("Searchable", sections: [.init("Marmara", ["Istanbul", "Bursa"]), .init("Aegean", ["Izmir", "Aydin"])],
                        selection: $city) { $0 }
                     .searchable()
+                // Native-menu subtitles via optionDescription.
+                Select("Plan (menu)", options: ["Basic", "Pro", "Team"], selection: $plan) { $0 }
+                    .optionDescription { planDetails[$0] }
+                // Panel rows with descriptions + custom leading content,
+                // driven by a controlled isExpanded binding.
+                Select("Plan (panel)", options: ["Basic", "Pro", "Team"], selection: $plan, isExpanded: $planPanelOpen) { $0 }
+                    .searchable()
+                    .optionDescription { planDetails[$0] }
+                    .optionLeading { StatusDot($0 == "Pro" ? .online : .neutral) }
+                Button(planPanelOpen ? "Close plan panel" : "Open plan panel") { planPanelOpen.toggle() }
                 // Chrome via the shared FieldStyle axis.
                 Select("Underlined", options: ["Istanbul", "Ankara", "Izmir"], selection: $city) { $0 }
                     .fieldStyle(.underlined)

--- a/Sources/ThemeKit/Components/Molecules/Slider.swift
+++ b/Sources/ThemeKit/Components/Molecules/Slider.swift
@@ -7,8 +7,9 @@
 import SwiftUI
 
 /// Molecule. Single-thumb value slider with optional labeled marks, a drag
-/// value tooltip and a disabled state. (Ant Slider parity.) Shares the visual
-/// language of RangeSlider (token track / fill / thumb).
+/// value tooltip, tap-to-set on the track, a persistent formatted value readout,
+/// a semantic accent and a disabled state. (Ant / HeroUI Slider parity.) Shares
+/// the visual language of RangeSlider (token track / fill / thumb).
 public struct Slider: View {
     @Environment(\.theme) private var theme
 
@@ -23,13 +24,18 @@ public struct Slider: View {
     private var axis: Axis = .horizontal
     private var verticalHeight: CGFloat = 160
     private var showValueTooltip: Bool = false
+    private var valueLabel: ((Double) -> String)? = nil
+    private var accent: SemanticColor? = nil
     private var onChangeEnd: ((Double) -> Void)? = nil
 
     @State private var dragging = false
-    @State private var dragStartValue: Double?
 
     private let thumbSize: CGFloat = 24
     private let trackHeight: CGFloat = 4
+    /// Extra tappable slop around the track so tap-to-set is easy to hit.
+    private let hitSlop: CGFloat = 8
+    /// HeroUI-style press feedback: the thumb scales down while dragging.
+    private let pressScale: CGFloat = 0.9
 
     public init(   // R1
         value: Binding<Double>,
@@ -51,8 +57,11 @@ public struct Slider: View {
 
     private var span: Double { bounds.upperBound - bounds.lowerBound }
 
+    /// One formatting point for the label row, the drag tooltip and the
+    /// accessibility value — the `valueLabel` closure wins when provided.
     private func valueText(_ v: Double) -> String {
-        step.truncatingRemainder(dividingBy: 1) == 0 ? "\(Int(v))" : String(format: "%.1f", v)
+        if let valueLabel { return valueLabel(v) }
+        return step.truncatingRemainder(dividingBy: 1) == 0 ? "\(Int(v))" : String(format: "%.1f", v)
     }
 
     public var body: some View {
@@ -61,8 +70,13 @@ public struct Slider: View {
 
     private var verticalBody: some View {
         VStack(spacing: Theme.SpacingKey.sm.value) {
-            if let label {
-                Text(label).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+            if label != nil || valueLabel != nil {
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    if let label { Text(label) }
+                    if valueLabel != nil { Text(valueText(value)) }
+                }
+                .textStyle(.labelBase600)
+                .foregroundStyle(theme.text(.textPrimary))
             }
             GeometryReader { geo in
                 let usable = max(geo.size.height - thumbSize, 1)
@@ -70,11 +84,13 @@ public struct Slider: View {
                 ZStack(alignment: .bottom) {
                     Capsule().fill(theme.border(.borderPrimary)).frame(width: trackHeight)
                     Capsule().fill(fillColor).frame(width: trackHeight, height: y + thumbSize / 2)
-                    thumb
-                        .offset(y: -y)
-                        .gesture(verticalDrag(usable: usable))
+                    thumb.offset(y: -y)
                 }
                 .frame(maxWidth: .infinity)
+                // Tap-to-set: the whole (slop-enlarged) track accepts the drag,
+                // so a tap anywhere jumps the thumb to that value.
+                .contentShape(Rectangle().inset(by: -hitSlop))
+                .gesture(verticalDrag(usable: usable))
             }
             .frame(width: thumbSize, height: verticalHeight)
         }
@@ -94,10 +110,14 @@ public struct Slider: View {
 
     private var horizontalBody: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
-            if let label {
-                Text(label)
-                    .textStyle(.labelBase600)
-                    .foregroundStyle(theme.text(.textPrimary))
+            if label != nil || valueLabel != nil {
+                HStack {
+                    if let label { Text(label) }
+                    Spacer()
+                    if valueLabel != nil { Text(valueText(value)) }
+                }
+                .textStyle(.labelBase600)
+                .foregroundStyle(theme.text(.textPrimary))
             }
             GeometryReader { geo in
                 let usable = max(geo.size.width - thumbSize, 1)
@@ -118,9 +138,12 @@ public struct Slider: View {
                     thumb
                         .offset(x: x)
                         .overlay(alignment: .top) { tooltip.offset(x: x, y: -thumbSize) }
-                        .gesture(drag(usable: usable))
                 }
                 .frame(height: thumbSize)
+                // Tap-to-set: the whole (slop-enlarged) track accepts the drag,
+                // so a tap anywhere jumps the thumb to that value.
+                .contentShape(Rectangle().inset(by: -hitSlop))
+                .gesture(drag(usable: usable))
             }
             .frame(height: thumbSize)
 
@@ -158,6 +181,8 @@ public struct Slider: View {
             .overlay(Circle().strokeBorder(theme.foreground(.fgSecondary), lineWidth: 2))
             .frame(width: thumbSize, height: thumbSize)
             .themeShadow(.soft)
+            // Press feedback while dragging — gated on microAnimations + Reduce Motion.
+            .microPressScale(dragging, scale: pressScale)
     }
 
     @ViewBuilder

--- a/Sources/ThemeKit/Components/Molecules/Slider.swift
+++ b/Sources/ThemeKit/Components/Molecules/Slider.swift
@@ -199,11 +199,15 @@ public struct Slider: View {
     }
 
     private var fillColor: Color {
-        theme.background(isEnabled ? .bgHero : .bgSecondary)
+        guard isEnabled else { return theme.background(.bgSecondary) }
+        return accent?.solid ?? theme.background(.bgHero)
     }
 
+    /// Attached to the whole track (minimumDistance 0), so a tap anywhere sets
+    /// the value from its absolute location and a drag keeps tracking it; the
+    /// change-end callback fires on release either way.
     private func drag(usable: CGFloat) -> some Gesture {
-        DragGesture()
+        DragGesture(minimumDistance: 0)
             .onChanged { g in
                 guard isEnabled else { return }
                 dragging = true
@@ -214,20 +218,19 @@ public struct Slider: View {
             .onEnded { _ in dragging = false; onChangeEnd?(value) }
     }
 
-    /// Vertical drag uses translation (up = increase) so the math stays correct
-    /// regardless of the thumb-local gesture coordinate space.
+    /// Vertical variant of the track gesture — the track is a fixed coordinate
+    /// space, so the value maps from the absolute touch location (up = increase).
     private func verticalDrag(usable: CGFloat) -> some Gesture {
-        DragGesture()
+        DragGesture(minimumDistance: 0)
             .onChanged { g in
                 guard isEnabled else { return }
                 dragging = true
-                let start = dragStartValue ?? value
-                if dragStartValue == nil { dragStartValue = value }
-                let deltaRatio = Double(-g.translation.height / usable)
-                let raw = start + deltaRatio * span
+                let fromBottom = usable + thumbSize / 2 - g.location.y
+                let ratio = Double(min(max(fromBottom, 0), usable) / usable)
+                let raw = bounds.lowerBound + ratio * span
                 value = min(max(bounds.lowerBound, (raw / step).rounded() * step), bounds.upperBound)
             }
-            .onEnded { _ in dragging = false; dragStartValue = nil; onChangeEnd?(value) }
+            .onEnded { _ in dragging = false; onChangeEnd?(value) }
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/Slider.swift
+++ b/Sources/ThemeKit/Components/Molecules/Slider.swift
@@ -237,11 +237,23 @@ public struct Slider: View {
 #Preview {
     struct Demo: View {
         @State var v: Double = 4
+        @State var price: Double = 240
         var body: some View {
+            // Tap-to-set: tapping anywhere on a track jumps the thumb there.
             VStack(spacing: 32) {
                 Slider(value: $v, in: 0...8, label: "Volume \(Int(v))").showsValueTooltip()
                 Slider(value: $v, in: 0...8).step(2).marks([0: "0", 4: "Mid", 8: "Max"])
+                Slider(value: $price, in: 0...1000, label: "Budget")
+                    .step(10)
+                    .valueLabel { "$\(Int($0))" }   // currency-style readout + tooltip
+                    .showsValueTooltip()
+                Slider(value: $v, in: 0...8, label: "Accented")
+                    .accent(.success)
+                    .valueLabel { "\(Int($0))" }
                 Slider(value: .constant(3), in: 0...8, label: "Disabled").disabled(true)
+                Slider(value: $v, in: 0...8, label: "Vertical")
+                    .axis(.vertical, height: 120)
+                    .valueLabel { "\(Int($0))" }
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/Slider.swift
+++ b/Sources/ThemeKit/Components/Molecules/Slider.swift
@@ -264,6 +264,13 @@ public extension Slider {
     }
     /// Shows a value tooltip above the thumb while dragging.
     func showsValueTooltip(_ on: Bool = true) -> Self { copy { $0.showValueTooltip = on } }
+    /// Formats the persistent value readout on the label row (e.g. "$500");
+    /// the same closure formats the drag tooltip and the accessibility value.
+    /// `nil` (default) hides the readout and keeps plain numeric formatting.
+    func valueLabel(_ format: ((Double) -> String)?) -> Self { copy { $0.valueLabel = format } }
+    /// Semantic tint for the track fill and thumb; `nil` (default) keeps the
+    /// hero tokens.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     /// Fires with the snapped value when a drag ends (not on every step).
     func onChangeEnd(_ action: ((Double) -> Void)?) -> Self { copy { $0.onChangeEnd = action } }
 

--- a/Sources/ThemeKit/Components/Molecules/ThemeToggle.swift
+++ b/Sources/ThemeKit/Components/Molecules/ThemeToggle.swift
@@ -16,6 +16,9 @@ public struct ThemeToggle: View {
     private var isLoading = false
     private var onSystemImage: String?
     private var offSystemImage: String?
+    private var trackOnSymbol: String?
+    private var trackOffSymbol: String?
+    private var customThumb: ((Bool) -> AnyView)?
     private var accent: SemanticColor?
     private var accessibilityID: String? = nil
 
@@ -44,13 +47,14 @@ public struct ThemeToggle: View {
             Capsule()
                 .fill(track)
                 .frame(width: trackWidth, height: trackHeight)
+                .overlay(trackSymbol)   // under the knob so it never overlaps it mid-slide
                 .overlay(
                     knob
                         .padding(2)
                         .frame(maxWidth: .infinity, alignment: isOn ? .trailing : .leading)
                 )
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressFeedbackStyle())   // subtle press scale, gated by microAnimations + Reduce Motion
         .disabled(!interactive)
         .opacity(isEnabled ? 1 : 0.6)
         .a11y(A11yElement.Control.toggle, in: accessibilityID)
@@ -58,6 +62,7 @@ public struct ThemeToggle: View {
         .accessibilityAddTraits(isOn ? .isSelected : [])
     }
 
+    /// Knob content precedence: loading spinner > custom `thumbContent` > `symbols` glyph.
     private var knob: some View {
         Circle()
             .fill(theme.foreground(.fgSecondary))
@@ -67,12 +72,40 @@ public struct ThemeToggle: View {
                     ProgressView()
                         .controlSize(.mini)
                         .tint(theme.foreground(.fgHero))
+                } else if let customThumb {
+                    customThumb(isOn)
+                        .frame(width: knobSize, height: knobSize)
+                        .clipShape(Circle())
                 } else if let glyph = isOn ? onSystemImage : offSystemImage {
                     Image(systemName: glyph)
                         .font(.system(size: knobSize * 0.55, weight: .bold))
                         .foregroundStyle(isOn ? theme.text(.textHero) : theme.text(.textTertiary))
                 }
             }
+    }
+
+    /// On-track glyph rendered on the side the knob vacated (HeroUI
+    /// `Switch.StartContent` / `Switch.EndContent` parity): on-symbol at the
+    /// leading edge while on, off-symbol at the trailing edge while off.
+    @ViewBuilder private var trackSymbol: some View {
+        if let glyph = isOn ? trackOnSymbol : trackOffSymbol {
+            Image(systemName: glyph)
+                .font(.system(size: knobSize * 0.55, weight: .bold))
+                .foregroundStyle(trackSymbolColor)
+                .frame(width: knobSize, height: knobSize)   // centered in the knob-sized vacated zone
+                .padding(2)
+                .frame(maxWidth: .infinity, alignment: isOn ? .leading : .trailing)
+                .transition(.opacity)
+                .id(glyph)   // crossfade between on/off glyphs under the file's motion
+        }
+    }
+
+    /// Contrast-correct color for the visible track glyph: it sits on `track`,
+    /// which is the accent/hero solid only when on **and** enabled, otherwise
+    /// the secondary background.
+    private var trackSymbolColor: Color {
+        guard isOn, isEnabled else { return theme.text(.textTertiary) }
+        return accent?.onSolid ?? theme.text(.textHero)
     }
 
     private var track: Color {
@@ -83,6 +116,7 @@ public struct ThemeToggle: View {
 }
 
 #Preview {
+    @Previewable @State var live = true   // interactive rows: slide + press-scale feedback
     VStack(alignment: .leading, spacing: 16) {
         ThemeToggle(isOn: .constant(true))
         ThemeToggle(isOn: .constant(false))
@@ -92,6 +126,17 @@ public struct ThemeToggle: View {
         ThemeToggle(isOn: .constant(true)).disabled(true)
         ThemeToggle(isOn: .constant(true)).accent(.success)
         ThemeToggle(isOn: .constant(true)).accent(.error).controlSize(.small)
+        // Track symbols (HeroUI start/end content) — tap to see the crossfade + press scale.
+        ThemeToggle(isOn: $live).trackSymbols(on: "sun.max.fill", off: "moon.fill")
+        ThemeToggle(isOn: .constant(false)).trackSymbols(on: "sun.max.fill", off: "moon.fill")
+        ThemeToggle(isOn: .constant(true)).trackSymbols(on: "sun.max.fill", off: "moon.fill").disabled(true)
+        ThemeToggle(isOn: .constant(true)).trackSymbols(on: "checkmark").accent(.success).controlSize(.small)
+        // Custom thumb content (HeroUI Switch.Thumb children); spinner still wins while loading.
+        ThemeToggle(isOn: $live).thumbContent { on in
+            Image(systemName: on ? "sun.max.fill" : "moon.fill")
+                .font(.system(size: 10, weight: .bold))
+        }
+        ThemeToggle(isOn: .constant(true)).thumbContent { _ in Text("A").font(.system(size: 10, weight: .bold)) }.loading()
     }
     .padding()
 }
@@ -105,6 +150,21 @@ public extension ThemeToggle {
     /// Optional SF Symbols shown inside the knob for the on / off states.
     func symbols(on: String? = nil, off: String? = nil) -> Self {
         copy { $0.onSystemImage = on; $0.offSystemImage = off }
+    }
+
+    /// Optional SF Symbols shown inside the *track*, on the side opposite the
+    /// knob — the on-symbol while on, the off-symbol while off (HeroUI
+    /// `Switch.StartContent`/`EndContent`). Distinct from `symbols(on:off:)`,
+    /// which decorates the knob itself; both may be combined.
+    func trackSymbols(on: String? = nil, off: String? = nil) -> Self {
+        copy { $0.trackOnSymbol = on; $0.trackOffSymbol = off }
+    }
+
+    /// Custom view rendered inside the knob (receives `isOn`), replacing the
+    /// `symbols(on:off:)` glyph (HeroUI `Switch.Thumb` children). The loading
+    /// spinner keeps priority: spinner > `thumbContent` > `symbols`.
+    func thumbContent<C: View>(@ViewBuilder _ content: @escaping (Bool) -> C) -> Self {
+        copy { $0.customThumb = { AnyView(content($0)) } }
     }
 
     /// Semantic tint for the on-state track; `nil` (default) uses the hero


### PR DESCRIPTION
## Summary

Second wave of the gap plans from `HEROUI_NATIVE_AUDIT.md` (#216): closes the audited selection & control gaps vs HeroUI Native across 10 files. All changes additive/backward compatible.

### Dropdown (Menu parity)
- Selection: `DropdownSection` (optional headed groups), `isSelected:` items, `.indicator(.checkmark/.dot)`, `.shouldCloseOnSelect(false)`, `.isSelected` a11y traits; indicator slot reserved for aligned titles.
- `subtitle:` second line on items; non-interactive section headings (`.isHeader`).
- `.submenu(...)` — inline expandable tier with MicroMotion chevron rotation (RTL-stable), keyed on content-stable identity so parent re-renders don't collapse open submenus.
- Controlled open state via defaulted `isPresented:` binding.

### Select / MultiSelect
- `.optionDescription(_:)` second lines (system subtitles in native Menu, token-styled in panels); `.optionLeading` slot; defaulted `isExpanded:` binding for panel presentations; panel rows announce `.isSelected`.

### RadioGroup
- `.optionDescription(_:)` (ToggleGroup idiom, top-aligned rows), group-level `.accent(_:)`, `.axis(.horizontal)`.

### ChipGroup / FilterGroup (TagGroup parity)
- `.optionEnabled(_:)` per-option disabled (sibling-group convention), `.removable(_:)` trailing remove with localized label, `.infoMessages(_:)` validation with the MicroMotion-gated message animation, `.emptyContent` slot.

### Tag (Chip parity)
- `.size(ChipSize)` ramp with token-derived paddings (fixed 28pt height dropped — Dynamic Type safe), `leading`/`trailing` ViewBuilder slots.

### ThemeToggle (Switch parity)
- `.trackSymbols(on:off:)` on the vacated track side, `.thumbContent` custom knob slot (spinner keeps priority), press feedback via `PressFeedbackStyle`.

### Slider / RangeSlider
- `Slider.valueLabel(_:)` (single formatting funnel: label row, tooltip, accessibilityValue), tap-to-set on the full track (nearest thumb on RangeSlider), `.accent(_:)`, vertical RangeSlider, thumb press-scale via `microPressScale`.

### Review
Two adversarial lenses (compile-correctness; house-rules + a11y/l10n/RTL); 4 findings fixed (stable submenu identity, RTL chevron, `.isSelected` trait, deprecated-API migration).

Previews extended throughout. No Swift toolchain in the authoring environment — all APIs cross-checked against real declarations; local build + snapshot run recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NurTVFpssqcMiR3BBb2H24

---
_Generated by [Claude Code](https://claude.ai/code/session_01NurTVFpssqcMiR3BBb2H24)_