### PR TITLE
demo: "New" badges for freshly shipped components + Showcase pod

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -24,14 +24,15 @@ struct ComponentEntry: Identifiable {
     let name: String
     let category: ComponentCategory
     let usage: String?
+    let isNew: Bool
     let make: () -> AnyView
 
-    static func knob<D: View>(_ name: String, _ category: ComponentCategory, demo: @escaping @autoclosure () -> D, usage: String? = nil) -> ComponentEntry {
-        ComponentEntry(name: name, category: category, usage: usage) { AnyView(demo()) }
+    static func knob<D: View>(_ name: String, _ category: ComponentCategory, demo: @escaping @autoclosure () -> D, usage: String? = nil, isNew: Bool = false) -> ComponentEntry {
+        ComponentEntry(name: name, category: category, usage: usage, isNew: isNew) { AnyView(demo()) }
     }
 
-    static func `static`<P: View>(_ name: String, _ category: ComponentCategory, usage: String? = nil, @ViewBuilder preview: @escaping () -> P) -> ComponentEntry {
-        ComponentEntry(name: name, category: category, usage: usage) { AnyView(ComponentStage(name) { preview() }) }
+    static func `static`<P: View>(_ name: String, _ category: ComponentCategory, usage: String? = nil, isNew: Bool = false, @ViewBuilder preview: @escaping () -> P) -> ComponentEntry {
+        ComponentEntry(name: name, category: category, usage: usage, isNew: isNew) { AnyView(ComponentStage(name) { preview() }) }
     }
 }
 
@@ -122,10 +123,10 @@ enum ComponentRegistry {
                 CodeLine("Done!", prefix: ">", highlight: .success)
             ]).copyable()
         },
-        .knob("CloseButton", .atoms, demo: CloseButtonDemo(), usage: #"CloseButton { dismiss() }.tint(.error).controlSize(.small)   // .plain() ghost glyph for image overlays"#),
-        .knob("HelperText", .atoms, demo: HelperTextDemo(), usage: #"HelperText("Min. 8 characters, one number.").hasError(invalid).hidesOnError()"#),
-        .knob("Surface", .atoms, demo: SurfaceViewDemo(), usage: #"SurfaceView { content }.level(.secondary).elevation(.soft).radius(.box)   // nestable; or view.surfaceChrome(.secondary)"#),
-        .knob("SkeletonGroup", .atoms, demo: SkeletonGroupDemo(), usage: #"SkeletonGroup { rows.skeleton() }.loading(isLoading)   // .skeletonOnly() collapses when loaded"#),
+        .knob("CloseButton", .atoms, demo: CloseButtonDemo(), usage: #"CloseButton { dismiss() }.tint(.error).controlSize(.small)   // .plain() ghost glyph for image overlays"#, isNew: true),
+        .knob("HelperText", .atoms, demo: HelperTextDemo(), usage: #"HelperText("Min. 8 characters, one number.").hasError(invalid).hidesOnError()"#, isNew: true),
+        .knob("Surface", .atoms, demo: SurfaceViewDemo(), usage: #"SurfaceView { content }.level(.secondary).elevation(.soft).radius(.box)   // nestable; or view.surfaceChrome(.secondary)"#, isNew: true),
+        .knob("SkeletonGroup", .atoms, demo: SkeletonGroupDemo(), usage: #"SkeletonGroup { rows.skeleton() }.loading(isLoading)   // .skeletonOnly() collapses when loaded"#, isNew: true),
 
         // MARK: Molecules
         .knob("ColorField", .molecules, demo: ColorFieldDemo(), usage: #"ColorField("Brand color", selection: $color).supportsOpacity()"#),
@@ -236,8 +237,8 @@ enum ComponentRegistry {
             }
             .padding(.horizontal, 24)
         },
-        .knob("ControlRow", .molecules, demo: ControlRowDemo(), usage: #"ControlRow("I agree to the terms", isOn: $accepted).control(.checkbox).description("…").required().hasError(showErrors && !accepted).errorText("This field is required.")"#),
-        .knob("ScrollShadow", .molecules, demo: ScrollShadowDemo(), usage: #"ScrollShadow { ScrollView(.horizontal) { chipRow } }.axis(.horizontal).length(.lg).fadeColor(.bgWhite)   // .visibility(.auto/.start/.end/.both/.none)"#),
+        .knob("ControlRow", .molecules, demo: ControlRowDemo(), usage: #"ControlRow("I agree to the terms", isOn: $accepted).control(.checkbox).description("…").required().hasError(showErrors && !accepted).errorText("This field is required.")"#, isNew: true),
+        .knob("ScrollShadow", .molecules, demo: ScrollShadowDemo(), usage: #"ScrollShadow { ScrollView(.horizontal) { chipRow } }.axis(.horizontal).length(.lg).fadeColor(.bgWhite)   // .visibility(.auto/.start/.end/.both/.none)"#, isNew: true),
 
         // MARK: Organisms
         .knob("Accordion", .organisms, demo: AccordionDemo(), usage: #"Accordion("Title", initiallyExpanded: false) { Text("Body") }"#),

--- a/Demo/Demo/Gallery/Showcase/RichComponentsBrowser.swift
+++ b/Demo/Demo/Gallery/Showcase/RichComponentsBrowser.swift
@@ -199,9 +199,14 @@ private struct ShelfCard: View {
             Text(entry.category.rawValue.uppercased())
                 .font(.caption2.weight(.bold))
                 .foregroundStyle(accent)
-            Text(entry.name)
-                .font(.title3.weight(.bold))
-                .lineLimit(1)
+            HStack(spacing: 8) {
+                Text(entry.name)
+                    .font(.title3.weight(.bold))
+                    .lineLimit(1)
+                if entry.isNew {
+                    Badge("New").badgeStyle(.success).size(.small)
+                }
+            }
 
             if let usage = entry.usage, !usage.isEmpty {
                 Text(usage)

--- a/Demo/Demo/Gallery/Showcase/ShowcaseView.swift
+++ b/Demo/Demo/Gallery/Showcase/ShowcaseView.swift
@@ -725,6 +725,8 @@ private struct FormsPage: View {
     @State private var newsletter = true
     @State private var interests: Set<String> = ["Design", "Code"]
     @State private var cities: Set<String> = ["Istanbul", "Rome"]
+    @State private var nickname = ""
+    @State private var priceAlerts = true
 
     var body: some View {
         PageScaffold(title: "Forms & lists",
@@ -732,7 +734,7 @@ private struct FormsPage: View {
             HStack(alignment: .top, spacing: 16) {
                 VStack(spacing: 16) { fieldsetCard; checkboxGroupCard }
                 VStack(spacing: 16) { multiSelectCard; amenitiesCard }
-                VStack(spacing: 16) { passengersCard }
+                VStack(spacing: 16) { passengersCard; whatsNewCard }
             }
         }
     }
@@ -785,6 +787,71 @@ private struct FormsPage: View {
                 PassengerRow("İsa Mercan").type("Adult").subtitle("Passport · TR12345").seat("14C").status("Checked in").onEdit { }
                 PassengerRow("Ada Lovelace").type("Adult").subtitle("Passport · UK88231").seat("14D").onEdit { }
                 PassengerRow("Kid Mercan").type("Child").subtitle("12 years").seat("14E").onEdit { }
+            }
+        }
+    }
+
+    /// Compact tour of the six freshly-shipped components: CloseButton,
+    /// HelperText, SurfaceView, SkeletonGroup, ControlRow and ScrollShadow.
+    private var whatsNewCard: some View {
+        CollageCard {
+            VStack(alignment: .leading, spacing: 12) {
+                // Title row — Badge-tagged, with a CloseButton in the corner.
+                HStack(spacing: 8) {
+                    Text("Just shipped").font(.footnote.weight(.semibold)).foregroundStyle(.secondary)
+                    Badge("New").badgeStyle(.success).size(.small)
+                    Spacer()
+                    CloseButton { }.controlSize(.mini)
+                }
+
+                // HelperText under a mock field.
+                VStack(alignment: .leading, spacing: 4) {
+                    TextInput("Nickname", text: $nickname).placeholder("e.g. skywalker")
+                    HelperText("Visible only to your travel group.")
+                }
+
+                // ControlRow with a checkbox control.
+                ControlRow("Email me price drops", isOn: $priceAlerts)
+                    .control(.checkbox)
+                    .description("One email per route, max.")
+
+                // Horizontal chip row fading at the edges via ScrollShadow.
+                ScrollShadow {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(["Nonstop", "Morning", "Refundable", "Baggage", "Window seat"], id: \.self) { title in
+                                Chip(title, isSelected: .constant(false))
+                            }
+                        }
+                    }
+                }
+                .axis(.horizontal)
+                .length(.md)
+                .fadeColor(.bgWhite)
+
+                // Nested SurfaceView levels wrapping a skeleton-only SkeletonGroup.
+                SurfaceView {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Surface · secondary").font(.caption).foregroundStyle(.secondary)
+                        SurfaceView {
+                            SkeletonGroup {
+                                HStack(spacing: 8) {
+                                    Skeleton(.circle).size(width: 28, height: 28)
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Skeleton(.capsule).size(width: 120, height: 8)
+                                        Skeleton(.capsule).size(width: 80, height: 8)
+                                    }
+                                }
+                            }
+                            .skeletonOnly()
+                            .loading(true)
+                        }
+                        .level(.tertiary)
+                        .contentPadding(.sm)
+                    }
+                }
+                .level(.secondary)
+                .contentPadding(.sm)
             }
         }
     }

--- a/Demo/Demo/Views/CatalogView.swift
+++ b/Demo/Demo/Views/CatalogView.swift
@@ -23,7 +23,14 @@ struct CatalogView: View {
                     if !entries.isEmpty {
                         Section("\(category.rawValue) · \(entries.count)") {
                             ForEach(entries) { entry in
-                                NavigationLink(value: entry.name) { Text(entry.name) }
+                                NavigationLink(value: entry.name) {
+                                    HStack(spacing: 8) {
+                                        Text(entry.name)
+                                        if entry.isNew {
+                                            Badge("New").badgeStyle(.success).size(.small)
+                                        }
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Demo-app follow-up to the HeroUI parity series (#216, #220–#222, #225): surfaces the six newly built components in the Showcase and marks them as new throughout the gallery.

- **`ComponentEntry.isNew` flag** (defaulted `false` — all ~190 existing entries untouched); the six new components marked: CloseButton, HelperText, Surface, SkeletonGroup, ControlRow, ScrollShadow.
- **`Badge("New").badgeStyle(.success).size(.small)`** rendered next to marked names in the gallery component list (`CatalogView`) and the Rich components shelf cards (`RichComponentsBrowser`) — dogfooding the library's own Badge atom.
- **Showcase wall**: the Forms & lists page gains a "Just shipped" `CollageCard` pod composing the new components live — `TextInput` + `HelperText`, a checkbox `ControlRow`, a `Chip` row inside `ScrollShadow`, nested `SurfaceView` levels wrapping a skeleton-only `SkeletonGroup`, and a `CloseButton` in the corner.

Demo target only; `Sources/ThemeKit` untouched. No Swift toolchain in the authoring environment — APIs cross-checked against real declarations; a quick Xcode run of the Demo scheme is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NurTVFpssqcMiR3BBb2H24

---
_Generated by [Claude Code](https://claude.ai/code/session_01NurTVFpssqcMiR3BBb2H24)_