### PR TITLE
fix(a11y): presenter accessibility — announcements, .isModal, Escape (sprint 7)

### DIFF
--- a/Sources/ThemeKit/Components/Organisms/AlertToast.swift
+++ b/Sources/ThemeKit/Components/Organisms/AlertToast.swift
@@ -90,11 +90,20 @@ public struct AlertToast: View {
     }
 
     public var body: some View {
-        // Shell chrome is delegated to the active `ToastStyle`. When no
-        // `.toastStyle(_:)` is set anywhere up the tree we keep the original
-        // inline shell, so the stock look stays pixel-identical by construction;
-        // an explicitly set style (including `.default`) routes through
-        // `makeBody` with the pre-composed content row.
+        presentation
+            // VoiceOver gets no signal that a toast surfaced, so announce its
+            // content when it appears. Uses the cross-platform SwiftUI API
+            // (no UIKit `UIAccessibility.post`) so the macOS build stays green.
+            .onAppear { AccessibilityNotification.Announcement(announcementText).post() }
+    }
+
+    /// The composed shell. Chrome is delegated to the active `ToastStyle`. When
+    /// no `.toastStyle(_:)` is set anywhere up the tree we keep the original
+    /// inline shell, so the stock look stays pixel-identical by construction;
+    /// an explicitly set style (including `.default`) routes through `makeBody`
+    /// with the pre-composed content row.
+    @ViewBuilder
+    private var presentation: some View {
         if style.isDefault {
             row
                 .foregroundStyle(type.foreground(theme))
@@ -106,6 +115,13 @@ public struct AlertToast: View {
                 content: AnyView(row), variant: type, isLoading: isLoading
             ))
         }
+    }
+
+    /// What VoiceOver reads aloud when the toast surfaces — the title, plus the
+    /// secondary line when present.
+    private var announcementText: String {
+        if let message { return "\(title), \(message)" }
+        return title
     }
 
     /// The content row a style receives: leading icon/spinner, title + message,

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -73,6 +73,9 @@ private struct DialogPresentation<Card: View>: View {
                 .offset(y: dragOffset)
                 .gesture(swipe, including: swipeToDismiss ? .all : .subviews)
                 .transition(cardTransition)
+                // Modal presenter: VoiceOver ignores the dimmed scrim and the
+                // background content behind the card while the dialog is up.
+                .accessibilityAddTraits(.isModal)
                 // Assistive-tech equivalent of the swipe/scrim dismissal —
                 // VoiceOver's two-finger scrub closes what a swipe would.
                 // Both handlers carry the caller's own gating (loading state,

--- a/Sources/ThemeKit/Components/Organisms/Drawer.swift
+++ b/Sources/ThemeKit/Components/Organisms/Drawer.swift
@@ -47,6 +47,9 @@ private struct DrawerContainer<DrawerContent: View>: View {
                 .offset(x: dragX)
                 .gesture(dragGesture)
                 .transition(.move(edge: edge == .leading ? .leading : .trailing))
+                // Modal: hide the dimmed background from VoiceOver; scrub-to-dismiss.
+                .accessibilityAddTraits(.isModal)
+                .accessibilityAction(.escape) { onDismiss() }
         }
         .zIndex(1)
     }

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -430,6 +430,8 @@ private struct FeedbackHostModifier: ViewModifier {
                     primaryColor: confirm.primaryKind.semanticColor
                 )
                 .padding(Theme.SpacingKey.lg.value)
+                .accessibilityAddTraits(.isModal)   // VoiceOver ignores the dimmed content behind it
+                .accessibilityAction(.escape) { presenter.dismissConfirm() }   // two-finger scrub dismisses
             }
             .transition(.opacity)
         }

--- a/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
+++ b/Sources/ThemeKit/Components/Organisms/Popconfirm.swift
@@ -49,6 +49,14 @@ private struct PopconfirmPresenter<Card: View>: ViewModifier {
                     decoratedCard
                         .modifier(PopconfirmPlacement(edge: edge))
                         .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                        // While the card is up, keep VoiceOver inside it so the
+                        // dimmed trigger/background isn't reachable; a two-finger
+                        // scrub triggers the same dismissal as an outside tap
+                        // (and, like it, is suppressed while pinned or loading).
+                        .accessibilityAddTraits(.isModal)
+                        .accessibilityAction(.escape) {
+                            if dismissOnOutsideTap { isPresented = false }
+                        }
                         .zIndex(1)
                 }
             }

--- a/Sources/ThemeKit/Components/Organisms/Toast.swift
+++ b/Sources/ThemeKit/Components/Organisms/Toast.swift
@@ -17,6 +17,9 @@ import SwiftUI
 private struct ToastPresentationModifier<Toast: View>: ViewModifier {
     @Binding var isPresented: Bool
     let autoDismiss: Double?
+    /// Text posted to VoiceOver when the toast appears, so assistive-technology
+    /// users hear the notification. `nil` for fully custom content the caller owns.
+    let announcement: String?
     let toast: Toast
 
     @Environment(\.microAnimations) private var micro
@@ -29,6 +32,11 @@ private struct ToastPresentationModifier<Toast: View>: ViewModifier {
                 toast
                     .padding(Theme.SpacingKey.md.value)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .onAppear {
+                        if let announcement, !announcement.isEmpty {
+                            AccessibilityNotification.Announcement(announcement).post()
+                        }
+                    }
                     .task {
                         guard let autoDismiss else { return }
                         try? await Task.sleep(nanoseconds: UInt64(autoDismiss * 1_000_000_000))
@@ -51,6 +59,7 @@ public extension View {
         modifier(ToastPresentationModifier(
             isPresented: isPresented,
             autoDismiss: autoDismiss,
+            announcement: [title, message].compactMap { $0 }.joined(separator: ", "),
             toast: AlertToast(title).message(message).variant(type).onClose { isPresented.wrappedValue = false }
         ))
     }
@@ -68,6 +77,7 @@ public extension View {
         modifier(ToastPresentationModifier(
             isPresented: isPresented,
             autoDismiss: autoDismiss,
+            announcement: nil,
             toast: content()
         ))
     }


### PR DESCRIPTION
Multi-agent **presenter-accessibility** round (beyond-daisyUI sprint 7). **6 fixed, 1 already-handled** (BottomSheet — native `.sheet()`). Cross-platform SwiftUI only (no UIKit → macOS stays green).

| Component | Fix |
|---|---|
| **Toast / AlertToast** | `AccessibilityNotification.Announcement(message).post()` on appear → VoiceOver announces the toast |
| **Dialog** | `.accessibilityAddTraits(.isModal)` (Escape already added round 4) |
| **Drawer / Feedback / Popconfirm** | `.isModal` + `.accessibilityAction(.escape)` wired to the existing dismiss path |
| **BottomSheet** | already handled — native `.sheet()` isolates the context + provides swipe/Escape |

## Verified
`swift build` + **230 tests pass** (snapshots unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)