### PR TITLE
fix(ci): add --hosting-base-path to docs.yml nested DocC outputs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,19 +29,24 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      # Static-hosting transform (no base path) → a self-contained, browsable
-      # site. Download the artifact and serve it, e.g. `python3 -m http.server`.
+      # Static-hosting transform for two modules under one artifact. Each site
+      # lives in its own subdir, so it needs a matching --hosting-base-path or DocC
+      # emits absolute /js//css asset URLs that 404 under the subpath. Download the
+      # artifact, serve `docs-out` (e.g. `python3 -m http.server`), and open
+      # `/themekit/` or `/themekitcore/`.
       - name: Build DocC (static hosting)
         run: |
           swift package --disable-sandbox \
             generate-documentation \
             --target ThemeKit \
             --transform-for-static-hosting \
+            --hosting-base-path themekit \
             --output-path ./docs-out/themekit
           swift package --disable-sandbox \
             generate-documentation \
             --target ThemeKitCore \
             --transform-for-static-hosting \
+            --hosting-base-path themekitcore \
             --output-path ./docs-out/themekitcore
 
       # DocC emits operator pages whose filenames contain ':' (e.g.


### PR DESCRIPTION
Fixes a P2 from **Codex review** on #234. The on-demand DocC artifact writes each module under a subdir (`docs-out/themekit`, `docs-out/themekitcore`) but the `generate-documentation` calls omitted `--hosting-base-path`, so DocC emitted `baseUrl='/'` + absolute `/js/` `/css/` asset URLs — those 404 when the artifact is served from `docs-out` root and opened at `/themekit/` or `/themekitcore/`.

Added matching `--hosting-base-path themekit` / `themekitcore`. **Verified locally:** the emitted `index.html` now references `/themekitcore/js/…` under the subpath.

Only affects the on-demand downloadable artifact (`docs.yml`); the published Pages deploy (`pages.yml`) already set `ThemeKit/api` + `ThemeKit/api-core` correctly and is unaffected.

Refs #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)