### PR TITLE
fix(a11y): AnimatedImage honors Reduce Motion (audit P0)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/AnimatedImage.swift
+++ b/Sources/ThemeKit/Components/Atoms/AnimatedImage.swift
@@ -13,6 +13,7 @@ import ImageIO
 /// (Reference AVIFAnimatedImage / animated `ImageView` role, native.)
 public struct AnimatedImage: View {
     @Environment(\.theme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let url: URL?
     // Appearance/config — mutated only through the modifiers below (R2).
@@ -37,7 +38,7 @@ public struct AnimatedImage: View {
 
     @ViewBuilder
     private var content: some View {
-        if frames.count > 1, total > 0 {
+        if !reduceMotion, frames.count > 1, total > 0 {
             TimelineView(.animation) { context in
                 let t = context.date.timeIntervalSince(start).truncatingRemainder(dividingBy: total)
                 Image(decorative: frame(at: t), scale: 1)


### PR DESCRIPTION
Slice 2 of the two-slice sequence — the beyond-daisyUI audit's **P0 behavior-bug** list. A multi-agent pass (one agent per bug) verified each against current code: **1 real bug fixed, 5 already resolved** in intervening work.

## Fixed
- **AnimatedImage** — GIF/APNG frames ran through `TimelineView(.animation)` unconditionally, ignoring **Reduce Motion**. Added `@Environment(\.accessibilityReduceMotion)` and gated the animated branch on `!reduceMotion` (matching `BorderBeam`), so it falls through to the existing static-first-frame render. No change when Reduce Motion is off.

## Verified already-fixed (no change — audit was stale)
| P0 | Reality |
|---|---|
| GaugeView "7200%" | already normalizes: `(value-lo)/(hi-lo)` + `.formatted(.percent)` |
| Steps.small() no-op | real: `.labelSm600` (12pt) vs `.labelBase600` (14pt) + dot 22/28 + icon 10/12 |
| RollingNumber scaffold | already `.accessibilityElement(children: .ignore)` + `.accessibilityLabel(value.formatted())` |
| VideoPlayerView macOS flags | flags consumed in platform-agnostic `InlineVideo`; no macOS branch drops them |
| PriceAlertCard `.combine` | Toggle already standalone/operable; non-interactive parts `.accessibilityHidden` |

## Verified
`swift build` + **230 tests pass** (0 failures). 1 file, +2/-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)