### PR TITLE
fix(a11y): known audit P0s (round 5) — labels, values, combined route

### DIFF
--- a/Sources/ThemeKit/Components/Molecules/CurrencyPicker.swift
+++ b/Sources/ThemeKit/Components/Molecules/CurrencyPicker.swift
@@ -125,6 +125,8 @@ public struct CurrencyPicker: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(currency.name), \(currency.code)")
+        .accessibilityAddTraits(selected ? .isSelected : [])
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/InstallmentSelector.swift
+++ b/Sources/ThemeKit/Components/Molecules/InstallmentSelector.swift
@@ -83,10 +83,22 @@ public struct InstallmentSelector: View {
                 .stroke(selected ? theme.foreground(.fgHero) : theme.border(.borderPrimary), lineWidth: selected ? 1.5 : 1))
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel(count, planTotal: planTotal, interestFree: interestFree))
+        .accessibilityAddTraits(selected ? .isSelected : [])
     }
 
     /// The plan's grand total — base plus any per-plan surcharge (interest).
     private func effectiveTotal(_ count: Int) -> Decimal { total + (surcharge[count] ?? 0) }
+
+    /// Spoken description of a plan row — the visible content combined into one label.
+    private func accessibilityLabel(_ count: Int, planTotal: Decimal, interestFree: Bool) -> String {
+        var parts = [count <= 1 ? String(themeKit: "Single payment") : String(themeKit: "\(count) installments")]
+        if count == recommendedCount { parts.append(String(themeKit: "Recommended")) }
+        if interestFree { parts.append(String(themeKit: "Interest-free")) }
+        if count > 1 { parts.append(String(themeKit: "\(formatted(planTotal / Decimal(count))) per month")) }
+        parts.append(String(themeKit: "\(formatted(planTotal)) total"))
+        return parts.joined(separator: ", ")
+    }
 
     private func formatted(_ value: Decimal) -> String {
         value.formatted(.currency(code: currencyCode).precision(.fractionLength(0)))

--- a/Sources/ThemeKit/Components/Molecules/Pagination.swift
+++ b/Sources/ThemeKit/Components/Molecules/Pagination.swift
@@ -46,13 +46,15 @@ public struct Pagination: View {
                     .padding(.trailing, Theme.SpacingKey.xs.value)
             }
 
-            arrow(systemName: "chevron.left", enabled: isEnabled && current > 1) { current = max(1, current - 1) }
+            arrow(systemName: "chevron.left", label: String(themeKit: "Previous page"), enabled: isEnabled && current > 1) { current = max(1, current - 1) }
 
             if simple {
                 Text("\(current) / \(total)")
                     .textStyle(.labelBase600)
                     .foregroundStyle(theme.text(.textPrimary))
                     .frame(minWidth: 48)
+                    .accessibilityLabel(String(themeKit: "Page"))
+                    .accessibilityValue(String(themeKit: "\(current) of \(total)"))
             } else {
                 ForEach(Array(pages.enumerated()), id: \.offset) { _, page in
                     if page == -1 {
@@ -63,7 +65,7 @@ public struct Pagination: View {
                 }
             }
 
-            arrow(systemName: "chevron.right", enabled: isEnabled && current < total) { current = min(total, current + 1) }
+            arrow(systemName: "chevron.right", label: String(themeKit: "Next page"), enabled: isEnabled && current < total) { current = min(total, current + 1) }
 
             if showJumper { jumper }
         }
@@ -122,9 +124,11 @@ public struct Pagination: View {
         .buttonStyle(.plain)
         .disabled(!isEnabled)
         .accessibilityLabel(String(themeKit: "Page \(page)"))
+        .accessibilityValue(isCurrent ? String(themeKit: "\(current) of \(total)") : "")
+        .accessibilityAddTraits(isCurrent ? .isSelected : [])
     }
 
-    private func arrow(systemName: String, enabled: Bool, action: @escaping () -> Void) -> some View {
+    private func arrow(systemName: String, label: String, enabled: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Icon(systemName: systemName)
                 .size(.sm)
@@ -134,6 +138,7 @@ public struct Pagination: View {
         }
         .buttonStyle(.plain)
         .disabled(!enabled)
+        .accessibilityLabel(label)
     }
 
     // MARK: - Pure windowing (extracted for testing)

--- a/Sources/ThemeKit/Components/Molecules/TreeSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/TreeSelect.swift
@@ -140,6 +140,8 @@ public struct TreeSelect: View {
         }
         .buttonStyle(.plain)
         .disabled(!isEnabled)
+        .accessibilityLabel(label ?? placeholder)
+        .accessibilityValue(summary)
     }
 
     /// The composed trigger row (summary + chevron) — everything a `FieldStyle`

--- a/Sources/ThemeKit/Components/Organisms/AncillaryCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/AncillaryCard.swift
@@ -110,12 +110,12 @@ public struct AncillaryCard: View {
 
     private func stepper(_ qty: Binding<Int>) -> some View {
         HStack(spacing: 0) {
-            stepButton("minus", enabled: qty.wrappedValue > quantityRange.lowerBound) {
+            stepButton("minus", label: String(themeKit: "Decrease"), value: qty.wrappedValue, enabled: qty.wrappedValue > quantityRange.lowerBound) {
                 qty.wrappedValue = max(quantityRange.lowerBound, qty.wrappedValue - 1)
             }
             Text("\(qty.wrappedValue)").textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
                 .frame(minWidth: 28).monospacedDigit()
-            stepButton("plus", enabled: qty.wrappedValue < quantityRange.upperBound) {
+            stepButton("plus", label: String(themeKit: "Increase"), value: qty.wrappedValue, enabled: qty.wrappedValue < quantityRange.upperBound) {
                 qty.wrappedValue = min(quantityRange.upperBound, qty.wrappedValue + 1)
             }
         }
@@ -123,7 +123,7 @@ public struct AncillaryCard: View {
         .background(theme.background(.bgSecondary), in: Capsule())
     }
 
-    private func stepButton(_ icon: String, enabled: Bool, _ action: @escaping () -> Void) -> some View {
+    private func stepButton(_ icon: String, label: String, value: Int, enabled: Bool, _ action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: icon).font(.system(size: 13, weight: .bold))
                 .foregroundStyle(enabled ? accentSemantic.base : theme.text(.textDisabled))
@@ -131,6 +131,8 @@ public struct AncillaryCard: View {
         }
         .buttonStyle(.plain)
         .disabled(!enabled)
+        .accessibilityLabel(label)
+        .accessibilityValue("\(value)")
     }
 
     private func addButton(_ added: Binding<Bool>) -> some View {

--- a/Sources/ThemeKit/Components/Organisms/FlightCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightCard.swift
@@ -182,6 +182,7 @@ public struct FlightCard: View {
                 legPath(leg)
                 timeColumn(leg.arrival, code: leg.destination, alignment: .trailing)
             }
+            .accessibilityElement(children: .combine)
         }
     }
 
@@ -223,6 +224,7 @@ public struct FlightCard: View {
             pathView
             timeColumn(arrival, code: destination, alignment: .trailing)
         }
+        .accessibilityElement(children: .combine)
     }
 
     private func timeColumn(_ date: Date, code: String, alignment: HorizontalAlignment) -> some View {

--- a/Sources/ThemeKit/Components/Organisms/RatingSummary.swift
+++ b/Sources/ThemeKit/Components/Organisms/RatingSummary.swift
@@ -44,6 +44,20 @@ public struct RatingSummary: View {
                 .disabled(onReviews == nil)
             }
         }
+        // Fold the score badge, qualitative label, and review-count link into one
+        // VoiceOver element so the rating is announced as a single phrase.
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(String(themeKit: "Rating")))
+        .accessibilityValue(Text(accessibilityValueText))
+    }
+
+    /// Spoken value — the numeric score, then the qualitative label and review
+    /// count when present (e.g. "9.0, Excellent, 1200 reviews").
+    private var accessibilityValueText: String {
+        var parts: [String] = [String(format: "%.1f", score)]
+        if let label { parts.append(label) }
+        if let reviewCount { parts.append(String(themeKit: "\(reviewCount) reviews")) }
+        return parts.joined(separator: ", ")
     }
 }
 


### PR DESCRIPTION
Second **multi-agent accessibility round**, targeting 9 known a11y P0s from the beyond-daisyUI audit. **7 fixed, 2 already-handled** (NavigationBar + Chips — the audit had gone stale on those; the agents correctly verified and skipped). All additive, non-breaking, English-only via `String(themeKit:)`.

## Fixed (7)
| Component | Fix |
|---|---|
| **InstallmentSelector** | composed row label + `.isSelected` (was fragmented children across radio/count/badge/price) |
| **CurrencyPicker** | clean `"<name>, <code>"` label (was flag-emoji regional-indicator noise) + `.isSelected` |
| **AncillaryCard** | 32pt icon steppers → `Increase`/`Decrease` labels + `.accessibilityValue(quantity)` |
| **TreeSelect** | trigger → label (selection/placeholder) + `.accessibilityValue(summary)` |
| **FlightCard** | route → `.accessibilityElement(children: .combine)` (single + multi-leg) so VoiceOver reads one phrase, not fragments |
| **RatingSummary** | combined element + label + value (`"9.0, Excellent, 1200 reviews"`) |
| **Pagination** | Previous/Next page labels + current-page value + `.isSelected` |

## Verified
`swift build` + **230 tests pass** (snapshots unchanged; a11y is non-visual). 7 files, +45/-6.

Part 1 of the user's two-slice sequence; the P0 behavior-bug slice follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)