### PR TITLE
fix: read theme from environment in LottieEmptyState + InfoMessageList (#229)

### DIFF
--- a/Sources/ThemeKit/Validation/InfoMessageUI.swift
+++ b/Sources/ThemeKit/Validation/InfoMessageUI.swift
@@ -11,19 +11,22 @@
 import SwiftUI
 
 extension InfoMessage.Kind {
-    /// Theme-bound severity color (UI layer — depends on the active `Theme`).
-    var color: Color {
+    /// Theme-bound severity color (UI layer — resolved against the passed `Theme`,
+    /// matching `StatusDot.Kind.color(_:)`). Value-type accessors can't read the
+    /// SwiftUI environment, so the owning view hands its active theme in.
+    func color(_ theme: Theme) -> Color {
         switch self {
-        case .info: return Theme.shared.text(.textTertiary)
-        case .success: return Theme.shared.foreground(.systemcolorsFgSuccess)
-        case .warning: return Theme.shared.foreground(.systemcolorsFgWarning)
-        case .error: return Theme.shared.foreground(.systemcolorsFgError)
+        case .info: return theme.text(.textTertiary)
+        case .success: return theme.foreground(.systemcolorsFgSuccess)
+        case .warning: return theme.foreground(.systemcolorsFgWarning)
+        case .error: return theme.foreground(.systemcolorsFgError)
         }
     }
 }
 
 /// Renders a list of `InfoMessage`s (icon + colored text) under a field.
 public struct InfoMessageList: View {
+    @Environment(\.theme) private var theme
     private let messages: [InfoMessage]
     public init(_ messages: [InfoMessage]) { self.messages = messages }
 
@@ -36,12 +39,12 @@ public struct InfoMessageList: View {
             ForEach(messages, id: \.diffIdentity) { message in
                 HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.xs.value) {
                     if let icon = message.resolvedSystemImage {
-                        Image(systemName: icon).font(.system(size: 11)).foregroundStyle(message.kind.color)
+                        Image(systemName: icon).font(.system(size: 11)).foregroundStyle(message.kind.color(theme))
                     }
                     if message.links.isEmpty {
-                        Text(message.text).textStyle(.bodySm400).foregroundStyle(message.kind.color)
+                        Text(message.text).textStyle(.bodySm400).foregroundStyle(message.kind.color(theme))
                     } else {
-                        InlineText(message.text, links: message.links).color(message.kind.color)
+                        InlineText(message.text, links: message.links).color(message.kind.color(theme))
                     }
                 }
                 // Animated appearance/disappearance (HeroUI FieldError parity).

--- a/Sources/ThemeKitLottie/LottieEmptyState.swift
+++ b/Sources/ThemeKitLottie/LottieEmptyState.swift
@@ -30,6 +30,8 @@ public struct LottieEmptyState: View {
         case url(URL)
     }
 
+    @Environment(\.theme) private var theme
+
     private let media: Media
     private let title: String?
 
@@ -80,13 +82,13 @@ public struct LottieEmptyState: View {
                 if let title {
                     Text(title)
                         .textStyle(.headingBase)
-                        .foregroundStyle(Theme.shared.text(.textPrimary))
+                        .foregroundStyle(theme.text(.textPrimary))
                         .multilineTextAlignment(.center)
                 }
                 if let message {
                     Text(message)
                         .textStyle(.bodyBase400)
-                        .foregroundStyle(Theme.shared.text(.textSecondary))
+                        .foregroundStyle(theme.text(.textSecondary))
                         .multilineTextAlignment(.center)
                 }
             }


### PR DESCRIPTION
Addresses concern **#1** from the architecture review in #229: a few shipped view bodies resolved theme colors through the `Theme.shared` singleton instead of `@Environment(\.theme)`, which undercuts scoped themes, isolated previews, and per-subtree `.theme(_:)`.

## Changes
- **`LottieEmptyState`** (ThemeKitLottie) — now declares `@Environment(\.theme)` and resolves text colors via `theme.text(...)` instead of `Theme.shared.text(...)`. Brings the add-on in line with the rest of the library (e.g. `ThemeKitCalendar` already reads the environment).
- **`InfoMessageList`** — declares `@Environment(\.theme)`; `InfoMessage.Kind.color(_:)` is now a function that takes the active `Theme` in, mirroring the existing `StatusDot.Kind.color(_:)` pattern (value-type accessors can't read the environment, so the owning view hands its theme in).

## Not touched (intentional)
`Theme.shared` legitimately remains as the `EnvironmentValues.theme` **default value** and the resolution point for value-type accessors (`SemanticColor`, typography) that can't read the environment. Those are the correct home for the shared default, not a bug.

## Verification
- `swift build --enable-all-traits` → **Build complete** (273/273), so the Lottie add-on change compiles under its trait.
- Rendering is unchanged — `Theme.shared` is the environment default, so snapshot tests hold.

Refs #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)