### PR TITLE
fix(a11y): label icon-only controls + selection state (audit round 4)

### DIFF
--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -176,6 +176,7 @@ struct DialogCard: View {
                         .padding(Theme.SpacingKey.md.value)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(String(themeKit: "Close"))
             }
         }
         .themeShadow(.elevated)
@@ -310,6 +311,7 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
                                         Icon(systemName: "xmark").size(.sm).color(theme.text(.textTertiary))
                                     }
                                     .buttonStyle(.plain)
+                                    .accessibilityLabel(String(themeKit: "Close"))
                                 }
                             }
                             .padding(Theme.SpacingKey.lg.value)
@@ -408,6 +410,7 @@ private struct FreeformDialogModifier<DialogContent: View>: ViewModifier {
                                         .padding(Theme.SpacingKey.md.value)
                                 }
                                 .buttonStyle(.plain)
+                                .accessibilityLabel(String(themeKit: "Close"))
                             }
                         }
                         .themeShadow(.elevated)

--- a/Sources/ThemeKit/Components/Organisms/Drawer.swift
+++ b/Sources/ThemeKit/Components/Organisms/Drawer.swift
@@ -34,6 +34,9 @@ private struct DrawerContainer<DrawerContent: View>: View {
             theme.background(.bgTertiary).opacity(0.4 * scrimFactor)
                 .ignoresSafeArea()
                 .onTapGesture { if dismissOnScrimTap { onDismiss() } }
+                .accessibilityLabel(String(themeKit: "Close"))
+                .accessibilityAddTraits(dismissOnScrimTap ? .isButton : [])
+                .accessibilityHidden(!dismissOnScrimTap)
 
             content()
                 .frame(maxWidth: width, maxHeight: .infinity, alignment: .topLeading)

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -372,6 +372,7 @@ private struct FeedbackHostModifier: ViewModifier {
                     Icon(systemName: "xmark").size(.xs).color(theme.text(.textTertiary))
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(String(themeKit: "Close"))
             }
             .padding(Theme.SpacingKey.md.value)
             .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))

--- a/Sources/ThemeKit/Components/Organisms/ImageCollage.swift
+++ b/Sources/ThemeKit/Components/Organisms/ImageCollage.swift
@@ -63,6 +63,10 @@ public struct ImageCollage: View {
         }
         .contentShape(Rectangle())
         .onTapGesture { onTap?(index) }
+        .accessibilityAddTraits(onTap != nil ? .isButton : [])
+        .accessibilityLabel(overlayExtra > 0
+            ? String(themeKit: "View more photos")
+            : String(themeKit: "Photo"))
     }
 
     private var placeholder: some View {

--- a/Sources/ThemeKit/Components/Organisms/ListRow.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListRow.swift
@@ -159,6 +159,7 @@ public struct ListRow: View {
                     Icon(systemName: "info.circle").size(.sm).color(theme.text(.textTertiary))
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(String(themeKit: "Info"))
             }
             if let trailingSlot {
                 trailingSlot

--- a/Sources/ThemeKit/Components/Organisms/SelectionCards.swift
+++ b/Sources/ThemeKit/Components/Organisms/SelectionCards.swift
@@ -33,6 +33,7 @@ private struct SelectionCard<Control: View>: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     /// The card's inner layout — everything inside the shell.

--- a/Sources/ThemeKit/Components/Organisms/Tour.swift
+++ b/Sources/ThemeKit/Components/Organisms/Tour.swift
@@ -174,6 +174,7 @@ private struct TourHostModifier: ViewModifier {
                 Icon(systemName: "xmark").size(.xs).color(theme.text(.textTertiary)).padding(Theme.SpacingKey.sm.value)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel(String(themeKit: "Close"))
         }
         .position(x: proxy.size.width / 2, y: max(90, min(y, proxy.size.height - 90)))
     }


### PR DESCRIPTION
A **multi-agent accessibility sweep** (one agent per file) over 30 interactive-component candidates flagged by an audit. **7 genuine gaps fixed, 23 correctly skipped** — all additive, non-breaking, English-only via `String(themeKit:)`.

## Fixed (7)
| Component | Gap | Fix |
|---|---|---|
| **Dialog** | 3 icon-only close (X) buttons | `.accessibilityLabel("Close")` on each |
| **Drawer** | scrim dismiss had no name/role | label + `.isButton` (gated on `dismissOnScrimTap`) + `.accessibilityHidden` when inert |
| **Feedback** | notification close button icon-only | `.accessibilityLabel("Close")` |
| **ImageCollage** | gallery tiles tappable non-Button | `.isButton` + label (`Photo` / `View more photos` for the +N tile) |
| **ListRow** | icon-only info button | `.accessibilityLabel("Info")` |
| **SelectionCards** | selected state invisible to VoiceOver (inner radio/checkbox are visual-only) | `.accessibilityAddTraits(isSelected ? .isSelected : [])` on the shared card Button |
| **Tour** | step-card close button icon-only | `.accessibilityLabel("Close")` |

## Skipped (23, correctly)
Layout containers (Flex/Space/Affix/Join/ButtonGroup), text-labeled buttons that SwiftUI names automatically (Badge/TextLink/Title/ShareButton), non-Views (ValidationRule), decorative/non-interactive (Skeleton), and cards whose action derives its name from visible title text (BlogCard/AgentPriceRow/StickyBookingBar/Card/EmptyState/PromoBanner/Hero/ButtonDock/Popconfirm/Toast/BottomSheet/ResultView).

## Verified
`swift build` + **230 tests pass** (0 failures; snapshots unchanged — a11y is non-visual). 7 files, +14 lines.

First of the 1.x pre-2.0 quality rounds (accessibility was the audit's weakest dimension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)