### PR TITLE
feat(elevation): shared View.elevation(_:) + token-bind 4 raw shadows

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/Badge.swift
+++ b/Sources/ThemeKit/Components/Atoms/Badge.swift
@@ -221,7 +221,7 @@ private struct BadgeHighlight: ViewModifier {
     let on: Bool
     func body(content: Content) -> some View {
         if on {
-            content.shadow(color: .black.opacity(0.22), radius: 3, x: 0, y: 2)
+            content.themeShadow(.soft)
         } else {
             content
         }

--- a/Sources/ThemeKit/Components/Atoms/CountBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/CountBadge.swift
@@ -82,7 +82,7 @@ public struct Ribbon<Content: View>: View {
                 .background(color.solid)
                 .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
                 .offset(x: 6, y: 8)
-                .shadow(color: .black.opacity(0.15), radius: 2, y: 1)
+                .themeShadow(.soft)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Atoms/TiltCard.swift
+++ b/Sources/ThemeKit/Components/Atoms/TiltCard.swift
@@ -149,7 +149,7 @@ private struct Tilt3DModifier: ViewModifier {
         .padding(32)
         .frame(width: 260)
         .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: 20))
-        .shadow(color: .black.opacity(0.15), radius: 18, y: 10)
+        .themeShadow(.elevated)
         .tilt3D(shine: true)
 
         TiltCard {

--- a/Sources/ThemeKit/Components/Organisms/Card.swift
+++ b/Sources/ThemeKit/Components/Organisms/Card.swift
@@ -198,6 +198,22 @@ struct CardShadow: ViewModifier {
     }
 }
 
+public extension View {
+    /// Applies token-bound elevation — a themed drop shadow — to **any** view, using
+    /// the same `.none / .soft / .elevated` ladder ThemeKit's surface components use.
+    /// Lift your own view to a design-system elevation without hand-rolling a raw
+    /// `.shadow(...)`, so it re-skins with the theme (and dark mode) for free:
+    ///
+    ///     myPanel.elevation(.soft)
+    ///
+    /// ThemeKit's own surfaces (``Card``, ``SurfaceView``, …) expose an
+    /// `.elevation(_:)` returning `Self`; on those the component's own modifier wins,
+    /// so this never changes their behaviour.
+    func elevation(_ elevation: CardElevation) -> some View {
+        modifier(CardShadow(elevation: elevation))
+    }
+}
+
 #Preview {
     @Previewable @Environment(\.theme) var theme
     ScrollView {

--- a/Sources/ThemeKit/Components/Organisms/DestinationCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/DestinationCard.swift
@@ -116,7 +116,7 @@ public struct DestinationCard: View {
             .padding(.vertical, 4)
             .background(ribbonColor.solid, in: Capsule())
             .padding(Theme.SpacingKey.sm.value)
-            .shadow(color: .black.opacity(0.15), radius: 2, y: 1)
+            .themeShadow(.soft)
     }
 
     private func heartButton(_ fav: Binding<Bool>) -> some View {


### PR DESCRIPTION
**Strengthens the elevation system** (instead of spreading `.elevation` to more components by default — a developer opts in themselves).

## 1. Shared `View.elevation(_:)` modifier
Promotes `.elevation(_ CardElevation)` from a per-component modifier to a **public `View` extension**, so **any** view — including a consumer's own — can lift to a token-bound, theme-adaptive elevation:
```swift
myPanel.elevation(.soft)   // .none / .soft / .elevated, re-skins + dark-mode adapts
```
ThemeKit's own surfaces (Card, SurfaceView, …) keep their `Self`-returning `.elevation(_:)` — the concrete-type member wins over the protocol extension (verified: no ambiguity, build clean).

## 2. Token-bind raw shadows (multi-agent, 4 fixed / 1 correctly kept)
5 components hardcoded `.shadow(color: .black.opacity(...))`, bypassing the theme:
| Component | Result |
|---|---|
| **Badge** (`.highlighted`), **CountBadge** (Ribbon), **DestinationCard** (ribbonTag), **TiltCard** | → `.themeShadow(.soft/.elevated)` — now re-skins + dark-mode adapts |
| **ScrubGallery** | kept raw — a fixed-tint hairline legibility separator over photos (not elevation; a token would defeat it) |

## Verified
`swift build` + **230 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)