### PR TITLE
fix(a11y): 44pt touch targets + RTL-directional mirroring (sprint 2)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/MeterStyle.swift
+++ b/Sources/ThemeKit/Components/Atoms/MeterStyle.swift
@@ -168,6 +168,7 @@ private struct DiagonalStripes: View {
                 }
             }
             .stroke(Color.white.opacity(0.35), lineWidth: lineWidth)
+            .flipsForRightToLeftLayoutDirection(true)
         }
         .allowsHitTesting(false)
     }

--- a/Sources/ThemeKit/Components/Molecules/CalendarView.swift
+++ b/Sources/ThemeKit/Components/Molecules/CalendarView.swift
@@ -69,6 +69,8 @@ public struct CalendarView: View {
             Icon(systemName: name).size(.sm).color(theme.text(.textPrimary))
                 .frame(width: 32, height: 32)
                 .mirrorsInRTL()
+                .frame(minWidth: 44, minHeight: 44)   // A11y: ≥44pt tap target (glyph stays 32)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(label)
@@ -91,7 +93,7 @@ public struct CalendarView: View {
                 if let date {
                     dayCell(date)
                 } else {
-                    Color.clear.frame(height: 36)
+                    Color.clear.frame(height: 44)
                 }
             }
         }
@@ -109,6 +111,8 @@ public struct CalendarView: View {
                 .frame(width: 36, height: 36)
                 .background(isSelected ? selectedFill : .clear, in: Circle())
                 .overlay { if isToday && !isSelected { Circle().stroke(todayRing, lineWidth: 1) } }
+                .frame(maxWidth: .infinity, minHeight: 44)   // A11y: ≥44pt tap target (circle stays 36)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/Sources/ThemeKit/Components/Molecules/Pagination.swift
+++ b/Sources/ThemeKit/Components/Molecules/Pagination.swift
@@ -122,6 +122,8 @@ public struct Pagination: View {
                 )
         }
         .buttonStyle(.plain)
+        .frame(minWidth: 44, minHeight: 44)   // >=44pt hit area (WCAG 2.5.5); glyph stays 36pt
+        .contentShape(Rectangle())
         .disabled(!isEnabled)
         .accessibilityLabel(String(themeKit: "Page \(page)"))
         .accessibilityValue(isCurrent ? String(themeKit: "\(current) of \(total)") : "")
@@ -137,6 +139,8 @@ public struct Pagination: View {
                 .mirrorsInRTL()
         }
         .buttonStyle(.plain)
+        .frame(minWidth: 44, minHeight: 44)   // >=44pt hit area (WCAG 2.5.5); glyph stays 36pt
+        .contentShape(Rectangle())
         .disabled(!enabled)
         .accessibilityLabel(label)
     }

--- a/Sources/ThemeKit/Components/Molecules/QuantityStepper.swift
+++ b/Sources/ThemeKit/Components/Molecules/QuantityStepper.swift
@@ -56,6 +56,9 @@ public struct QuantityStepper: View {
                 .size(.sm)
                 .color(enabled && isEnabled ? theme.text(.textHero) : theme.text(.textDisabled))
                 .frame(width: 32, height: 32)
+                // Glyph stays 32pt; expand the hit area to the 44pt WCAG 2.5.5 / HIG minimum.
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(!enabled || !isEnabled)

--- a/Sources/ThemeKit/Components/Molecules/Transfer.swift
+++ b/Sources/ThemeKit/Components/Molecules/Transfer.swift
@@ -109,6 +109,8 @@ public struct Transfer: View {
                 .frame(width: 32, height: 32)
                 .background(enabled ? SemanticColor.primary.solid : theme.background(.bgElevatorTertiary),
                             in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(!enabled)

--- a/Sources/ThemeKit/Components/Organisms/Carousel.swift
+++ b/Sources/ThemeKit/Components/Organisms/Carousel.swift
@@ -176,6 +176,10 @@ public struct Carousel<Item: Identifiable, Content: View>: View {
                 .frame(width: 32, height: 32)
                 .mirrorsInRTL()
                 .background(theme.background(.bgTertiary).opacity(0.5), in: Circle())
+                // A11y: keep the 32pt circle glyph but grow the tap target to the
+                // 44pt WCAG 2.5.5 / HIG minimum via transparent padding.
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(label)

--- a/Sources/ThemeKit/Components/Organisms/Upload.swift
+++ b/Sources/ThemeKit/Components/Organisms/Upload.swift
@@ -97,6 +97,8 @@ public struct Upload: View {
             if let onRetry, case .failed = file.status {
                 Button { onRetry(file) } label: {
                     Icon(systemName: "arrow.clockwise").size(.sm).color(theme.foreground(.fgHero))
+                        .frame(minWidth: 44, minHeight: 44)   // >=44pt hit area (WCAG 2.5.5); glyph stays .sm
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(String(themeKit: "Retry"))
@@ -104,6 +106,8 @@ public struct Upload: View {
 
             Button { onRemove(file) } label: {
                 Icon(systemName: "trash").size(.sm).color(theme.text(.textTertiary))
+                    .frame(minWidth: 44, minHeight: 44)   // >=44pt hit area (WCAG 2.5.5); glyph stays .sm
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
         }


### PR DESCRIPTION
Multi-agent sweep over 13 components (beyond-daisyUI sprint 2). **7 fixed, 6 already-safe** (agents verified & skipped). Non-breaking; no glyph/color changes.

## 44pt touch targets (WCAG 2.5.5 / Apple HIG)
Expand the tappable region to ≥44pt **without enlarging the glyph** (`.frame(minWidth:44,minHeight:44)` + `.contentShape`):
**QuantityStepper** (32→44), **Pagination** (36→44 arrows + page pills), **Carousel** (32→44), **Transfer** (32→44), **CalendarView** (32→44 nav + day cells), **Upload** (retry/remove).

## RTL
**MeterStyle** — `.flipsForRightToLeftLayoutDirection(true)` on the `DiagonalStripes` hatch (the meter fill already mirrors via `ZStack(.leading)`).

## Correctly skipped (already RTL-safe / already ≥44pt)
FloatingActionButton (56/44), PriceTrendChart, ProgressIndicator, TicketStub, Diff, Splitter — HStack / `.leading`-anchored / symmetric geometry mirrors automatically.

## Verified
`swift build` + **230 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)