### PR TITLE
fix: Codex review follow-ups — scoped-theme shadows + non-mixed a11y hint

### DIFF
--- a/Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift
@@ -71,7 +71,9 @@ public struct LoyaltyCard: View {
             withAnimation(Animation.spring(.smooth).ifMotionAllowed(reduceMotion)) { flipped.toggle() }
         }
         .accessibilityAddTraits(flippable && membership != nil ? .isButton : [])
-        .accessibilityHint(flippable && membership != nil ? String(themeKit: "Double-tap to \(flipped ? "show card" : "show membership code")") : "")
+        .accessibilityHint(flippable && membership != nil
+            ? (flipped ? String(themeKit: "Double-tap to show card") : String(themeKit: "Double-tap to show membership code"))
+            : "")
     }
 
     private var frontFace: some View {

--- a/Sources/ThemeKitCore/Theme/Shadows.swift
+++ b/Sources/ThemeKitCore/Theme/Shadows.swift
@@ -22,9 +22,11 @@ public enum ShadowStyle: String, CaseIterable {
     private static let shadow5 = Color(hex: "3352a40d")
     private static let shadow8 = Color(hex: "3352a414")
 
-    /// Resolved layers from the active theme; falls back to the in-code spec.
-    var layers: [Theme.ResolvedShadowLayer] {
-        Theme.shared.shadow(self) ?? fallbackLayers
+    /// Resolved layers from a specific theme; falls back to the in-code spec.
+    /// Takes the theme explicitly so the modifier can pass the *environment* theme
+    /// (respecting per-subtree `.theme(_:)`) rather than always reading `Theme.shared`.
+    func layers(from theme: Theme) -> [Theme.ResolvedShadowLayer] {
+        theme.shadow(self) ?? fallbackLayers
     }
 
     private var fallbackLayers: [Theme.ResolvedShadowLayer] {
@@ -44,10 +46,11 @@ public enum ShadowStyle: String, CaseIterable {
 }
 
 private struct ThemeShadowModifier: ViewModifier {
+    @Environment(\.theme) private var theme
     let style: ShadowStyle
 
     func body(content: Content) -> some View {
-        style.layers.reduce(AnyView(content)) { view, layer in
+        style.layers(from: theme).reduce(AnyView(content)) { view, layer in
             AnyView(view.shadow(color: layer.color, radius: layer.radius, x: layer.x, y: layer.y))
         }
     }


### PR DESCRIPTION
Addresses the P2 Codex review notes from #243 and #239.

## 1. Elevation/shadows now respect the environment theme (#243)
`ShadowStyle.layers` resolved from `Theme.shared`, so `themeShadow` / the new public `View.elevation()` ignored a per-subtree `.theme(customTheme)` — scoped previews/tests and per-branch themes got inconsistent elevation. `ThemeShadowModifier` now reads `@Environment(\.theme)` and resolves via `ShadowStyle.layers(from: theme)`. **Default behaviour is identical** (the env theme defaults to `Theme.shared`), so 230 tests + snapshots are unchanged; scoped themes are now correct.

## 2. LoyaltyCard mixed-language a11y hint (#239)
The flip hint interpolated an English literal into `String(themeKit:)` (`"Double-tap to \(show card / show membership code)"`), so only the shell localized → mixed-language hint in non-English VoiceOver. Split into two complete localizable strings.

## Note on the third Codex comment (#239, SeatMap catalog keys)
The newly-wrapped seat labels (`Window`/`Aisle`/…) are correctly **extraction-ready** — `String(themeKit:)` makes them localizable and Xcode's String Catalog auto-extracts them on the next catalog build. Adding `tr` (or other) **translations** is separate translation work; the project ships English defaults with the English source resolving as fallback, so this is a follow-up translation task, not a code defect.

## Verified
`swift build` + **230 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)