### PR TITLE
demo: register TimeField in the component gallery (audit sprint 8)

### DIFF
--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -153,6 +153,7 @@ enum ComponentRegistry {
         .knob("Breadcrumbs", .molecules, demo: BreadcrumbsDemo(), usage: #"Breadcrumbs([.init("Home", action: { }), .init("Current")], maxItems: 4)"#),
         .knob("Calendar", .molecules, demo: CalendarDemo(), usage: #"CalendarView(selection: $date)"#),
         .knob("DateField", .molecules, demo: DateFieldDemo(), usage: ##"DateField("Check-in", date: $date).style(.custom("EEE, d MMM")).clearable()"##),
+        .knob("TimeField", .molecules, demo: TimeFieldDemo(), usage: #"TimeField("Pickup", time: $time).hourCycle(.h24).minuteInterval(5).clearable()"#),
         .knob("Fieldset", .molecules, demo: FieldsetDemo(), usage: #"Fieldset("Contact") { inputs }.helper("…")"#),
         .knob("Form", .molecules, demo: FormDemo(), usage: ##"@State var form = FormValidator<Field>([.email: [.required(), .email()]])\nform.validateAll([.email: email])  // → first invalid field, focuses it"##),
         .knob("FileInput", .molecules, demo: FileInputDemo(), usage: #"FileInput("Passport") { pick() }.fileName(name)"#),

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -1271,6 +1271,45 @@ struct DateFieldDemo: View {
     }
 }
 
+struct TimeFieldDemo: View {
+    private enum Cycle: String, CaseIterable { case locale, h12, h24 }
+    @State private var time: Date? = .now
+    @State private var cycleSel: Cycle = .locale
+    @State private var interval = 5
+    @State private var clearable = true
+    @State private var enabled = true
+    @State private var error = false
+
+    private var cycle: TimeFieldHourCycle {
+        switch cycleSel {
+        case .locale: return .locale
+        case .h12: return .h12
+        case .h24: return .h24
+        }
+    }
+    private var messages: [InfoMessage] { error ? [InfoMessage("Time is required", kind: .error)] : [] }
+
+    var body: some View {
+        ComponentStage("TimeField", inspector: [("hourCycle", cycleSel.rawValue), ("value", time.map { $0.formatted(date: .omitted, time: .shortened) } ?? "nil")]) {
+            TimeField("Time", time: $time)
+                .hourCycle(cycle)
+                .minuteInterval(interval)
+                .infoMessages(messages)
+                .clearable(clearable)
+                .icon("clock")
+                .a11yID("demoTime")
+                .disabled(!enabled)
+        } knobs: {
+            Text("hourCycle = locale / 12h / 24h. minuteInterval snaps the wheel. Tap the field to open the themed picker.").font(.caption).foregroundStyle(.secondary)
+            Picker("Hour cycle", selection: $cycleSel) { ForEach(Cycle.allCases, id: \.self) { Text($0.rawValue).tag($0) } }
+            Stepper("Minute interval: \(interval)", value: $interval, in: 1...30, step: 5)
+            Toggle("Clearable", isOn: $clearable)
+            Toggle("Error message", isOn: $error)
+            Toggle("Enabled", isOn: $enabled)
+        }
+    }
+}
+
 struct DataTableDemo: View {
     private struct Booking: Identifiable { let id = UUID(); let hotel: String; let nights: Int; let price: Double }
     private let rows: [Booking] = [


### PR DESCRIPTION
Fixes the beyond-daisyUI audit's demo-debt item: **TimeField ships in the library but was never registered** in `ComponentRegistry`, so it never appeared in the demo gallery.

- Added `TimeFieldDemo` (mirrors `DateFieldDemo`) with hour-cycle picker (locale/12h/24h), minute-interval stepper, clearable/error/enabled toggles.
- Registered `.knob("TimeField", .molecules, demo: TimeFieldDemo(), …)` right after DateField.

Demo-only change (no library code). Validated by the iOS Simulator CI lane, which builds the Demo app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)