### PR TITLE
docs(site): showcase the llms.txt layer on GitHub Pages

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -58,9 +58,10 @@ export default defineConfig({
           ],
         },
         {
-          label: 'MCP Server',
+          label: 'AI Integration',
           items: [
-            { label: 'Overview', link: '/ai/mcp/', badge: { text: 'AI', variant: 'tip' } },
+            { label: 'MCP Server', link: '/ai/mcp/', badge: { text: 'AI', variant: 'tip' } },
+            { label: 'llms.txt', link: '/ai/llms/', badge: { text: 'New', variant: 'success' } },
             { label: 'Design Tokens ⇄ Figma Variables', link: '/ai/figma-variables/', badge: { text: 'New', variant: 'success' } },
           ],
         },

--- a/website/src/content/docs/ai/llms.mdx
+++ b/website/src/content/docs/ai/llms.mdx
@@ -1,0 +1,91 @@
+---
+title: llms.txt
+description: A static context layer for LLMs — index, full docs, per-component API, and patterns that any AI tool can fetch to generate correct, token-bound ThemeKit code.
+---
+
+import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+export const base = import.meta.env.BASE_URL;
+
+ThemeKit ships a **static context layer for large language models** — plain-text
+files, following the [llms.txt convention](https://llmstxt.org/), that any AI editor
+or agent can fetch to generate **correct, token-bound** ThemeKit code without guessing
+APIs or hardcoding colors.
+
+It's the drop-in companion to the [MCP server](/ThemeKit/ai/mcp/): the MCP gives your
+editor **live, on-demand tools**, while these files give **any** tool a complete
+snapshot it can attach or fetch in one shot.
+
+:::tip[Generated, never stale]
+`llms.txt` and `llms-components.txt` are generated from source by `tools/gen_skill.py`
+(`make skill`), so they can't drift from the library — currently **205 components**,
+**34 theme presets**, and **217 design tokens**.
+:::
+
+## The files
+
+<CardGrid>
+  <LinkCard
+    title="llms.txt"
+    href={`${base}llms.txt`}
+    description="Quick-reference index — philosophy, code-generation rules, token summary, the full component catalog, presets, style protocols, and links. Start here."
+  />
+  <LinkCard
+    title="llms-full.txt"
+    href={`${base}llms-full.txt`}
+    description="Full documentation — architecture, token deep-dive, runtime theming, the six style protocols, code-gen rules, patterns, and AI-native integration."
+  />
+  <LinkCard
+    title="llms-components.txt"
+    href={`${base}llms-components.txt`}
+    description="Per-component API for all 205 components — init signature, chainable modifiers, and a usage snippet."
+  />
+  <LinkCard
+    title="llms-patterns.txt"
+    href={`${base}llms-patterns.txt`}
+    description="Recipes & anti-patterns — custom themes, per-subtree theming, custom styles, forms, navigation, and data display."
+  />
+</CardGrid>
+
+## How to use
+
+Point your tool at the hosted URL, or download the file and attach it:
+
+```text
+https://isamercan.github.io/ThemeKit/llms.txt
+https://isamercan.github.io/ThemeKit/llms-full.txt
+https://isamercan.github.io/ThemeKit/llms-components.txt
+https://isamercan.github.io/ThemeKit/llms-patterns.txt
+```
+
+- **Claude · ChatGPT · Cursor · Copilot** — attach `llms.txt` as project context, then
+  ask for a screen. For deep API detail, add `llms-components.txt`.
+- **URL-fetching agents** — hand them the link above; `llms.txt` cross-links the rest.
+- **The one rule that keeps generated code correct** — read the theme from the
+  environment and never hardcode a color:
+
+```swift
+@Environment(\.theme) private var theme          // not Theme.shared inside a subview
+theme.text(.textPrimary)                          // not .foregroundStyle(.blue)
+Theme.SpacingKey.md.value                          // not .padding(16)
+Theme.RadiusRole.box.value                         // not cornerRadius: 12
+```
+
+## Prefer live tools?
+
+If your editor speaks MCP, the [ThemeKit MCP server](/ThemeKit/ai/mcp/) exposes the
+same data as **on-demand tools** (`get_component_api`, `get_design_tokens`,
+`generate_theme`, `a11y_audit`, Figma round-trip…) — focused context pulled exactly
+when the model needs it, instead of one large paste. The `llms.*` files and the MCP
+server are built from the **same source**, so they always agree.
+
+<CardGrid>
+  <Card title="Static context" icon="document">
+    One fetch or paste, works everywhere. Best for tools without MCP, or for a
+    complete snapshot in a single file.
+  </Card>
+  <Card title="Live tools (MCP)" icon="puzzle">
+    On-demand, focused API/token lookups while the model codes. Best for
+    MCP-capable editors. [Set it up →](/ThemeKit/ai/mcp/)
+  </Card>
+</CardGrid>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -44,6 +44,12 @@ export const base = import.meta.env.BASE_URL;
 		token-only theme engine in the
 		[ThemeKitCore reference](/ThemeKit/api-core/documentation/themekitcore/).
 	</Card>
+	<Card title="AI-native" icon="rocket">
+		Generate correct, token-bound code from an
+		[MCP server](/ThemeKit/ai/mcp/) or a static
+		[llms.txt context layer](/ThemeKit/ai/llms/) — no guessing APIs, no
+		hardcoded colors.
+	</Card>
 </CardGrid>
 
 ## One library, every theme


### PR DESCRIPTION
## What

Makes the `llms.*` layer **shine on GitHub Pages** (HeroUI-style) instead of only existing as raw files.

- **New page** `/ai/llms/` — presents the four files with `LinkCard` download links (`/ThemeKit/llms.txt` …), how-to-use guidance for Claude/ChatGPT/Cursor/Copilot, the "one rule" that keeps generated code token-bound, and a **static-context vs. live-MCP** comparison.
- **Sidebar** — renamed the `MCP Server` group to **AI Integration** and added the `llms.txt` entry (alongside MCP Server + Figma Variables).
- **Homepage** — added an **AI-native** card linking to the MCP server and the llms.txt page.

The raw `llms.*` files already ship at `website/public/` (from #246), so the download links resolve on the live site.

## Verification

`astro build` passes — **20 pages** built (was 19). Confirmed: `dist/ai/llms/index.html` renders, the four `dist/llms*.txt` are served at the site root, and the in-page links resolve to `/ThemeKit/llms-*.txt`.

Docs/site only — no Swift touched. Authored in an isolated worktree off `main`; the active HeroUI branch is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)