### PR TITLE
feat: HeroUI gap wave 3 — overlay & feedback parity (Dialog, BottomSheet, popovers, toasts…)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/Skeleton.swift
+++ b/Sources/ThemeKit/Components/Atoms/Skeleton.swift
@@ -3,20 +3,31 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Improved, token-bound rewrite of the reference SkeletonView. A shimmering
+//  Improved, token-bound rewrite of the reference SkeletonView. An animated
 //  placeholder driven by the skeleton color tokens (which adapt to the dark
 //  theme automatically), applied via `.skeleton(_:)` over any view, via
 //  `.skeleton(_:shape:)` for a custom outline, or as a standalone `Skeleton`
-//  primitive of an arbitrary shape and size.
+//  primitive of an arbitrary shape and size. Three variants (HeroUI Native
+//  parity): a traveling `shimmer` sweep (default), an opacity `pulse`, and
+//  `none` for a static fill. When loading ends the placeholder cross-fades
+//  into the revealed content, honoring `microAnimations` + Reduce Motion.
 //
 
 import SwiftUI
 
 /// The outline of a skeleton placeholder.
 public enum SkeletonShape: Equatable {
+    /// Raw corner radius. Prefer the token-fed `rounded(_ role:)` overload so a
+    /// theme can re-round every skeleton from one token.
     case rounded(CGFloat)
     case circle
     case capsule
+
+    /// Token-fed rounded outline: the corner resolves from the active theme's
+    /// radius *role* (`.box` cards · `.field` controls · `.selector` chips).
+    public static func rounded(_ role: Theme.RadiusRole) -> SkeletonShape {
+        .rounded(role.value)
+    }
 
     var anyShape: AnyShape {
         switch self {
@@ -27,23 +38,56 @@ public enum SkeletonShape: Equatable {
     }
 }
 
-/// The shimmering fill, reused by the modifier and the standalone view.
+/// How a skeleton placeholder animates while loading (HeroUI Native parity).
+public enum SkeletonVariant: CaseIterable, Equatable {
+    /// A traveling highlight sweep over the fill (default).
+    case shimmer
+    /// The fill breathes between two fixed opacities.
+    case pulse
+    /// A static fill — no motion at all.
+    case none
+}
+
+/// The animated fill, reused by the modifier and the standalone view.
 struct SkeletonShimmer: View {
     @Environment(\.theme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let shape: SkeletonShape
+    var variant: SkeletonVariant = .shimmer
+    var highlight: SemanticColor? = nil
     @State private var animate = false
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    // Fixed internal motion constants (HeroUI Native defaults) — genuine
+    // non-semantic dimensions, deliberately not exposed as knobs.
+    private static let shimmerDuration: TimeInterval = 1.2
+    private static let pulseDuration: TimeInterval = 1.0
+    private static let pulseMinOpacity: Double = 0.5
+    private static let pulseMaxOpacity: Double = 1.0
+
+    /// The sweep's tint — a semantic color's soft shade when set, else the
+    /// token default.
+    private var highlightColor: Color {
+        highlight?.soft ?? theme.background(.bgWhite).opacity(0.7)
+    }
+
+    /// Pulse breathes the fill; shimmer / `none` / Reduce Motion keep it solid.
+    private var fillOpacity: Double {
+        guard variant == .pulse, !reduceMotion else { return Self.pulseMaxOpacity }
+        return animate ? Self.pulseMinOpacity : Self.pulseMaxOpacity
+    }
 
     var body: some View {
         shape.anyShape
             .fill(theme.background(.skeletonBgSkeletonBase))
+            .opacity(fillOpacity)
             .overlay {
-                // Honor Reduce Motion: a static placeholder, no traveling sweep.
-                if !reduceMotion {
+                // Honor Reduce Motion (and `.none`): a static placeholder,
+                // no traveling sweep.
+                if variant == .shimmer && !reduceMotion {
                     GeometryReader { geo in
                         LinearGradient(
-                            colors: [.clear, theme.background(.bgWhite).opacity(0.7), .clear],
+                            colors: [.clear, highlightColor, .clear],
                             startPoint: .leading, endPoint: .trailing
                         )
                         .frame(width: geo.size.width * 0.5)
@@ -54,8 +98,17 @@ struct SkeletonShimmer: View {
             .clipShape(shape.anyShape)
             .onAppear {
                 guard !reduceMotion else { return }
-                withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) {
-                    animate = true
+                switch variant {
+                case .shimmer:
+                    withAnimation(.linear(duration: Self.shimmerDuration).repeatForever(autoreverses: false)) {
+                        animate = true
+                    }
+                case .pulse:
+                    withAnimation(.easeInOut(duration: Self.pulseDuration).repeatForever(autoreverses: true)) {
+                        animate = true
+                    }
+                case .none:
+                    break   // static fill — same no-motion path as Reduce Motion
                 }
             }
     }
@@ -67,13 +120,15 @@ public struct Skeleton: View {
     // Appearance/config — mutated only through the modifiers below (R2).
     private var width: CGFloat? = nil
     private var height: CGFloat? = nil
+    private var variant: SkeletonVariant = .shimmer
+    private var highlight: SemanticColor? = nil
 
     public init(_ shape: SkeletonShape = .rounded(8)) {   // R1 — shape only
         self.shape = shape
     }
 
     public var body: some View {
-        SkeletonShimmer(shape: shape)
+        SkeletonShimmer(shape: shape, variant: variant, highlight: highlight)
             .frame(width: width, height: height)
     }
 }
@@ -86,6 +141,17 @@ public extension Skeleton {
         copy { $0.width = width; $0.height = height }
     }
 
+    /// Animation variant: `.shimmer` (default) · `.pulse` · `.none`.
+    func variant(_ v: SkeletonVariant) -> Self {
+        copy { $0.variant = v }
+    }
+
+    /// Tints the shimmer sweep with a semantic color's soft shade;
+    /// `nil` restores the default token highlight.
+    func highlight(_ color: SemanticColor?) -> Self {
+        copy { $0.highlight = color }
+    }
+
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
         mutate(&c)
@@ -94,29 +160,68 @@ public extension Skeleton {
 }
 
 private struct SkeletonModifier: ViewModifier {
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     let isLoading: Bool
     let shape: SkeletonShape
+    var variant: SkeletonVariant = .shimmer
+    var highlight: SemanticColor? = nil
 
     func body(content: Content) -> some View {
         content
             .opacity(isLoading ? 0 : 1)
-            .overlay { if isLoading { SkeletonShimmer(shape: shape) } }
+            .overlay {
+                if isLoading {
+                    SkeletonShimmer(shape: shape, variant: variant, highlight: highlight)
+                        .transition(.opacity)
+                }
+            }
+            // Animated reveal: fade the placeholder out / the content in when
+            // loading flips, honoring the `microAnimations` switch and Reduce
+            // Motion exactly like SkeletonGroup does (nil = instant swap).
+            .animation(MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion), value: isLoading)
     }
 }
 
 public extension View {
-    /// Replaces the view with a shimmering rounded skeleton while `isLoading` is true.
-    func skeleton(_ isLoading: Bool, cornerRadius: CGFloat = 8) -> some View {
-        modifier(SkeletonModifier(isLoading: isLoading, shape: .rounded(cornerRadius)))
+    /// Replaces the view with an animated rounded skeleton while `isLoading` is
+    /// true, cross-fading back to the content when loading ends.
+    /// Prefer `skeleton(_:radius:variant:highlight:)` — the token-fed overload.
+    func skeleton(
+        _ isLoading: Bool,
+        cornerRadius: CGFloat = 8,
+        variant: SkeletonVariant = .shimmer,
+        highlight: SemanticColor? = nil
+    ) -> some View {
+        modifier(SkeletonModifier(isLoading: isLoading, shape: .rounded(cornerRadius), variant: variant, highlight: highlight))
     }
 
-    /// Replaces the view with a shimmering skeleton of a custom shape while loading.
-    func skeleton(_ isLoading: Bool, shape: SkeletonShape) -> some View {
-        modifier(SkeletonModifier(isLoading: isLoading, shape: shape))
+    /// Token-fed rounded skeleton: the corner resolves from the active theme's
+    /// radius role (`.box` · `.field` · `.selector`).
+    func skeleton(
+        _ isLoading: Bool,
+        radius: Theme.RadiusRole,
+        variant: SkeletonVariant = .shimmer,
+        highlight: SemanticColor? = nil
+    ) -> some View {
+        modifier(SkeletonModifier(isLoading: isLoading, shape: .rounded(radius), variant: variant, highlight: highlight))
+    }
+
+    /// Replaces the view with an animated skeleton of a custom shape while loading.
+    func skeleton(
+        _ isLoading: Bool,
+        shape: SkeletonShape,
+        variant: SkeletonVariant = .shimmer,
+        highlight: SemanticColor? = nil
+    ) -> some View {
+        modifier(SkeletonModifier(isLoading: isLoading, shape: shape, variant: variant, highlight: highlight))
     }
 }
 
-#Preview {
+// MARK: - Previews
+
+#Preview("Shimmer (default)") {
     VStack(alignment: .leading, spacing: 12) {
         Text("Loading title").font(.title).skeleton(true)
         Text("A line of body text that is being loaded.").skeleton(true)
@@ -130,4 +235,39 @@ public extension View {
         }
     }
     .padding()
+}
+
+#Preview("Variants · highlight tint") {
+    VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+        Text("shimmer (default)").font(.caption).foregroundStyle(.secondary)
+        Skeleton(.capsule).size(width: 200, height: 12)
+
+        Text("pulse").font(.caption).foregroundStyle(.secondary)
+        Skeleton(.capsule).variant(.pulse).size(width: 200, height: 12)
+
+        Text("none (static)").font(.caption).foregroundStyle(.secondary)
+        Skeleton(.capsule).variant(.none).size(width: 200, height: 12)
+
+        Text("highlight tint — .info soft sweep").font(.caption).foregroundStyle(.secondary)
+        Skeleton(.rounded(.field)).highlight(.info).size(width: 200, height: 32)
+
+        Text("token radius role — .box").font(.caption).foregroundStyle(.secondary)
+        Skeleton(.rounded(.box)).size(width: 200, height: 64)
+
+        Text("Modifier-applied pulse").skeleton(true, radius: .selector, variant: .pulse)
+    }
+    .padding(Theme.SpacingKey.md.value)
+}
+
+#Preview("Reveal toggle") {
+    @Previewable @State var isLoading = true
+
+    VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+        Toggle("Loading", isOn: $isLoading)
+
+        Text("Cross-fades in when loading ends").skeleton(isLoading)
+        Text("Token radius + pulse placeholder").skeleton(isLoading, radius: .field, variant: .pulse)
+        Text("Tinted shimmer placeholder").skeleton(isLoading, highlight: .success)
+    }
+    .padding(Theme.SpacingKey.md.value)
 }

--- a/Sources/ThemeKit/Components/Atoms/Spinner.swift
+++ b/Sources/ThemeKit/Components/Atoms/Spinner.swift
@@ -335,7 +335,7 @@ private struct SpinnerInfinity: View {
             Spinner().controlSize(.small)
             Spinner()
             Spinner().controlSize(.large)
-            Spinner().controlSize(.large).size(28)
+            Spinner().size(28).controlSize(.large)
         }
         // Custom indicator slot — spun by the shared rotation driver.
         // Under Reduce Motion every style renders static: the ring stays a
@@ -346,10 +346,11 @@ private struct SpinnerInfinity: View {
                 Image(systemName: "arrow.triangle.2.circlepath")
                     .resizable().scaledToFit()
             }
-            Spinner().controlSize(.large).indicator {
+            Spinner().indicator {
                 Image(systemName: "rays")
                     .resizable().scaledToFit()
             }
+            .controlSize(.large)
         }
     }
     .padding()

--- a/Sources/ThemeKit/Components/Atoms/Spinner.swift
+++ b/Sources/ThemeKit/Components/Atoms/Spinner.swift
@@ -20,31 +20,73 @@ public enum SpinnerStyle: String, CaseIterable, Sendable {
     case infinity
 }
 
+/// Default diameter/stroke presets riding the native `.controlSize(_:)` cascade.
+/// An explicit `.size(_:)` / `.lineWidth(_:)` override always wins (R5).
+private extension ControlSize {
+    var spinnerDiameter: CGFloat {
+        switch self {
+        case .mini, .small: return 16
+        case .large, .extraLarge: return 40
+        default: return 24   // .regular (default)
+        }
+    }
+
+    var spinnerStroke: CGFloat {
+        switch self {
+        case .mini, .small: return 2
+        case .large, .extraLarge: return 4
+        default: return 3    // .regular (default)
+        }
+    }
+}
+
 /// Atom. Indeterminate loading indicator (token-tinted) in five shapes:
 /// ring / dots / bars / ball / infinity. (daisyUI "Loading".)
+///
+/// Sizes ride the native `.controlSize(_:)` cascade (small ≈ 16/2, regular
+/// 24/3, large 40/4) unless `.size(_:)`/`.lineWidth(_:)` override them.
+/// `.indicator { … }` swaps the built-in shape for custom content spun by the
+/// shared rotation driver. Honors Reduce Motion: every style renders a static
+/// form (the ring becomes a fixed 270° arc with no rotation).
 public struct Spinner: View {
     @Environment(\.theme) private var theme
+    @Environment(\.controlSize) private var controlSize
 
     // Appearance/config — mutated only through the modifiers below (R2).
-    private var size: CGFloat = 24
-    private var lineWidth: CGFloat = 3
+    private var size: CGFloat?
+    private var lineWidth: CGFloat?
     private var color: Color?
     private var semantic: SemanticColor?
     private var style: SpinnerStyle = .ring
+    private var indicator: AnyView?
 
     public init() {}   // R1
 
     /// Raw override wins, then the semantic accent, then the theme hero foreground.
     private var tint: Color { color ?? semantic?.accent ?? theme.foreground(.fgHero) }
 
+    /// Explicit override wins; else the `.controlSize(_:)` preset.
+    private var resolvedSize: CGFloat { size ?? controlSize.spinnerDiameter }
+    private var resolvedLineWidth: CGFloat { lineWidth ?? controlSize.spinnerStroke }
+
     public var body: some View {
-        switch style {
-        case .ring: SpinnerRing(tint: tint, size: size, lineWidth: lineWidth)
-        case .dots: SpinnerDots(tint: tint, size: size)
-        case .bars: SpinnerBars(tint: tint, size: size)
-        case .ball: SpinnerBall(tint: tint, size: size)
-        case .infinity: SpinnerInfinity(tint: tint, size: size, lineWidth: lineWidth)
+        Group {
+            if let indicator {
+                // Custom slot rides the shared rotor (static under Reduce Motion).
+                SpinnerRotor {
+                    indicator.frame(width: resolvedSize, height: resolvedSize)
+                }
+            } else {
+                switch style {
+                case .ring: SpinnerRing(tint: tint, size: resolvedSize, lineWidth: resolvedLineWidth)
+                case .dots: SpinnerDots(tint: tint, size: resolvedSize)
+                case .bars: SpinnerBars(tint: tint, size: resolvedSize)
+                case .ball: SpinnerBall(tint: tint, size: resolvedSize)
+                case .infinity: SpinnerInfinity(tint: tint, size: resolvedSize, lineWidth: resolvedLineWidth)
+                }
+            }
         }
+        .accessibilityLabel(String(themeKit: "Loading"))
     }
 }
 

--- a/Sources/ThemeKit/Components/Atoms/Spinner.swift
+++ b/Sources/ThemeKit/Components/Atoms/Spinner.swift
@@ -96,11 +96,19 @@ public extension Spinner {
     /// Loading shape: ring (default) / dots / bars / ball / infinity.
     func style(_ s: SpinnerStyle) -> Self { copy { $0.style = s } }
 
-    /// Diameter in points (default 24).
+    /// Diameter in points; unset (default) follows `.controlSize(_:)` (regular = 24).
     func size(_ points: CGFloat) -> Self { copy { $0.size = points } }
 
-    /// Stroke thickness in points (default 3) — used by the ring and infinity shapes.
+    /// Stroke thickness in points, used by the ring and infinity shapes;
+    /// unset (default) follows `.controlSize(_:)` (regular = 3).
     func lineWidth(_ width: CGFloat) -> Self { copy { $0.lineWidth = width } }
+
+    /// Custom indicator content spun in place of the built-in shape, framed to
+    /// the resolved diameter. Rides the same continuous-rotation driver as the
+    /// ring — and renders static (no rotation) under Reduce Motion.
+    func indicator<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.indicator = AnyView(content()) }
+    }
 
     /// Semantic tint; `nil` (default) uses the theme's hero foreground.
     func accent(_ color: SemanticColor?) -> Self { copy { $0.semantic = color } }
@@ -116,34 +124,60 @@ public extension Spinner {
     }
 }
 
-// MARK: - Shapes
+// MARK: - Rotation driver
 
-/// Rotating open ring — the original `Spinner` body.
-private struct SpinnerRing: View {
-    let tint: Color
-    let size: CGFloat
-    let lineWidth: CGFloat
+/// Continuous-rotation driver shared by the ring shape and the custom
+/// indicator slot. Honors Reduce Motion (house pattern, see `SkeletonShimmer`):
+/// the content renders static — no rotation is ever started.
+private struct SpinnerRotor<Content: View>: View {
+    let duration: Double
+    let content: Content
     @State private var rotating = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    init(duration: Double = 0.8, @ViewBuilder content: () -> Content) {
+        self.duration = duration
+        self.content = content()
+    }
 
     var body: some View {
-        Circle()
-            .trim(from: 0, to: 0.75)
-            .stroke(tint, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
-            .frame(width: size, height: size)
+        content
             .rotationEffect(.degrees(rotating ? 360 : 0))
             .onAppear {
-                withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
+                guard !reduceMotion else { return }
+                withAnimation(.linear(duration: duration).repeatForever(autoreverses: false)) {
                     rotating = true
                 }
             }
     }
 }
 
-/// Three dots bouncing in sequence.
+// MARK: - Shapes
+
+/// Rotating open ring — the original `Spinner` body. Under Reduce Motion the
+/// rotor never spins, leaving the fixed 270° arc as the static fallback.
+private struct SpinnerRing: View {
+    let tint: Color
+    let size: CGFloat
+    let lineWidth: CGFloat
+
+    var body: some View {
+        SpinnerRotor {
+            Circle()
+                .trim(from: 0, to: 0.75)
+                .stroke(tint, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .frame(width: size, height: size)
+        }
+    }
+}
+
+/// Three dots bouncing in sequence. Under Reduce Motion: three static,
+/// vertically centered dots.
 private struct SpinnerDots: View {
     let tint: Color
     let size: CGFloat
     @State private var bouncing = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         HStack(spacing: size * 0.12) {
@@ -151,25 +185,31 @@ private struct SpinnerDots: View {
                 Circle()
                     .fill(tint)
                     .frame(width: size * 0.26, height: size * 0.26)
-                    .offset(y: bouncing ? -size * 0.16 : size * 0.16)
+                    .offset(y: reduceMotion ? 0 : (bouncing ? -size * 0.16 : size * 0.16))
                     .animation(
                         .easeInOut(duration: 0.4)
                             .repeatForever(autoreverses: true)
-                            .delay(Double(index) * 0.13),
+                            .delay(Double(index) * 0.13)
+                            .ifMotionAllowed(reduceMotion),
                         value: bouncing
                     )
             }
         }
         .frame(width: size, height: size)
-        .onAppear { bouncing = true }
+        .onAppear {
+            guard !reduceMotion else { return }
+            bouncing = true
+        }
     }
 }
 
-/// Three vertical bars scaling in sequence.
+/// Three vertical bars scaling in sequence. Under Reduce Motion: three static
+/// full-height bars.
 private struct SpinnerBars: View {
     let tint: Color
     let size: CGFloat
     @State private var scaled = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         HStack(spacing: size * 0.14) {
@@ -177,34 +217,48 @@ private struct SpinnerBars: View {
                 RoundedRectangle(cornerRadius: size * 0.09, style: .continuous)
                     .fill(tint)
                     .frame(width: size * 0.18, height: size)
-                    .scaleEffect(y: scaled ? 1 : 0.4, anchor: .center)
+                    .scaleEffect(y: reduceMotion ? 1 : (scaled ? 1 : 0.4), anchor: .center)
                     .animation(
                         .easeInOut(duration: 0.45)
                             .repeatForever(autoreverses: true)
-                            .delay(Double(index) * 0.15),
+                            .delay(Double(index) * 0.15)
+                            .ifMotionAllowed(reduceMotion),
                         value: scaled
                     )
             }
         }
         .frame(width: size, height: size)
-        .onAppear { scaled = true }
+        .onAppear {
+            guard !reduceMotion else { return }
+            scaled = true
+        }
     }
 }
 
-/// A single ball bouncing up and down.
+/// A single ball bouncing up and down. Under Reduce Motion: one static,
+/// vertically centered ball.
 private struct SpinnerBall: View {
     let tint: Color
     let size: CGFloat
     @State private var up = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         Circle()
             .fill(tint)
             .frame(width: size * 0.5, height: size * 0.5)
-            .offset(y: up ? -size * 0.25 : size * 0.25)
-            .animation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true), value: up)
+            .offset(y: reduceMotion ? 0 : (up ? -size * 0.25 : size * 0.25))
+            .animation(
+                .easeInOut(duration: 0.4)
+                    .repeatForever(autoreverses: true)
+                    .ifMotionAllowed(reduceMotion),
+                value: up
+            )
             .frame(width: size, height: size)
-            .onAppear { up = true }
+            .onAppear {
+                guard !reduceMotion else { return }
+                up = true
+            }
     }
 }
 
@@ -229,23 +283,27 @@ private struct InfinityShape: Shape {
     }
 }
 
-/// A comet segment sweeping along a faint figure-eight track.
+/// A comet segment sweeping along a faint figure-eight track. Under Reduce
+/// Motion: the track plus a fixed quarter segment, no sweep.
 private struct SpinnerInfinity: View {
     let tint: Color
     let size: CGFloat
     let lineWidth: CGFloat
     @State private var phase: CGFloat = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         ZStack {
             InfinityShape()
                 .stroke(tint.opacity(0.25), style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
             InfinityShape()
-                .trim(from: phase * 0.75, to: phase)
+                .trim(from: reduceMotion ? 0 : phase * 0.75,
+                      to: reduceMotion ? 0.25 : phase)
                 .stroke(tint, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
         }
         .frame(width: size * 1.7, height: size)
         .onAppear {
+            guard !reduceMotion else { return }
             withAnimation(.linear(duration: 1.4).repeatForever(autoreverses: false)) {
                 phase = 1
             }
@@ -270,6 +328,28 @@ private struct SpinnerInfinity: View {
             Spinner().style(.dots).accent(.success).size(32)
             Spinner().style(.bars).accent(.warning).size(32)
             Spinner().style(.infinity).accent(.error).size(32)
+        }
+        // Native size cascade — small ≈ 16/2, regular 24/3, large 40/4;
+        // an explicit .size(_:)/.lineWidth(_:) always wins over the preset.
+        HStack(spacing: 24) {
+            Spinner().controlSize(.small)
+            Spinner()
+            Spinner().controlSize(.large)
+            Spinner().controlSize(.large).size(28)
+        }
+        // Custom indicator slot — spun by the shared rotation driver.
+        // Under Reduce Motion every style renders static: the ring stays a
+        // fixed 270° arc (no rotation), dots/bars/ball settle centered, the
+        // infinity keeps a fixed segment, and this slot does not rotate.
+        HStack(spacing: 24) {
+            Spinner().indicator {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .resizable().scaledToFit()
+            }
+            Spinner().controlSize(.large).indicator {
+                Image(systemName: "rays")
+                    .resizable().scaledToFit()
+            }
         }
     }
     .padding()

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -22,14 +22,39 @@ public enum TooltipEdge: Sendable {
     var isVertical: Bool { self == .top || self == .bottom }
 
     /// The overlay alignment that pins the bubble to this edge of the anchor.
-    var alignment: Alignment {
-        switch self {
-        case .top: return .top
-        case .bottom: return .bottom
-        case .leading: return .leading
-        case .trailing: return .trailing
+    var alignment: Alignment { alignment(.center) }
+
+    /// Overlay alignment for this edge with `align` choosing where along that
+    /// edge the bubble/card anchors (leading/top for `.start`, centered, or
+    /// trailing/bottom for `.end`). `.center` reproduces `alignment`.
+    func alignment(_ align: PopoverAlign) -> Alignment {
+        if isVertical {
+            let horizontal: HorizontalAlignment
+            switch align {
+            case .start: horizontal = .leading
+            case .center: horizontal = .center
+            case .end: horizontal = .trailing
+            }
+            return Alignment(horizontal: horizontal, vertical: self == .top ? .top : .bottom)
+        } else {
+            let vertical: VerticalAlignment
+            switch align {
+            case .start: vertical = .top
+            case .center: vertical = .center
+            case .end: vertical = .bottom
+            }
+            return Alignment(horizontal: self == .leading ? .leading : .trailing, vertical: vertical)
         }
     }
+}
+
+/// Cross-axis alignment of an anchored bubble or card along its edge —
+/// `.start` lines up the leading (or top) edges, `.end` the trailing (or
+/// bottom) edges, `.center` keeps the historical centered placement.
+/// (HeroUI Popover `align`.) Shared by `.tooltip`, `.popconfirm` and
+/// `.themePopover`.
+public enum PopoverAlign: Sendable {
+    case start, center, end
 }
 
 /// A triangle whose apex points toward the anchor for the given edge.

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -5,9 +5,11 @@
 //
 //  Molecule. A small bubble with an arrow, attached to one of four edges of an
 //  anchor via the `.tooltip(...)` modifier. Defaults to the original dark bubble;
-//  an optional semantic `style` recolors it (Ant Tooltip `color`), and `maxWidth`
-//  lets the text wrap onto multiple lines. Two entry points: a binding-driven
-//  modifier and a self-managed tap-to-toggle convenience. (Ant Tooltip parity.)
+//  an optional semantic `style` recolors it (Ant Tooltip `color`), `maxWidth`
+//  lets the text wrap onto multiple lines, and `align` slides the bubble along
+//  the anchored edge (HeroUI Popover `align`). Two entry points: a binding-driven
+//  modifier and a self-managed tap-to-toggle convenience that also dismisses on
+//  an outside tap. (Ant Tooltip / HeroUI Popover parity.)
 //
 
 import SwiftUI

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -151,16 +151,19 @@ private struct TooltipBubble: View {
     }
 }
 
-/// Pushes the bubble just outside the chosen edge of the anchor.
+/// Pushes the bubble just outside the chosen edge of the anchor, separated by
+/// the small spacing token.
 private struct TooltipPlacement: ViewModifier {
     let edge: TooltipEdge
 
+    private var gap: CGFloat { Theme.SpacingKey.sm.value }
+
     func body(content: Content) -> some View {
         switch edge {
-        case .top: content.offset(y: -8).alignmentGuide(.top) { $0[.bottom] }
-        case .bottom: content.offset(y: 8).alignmentGuide(.bottom) { $0[.top] }
-        case .leading: content.offset(x: -8).alignmentGuide(.leading) { $0[.trailing] }
-        case .trailing: content.offset(x: 8).alignmentGuide(.trailing) { $0[.leading] }
+        case .top: content.offset(y: -gap).alignmentGuide(.top) { $0[.bottom] }
+        case .bottom: content.offset(y: gap).alignmentGuide(.bottom) { $0[.top] }
+        case .leading: content.offset(x: -gap).alignmentGuide(.leading) { $0[.trailing] }
+        case .trailing: content.offset(x: gap).alignmentGuide(.trailing) { $0[.leading] }
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -173,6 +173,7 @@ private struct BindingTooltip: ViewModifier {
     let text: String
     @Binding var isPresented: Bool
     let edge: TooltipEdge
+    let align: PopoverAlign
     let style: BadgeStyle?
     let color: SemanticColor?
     let maxWidth: CGFloat?
@@ -182,7 +183,7 @@ private struct BindingTooltip: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .overlay(alignment: edge.alignment) {
+            .overlay(alignment: edge.alignment(align)) {
                 if isPresented {
                     TooltipBubble(text: text, edge: edge, style: style, color: color, maxWidth: maxWidth)
                         .fixedSize(horizontal: maxWidth == nil, vertical: true)

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -58,31 +58,57 @@ public enum PopoverAlign: Sendable {
 }
 
 /// A triangle whose apex points toward the anchor for the given edge.
-private struct TooltipArrow: Shape {
+/// The path runs base-corner → apex → base-corner and is left *open* along the
+/// base: `fill` closes it implicitly (same triangle as before), while `stroke`
+/// draws a hairline on the two exposed sides only — exactly what a bordered
+/// card arrow needs (HeroUI Popover.Arrow's fill + open stroke path). Internal
+/// so `Popconfirm` can compose the same arrow onto its card.
+struct TooltipArrow: Shape {
     let edge: TooltipEdge
 
     func path(in rect: CGRect) -> Path {
         var p = Path()
         switch edge {
         case .top: // bubble above the anchor → point down
-            p.move(to: CGPoint(x: rect.midX, y: rect.maxY))
-            p.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+            p.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
             p.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
         case .bottom: // bubble below → point up
-            p.move(to: CGPoint(x: rect.midX, y: rect.minY))
-            p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+            p.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+            p.addLine(to: CGPoint(x: rect.midX, y: rect.minY))
             p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
         case .leading: // bubble to the left → point right
-            p.move(to: CGPoint(x: rect.maxX, y: rect.midY))
-            p.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+            p.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
             p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
         case .trailing: // bubble to the right → point left
-            p.move(to: CGPoint(x: rect.minX, y: rect.midY))
-            p.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+            p.move(to: CGPoint(x: rect.maxX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.midY))
             p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
         }
-        p.closeSubpath()
         return p
+    }
+}
+
+/// A transparent, effectively screen-covering hit target placed *behind* an
+/// anchored bubble/card so a tap anywhere outside it dismisses the popover
+/// (HeroUI Popover overlay `closeOnPress`). Only mounted while presented, so
+/// the anchor stays fully interactive when nothing is shown. Internal — shared
+/// by the self-managed tooltip and the Popconfirm/ThemePopover presenter.
+struct PopoverTapCatcher: View {
+    let onTap: () -> Void
+
+    /// Fixed catch radius around the anchor — a genuine dimension with no
+    /// semantic token; generous enough to cover any window from any anchor.
+    private static let side: CGFloat = 10_000
+
+    var body: some View {
+        Color.clear
+            .frame(width: Self.side, height: Self.side)
+            .contentShape(Rectangle())
+            .ignoresSafeArea()
+            .onTapGesture(perform: onTap)
+            .accessibilityHidden(true)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -196,18 +196,27 @@ private struct BindingTooltip: ViewModifier {
     }
 }
 
-/// Wraps an anchor so a tap toggles its own tooltip — no external binding needed.
+/// Wraps an anchor so a tap toggles its own tooltip — no external binding
+/// needed. While shown (and unless opted out), a transparent tap-catcher sits
+/// behind the bubble so tapping anywhere else dismisses it.
 private struct SelfTooltip: ViewModifier {
     let text: String
     let edge: TooltipEdge
+    let align: PopoverAlign
     let style: BadgeStyle?
     let color: SemanticColor?
     let maxWidth: CGFloat?
+    let dismissOnOutsideTap: Bool
     @State private var shown = false
 
     func body(content: Content) -> some View {
         content
-            .tooltip(text, isPresented: $shown, edge: edge, style: style, color: color, maxWidth: maxWidth)
+            .overlay { // Declared before the bubble's overlay so it stays behind it.
+                if shown && dismissOnOutsideTap {
+                    PopoverTapCatcher { shown = false }
+                }
+            }
+            .tooltip(text, isPresented: $shown, edge: edge, align: align, style: style, color: color, maxWidth: maxWidth)
             .contentShape(Rectangle())
             .onTapGesture { shown.toggle() }
             .accessibilityHint(Text(text))
@@ -216,30 +225,38 @@ private struct SelfTooltip: ViewModifier {
 
 public extension View {
     /// Binding-driven tooltip. `edge` chooses which side of the anchor it points
-    /// from; `style` recolors the bubble (nil keeps the dark default); `color`
-    /// tints it with any semantic color and wins over `style` (daisyUI
-    /// `tooltip-{color}`); `maxWidth` lets long text wrap.
+    /// from; `align` slides the bubble along that edge (HeroUI Popover `align`;
+    /// `.center` keeps the historical placement); `style` recolors the bubble
+    /// (nil keeps the dark default); `color` tints it with any semantic color
+    /// and wins over `style` (daisyUI `tooltip-{color}`); `maxWidth` lets long
+    /// text wrap.
     func tooltip(
         _ text: String,
         isPresented: Binding<Bool>,
         edge: TooltipEdge = .top,
+        align: PopoverAlign = .center,
         style: BadgeStyle? = nil,
         color: SemanticColor? = nil,
         maxWidth: CGFloat? = nil
     ) -> some View {
-        modifier(BindingTooltip(text: text, isPresented: isPresented, edge: edge, style: style, color: color, maxWidth: maxWidth))
+        modifier(BindingTooltip(text: text, isPresented: isPresented, edge: edge, align: align, style: style, color: color, maxWidth: maxWidth))
     }
 
     /// Self-managed tooltip: tap the anchor to toggle it (tap again to dismiss).
-    /// No external state required — use for simple hint glyphs.
+    /// No external state required — use for simple hint glyphs. While shown, a
+    /// tap anywhere outside the bubble also dismisses it (HeroUI Popover
+    /// `closeOnPress`); pass `dismissOnOutsideTap: false` to require tapping
+    /// the anchor again.
     func tooltip(
         _ text: String,
         edge: TooltipEdge = .top,
+        align: PopoverAlign = .center,
         style: BadgeStyle? = nil,
         color: SemanticColor? = nil,
-        maxWidth: CGFloat? = nil
+        maxWidth: CGFloat? = nil,
+        dismissOnOutsideTap: Bool = true
     ) -> some View {
-        modifier(SelfTooltip(text: text, edge: edge, style: style, color: color, maxWidth: maxWidth))
+        modifier(SelfTooltip(text: text, edge: edge, align: align, style: style, color: color, maxWidth: maxWidth, dismissOnOutsideTap: dismissOnOutsideTap))
     }
 }
 
@@ -260,6 +277,28 @@ public extension View {
                 }
                 Icon(systemName: "star.circle").size(.md).color(theme.foreground(.fgHero))
                     .tooltip("Primary-tinted tooltip", edge: .bottom, color: .primary)
+            }
+            .padding(80)
+        }
+    }
+    return Demo()
+}
+
+#Preview("Align start / end") {
+    struct Demo: View {
+        @State var start = true
+        @State var end = true
+        var body: some View {
+            VStack(spacing: 72) {
+                // .start lines the bubble's leading edge up with the anchor's.
+                ThemeButton("Align start") { start.toggle() }.variant(.outline)
+                    .tooltip("Leading edges aligned", isPresented: $start, edge: .top, align: .start)
+                // .end lines the trailing edges up instead.
+                ThemeButton("Align end") { end.toggle() }.variant(.outline)
+                    .tooltip("Trailing edges aligned", isPresented: $end, edge: .bottom, align: .end, style: .info)
+                // Self-managed: tap the glyph to show; tap anywhere else to dismiss.
+                Icon(systemName: "hand.tap").size(.md)
+                    .tooltip("Tap outside to dismiss", edge: .trailing, align: .start)
             }
             .padding(80)
         }

--- a/Sources/ThemeKit/Components/Organisms/AlertToast.swift
+++ b/Sources/ThemeKit/Components/Organisms/AlertToast.swift
@@ -8,6 +8,10 @@ import SwiftUI
 
 public enum AlertToastType {
     case success, warning, danger, info
+    /// Low-emphasis message on a muted surface (HeroUI's "default" variant).
+    case neutral
+    /// Brand-tinted toast fed by `SemanticColor.primary` (HeroUI's "accent").
+    case accent
 
     func background(_ theme: Theme) -> Color {
         switch self {
@@ -15,14 +19,18 @@ public enum AlertToastType {
         case .warning: return theme.background(.systemcolorsBgWarning)
         case .danger: return theme.background(.systemcolorsBgError)
         case .info: return theme.background(.systemcolorsBgInfo)
+        case .neutral: return theme.background(.bgTertiary)
+        case .accent: return SemanticColor.primary.solid
         }
     }
 
-    /// Warning uses dark text for contrast on the bright amber fill.
+    /// Warning uses dark text for contrast on the bright amber fill; accent
+    /// auto-contrasts against whatever the brand's solid primary resolves to.
     func foreground(_ theme: Theme) -> Color {
         switch self {
         case .warning: return theme.text(.textPrimary)
-        case .success, .danger, .info: return theme.foreground(.fgSecondary)
+        case .success, .danger, .info, .neutral: return theme.foreground(.fgSecondary)
+        case .accent: return SemanticColor.primary.onSolid
         }
     }
 
@@ -32,6 +40,8 @@ public enum AlertToastType {
         case .warning: return "exclamationmark.triangle.fill"
         case .danger: return "exclamationmark.octagon.fill"
         case .info: return "info.circle.fill"
+        case .neutral: return "bell.fill"
+        case .accent: return "sparkles"
         }
     }
 }
@@ -130,7 +140,8 @@ public extension AlertToast {
     /// Secondary line under the title.
     func message(_ text: String?) -> Self { copy { $0.message = text } }
 
-    /// Status treatment: success / warning / danger / info (drives fill + icon).
+    /// Status treatment: success / warning / danger / info / neutral / accent
+    /// (drives fill + icon).
     func variant(_ v: AlertToastType) -> Self { copy { $0.type = v } }
 
     /// Override the leading status glyph (otherwise derived from the variant).
@@ -158,6 +169,8 @@ public extension AlertToast {
         AlertToast("Check your input").message("One field needs attention.").variant(.warning)
         AlertToast("Something went wrong").variant(.danger).onClose {}
         AlertToast("New update available").variant(.info)
+        AlertToast("Notifications paused").variant(.neutral).onClose {}
+        AlertToast("Pro features unlocked").message("Enjoy the upgrade.").variant(.accent).onClose {}
         AlertToast("Message deleted").variant(.info).action(ToastAction("Undo") {}).onClose {}
         AlertToast("Uploading…").variant(.info).loading()
     }

--- a/Sources/ThemeKit/Components/Organisms/AlertToast.swift
+++ b/Sources/ThemeKit/Components/Organisms/AlertToast.swift
@@ -44,6 +44,18 @@ public enum AlertToastType {
         case .accent: return "sparkles"
         }
     }
+
+    /// Localized VoiceOver label for the status icon — the variant's meaning
+    /// is otherwise carried only by glyph + fill color.
+    var accessibilityLabel: String {
+        switch self {
+        case .success: return String(themeKit: "Success")
+        case .warning: return String(themeKit: "Warning")
+        case .danger: return String(themeKit: "Error")
+        case .info, .accent: return String(themeKit: "Information")
+        case .neutral: return String(themeKit: "Note")
+        }
+    }
 }
 
 /// An optional tappable action rendered inline in a toast (e.g. "Undo"). Its
@@ -107,6 +119,7 @@ public struct AlertToast: View {
                 Spinner().size(IconSize.sm.value).lineWidth(2).color(type.foreground(theme))
             } else {
                 Icon(systemName: systemImage ?? type.systemImage).size(.sm).color(type.foreground(theme))
+                    .accessibilityLabel(type.accessibilityLabel)
             }
 
             VStack(alignment: .leading, spacing: 2) {

--- a/Sources/ThemeKit/Components/Organisms/BottomSheet.swift
+++ b/Sources/ThemeKit/Components/Organisms/BottomSheet.swift
@@ -8,7 +8,9 @@
 //    • `.bottomSheet(isPresented:detents:)` — declarative, binding-driven.
 //    • `.sheetHost()` + `@Environment(SheetPresenter.self)` — imperative; present
 //      a sheet from anywhere without owning a binding.
-//  Detent modifiers are iOS-only; the content still presents on macOS.
+//  Both paths support a `detached` floating-card presentation (HeroUI parity),
+//  a `surface` background-token override, and a `radius` corner-role override.
+//  Detent + corner-radius modifiers are iOS-only; the content still presents on macOS.
 //
 
 import SwiftUI
@@ -34,10 +36,23 @@ public enum BottomSheetDetent: Hashable {
 public extension View {
     /// Declarative bottom sheet. Pass custom `detents` (default medium + large)
     /// and toggle the drag indicator.
+    ///
+    /// - Parameters:
+    ///   - detached: When `true`, presents as an inset floating card — the native
+    ///     sheet background goes clear and the content is wrapped in a
+    ///     token-rounded card padded from the screen edges (HeroUI "detached").
+    ///   - surface: Background token for the sheet surface (card fill when
+    ///     `detached`). `nil` keeps the platform default (or `.bgWhite` for the
+    ///     detached card).
+    ///   - radius: Corner role for the sheet (card corner when `detached`).
+    ///     `nil` keeps the platform default (or `.box` for the detached card).
     func bottomSheet<SheetContent: View>(
         isPresented: Binding<Bool>,
         detents: [BottomSheetDetent] = [.medium, .large],
         showsDragIndicator: Bool = true,
+        detached: Bool = false,
+        surface: Theme.BackgroundColorKey? = nil,
+        radius: Theme.RadiusRole? = nil,
         @ViewBuilder content: @escaping () -> SheetContent
     ) -> some View {
         sheet(isPresented: isPresented) {
@@ -45,6 +60,7 @@ public extension View {
                 .padding(Theme.SpacingKey.md.value)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .sheetDetents(detents, dragIndicator: showsDragIndicator)
+                .modifier(SheetChrome(detached: detached, surface: surface, radius: radius))
         }
     }
 }
@@ -64,6 +80,9 @@ public final class SheetPresenter {
         let id = UUID()
         let detents: [BottomSheetDetent]
         let showsDragIndicator: Bool
+        let detached: Bool
+        let surface: Theme.BackgroundColorKey?
+        let radius: Theme.RadiusRole?
         let content: AnyView
     }
 
@@ -71,13 +90,25 @@ public final class SheetPresenter {
 
     public init() {}
 
-    /// Present a sheet. Replaces any visible sheet.
+    /// Present a sheet. Replaces any visible sheet. `detached` floats the sheet
+    /// as an inset card; `surface`/`radius` override the sheet background token
+    /// and corner role (see `bottomSheet(isPresented:…)`).
     public func present<C: View>(
         detents: [BottomSheetDetent] = [.medium, .large],
         showsDragIndicator: Bool = true,
+        detached: Bool = false,
+        surface: Theme.BackgroundColorKey? = nil,
+        radius: Theme.RadiusRole? = nil,
         @ViewBuilder _ content: () -> C
     ) {
-        current = Request(detents: detents, showsDragIndicator: showsDragIndicator, content: AnyView(content()))
+        current = Request(
+            detents: detents,
+            showsDragIndicator: showsDragIndicator,
+            detached: detached,
+            surface: surface,
+            radius: radius,
+            content: AnyView(content())
+        )
     }
 
     public func dismiss() { current = nil }
@@ -96,6 +127,7 @@ private struct SheetHostModifier: ViewModifier {
                     .padding(Theme.SpacingKey.md.value)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .sheetDetents(request.detents, dragIndicator: request.showsDragIndicator)
+                    .modifier(SheetChrome(detached: request.detached, surface: request.surface, radius: request.radius))
             }
     }
 }
@@ -117,6 +149,54 @@ private extension View {
             .presentationDragIndicator(dragIndicator ? .visible : .hidden)
         #else
         self
+        #endif
+    }
+}
+
+/// Presentation chrome shared by both entry points: detached floating-card mode,
+/// surface-token background, and radius-role corner.
+/// `presentationBackground` is iOS 16.4+ / macOS 13.3+ — inside our iOS 17 /
+/// macOS 14 floor, so no gating; `presentationCornerRadius` is unavailable on
+/// macOS, hence the `#if os(iOS)`.
+private struct SheetChrome: ViewModifier {
+    @Environment(\.theme) private var theme
+
+    let detached: Bool
+    let surface: Theme.BackgroundColorKey?
+    let radius: Theme.RadiusRole?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if detached {
+            content
+                .background(
+                    theme.background(surface ?? .bgWhite),
+                    in: RoundedRectangle(cornerRadius: (radius ?? .box).value, style: .continuous)
+                )
+                .padding(Theme.SpacingKey.md.value)
+                .presentationBackground(.clear)
+        } else {
+            attached(content)
+        }
+    }
+
+    @ViewBuilder
+    private func attached(_ content: Content) -> some View {
+        let surfaced = Group {
+            if let surface {
+                content.presentationBackground(theme.background(surface))
+            } else {
+                content
+            }
+        }
+        #if os(iOS)
+        if let radius {
+            surfaced.presentationCornerRadius(radius.value)
+        } else {
+            surfaced
+        }
+        #else
+        surfaced
         #endif
     }
 }
@@ -148,6 +228,48 @@ private extension View {
                 }
             }
             .padding()
+        }
+    }
+    return Demo().sheetHost()
+}
+
+#Preview("Detached card") {
+    struct Demo: View {
+        @State var show = false
+        var body: some View {
+            PrimaryButton("Open detached sheet") { show = true }
+                .padding()
+                .bottomSheet(isPresented: $show, detents: [.height(220)], detached: true) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Detached").textStyle(.headingSm)
+                        Text("Floats above the bottom edge as an inset card.").textStyle(.bodyBase400)
+                    }
+                }
+        }
+    }
+    return Demo()
+}
+
+#Preview("Tinted surface + custom radius") {
+    struct Demo: View {
+        @Environment(SheetPresenter.self) var sheet: SheetPresenter
+        @State var showTinted = false
+        var body: some View {
+            VStack(spacing: 12) {
+                PrimaryButton("Tinted surface") { showTinted = true }
+                PrimaryButton("Custom radius (imperative)") {
+                    sheet.present(detents: [.medium], radius: .field) {
+                        Text("Field-radius corners").textStyle(.headingSm)
+                    }
+                }
+            }
+            .padding()
+            .bottomSheet(isPresented: $showTinted, detents: [.medium], surface: .bgSecondaryLight, radius: .box) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Tinted").textStyle(.headingSm)
+                    Text("Sheet surface uses a background token.").textStyle(.bodyBase400)
+                }
+            }
         }
     }
     return Demo().sheetHost()

--- a/Sources/ThemeKit/Components/Organisms/Callout.swift
+++ b/Sources/ThemeKit/Components/Organisms/Callout.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 public enum CalloutType {
     case neutral, info, success, warning, error
+    /// Brand-primary emphasis (HeroUI Alert `accent` status).
+    case accent
 
     func accent(_ theme: Theme) -> Color {
         switch self {
@@ -16,6 +18,7 @@ public enum CalloutType {
         case .success: return theme.foreground(.systemcolorsFgSuccess)
         case .warning: return theme.foreground(.systemcolorsFgWarning)
         case .error: return theme.foreground(.systemcolorsFgError)
+        case .accent: return SemanticColor.primary.base
         }
     }
     func soft(_ theme: Theme) -> Color {
@@ -25,14 +28,26 @@ public enum CalloutType {
         case .success: return theme.background(.systemcolorsBgSuccessLight)
         case .warning: return theme.background(.systemcolorsBgWarningLight)
         case .error: return theme.background(.systemcolorsBgErrorLight)
+        case .accent: return SemanticColor.primary.soft
         }
     }
     var systemImage: String {
         switch self {
-        case .neutral, .info: return "info.circle"
+        case .neutral, .info, .accent: return "info.circle"
         case .success: return "checkmark.circle"
         case .warning: return "exclamationmark.triangle"
         case .error: return "exclamationmark.circle"
+        }
+    }
+
+    /// VoiceOver name for the stock status icon — the status itself, localized.
+    var accessibilityLabel: String {
+        switch self {
+        case .neutral: return String(themeKit: "Note")
+        case .info, .accent: return String(themeKit: "Information")
+        case .success: return String(themeKit: "Success")
+        case .warning: return String(themeKit: "Warning")
+        case .error: return String(themeKit: "Error")
         }
     }
 }
@@ -52,6 +67,7 @@ public struct Callout: View {
     private var type: CalloutType = .info
     private var style: CalloutStyle = .plain
     private var showIcon = true
+    private var iconOverride: String?
     private var actionTitle: String?
     private var onAction: (() -> Void)?
     private var onClose: (() -> Void)?
@@ -68,8 +84,9 @@ public struct Callout: View {
     public var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.xs.value) {
             if showIcon {
-                Image(systemName: type.systemImage)
+                Image(systemName: iconOverride ?? type.systemImage)
                     .font(.system(size: 14))
+                    .accessibilityLabel(type.accessibilityLabel)
             }
             Text(text)
                 .textStyle(.bodySm400)
@@ -104,7 +121,7 @@ public struct Callout: View {
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension Callout {
-    /// Semantic status: neutral / info / success / warning / error (drives accent + icon).
+    /// Semantic status: neutral / info / success / warning / error / accent (drives accent + icon).
     func variant(_ t: CalloutType) -> Self { copy { $0.type = t } }
 
     /// Surface treatment: plain (transparent) or soft (light tinted surface).
@@ -112,6 +129,10 @@ public extension Callout {
 
     /// Show or hide the leading status icon.
     func showsIcon(_ on: Bool = true) -> Self { copy { $0.showIcon = on } }
+
+    /// Override the leading status glyph (otherwise derived from the variant);
+    /// `nil` restores the variant's default.
+    func icon(_ systemName: String?) -> Self { copy { $0.iconOverride = systemName } }
 
     /// Trailing inline action button (title + handler).
     func action(_ title: String, onAction: @escaping () -> Void) -> Self {
@@ -135,6 +156,8 @@ public extension Callout {
         Callout("Lorem ipsum placeholder text.").variant(.info)
         Callout("Lorem ipsum placeholder text.").variant(.warning).calloutStyle(.soft)
         Callout("Lorem ipsum placeholder text.").variant(.neutral).calloutStyle(.soft)
+        Callout("Brand-primary emphasis.").variant(.accent).calloutStyle(.soft)
+        Callout("Custom glyph via icon override.").variant(.info).icon("bell.badge")
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -13,10 +13,99 @@
 //  Material via `glassChrome` (decorative, not a plain card fill), and ambient
 //  card styles are tuned for in-flow cards (e.g. `.outlined` has a transparent
 //  surface, which would leave the dialog illegible over the dimmed scrim).
-//  Scrim, transition and dismissal always stay in the component.
+//  Scrim, transition and dismissal always stay in the component. All three
+//  overloads present through the shared `DialogPresentation` chrome below:
+//  fade-only scrim, scale+fade card transition, optional swipe-to-dismiss —
+//  all motion gated by `microAnimations` + Reduce Motion.
 //
 
 import SwiftUI
+
+// MARK: - Shared presentation chrome (scrim + transitions + swipe-to-dismiss)
+
+/// Scrim + card presentation shared by every `.dialog(...)` overload: a dimmed
+/// fade-only scrim, a scale+fade card transition (HeroUI Dialog feel), and an
+/// optional swipe-down-to-dismiss drag (HeroUI `isSwipeable`). When
+/// micro-animations are off or Reduce Motion is on, the card transition
+/// collapses to a plain fade and the drag spring-back snaps instantly.
+private struct DialogPresentation<Card: View>: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Swipe-down-to-dismiss enabled (callers also gate this on loading state).
+    let swipeToDismiss: Bool
+    /// Scrim tap handler; the closure decides whether dismissal applies.
+    let onScrimTap: () -> Void
+    /// Called when a drag is released past the dismiss threshold.
+    let onSwipeDismiss: () -> Void
+    @ViewBuilder let card: () -> Card
+
+    @State private var dragOffset: CGFloat = 0
+    @State private var cardHeight: CGFloat = 0
+
+    // Internal swipe tuning (mirrors FeedbackToastRow's drag feel).
+    /// Resting scrim dim opacity.
+    private static var scrimOpacity: Double { 0.4 }
+    /// Drag distance before the swipe gesture engages.
+    private static var minimumDragDistance: CGFloat { 8 }
+    /// Fraction of the card height a drag must pass to dismiss on release.
+    private static var dismissFraction: CGFloat { 1 / 3 }
+
+    private var motionEnabled: Bool { micro && !reduceMotion }
+
+    var body: some View {
+        ZStack {
+            theme.background(.bgTertiary).opacity(Self.scrimOpacity * scrimFade)
+                .ignoresSafeArea()
+                .onTapGesture(perform: onScrimTap)
+                .transition(.opacity)   // Scrim always fades only.
+
+            card()
+                .background(GeometryReader { geo in
+                    Color.clear
+                        .onAppear { cardHeight = geo.size.height }
+                        .onChange(of: geo.size.height) { cardHeight = $1 }
+                })
+                // Drag tracking is direct manipulation, so it always follows the
+                // finger; only the animated parts (transition, spring-back) are
+                // motion-gated.
+                .offset(y: dragOffset)
+                .gesture(swipe, including: swipeToDismiss ? .all : .subviews)
+                .transition(cardTransition)
+        }
+        .zIndex(1)
+    }
+
+    /// Card presentation transition: scale+fade normally, plain fade when
+    /// micro-animations are off or Reduce Motion is on.
+    private var cardTransition: AnyTransition {
+        motionEnabled ? .opacity.combined(with: .scale(scale: 0.96)) : .opacity
+    }
+
+    /// Fade the scrim proportionally as the card is dragged toward dismissal.
+    private var scrimFade: Double {
+        guard dragOffset > 0, cardHeight > 0 else { return 1 }
+        return max(0, 1 - Double(dragOffset / cardHeight))
+    }
+
+    /// Downward drag offsets the card with the finger; releasing past
+    /// `dismissFraction` of the card height dismisses, anything less springs
+    /// back (instantly when motion is gated off).
+    private var swipe: some Gesture {
+        DragGesture(minimumDistance: Self.minimumDragDistance)
+            .onChanged { value in
+                dragOffset = max(0, value.translation.height)
+            }
+            .onEnded { _ in
+                if cardHeight > 0, dragOffset > cardHeight * Self.dismissFraction {
+                    onSwipeDismiss()
+                } else {
+                    withAnimation(motionEnabled ? Motion.fast.spring : nil) { dragOffset = 0 }
+                }
+            }
+    }
+}
 
 struct DialogCard: View {
     @Environment(\.theme) private var theme
@@ -87,8 +176,6 @@ struct DialogCard: View {
 }
 
 private struct DialogModifier: ViewModifier {
-    @Environment(\.theme) private var theme
-
     @Binding var isPresented: Bool
     let title: String
     let message: String?
@@ -99,6 +186,7 @@ private struct DialogModifier: ViewModifier {
     let kind: FeedbackKind?
     let closable: Bool
     let maskClosable: Bool
+    let swipeToDismiss: Bool
     let width: CGFloat?
 
     @State private var primaryLoading = false
@@ -109,10 +197,11 @@ private struct DialogModifier: ViewModifier {
     func body(content: Content) -> some View {
         content.overlay {
             if isPresented {
-                ZStack {
-                    theme.background(.bgTertiary).opacity(0.4)
-                        .ignoresSafeArea()
-                        .onTapGesture { if maskClosable, !primaryLoading { isPresented = false } }
+                DialogPresentation(
+                    swipeToDismiss: swipeToDismiss && !primaryLoading,
+                    onScrimTap: { if maskClosable, !primaryLoading { isPresented = false } },
+                    onSwipeDismiss: { isPresented = false }
+                ) {
                     DialogCard(
                         title: title, message: message,
                         primaryTitle: primaryTitle,
@@ -136,8 +225,6 @@ private struct DialogModifier: ViewModifier {
                     )
                     .padding(Theme.SpacingKey.lg.value)
                 }
-                .transition(.opacity)
-                .zIndex(1)
             }
         }
         .animation(motion, value: isPresented)
@@ -145,6 +232,8 @@ private struct DialogModifier: ViewModifier {
 }
 
 public extension View {
+    /// `swipeToDismiss` adds a swipe-down-to-dismiss drag on the card
+    /// (HeroUI Dialog `isSwipeable`); off by default.
     func dialog(
         isPresented: Binding<Bool>,
         title: String,
@@ -156,13 +245,15 @@ public extension View {
         kind: FeedbackKind? = nil,
         closable: Bool = false,
         maskClosable: Bool = true,
+        swipeToDismiss: Bool = false,
         width: CGFloat? = nil
     ) -> some View {
         modifier(DialogModifier(
             isPresented: isPresented, title: title, message: message,
             primaryTitle: primaryTitle, onPrimary: onPrimary,
             secondaryTitle: secondaryTitle, onSecondary: onSecondary,
-            kind: kind, closable: closable, maskClosable: maskClosable, width: width
+            kind: kind, closable: closable, maskClosable: maskClosable,
+            swipeToDismiss: swipeToDismiss, width: width
         ))
     }
 }
@@ -176,6 +267,7 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
     let title: String?
     let closable: Bool
     let maskClosable: Bool
+    let swipeToDismiss: Bool
     let width: CGFloat?
     let maxContentHeight: CGFloat
     let afterClose: (() -> Void)?
@@ -194,11 +286,11 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
     func body(content: Content) -> some View {
         content.overlay {
             if isPresented {
-                ZStack {
-                    theme.background(.bgTertiary).opacity(0.4)
-                        .ignoresSafeArea()
-                        .onTapGesture { if maskClosable { close() } }
-
+                DialogPresentation(
+                    swipeToDismiss: swipeToDismiss,
+                    onScrimTap: { if maskClosable { close() } },
+                    onSwipeDismiss: close
+                ) {
                     VStack(spacing: 0) {
                         if title != nil || closable {
                             HStack {
@@ -235,8 +327,6 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
                     .themeShadow(.elevated)
                     .padding(Theme.SpacingKey.lg.value)
                 }
-                .transition(.opacity)
-                .zIndex(1)
             }
         }
         .animation(motion, value: isPresented)
@@ -246,11 +336,14 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
 public extension View {
     /// A modal with custom scrollable content and a pinned footer slot
     /// (Ant Modal `footer` + long-content scroll + `afterClose`).
+    /// `swipeToDismiss` adds a swipe-down-to-dismiss drag on the card
+    /// (HeroUI Dialog `isSwipeable`); off by default.
     func dialog<DialogContent: View, Footer: View>(
         isPresented: Binding<Bool>,
         title: String? = nil,
         closable: Bool = true,
         maskClosable: Bool = true,
+        swipeToDismiss: Bool = false,
         width: CGFloat? = nil,
         maxContentHeight: CGFloat = 420,
         afterClose: (() -> Void)? = nil,
@@ -259,7 +352,8 @@ public extension View {
     ) -> some View {
         modifier(CustomDialogModifier(
             isPresented: isPresented, title: title, closable: closable, maskClosable: maskClosable,
-            width: width, maxContentHeight: maxContentHeight, afterClose: afterClose,
+            swipeToDismiss: swipeToDismiss, width: width,
+            maxContentHeight: maxContentHeight, afterClose: afterClose,
             dialogContent: dialogContent, footer: footer
         ))
     }
@@ -273,6 +367,7 @@ private struct FreeformDialogModifier<DialogContent: View>: ViewModifier {
     @Binding var isPresented: Bool
     let closable: Bool
     let maskClosable: Bool
+    let swipeToDismiss: Bool
     let width: CGFloat?
     let afterClose: (() -> Void)?
     let dialogContent: () -> DialogContent
@@ -289,11 +384,11 @@ private struct FreeformDialogModifier<DialogContent: View>: ViewModifier {
     func body(content: Content) -> some View {
         content.overlay {
             if isPresented {
-                ZStack {
-                    theme.background(.bgTertiary).opacity(0.4)
-                        .ignoresSafeArea()
-                        .onTapGesture { if maskClosable { close() } }
-
+                DialogPresentation(
+                    swipeToDismiss: swipeToDismiss,
+                    onScrimTap: { if maskClosable { close() } },
+                    onSwipeDismiss: close
+                ) {
                     dialogContent()
                         .padding(Theme.SpacingKey.lg.value)
                         .frame(maxWidth: width ?? 320)
@@ -311,8 +406,6 @@ private struct FreeformDialogModifier<DialogContent: View>: ViewModifier {
                         .themeShadow(.elevated)
                         .padding(Theme.SpacingKey.lg.value)
                 }
-                .transition(.opacity)
-                .zIndex(1)
             }
         }
         .animation(motion, value: isPresented)
@@ -321,21 +414,25 @@ private struct FreeformDialogModifier<DialogContent: View>: ViewModifier {
 
 public extension View {
     /// A modal whose card interior is entirely caller-drawn. Reuses the standard
-    /// dialog presentation — dimmed scrim, glass card chrome, fade transition,
-    /// scrim-tap / close-button dismissal — while the content is a free slot.
-    /// The fixed `title / message / actions` and `content:footer:` overloads
-    /// remain unchanged next to this one.
+    /// dialog presentation — dimmed scrim, glass card chrome, scale+fade
+    /// transition, scrim-tap / close-button / optional swipe dismissal — while
+    /// the content is a free slot. The fixed `title / message / actions` and
+    /// `content:footer:` overloads remain unchanged next to this one.
+    /// `swipeToDismiss` adds a swipe-down-to-dismiss drag on the card
+    /// (HeroUI Dialog `isSwipeable`); off by default.
     func dialog<DialogContent: View>(
         isPresented: Binding<Bool>,
         closable: Bool = false,
         maskClosable: Bool = true,
+        swipeToDismiss: Bool = false,
         width: CGFloat? = nil,
         afterClose: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> DialogContent
     ) -> some View {
         modifier(FreeformDialogModifier(
             isPresented: isPresented, closable: closable, maskClosable: maskClosable,
-            width: width, afterClose: afterClose, dialogContent: content
+            swipeToDismiss: swipeToDismiss, width: width,
+            afterClose: afterClose, dialogContent: content
         ))
     }
 }
@@ -348,6 +445,23 @@ public extension View {
                 .dialog(isPresented: $show, title: "Delete trip?",
                         message: "This action cannot be undone.",
                         primaryTitle: "Delete", secondaryTitle: "Cancel", onSecondary: {})
+        }
+    }
+    return Demo()
+}
+
+#Preview("Swipe to dismiss") {
+    struct Demo: View {
+        @State var show = true
+        var body: some View {
+            VStack {
+                PrimaryButton("Show dialog") { show = true }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.gray.opacity(0.1))
+            .dialog(isPresented: $show, title: "Swipe to dismiss",
+                    message: "Drag the card down past a third of its height to dismiss; a shorter drag springs back.",
+                    primaryTitle: "OK", swipeToDismiss: true)
         }
     }
     return Demo()

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -73,6 +73,13 @@ private struct DialogPresentation<Card: View>: View {
                 .offset(y: dragOffset)
                 .gesture(swipe, including: swipeToDismiss ? .all : .subviews)
                 .transition(cardTransition)
+                // Assistive-tech equivalent of the swipe/scrim dismissal —
+                // VoiceOver's two-finger scrub closes what a swipe would.
+                // Both handlers carry the caller's own gating (loading state,
+                // maskClosable), so escape can never dismiss more than touch.
+                .accessibilityAction(.escape) {
+                    if swipeToDismiss { onSwipeDismiss() } else { onScrimTap() }
+                }
         }
         .zIndex(1)
     }

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -231,13 +231,33 @@ public final class FeedbackPresenter {
     @discardableResult
     private func enqueue(_ item: ToastItem) -> UUID {
         toasts.append(item)
-        if toasts.count > maxVisibleToasts { toasts.removeFirst(toasts.count - maxVisibleToasts) }
+        if toasts.count > maxVisibleToasts {
+            let overflow = Set(toasts.prefix(toasts.count - maxVisibleToasts).map(\.id))
+            removeToasts { overflow.contains($0.id) }
+        }
+        item.onShow?()
         return item.id
     }
 
     private func replaceToast(_ id: UUID, with item: ToastItem) {
-        if let i = toasts.firstIndex(where: { $0.id == id }) { toasts[i] = item }
-        else { _ = enqueue(item) }
+        if let i = toasts.firstIndex(where: { $0.id == id }) {
+            toasts[i].onDismiss?()   // the old toast leaves the screen in place
+            toasts[i] = item
+            item.onShow?()
+        } else {
+            _ = enqueue(item)
+        }
+    }
+
+    /// The single removal point for toasts. Every dismissal path — the
+    /// auto-dismiss timer, swipe, the close button, `dismissToast(_:)`,
+    /// `dismissAllToasts()`, and overflow past the visible cap — funnels
+    /// through here, so each removed toast's `onDismiss` always reports.
+    private func removeToasts(where shouldRemove: (ToastItem) -> Bool) {
+        let removed = toasts.filter(shouldRemove)
+        guard !removed.isEmpty else { return }
+        toasts.removeAll(where: shouldRemove)
+        removed.forEach { $0.onDismiss?() }
     }
 
     /// Present a modal confirmation dialog with a primary (and optional secondary) action.

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -161,6 +161,14 @@ public final class FeedbackPresenter {
     /// Show a transient toast. Multiple toasts stack (the oldest drops past the
     /// visible cap). Pass `duration: nil` for a sticky toast — e.g. one with an
     /// `action` the user must reach (Undo). Returns the id for manual dismissal.
+    ///
+    /// - Parameters:
+    ///   - position: which edge this toast anchors to; `nil` (default) uses the
+    ///     host's `toastPosition`.
+    ///   - onShow: called when the toast is presented.
+    ///   - onDismiss: called when the toast leaves, on every dismissal path —
+    ///     auto-dismiss timer, swipe, close button, `dismissToast(_:)` /
+    ///     `dismissAllToasts()`, or being pushed past the visible cap.
     @discardableResult
     public func toast(
         _ title: String,
@@ -168,23 +176,33 @@ public final class FeedbackPresenter {
         kind: FeedbackKind = .success,
         systemImage: String? = nil,
         action: ToastAction? = nil,
-        duration: Double? = 2.5
+        duration: Double? = 2.5,
+        position: ToastPosition? = nil,
+        onShow: (() -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil
     ) -> UUID {
         enqueue(ToastItem(title: title, message: message, kind: kind,
-                          systemImage: systemImage, isLoading: false, action: action, duration: duration))
+                          systemImage: systemImage, isLoading: false, action: action,
+                          duration: duration, position: position,
+                          onShow: onShow, onDismiss: onDismiss))
     }
 
     /// Show a transient toast with fully custom content. Same stacking, cap,
-    /// auto-dismiss (pass `duration: nil` for sticky), elevation shadow and
-    /// swipe-to-dismiss as `toast(_:)` — only the row's visuals are yours.
+    /// auto-dismiss (pass `duration: nil` for sticky), elevation shadow,
+    /// swipe-to-dismiss, per-toast `position` and lifecycle callbacks as
+    /// `toast(_:)` — only the row's visuals are yours.
     /// Returns the id for manual dismissal via `dismissToast(_:)`.
     @discardableResult
     public func toast<Content: View>(
         duration: Double? = 2.5,
+        position: ToastPosition? = nil,
+        onShow: (() -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: () -> Content
     ) -> UUID {
         enqueue(ToastItem(title: "", message: nil, kind: .info, systemImage: nil,
                           isLoading: false, action: nil, duration: duration,
+                          position: position, onShow: onShow, onDismiss: onDismiss,
                           custom: AnyView(content())))
     }
 

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -30,6 +30,9 @@ import SwiftUI
 /// Semantic intent shared by every feedback surface (maps to the token system).
 public enum FeedbackKind: String, CaseIterable {
     case success, info, warning, error
+    /// Low-emphasis message on a muted surface (HeroUI's "default" toast),
+    /// and a brand-tinted accent fed by the theme's primary color.
+    case neutral, accent
 
     var toastType: AlertToastType {
         switch self {
@@ -37,6 +40,8 @@ public enum FeedbackKind: String, CaseIterable {
         case .info: return .info
         case .warning: return .warning
         case .error: return .danger
+        case .neutral: return .neutral
+        case .accent: return .accent
         }
     }
 
@@ -47,6 +52,8 @@ public enum FeedbackKind: String, CaseIterable {
         case .info: return .primary
         case .warning: return .warning
         case .error: return .error
+        case .neutral: return .neutral
+        case .accent: return .primary   // accent surfaces are fed by the brand primary
         }
     }
 
@@ -57,6 +64,8 @@ public enum FeedbackKind: String, CaseIterable {
         case .info: return "info.circle.fill"
         case .warning: return "exclamationmark.triangle.fill"
         case .error: return "xmark.octagon.fill"
+        case .neutral: return "bell.fill"
+        case .accent: return "sparkles"
         }
     }
 }
@@ -78,12 +87,21 @@ public final class FeedbackPresenter {
         let isLoading: Bool
         let action: ToastAction?
         let duration: Double?
+        /// Per-toast edge override; `nil` falls back to the host's default.
+        let position: ToastPosition?
+        /// Fired when the toast is presented.
+        let onShow: (() -> Void)?
+        /// Fired when the toast leaves, whatever the dismissal path (timer,
+        /// swipe, close button, programmatic dismissal, overflow past the cap).
+        let onDismiss: (() -> Void)?
         /// When set, the row renders this instead of the stock `AlertToast`
         /// (custom content slot); the presentation infrastructure is shared.
         let custom: AnyView?
 
         init(title: String, message: String?, kind: FeedbackKind, systemImage: String?,
-             isLoading: Bool, action: ToastAction?, duration: Double?, custom: AnyView? = nil) {
+             isLoading: Bool, action: ToastAction?, duration: Double?,
+             position: ToastPosition? = nil, onShow: (() -> Void)? = nil,
+             onDismiss: (() -> Void)? = nil, custom: AnyView? = nil) {
             self.title = title
             self.message = message
             self.kind = kind
@@ -91,6 +109,9 @@ public final class FeedbackPresenter {
             self.isLoading = isLoading
             self.action = action
             self.duration = duration
+            self.position = position
+            self.onShow = onShow
+            self.onDismiss = onDismiss
             self.custom = custom
         }
     }

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -292,8 +292,8 @@ public final class FeedbackPresenter {
     /// call `dismissLoading()` when the work completes (Ant `message.loading`).
     public func loading(_ title: String = String(themeKit: "Loading…")) { activeLoading = title }
 
-    public func dismissToast(_ id: UUID) { toasts.removeAll { $0.id == id } }
-    public func dismissAllToasts() { toasts.removeAll() }
+    public func dismissToast(_ id: UUID) { removeToasts { $0.id == id } }
+    public func dismissAllToasts() { removeToasts { _ in true } }
     public func dismissConfirm() { activeConfirm = nil }
     public func dismissNotification() { activeNotification = nil }
     public func dismissLoading() { activeLoading = nil }

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -303,20 +303,30 @@ public final class FeedbackPresenter {
 
 private struct FeedbackHostModifier: ViewModifier {
     @Environment(\.theme) private var theme
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var presenter: FeedbackPresenter
-    private let toastEdge: Edge
+    private let defaultPosition: ToastPosition
+
+    /// HeroUI-style stack depth: each toast behind the newest peeks out by a few
+    /// points and recedes at ~0.97 scale per depth step. Fixed chrome constants
+    /// (no semantic token exists for a stack-depth transform).
+    private let stackPeek: CGFloat = 6
+    private let stackScale: CGFloat = 0.97
+    private var depthOn: Bool { micro && !reduceMotion }
 
     init(maxVisibleToasts: Int, toastPosition: ToastPosition) {
         _presenter = State(wrappedValue: FeedbackPresenter(maxVisibleToasts: maxVisibleToasts))
-        toastEdge = toastPosition == .top ? .top : .bottom
+        defaultPosition = toastPosition
     }
 
     func body(content: Content) -> some View {
         content
             .environment(presenter)
             .overlay(alignment: .top) { notificationLayer }
-            .overlay(alignment: toastEdge == .top ? .top : .bottom) { toastLayer }
+            .overlay(alignment: .top) { toastLayer(.top) }
+            .overlay(alignment: .bottom) { toastLayer(.bottom) }
             .overlay { confirmLayer }
             .overlay { loadingLayer }
             .animation(Motion.base.spring, value: presenter.toasts.map(\.id))
@@ -375,16 +385,31 @@ private struct FeedbackHostModifier: ViewModifier {
         }
     }
 
-    private var toastLayer: some View {
-        // Newest nearest the anchored edge: bottom keeps array order, top reverses.
-        let ordered = toastEdge == .top ? Array(presenter.toasts.reversed()) : presenter.toasts
-        return VStack(spacing: Theme.SpacingKey.sm.value) {
-            ForEach(ordered) { item in
-                FeedbackToastRow(item: item, edge: toastEdge) { presenter.dismissToast(item.id) }
+    /// The toast stack anchored to one edge. Items route by their *effective*
+    /// position — the per-toast override, falling back to the host default.
+    @ViewBuilder
+    private func toastLayer(_ position: ToastPosition) -> some View {
+        let stack = presenter.toasts.filter { ($0.position ?? defaultPosition) == position }
+        if !stack.isEmpty {
+            let edge: Edge = position == .top ? .top : .bottom
+            // Newest nearest the anchored edge: bottom keeps array order, top reverses.
+            let ordered = position == .top ? Array(stack.reversed()) : stack
+            VStack(spacing: Theme.SpacingKey.sm.value) {
+                ForEach(Array(ordered.enumerated()), id: \.element.id) { index, item in
+                    // Depth 0 = the newest toast; ones behind it recede with a
+                    // subtle scale + peek offset toward the anchored edge.
+                    // Static (flat stack) under Reduce Motion / micro-animations off.
+                    let depth = position == .top ? index : ordered.count - 1 - index
+                    FeedbackToastRow(item: item, edge: edge) { presenter.dismissToast(item.id) }
+                        .scaleEffect(depthOn ? pow(stackScale, CGFloat(depth)) : 1,
+                                     anchor: position == .top ? .top : .bottom)
+                        .offset(y: depthOn ? CGFloat(depth) * stackPeek * (position == .top ? -1 : 1) : 0)
+                        .zIndex(Double(-depth))   // newest draws above what it overlaps
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(Theme.SpacingKey.md.value)
         }
-        .frame(maxWidth: .infinity, alignment: .center)
-        .padding(Theme.SpacingKey.md.value)
     }
 
     @ViewBuilder
@@ -478,7 +503,8 @@ public extension View {
     ///
     /// - Parameters:
     ///   - maxVisibleToasts: how many stacked toasts stay on screen (oldest drops).
-    ///   - toastPosition: which edge the toast stack anchors to (default `.bottom`).
+    ///   - toastPosition: the default edge the toast stack anchors to (default
+    ///     `.bottom`); a toast can override it per-call via `toast(position:)`.
     func feedbackHost(maxVisibleToasts: Int = 3, toastPosition: ToastPosition = .bottom) -> some View {
         modifier(FeedbackHostModifier(maxVisibleToasts: maxVisibleToasts, toastPosition: toastPosition))
     }
@@ -492,6 +518,17 @@ public extension View {
                 ThemeButton("Stack ×3") {
                     for i in 1 ... 3 { feedback.toast("Toast #\(i)", kind: .success) }
                 }
+                ThemeButton("Neutral / accent") {
+                    feedback.toast("Notifications paused", kind: .neutral)
+                    feedback.toast("Pro features unlocked", kind: .accent)
+                }
+                .variant(.outline)
+                ThemeButton("Top override + callbacks") {
+                    feedback.toast("Heads up", kind: .info, position: .top,
+                                   onShow: { print("shown") },
+                                   onDismiss: { print("dismissed") })
+                }
+                .variant(.outline)
                 ThemeButton("Undo (sticky + action)") {
                     feedback.toast("Message deleted", kind: .info,
                                    action: ToastAction("Undo") {}, duration: nil)

--- a/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
@@ -108,7 +108,7 @@ public struct InfoBanner: View {
             } else if showIcon {
                 Icon(systemName: iconOverride ?? type.systemImage)
                     .size(.sm)
-                    .color(type.accent(theme))
+                    .colorOverride(type.accent(theme))
                     .accessibilityLabel(type.accessibilityLabel)
             }
 

--- a/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
@@ -100,8 +100,16 @@ public struct InfoBanner: View {
 
     public var body: some View {
         HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
-            if showIcon {
-                Icon(systemName: type.systemImage).size(.sm).color(type.accent(theme))
+            // Leading indicator: a custom view replaces the stock icon entirely
+            // (HeroUI Alert.Indicator children); otherwise the status glyph,
+            // optionally overridden per-instance via `icon(_:)`.
+            if let leadingView {
+                leadingView
+            } else if showIcon {
+                Icon(systemName: iconOverride ?? type.systemImage)
+                    .size(.sm)
+                    .color(type.accent(theme))
+                    .accessibilityLabel(type.accessibilityLabel)
             }
 
             VStack(alignment: .leading, spacing: 2) {
@@ -119,6 +127,12 @@ public struct InfoBanner: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Custom trailing accessory (e.g. a small ThemeButton) — richer than
+            // the lightweight `action(_:onAction:)` text link below.
+            if let trailingView {
+                trailingView
+            }
 
             if let actionTitle, let onAction {
                 Button(action: onAction) {
@@ -141,6 +155,9 @@ public struct InfoBanner: View {
             RoundedRectangle(cornerRadius: radius, style: .continuous)
                 .stroke(type.border(theme), lineWidth: banner ? 0 : 1)
         )
+        // One VoiceOver element: "<status>, <title>, <message>"; child button
+        // actions surface as custom accessibility actions.
+        .accessibilityElement(children: .combine)
     }
 }
 
@@ -151,6 +168,14 @@ public struct InfoBanner: View {
         InfoBanner("Please double-check this field.").variant(.warning)
         InfoBanner("Something went wrong.").variant(.error).onDismiss {}
         InfoBanner("A neutral note.").variant(.neutral)
+        InfoBanner("Brand-primary emphasis.", title: "New feature").variant(.accent)
+        InfoBanner("Custom glyph via icon override.").variant(.info).icon("bell.badge")
+        InfoBanner("Uploading your document…", title: "Processing")
+            .variant(.accent)
+            .leading { Spinner().size(IconSize.sm.value).lineWidth(2).accent(.primary) }
+        InfoBanner("A new version is available.", title: "Update")
+            .variant(.info)
+            .trailing { ThemeButton("Install") {}.size(.small).color(.info) }
     }
     .padding()
 }
@@ -158,12 +183,30 @@ public struct InfoBanner: View {
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension InfoBanner {
-    /// Semantic type: neutral / info / success / warning / error — drives the
-    /// surface, accent, border and leading icon.
+    /// Semantic type: neutral / info / success / warning / error / accent —
+    /// drives the surface, accent, border and leading icon.
     func variant(_ t: InfoBannerType) -> Self { copy { $0.type = t } }
 
     /// Show or hide the type's leading icon.
     func showsIcon(_ on: Bool = true) -> Self { copy { $0.showIcon = on } }
+
+    /// Override the leading status glyph (otherwise derived from the variant);
+    /// `nil` restores the variant's default.
+    func icon(_ systemName: String?) -> Self { copy { $0.iconOverride = systemName } }
+
+    /// Replace the stock status icon with a custom leading view — e.g. a
+    /// `Spinner` for an in-progress alert (HeroUI `Alert.Indicator` children).
+    /// Wins over `icon(_:)` and `showsIcon(_:)`.
+    func leading<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.leadingView = AnyView(content()) }
+    }
+
+    /// Custom trailing accessory rendered after the text block — e.g. a small
+    /// `ThemeButton`. The lightweight `action(_:onAction:)` text link stays the
+    /// default for simple cases.
+    func trailing<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.trailingView = AnyView(content()) }
+    }
 
     /// Edge-to-edge banner treatment: stretch to full width and drop the
     /// rounded corners / border (Ant Alert `banner`).

--- a/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 public enum InfoBannerType {
     case neutral, info, success, warning, error
+    /// Brand-primary emphasis (HeroUI Alert `accent` status).
+    case accent
 
     func background(_ theme: Theme) -> Color {
         switch self {
@@ -16,6 +18,7 @@ public enum InfoBannerType {
         case .success: return theme.background(.systemcolorsBgSuccessLight)
         case .warning: return theme.background(.systemcolorsBgWarningLight)
         case .error: return theme.background(.systemcolorsBgErrorLight)
+        case .accent: return SemanticColor.primary.soft
         }
     }
 
@@ -26,6 +29,7 @@ public enum InfoBannerType {
         case .success: return theme.foreground(.systemcolorsFgSuccess)
         case .warning: return theme.foreground(.systemcolorsFgWarning)
         case .error: return theme.foreground(.systemcolorsFgError)
+        case .accent: return SemanticColor.primary.base
         }
     }
 
@@ -36,15 +40,27 @@ public enum InfoBannerType {
         case .success: return theme.border(.systemcolorsBorderSuccessLight)
         case .warning: return theme.border(.systemcolorsBorderWarningLight)
         case .error: return theme.border(.systemcolorsBorderErrorLight)
+        case .accent: return SemanticColor.primary.border
         }
     }
 
     var systemImage: String {
         switch self {
-        case .neutral, .info: return "info.circle.fill"
+        case .neutral, .info, .accent: return "info.circle.fill"
         case .success: return "checkmark.circle.fill"
         case .warning: return "exclamationmark.triangle.fill"
         case .error: return "exclamationmark.octagon.fill"
+        }
+    }
+
+    /// VoiceOver name for the stock status icon — the status itself, localized.
+    var accessibilityLabel: String {
+        switch self {
+        case .neutral: return String(themeKit: "Note")
+        case .info, .accent: return String(themeKit: "Information")
+        case .success: return String(themeKit: "Success")
+        case .warning: return String(themeKit: "Warning")
+        case .error: return String(themeKit: "Error")
         }
     }
 }
@@ -59,6 +75,9 @@ public struct InfoBanner: View {
     private var type: InfoBannerType = .info
     private var showIcon = true
     private var banner = false
+    private var iconOverride: String?
+    private var leadingView: AnyView?
+    private var trailingView: AnyView?
     private var actionTitle: String?
     private var onAction: (() -> Void)?
     private var onDismiss: (() -> Void)?

--- a/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
+++ b/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
@@ -65,6 +65,9 @@ private struct PopconfirmPresenter<Card: View>: ViewModifier {
             let arrow = TooltipArrow(edge: edge)
                 .fill(theme.background(.bgWhite))
                 .overlay(TooltipArrow(edge: edge).stroke(theme.border(.borderPrimary), lineWidth: 1))
+                // Path apex is drawn in absolute coordinates; mirror it with
+                // the layout so it keeps pointing at the trigger under RTL.
+                .flipsForRightToLeftLayoutDirection(true)
                 .frame(width: edge.isVertical ? 14 : 7, height: edge.isVertical ? 7 : 14)
                 .zIndex(1) // Draw over the card's border along the shared base.
             switch edge {

--- a/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
+++ b/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
@@ -6,35 +6,76 @@
 //  A lightweight confirmation popover anchored to its trigger element — unlike
 //  the full-screen modal `Dialog`, it points at what you're confirming.
 //  (Ant Popconfirm.) Apply with `.popconfirm(...)`. Anchors to any of the four
-//  edges (reusing `TooltipEdge`); the confirm closure may be async, in which case
-//  the OK button shows a spinner and the popover stays open until it resolves.
+//  edges (reusing `TooltipEdge`), slides along that edge with `align`, dismisses
+//  on an outside tap (HeroUI Popover `closeOnPress`; opt out with
+//  `dismissOnOutsideTap: false`), and can point at the trigger with
+//  `showsArrow`. The confirm closure may be async, in which case the OK button
+//  shows a spinner and the popover stays open until it resolves.
+//
+//  `.themePopover(...)` reuses the same surface/presenter for a plain titled
+//  card (HeroUI Popover.Title/Description/Close) with no confirm buttons.
 //
 
 import SwiftUI
 
-/// Shared presentation shell for both overloads: an overlay anchored to the
-/// chosen edge, fixed-size card, edge placement, fade+scale transition, and
-/// micro-motion animation. What the card contains is the caller's business.
+/// Shared presentation shell for all overloads (`.popconfirm` and
+/// `.themePopover`): an overlay anchored to the chosen edge, fixed-size card,
+/// edge placement with `align`, fade+scale transition, micro-motion animation,
+/// an optional arrow pointing at the trigger, and — while presented — a
+/// transparent tap-catcher behind the card that dismisses on an outside tap.
+/// What the card contains is the caller's business.
 private struct PopconfirmPresenter<Card: View>: ViewModifier {
     @Binding var isPresented: Bool
     let edge: TooltipEdge
+    var align: PopoverAlign = .center
+    var dismissOnOutsideTap: Bool = true
+    var showsArrow: Bool = false
     let card: Card
 
+    @Environment(\.theme) private var theme
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
 
     func body(content: Content) -> some View {
-        content.overlay(alignment: edge.alignment) {
-            if isPresented {
-                card
-                    .fixedSize()
-                    .modifier(PopconfirmPlacement(edge: edge))
-                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
-                    .zIndex(1)
+        content
+            .overlay { // Behind the card overlay below; only mounted while open.
+                if isPresented && dismissOnOutsideTap {
+                    PopoverTapCatcher { isPresented = false }
+                }
             }
+            .overlay(alignment: edge.alignment(align)) {
+                if isPresented {
+                    decoratedCard
+                        .modifier(PopconfirmPlacement(edge: edge))
+                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                        .zIndex(1)
+                }
+            }
+            .animation(motion, value: isPresented)
+    }
+
+    /// The fixed-size card, optionally with the shared tooltip arrow on its
+    /// anchor-facing side — filled with the card surface, hairline-stroked on
+    /// the two exposed edges, and overlapping the card border by 1pt so the
+    /// seam opens like a speech bubble.
+    @ViewBuilder private var decoratedCard: some View {
+        let sized = card.fixedSize()
+        if showsArrow {
+            let arrow = TooltipArrow(edge: edge)
+                .fill(theme.background(.bgWhite))
+                .overlay(TooltipArrow(edge: edge).stroke(theme.border(.borderPrimary), lineWidth: 1))
+                .frame(width: edge.isVertical ? 14 : 7, height: edge.isVertical ? 7 : 14)
+                .zIndex(1) // Draw over the card's border along the shared base.
+            switch edge {
+            case .top: VStack(spacing: -1) { sized; arrow }
+            case .bottom: VStack(spacing: -1) { arrow; sized }
+            case .leading: HStack(spacing: -1) { sized; arrow }
+            case .trailing: HStack(spacing: -1) { arrow; sized }
+            }
+        } else {
+            sized
         }
-        .animation(motion, value: isPresented)
     }
 }
 
@@ -65,13 +106,19 @@ private struct PopconfirmModifier: ViewModifier {
     let cancelTitle: String
     let confirmKind: FeedbackKind
     let edge: TooltipEdge
+    let align: PopoverAlign
+    let dismissOnOutsideTap: Bool
+    let showsArrow: Bool
     let onConfirm: () async -> Void
     let onCancel: (() -> Void)?
 
     @State private var loading = false
 
     func body(content: Content) -> some View {
-        content.modifier(PopconfirmPresenter(isPresented: $isPresented, edge: edge, card: card))
+        content.modifier(PopconfirmPresenter(
+            isPresented: $isPresented, edge: edge, align: align,
+            dismissOnOutsideTap: dismissOnOutsideTap, showsArrow: showsArrow, card: card
+        ))
     }
 
     private var card: some View {
@@ -106,23 +153,65 @@ private struct PopconfirmModifier: ViewModifier {
     }
 }
 
-/// Pushes the confirm card just outside the chosen edge of its trigger.
+/// Pushes the confirm card just outside the chosen edge of its trigger,
+/// separated by the small spacing token.
 private struct PopconfirmPlacement: ViewModifier {
     let edge: TooltipEdge
 
+    private var gap: CGFloat { Theme.SpacingKey.sm.value }
+
     func body(content: Content) -> some View {
         switch edge {
-        case .top: content.alignmentGuide(.top) { $0[.bottom] + 8 }
-        case .bottom: content.alignmentGuide(.bottom) { $0[.top] - 8 }
-        case .leading: content.alignmentGuide(.leading) { $0[.trailing] + 8 }
-        case .trailing: content.alignmentGuide(.trailing) { $0[.leading] - 8 }
+        case .top: content.alignmentGuide(.top) { $0[.bottom] + gap }
+        case .bottom: content.alignmentGuide(.bottom) { $0[.top] - gap }
+        case .leading: content.alignmentGuide(.leading) { $0[.trailing] + gap }
+        case .trailing: content.alignmentGuide(.trailing) { $0[.leading] - gap }
         }
+    }
+}
+
+/// The stock titled-popover card: title + optional message with the standard
+/// close affordance, on the shared Popconfirm surface. (HeroUI
+/// Popover.Title/Description/Close on Popover.Content.)
+private struct ThemePopoverModifier: ViewModifier {
+    @Environment(\.theme) private var theme
+
+    @Binding var isPresented: Bool
+    let title: String
+    let message: String?
+    let edge: TooltipEdge
+    let align: PopoverAlign
+    let dismissOnOutsideTap: Bool
+    let showsArrow: Bool
+
+    func body(content: Content) -> some View {
+        content.modifier(PopconfirmPresenter(
+            isPresented: $isPresented, edge: edge, align: align,
+            dismissOnOutsideTap: dismissOnOutsideTap, showsArrow: showsArrow, card: card
+        ))
+    }
+
+    private var card: some View {
+        HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
+                Text(title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+                if let message {
+                    Text(message).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                }
+            }
+            Spacer(minLength: 0)
+            CloseButton { isPresented = false }.controlSize(.mini)
+        }
+        .modifier(PopconfirmSurface())
     }
 }
 
 public extension View {
     /// Anchored confirmation popover. `edge` chooses which side of the trigger the
-    /// card points from (top / bottom / leading / trailing). `onConfirm` may be
+    /// card points from (top / bottom / leading / trailing) and `align` slides it
+    /// along that edge. While open, tapping anywhere outside the card dismisses
+    /// it (HeroUI Popover `closeOnPress`; `dismissOnOutsideTap: false` opts out),
+    /// and `showsArrow` adds a pointer toward the trigger. `onConfirm` may be
     /// async — while it runs the OK button spins, Cancel is disabled, and the
     /// popover stays open; it dismisses once the work completes.
     func popconfirm(
@@ -133,30 +222,64 @@ public extension View {
         cancelTitle: String = String(themeKit: "No"),
         confirmKind: FeedbackKind = .error,
         edge: TooltipEdge = .top,
+        align: PopoverAlign = .center,
+        dismissOnOutsideTap: Bool = true,
+        showsArrow: Bool = false,
         onConfirm: @escaping () async -> Void,
         onCancel: (() -> Void)? = nil
     ) -> some View {
         modifier(PopconfirmModifier(
             isPresented: isPresented, title: title, message: message,
             confirmTitle: confirmTitle, cancelTitle: cancelTitle, confirmKind: confirmKind,
-            edge: edge, onConfirm: onConfirm, onCancel: onCancel
+            edge: edge, align: align, dismissOnOutsideTap: dismissOnOutsideTap,
+            showsArrow: showsArrow, onConfirm: onConfirm, onCancel: onCancel
         ))
     }
 
     /// Anchored popover with fully custom content in place of the stock
     /// title/message/buttons layout. The card shell (white surface, hairline,
     /// elevated shadow, 260pt width) and the presentation (edge placement,
-    /// transition, motion) match the standard `.popconfirm(...)`; what's inside
-    /// — and how it dismisses, typically by flipping `isPresented` — is the
-    /// caller's.
+    /// `align`, outside-tap dismissal, optional arrow, transition, motion)
+    /// match the standard `.popconfirm(...)`; what's inside — and how else it
+    /// dismisses, typically by flipping `isPresented` — is the caller's.
     func popconfirm<V: View>(
         isPresented: Binding<Bool>,
         edge: TooltipEdge = .top,
+        align: PopoverAlign = .center,
+        dismissOnOutsideTap: Bool = true,
+        showsArrow: Bool = false,
         @ViewBuilder content: () -> V
     ) -> some View {
         modifier(PopconfirmPresenter(
-            isPresented: isPresented, edge: edge,
+            isPresented: isPresented, edge: edge, align: align,
+            dismissOnOutsideTap: dismissOnOutsideTap, showsArrow: showsArrow,
             card: content().modifier(PopconfirmSurface())
+        ))
+    }
+
+    /// Stock titled popover: a title, an optional message and the standard
+    /// close button on the same anchored card as `.popconfirm(...)` — for
+    /// contextual explanations that need no confirm/cancel decision. (HeroUI
+    /// Popover with Title/Description/Close.)
+    ///
+    /// Named `themePopover` rather than overloading SwiftUI's own
+    /// `popover(isPresented:...)`: an overload distinguished only by the
+    /// `title:`/`message:` labels would be legal, but it reads as the native
+    /// UIKit-backed popover while presenting an in-canvas ThemeKit card, and
+    /// it risks source ambiguity if SwiftUI ever grows similar labels. The
+    /// `theme` prefix follows `ThemeButton`/`themeShadow` precedent.
+    func themePopover(
+        isPresented: Binding<Bool>,
+        title: String,
+        message: String? = nil,
+        edge: TooltipEdge = .top,
+        align: PopoverAlign = .center,
+        dismissOnOutsideTap: Bool = true,
+        showsArrow: Bool = false
+    ) -> some View {
+        modifier(ThemePopoverModifier(
+            isPresented: isPresented, title: title, message: message, edge: edge,
+            align: align, dismissOnOutsideTap: dismissOnOutsideTap, showsArrow: showsArrow
         ))
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
+++ b/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
@@ -120,7 +120,9 @@ private struct PopconfirmModifier: ViewModifier {
     func body(content: Content) -> some View {
         content.modifier(PopconfirmPresenter(
             isPresented: $isPresented, edge: edge, align: align,
-            dismissOnOutsideTap: dismissOnOutsideTap, showsArrow: showsArrow, card: card
+            // While the async confirm runs the popover must stay open (Cancel
+            // is disabled for the same reason), so outside taps are ignored.
+            dismissOnOutsideTap: dismissOnOutsideTap && !loading, showsArrow: showsArrow, card: card
         ))
     }
 

--- a/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
+++ b/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
@@ -288,10 +288,54 @@ public extension View {
     struct Demo: View {
         @State var show = true
         var body: some View {
+            // Default: tapping anywhere outside the card dismisses it.
             ThemeButton("Delete") { show.toggle() }.color(.error).variant(.soft)
                 .popconfirm(isPresented: $show, title: "Delete this item?", message: "This can't be undone.",
                             confirmTitle: "Delete", cancelTitle: "Cancel") {}
                 .padding(80)
+        }
+    }
+    return Demo()
+}
+
+#Preview("Arrow + align + outside tap") {
+    struct Demo: View {
+        @State var arrow = true
+        @State var pinned = true
+        var body: some View {
+            VStack(spacing: 140) {
+                // Arrow pointing at the trigger; default outside-tap dismissal.
+                ThemeButton("Remove card") { arrow.toggle() }.color(.error).variant(.outline)
+                    .popconfirm(isPresented: $arrow, title: "Remove this card?",
+                                confirmTitle: "Remove", cancelTitle: "Keep",
+                                edge: .bottom, showsArrow: true) {}
+                // Start-aligned, and pinned open: outside taps don't dismiss it.
+                ThemeButton("Sign out") { pinned.toggle() }.variant(.soft)
+                    .popconfirm(isPresented: $pinned, title: "Sign out of this device?",
+                                edge: .top, align: .start, dismissOnOutsideTap: false) {}
+            }
+            .padding(80)
+        }
+    }
+    return Demo()
+}
+
+#Preview("Titled popover") {
+    struct Demo: View {
+        @State var top = true
+        @State var end = true
+        var body: some View {
+            VStack(spacing: 160) {
+                ThemeButton("What's this?") { top.toggle() }.variant(.outline)
+                    .themePopover(isPresented: $top, title: "Flexible fare",
+                                  message: "Change your flight up to 2 hours before departure at no extra cost.",
+                                  edge: .top, showsArrow: true)
+                ThemeButton("End-aligned") { end.toggle() }.variant(.soft)
+                    .themePopover(isPresented: $end, title: "Heads up",
+                                  message: "This card hangs from the trigger's trailing edge.",
+                                  edge: .bottom, align: .end)
+            }
+            .padding(80)
         }
     }
     return Demo()

--- a/Sources/ThemeKit/Resources/Localizable.xcstrings
+++ b/Sources/ThemeKit/Resources/Localizable.xcstrings
@@ -648,6 +648,50 @@
         }
       }
     },
+    "Information" : {
+      "comment" : "Accessibility label for an informational status icon.",
+      "localizations" : {
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bilgi"
+          }
+        }
+      }
+    },
+    "Note" : {
+      "comment" : "Accessibility label for a neutral status icon.",
+      "localizations" : {
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not"
+          }
+        }
+      }
+    },
+    "Success" : {
+      "comment" : "Accessibility label for a success status icon.",
+      "localizations" : {
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Başarılı"
+          }
+        }
+      }
+    },
+    "Warning" : {
+      "comment" : "Accessibility label for a warning status icon.",
+      "localizations" : {
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uyarı"
+          }
+        }
+      }
+    },
     "Excellent" : {
       "comment" : "Rating: default sentiment for the top score band.",
       "localizations" : {


### PR DESCRIPTION
## Summary

Third wave of the gap plans from `HEROUI_NATIVE_AUDIT.md` (#216): closes the audited overlay & feedback gaps vs HeroUI Native across 10 files (+ string catalog). All changes additive/backward compatible (new parameters defaulted).

### BottomSheet
- `detached:` inset floating-card presentation (clear presentation background, token fill/corner), `surface:` and `radius:` overrides on both the declarative and imperative paths.

### Dialog
- Shared `DialogPresentation` container dedupes scrim/transition chrome across the three overloads; `swipeToDismiss:` drags the card with proportional scrim fade and 1/3-height threshold; card enters with opacity+scale (fade-only under Reduce Motion); `accessibilityAction(.escape)` mirrors the swipe/scrim dismissal for VoiceOver.

### Popconfirm / Tooltip (Popover parity)
- Outside-tap dismissal (default on, HeroUI `closeOnPress`), gated off while an async confirm runs.
- `themePopover(isPresented:title:message:...)` stock titled layout on the Popconfirm chrome with a `CloseButton`.
- `PopoverAlign` start/center/end alignment on tooltips and popconfirms; hardcoded gaps replaced with spacing tokens.
- Optional arrow on cards (speech-bubble open-stroke border), RTL-mirrored.

### AlertToast / Feedback (Toast parity)
- `.neutral` and `.accent` variants with `FeedbackKind` mapping and localized status-icon labels; per-toast `position:` override (top+bottom anchored stacks); `onShow`/`onDismiss` lifecycle callbacks reporting from a single removal funnel; stacked depth (peek + scale) under the motion gates.

### InfoBanner / Callout (Alert parity)
- `.icon` override + `.leading` view slot (spinner alerts), `.trailing` accessory slot for real buttons, `SemanticColor.primary`-fed `.accent` case, combined a11y element with localized status labels.

### Skeleton
- `SkeletonVariant` (shimmer/pulse/none), animated placeholder→content cross-fade, `Theme.RadiusRole` shape/modifier overloads, `highlight(_:)` shimmer tint.

### Spinner
- Localized "Loading" label; static per-style rendering under Reduce Motion; `controlSize` presets (explicit size/lineWidth win); custom rotating `indicator` slot.

### Review
Two adversarial lenses; 8 findings fixed (incl. a preview that would not compile, RTL arrow mirroring, VoiceOver escape path, and four new localized keys with tr translations).

No Swift toolchain in the authoring environment — all APIs cross-checked against real declarations; local build + snapshot run recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NurTVFpssqcMiR3BBb2H24

---
_Generated by [Claude Code](https://claude.ai/code/session_01NurTVFpssqcMiR3BBb2H24)_