### PR TITLE
docs(docc): host ThemeKitCore reference at /api-core

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,12 @@ jobs:
             generate-documentation \
             --target ThemeKit \
             --transform-for-static-hosting \
-            --output-path ./docs-out
+            --output-path ./docs-out/themekit
+          swift package --disable-sandbox \
+            generate-documentation \
+            --target ThemeKitCore \
+            --transform-for-static-hosting \
+            --output-path ./docs-out/themekitcore
 
       # DocC emits operator pages whose filenames contain ':' (e.g.
       # `!=(_:_:).json`), which actions/upload-artifact rejects. Tar the site into

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -80,6 +80,30 @@ jobs:
           <p>Redirecting to the <a href="./documentation/themekit/">ThemeKit API reference</a>…</p>
           HTML
 
+      # ThemeKitCore (token-only theme engine) → served under /ThemeKit/api-core/.
+      # A second archive: DocC static-hosting is per-module and `@_exported` does not
+      # carry re-exported symbols into ThemeKit's graph, so the engine reference lives
+      # at its own base path.
+      - name: Build DocC for ThemeKitCore into /api-core
+        run: |
+          swift package --disable-sandbox \
+            generate-documentation \
+            --target ThemeKitCore \
+            --transform-for-static-hosting \
+            --hosting-base-path ThemeKit/api-core \
+            --output-path ./website/dist/api-core
+
+      - name: Redirect /api-core root → documentation
+        run: |
+          cat > ./website/dist/api-core/index.html <<'HTML'
+          <!doctype html>
+          <meta charset="utf-8">
+          <title>ThemeKitCore API Reference</title>
+          <meta http-equiv="refresh" content="0; url=./documentation/themekitcore/">
+          <link rel="canonical" href="./documentation/themekitcore/">
+          <p>Redirecting to the <a href="./documentation/themekitcore/">ThemeKitCore API reference</a>…</p>
+          HTML
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/Sources/ThemeKit/Documentation.docc/GettingStarted.md
+++ b/Sources/ThemeKit/Documentation.docc/GettingStarted.md
@@ -12,7 +12,7 @@ re-skins.
 ### 1. Install the theme
 
 Apply `themeKit(reactToRuntimeChanges:)` once, at the top of your scene. It
-loads the default theme, bundles the type ramp, and makes the active ``Theme``
+loads the default theme, bundles the type ramp, and makes the active `Theme`
 available to every component below it.
 
 ```swift
@@ -64,8 +64,8 @@ struct SignInView: View {
 
 ### 3. Switch light / dark or re-skin at runtime
 
-The active ``Theme`` is a singleton you can drive imperatively — flip the color
-scheme, or generate a whole palette from one accent color with ``ThemeConfig``.
+The active `Theme` is a singleton you can drive imperatively — flip the color
+scheme, or generate a whole palette from one accent color with `ThemeConfig`.
 
 ```swift
 Theme.shared.setColorScheme(dark: true)                 // light ⇄ dark
@@ -86,7 +86,7 @@ Theme.shared.apply(ThemeConfig(primaryHex: "#7C3AED"))  // re-skin from an accen
 
 ### Essentials
 
-- ``Theme``
-- ``TextStyle``
+- `Theme`
+- `TextStyle`
 - ``ThemeButton``
 - ``TextInput``

--- a/Sources/ThemeKit/Documentation.docc/ThemeKit.md
+++ b/Sources/ThemeKit/Documentation.docc/ThemeKit.md
@@ -16,12 +16,12 @@ dependencies.
 `ThemeKit` is built in layers, bottom to top:
 
 - **Tokens** — every color, radius, spacing step, type ramp entry, and shadow is
-  a semantic token resolved from the active ``Theme``. Components never hard-code
+  a semantic token resolved from the active `Theme`. Components never hard-code
   a value; they ask the theme. Swap the theme and the whole UI re-skins.
 - **Components** — ~130 SwiftUI views grouped as Atoms (``Badge``, ``Chip``,
   ``Avatar``…), Molecules (``TextInput``, ``ThemeButton``, ``OTPInput``…), and
   Organisms (``Carousel``, ``DataTable``, ``ResultView``…). All token-bound.
-- **Theming** — recipes (``ThemeConfig``) generate a complete palette from a
+- **Theming** — recipes (`ThemeConfig`) generate a complete palette from a
   single accent color at runtime, and persist/export it. See <doc:Theming>.
 - **Validation** — a pure logic layer (``Validators`` / ``ValidationRule`` /
   ``Validator``) with a separate SwiftUI presentation layer. See <doc:FormValidation>.
@@ -64,15 +64,15 @@ views; the core library stays dependency-free.
 
 ### Theme & Tokens
 
-- ``Theme``
-- ``ThemeConfig``
-- ``ThemeContext``
-- ``TextStyle``
-- ``SemanticColor``
-- ``Theme/SpacingKey``
-- ``Theme/RadiusKey``
-- ``ShadowStyle``
-- ``Motion``
+- `Theme`
+- `ThemeConfig`
+- `ThemeContext`
+- `TextStyle`
+- `SemanticColor`
+- `Theme.SpacingKey`
+- `Theme.RadiusKey`
+- `ShadowStyle`
+- `Motion`
 
 ### Buttons
 

--- a/Sources/ThemeKit/Documentation.docc/Theming.md
+++ b/Sources/ThemeKit/Documentation.docc/Theming.md
@@ -2,10 +2,16 @@
 
 Drive the entire UI from a single accent color, then persist or export the recipe.
 
+> Note: The theme engine and design tokens (`Theme`, `SemanticColor`, `TextStyle`, …)
+> live in the standalone **ThemeKitCore** module — adopt it alone with
+> `import ThemeKitCore` for a token-only theme layer, no components. Its full API is
+> in the [ThemeKitCore reference](/ThemeKit/api-core/documentation/themekitcore/).
+> `import ThemeKit` re-exports all of it, so the examples below work unchanged.
+
 ## Overview
 
 Every component reads its colors, radii, spacing, type, and shadows from the
-active ``Theme``. There are two ways to set one.
+active `Theme`. There are two ways to set one.
 
 ### Built-in themes
 
@@ -18,7 +24,7 @@ Theme.shared.loadTheme(named: "defaultTheme", dark: true)
 
 ### Generated themes (recipe → full palette)
 
-A ``ThemeConfig`` is a small, `Codable` recipe. Applying it regenerates a
+A `ThemeConfig` is a small, `Codable` recipe. Applying it regenerates a
 complete Ant-style 50–900 palette from your accent color at runtime — primary,
 info, the neutral ramp, surfaces, borders, and text all re-tint toward the hue,
 while success / warning / error keep their meaning.
@@ -66,14 +72,14 @@ WindowGroup { RootView().themeKit() }
 
 ### Core
 
-- ``Theme``
-- ``ThemeConfig``
-- ``ThemeContext``
+- `Theme`
+- `ThemeConfig`
+- `ThemeContext`
 
 ### Token namespaces
 
-- ``TextStyle``
-- ``SemanticColor``
-- ``Theme/SpacingKey``
-- ``Theme/RadiusKey``
-- ``ShadowStyle``
+- `TextStyle`
+- `SemanticColor`
+- `Theme.SpacingKey`
+- `Theme.RadiusKey`
+- `ShadowStyle`

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -95,6 +95,12 @@ export default defineConfig({
               attrs: { target: '_blank', rel: 'noopener' },
               badge: { text: 'Swift', variant: 'note' },
             },
+            {
+              label: 'ThemeKitCore (tokens) ↗',
+              link: '/api-core/documentation/themekitcore/',
+              attrs: { target: '_blank', rel: 'noopener' },
+              badge: { text: 'Core', variant: 'tip' },
+            },
           ],
         },
       ],

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -40,7 +40,9 @@ export const base = import.meta.env.BASE_URL;
 	</Card>
 	<Card title="Swift Package" icon="seti:swift">
 		Drop-in via SwiftPM. Browse the full API in the
-		[DocC reference](/ThemeKit/api/documentation/themekit/).
+		[DocC reference](/ThemeKit/api/documentation/themekit/), or just the
+		token-only theme engine in the
+		[ThemeKitCore reference](/ThemeKit/api-core/documentation/themekitcore/).
 	</Card>
 </CardGrid>
 


### PR DESCRIPTION
**PR 2** of the modularization — brings the DocC `/api` reference back in sync after the ThemeKitCore extraction (v1.1.0, #231). The engine symbols moved to `ThemeKitCore`, so the `--target ThemeKit` docs no longer carry the theming reference and the landing docs' engine symbol links went cross-module.

## Changes
- **`pages.yml` + `docs.yml`** — a second `generate-documentation` run for `--target ThemeKitCore`, hosted at **`/ThemeKit/api-core/`** (own `--hosting-base-path` + `--output-path`) + a root redirect. DocC static-hosting is per-module and `@_exported` doesn't carry re-exported symbols into ThemeKit's graph, so the engine reference needs its own archive.
- **3 landing docs** (`ThemeKit.md`, `Theming.md`, `GettingStarted.md`) — **26** now-cross-module engine symbol links (`Theme`, `SemanticColor`, `TextStyle`, `ThemeConfig`, `ThemeContext`, `Motion`, `Theme/SpacingKey`, `Theme/RadiusKey`, `ShadowStyle`) → inline code, so ThemeKit's DocC build stops emitting unresolved-reference warnings. `Theming.md` now points to the ThemeKitCore reference. Component links (`Badge`, `Card`, …) are unchanged — they still resolve.
- **website** — nav (`astro.config.mjs`) + landing (`index.mdx`) link to the ThemeKitCore reference.

## Verified locally
`generate-documentation --target ThemeKitCore --transform-for-static-hosting --hosting-base-path ThemeKit/api-core` emits `documentation/themekitcore/` with the engine pages (`theme`, `semanticcolor`, `textstyle`, `themeconfig`, `themecontext`).

## Deploy verification (after merge)
The Pages deploy runs on merge (touches `Sources/**` + `website/**` + the workflow). I'll confirm **`/api`** (components) and **`/api-core`** (engine) both render and the redirects + nav links resolve.

Refs #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)