### PR TITLE
docs: 1.1.0 changelog + ThemeKitCore in products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to **ThemeKit** are documented here. The format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — from **1.0.0** on,
 breaking changes bump the **major**.
 
+## [1.1.0] - 2026-07-10
+
+**New `ThemeKitCore` product — the token-only theme layer.** The theme engine,
+design tokens, and `@Environment(\.theme)` now ship as a standalone
+`ThemeKitCore` library you can adopt on its own, without the 204-component
+catalog. The full `ThemeKit` product depends on it and `@_exported import`s it,
+so **existing `import ThemeKit` code is unchanged** — `Theme`, `SemanticColor`,
+`Theme.SpacingKey` and friends still resolve exactly as before.
+
+First step of the modularization from the architecture review
+([#229](https://github.com/isamercan/ThemeKit/issues/229)): a narrow, value-based
+core for apps that only want theming, with the opinionated domain organisms to
+move into later editions.
+
+### Added
+- **`ThemeKitCore`** library product — `Theme`, tokens (`SemanticColor`, `Theme.SpacingKey`, `Theme.RadiusRole`, typography), `@Environment(\.theme)`, `.themeKit()`, presets, and the theme generator, with **zero components and zero third-party dependencies**. Adopt with `import ThemeKitCore`.
+
+### Changed
+- **`ThemeKit` now re-exports `ThemeKitCore`** (`@_exported import`), so a plain `import ThemeKit` surfaces every token and theme symbol unchanged — no source changes for existing consumers.
+- The theme engine, `Localizable.xcstrings`, and the theme JSON now live in the `ThemeKitCore` target's resource bundle.
+
+### Migration (only if affected)
+- Fully-qualified references to engine symbols — e.g. `ThemeKit.Theme`, `ThemeKit.SemanticColor` — must drop the qualifier or use `ThemeKitCore.Theme`. Unqualified use (`Theme(…)`, `SemanticColor.primary`, `.textStyle(…)`) is unaffected.
+
 ## [1.0.0] - 2026-07-09
 
 **The 1.0 stability milestone.** ThemeKit reaches **204 components** (50 atoms ·

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ the repository URL, or add it to your `Package.swift`:
 ```swift
 dependencies: [
     // Core only — a plain install resolves ZERO third-party packages.
-    .package(url: "https://github.com/isamercan/ThemeKit.git", from: "0.3.0"),
+    .package(url: "https://github.com/isamercan/ThemeKit.git", from: "1.1.0"),
 
     // Opt into an add-on's dependency via package traits (Swift 6.1+):
-    // .package(url: "https://github.com/isamercan/ThemeKit.git", from: "0.3.0",
+    // .package(url: "https://github.com/isamercan/ThemeKit.git", from: "1.1.0",
     //          traits: ["Lottie", "Calendar"]),
 ],
 targets: [
@@ -97,6 +97,8 @@ targets: [
         name: "MyApp",
         dependencies: [
             .product(name: "ThemeKit", package: "ThemeKit"),
+            // Or, for just the theme layer (tokens + @Environment(\.theme), no components):
+            // .product(name: "ThemeKitCore", package: "ThemeKit"),
             // Only with the matching trait enabled above:
             // .product(name: "ThemeKitLottie", package: "ThemeKit"),
             // .product(name: "ThemeKitCalendar", package: "ThemeKit"),
@@ -113,7 +115,8 @@ so without a trait enabled SwiftPM never even fetches Lottie or Almanac.
 
 | Product | Trait | Pulls | Use |
 |---|---|---|---|
-| `ThemeKit` | — (default) | **nothing** | the full design system (core) |
+| `ThemeKit` | — (default) | **nothing** | the full design system — tokens **and** all 204 components (re-exports `ThemeKitCore`) |
+| `ThemeKitCore` | — (default) | **nothing** | token-only theme engine: `Theme`, `SemanticColor`, `@Environment(\.theme)`, presets, generator — **no components**. Adopt alone for a minimal theme layer. |
 | `ThemeKitLottie` | `Lottie` | `lottie-ios` | Lottie (After Effects / JSON) animation views |
 | `ThemeKitCalendar` | `Calendar` | `Almanac` (→ `HorizonCalendar`, iOS-only) | a token-bound date-range calendar (`DateRangePicker`) that re-skins with the active theme |
 


### PR DESCRIPTION
Release housekeeping for **1.1.0** (follows #231, the ThemeKitCore extraction):

- **CHANGELOG** `[1.1.0]` entry — new `ThemeKitCore` product, the `@_exported` re-export (existing consumers unchanged), and the qualified-symbol migration note.
- **README** — `ThemeKitCore` added to the products table + install example; install snippet version bumped 0.3.0 → 1.1.0.

Docs only; no code changes. DocC `/api` hosting for ThemeKitCore is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)