### PR TITLE
feat(flexibility): library-wide flexibility sweep — HeroUI Pro + Ant Design parity (46 gaps, 8 waves)

### DIFF
--- a/Demo/Demo/Examples/HotelSearchView.swift
+++ b/Demo/Demo/Examples/HotelSearchView.swift
@@ -37,7 +37,7 @@ struct HotelSearchView: View {
                                 DateField("Check-out", date: $checkOut)
                                     .style(.custom("EEE, d MMM")).clearable().icon("calendar")
                             }
-                            InputNumber("Guests", value: $guests, range: 1...9).large()
+                            InputNumber("Guests", value: $guests, range: 1...9).size(.large)
                         }
                     }
 

--- a/HEROUI_STYLE_GAP_AUDIT.md
+++ b/HEROUI_STYLE_GAP_AUDIT.md
@@ -1,0 +1,296 @@
+# ThemeKit Flexibility Gap Audit — HeroUI + Ant Design parity, implementation-ready
+
+**Scope:** every component under `Sources/ThemeKit/Components` (Atoms 56 · Molecules 104
+incl. `Buttons/`+`Charts/` · Organisms 87 — all enumerated, see the Coverage Index).
+**References:** HeroUI core (heroui.com/docs/components), HeroUI Pro
+(heroui.pro/docs/react/components), **Ant Design** (ant.design/components — Input,
+Button, Select, notification API tables fetched and quoted 2026-07-10; the rest from the
+prior Ant-parity sweep, PRs #13–#44 / #202–#211).
+**Method:** full public-modifier-surface extraction for all 217 files + deep reads of the
+field/control/feedback/button/row families. Every gap cites verified `file:line` on
+`main` @ `3cf0721`. **Survey-before-adding was applied** — the library is far more
+Ant/HeroUI-complete than it looks; components listed "✓" in the Coverage Index were
+checked and need nothing.
+
+**This document is the implementation plan.** Each gap has a concrete, house-rules-
+compliant API (copy-on-write modifier, token-fed signature, `SlotContent` slot, or
+environment default) and is sequenced into waves at the end. It does not re-open
+`HEROUI_NATIVE_AUDIT.md`'s shipped per-component plans or `HEROUI_INFRA_PLAN.md`'s
+13 shipped infra units.
+
+---
+
+## Executive summary
+
+| Severity | Count | Themes |
+|---|---|---|
+| **P0** (blocks parity) | 2 | No read-only axis anywhere; per-instance `size` missing/bespoke on 12 of 15 field components |
+| **P1** (common usage) | 10 | ControlRow trailing-only control; helper/description text can't carry links (whole form stack); `required()` missing on 8 fields; TextInput fixed height clips under Dynamic Type; InputNumber off the size ramp; FeedbackDefaults missing 7 provider knobs (Ant `notification.config` / HeroUI ToastProvider); ComponentDefaults consumed by only 5/217 components; EmptyState & Callout plain-text bodies |
+| **P2** (nice-to-have) | 34 | Leading-only controls; label slots; Tooltip rich content; toast placement/haptics/progress; RTL-unmirrored chevrons; long-tail per-component axes (clearable/searchable/loading/marker slots/decimal InputNumber/…); size-vocabulary booleans; raw-Color/CGFloat deprecation batch |
+
+Two structural stories: **(1)** the field family shipped its axes piecemeal — `size`,
+`required`, `helperText`, `validate`, height-scaling each exist on 2–4 components and
+are absent or bespoke on the rest; **(2)** the provider layer (`FieldDefaults` /
+`FeedbackDefaults` / `ComponentDefaults`) exists but is thin — few knobs, few
+consumers — vs `HeroUIProvider` + Ant's `ConfigProvider`/`notification.config`.
+
+---
+
+## A. Placement / mirroring / orientation
+
+| # | Component | Gap | Reference behavior | Sev | API to add | Source |
+|---|---|---|---|---|---|---|
+| A1 | **ControlRow** | Boolean control renders only **trailing** (label block → `Spacer` → `indicator`); no placement modifier in the surface (`description/control/indicator/required/hasError/errorText/a11yID`). | HeroUI checkbox/radio/switch rows: control on either side; Ant Checkbox/Radio: control leads. | **P1** | `func controlPlacement(_ edge: HorizontalEdge) -> Self` (default `.trailing`); branch the `HStack` order. Keep the row as the single a11y element (`.accessibilityHidden(true)` on the indicator, :80, must survive both orders). | `Molecules/ControlRow.swift:68-81, 138-170` |
+| A2 | **Checkbox** | Box hard-wired **leading**. Inconsistent with A1 (same control family, opposite fixed side, no axis on either). | Same. | P2 | Same `controlPlacement(_:)` vocabulary. | `Molecules/Checkbox.swift:91-98` |
+| A3 | **RadioButton** | Control hard-wired leading. | Same. | P2 | Same axis. | `Molecules/RadioButton.swift:92-100` |
+| A4 | **RadioGroup** | Option rows: radio leading, `Spacer` last; no group-level placement. | Same. | P2 | Group-level `controlPlacement(_:)` forwarded to rows. | `Molecules/RadioGroup.swift:80-93` |
+| A5 | **CheckboxGroup** | Rows `HStack { Checkbox…; Spacer() }` — leading-only, incl. select-all row. | Same. | P2 | Same forwarded axis. | `Molecules/CheckboxGroup.swift:66-71, 88-93` |
+| A6 | **CheckboxGroup** | No layout-orientation axis — always a `VStack`; `RadioGroup` has `.axis(_:)` (`RadioGroup.swift:234`), CheckboxGroup doesn't (surface: `infoMessages/selectAll/optionEnabled/a11yID`). | Ant `Checkbox.Group` lays out horizontally by default; HeroUI `orientation`. | P2 | `func axis(_ a: Axis) -> Self` — copy RadioGroup's implementation (`RadioGroup.swift:62-68`). | `Molecules/CheckboxGroup.swift:60-71, 126-136` |
+| A7 | **ThemeButton** | `loading(_:)` swaps the entire label for a `ProgressView`; no spinner-alongside-label. (Icon placement itself is fine — `icon(leading:trailing:)` ✓ = Ant `iconPlacement`.) | Ant Button `loading: { icon }` keeps label; HeroUI `spinnerPlacement="start"/"end"`. | P2 | `func spinnerPlacement(_ edge: HorizontalEdge) -> Self`; when set, compose the spinner into the label `HStack` at :139 instead of replacing `content`. | `Molecules/Buttons/ThemeButton.swift:123-124, 139-152` |
+
+---
+
+## B. Rich text / link slots
+
+The library owns the link-capable atom — `InlineText`
+(`Atoms/InlineText.swift:12-50`) — and **InfoBanner already uses it**
+(`Organisms/InfoBanner.swift:126`: `InlineText(message, links: links)`). Every other
+description/helper/caption surface is plain `Text`.
+
+**One idiom for all fixes:** a `links:` axis (the InfoBanner pattern) for string
+surfaces; `SlotContent` slots only where full composition is warranted (D-section).
+
+| # | Component | Gap | Reference | Sev | API to add | Source |
+|---|---|---|---|---|---|---|
+| B1 | **HelperText** (atom) | Body is `Text(text)`. This atom is the description line for the whole form stack — `TextInput.helperText(_:)` and `ControlRow.description(_:)` route through it — so "agree to the *Terms*" copy can't link. | HeroUI `description` is a node; Ant `extra`/`help` are ReactNode. | **P1** | `func links(_ links: [(substring: String, action: () -> Void)]) -> Self`; render via `InlineText` when non-empty. Fix once, upgrade every consumer. | `Atoms/HelperText.swift:43`; consumers `Molecules/TextInput.swift:511`, `Molecules/ControlRow.swift:74` |
+| B2 | **EmptyState** | `message` renders plain `Text(message)`. | HeroUI Pro empty-state descriptions carry anchors; Ant Empty `description` is a node. | **P1** | `func message(_ text: String, links: [(String, () -> Void)]) -> Self` overload. | `Organisms/EmptyState.swift:92, 121` |
+| B3 | **Callout** | Body `Text(text)` — sibling InfoBanner supports links, Callout doesn't. | Ant Alert `description` node; HeroUI Alert. | **P1** | Same `links:` pattern for API symmetry with InfoBanner. | `Organisms/Callout.swift:91` |
+| B4 | **InputLabel** (atom) | `Text(text)` only. | HeroUI `label` node; Ant Form label node. | P2 | `links:` on the atom (asterisk/info glyphs unchanged). | `Atoms/InputLabel.swift:28` |
+| B5 | **AlertToast** | `message` plain `Text` (one tappable `action(_:)` title exists, :151). | Ant notification `description` node. | P2 | `links:` on `message(_:)`; forward through `FeedbackPresenter.toast(...)`. | `Organisms/AlertToast.swift:144` |
+| B6 | **Feedback notification layer** | Notification-card message plain `Text(message)`. | Ant notification `description` node. | P2 | Forward `links:` through `FeedbackPresenter.notify(...)`. | `Organisms/Feedback.swift:453` |
+| B7 | **RadioGroup** | Per-option `description` plain `Text`. | Ant Radio description node. | P2 | Render option descriptions through `HelperText` (inherits B1 + disabled/error tokens). | `Molecules/RadioGroup.swift:88-91` |
+| B8 | **Checkbox / RadioButton** | Label plain `Text(label)` — no rich text, no slot (see D1). | Checkbox children are nodes. | P2 | Covered by D1. | `Checkbox.swift:94`, `RadioButton.swift:100` |
+| B9 | **Tooltip** | Bubble is `Text(text)` only. | HeroUI/Ant Tooltip content node. | P2 | Covered by D2. | `Molecules/Tooltip.swift:134` |
+
+---
+
+## C. Size axes that don't enforce geometry
+
+`TextInputSize` defines the family ramp — xsmall 36 / small 44 / medium 56 / large 64
+(`Molecules/TextInput.swift:12-21`) — matching Ant Input's small/medium/large and
+HeroUI's sm/md/lg fixed heights. Per-instance adoption is 3 of ~15.
+
+| # | Component | Gap | Reference | Sev | API to add | Source |
+|---|---|---|---|---|---|---|
+| C1 | **Field family — 12 components** | Per-instance `.size(_:)` exists only on TextInput (:505), Select (:315), MultiLineTextInput (:222). **Subtree-`FieldDefaults`-only** (no per-instance modifier): SearchBar (:137), DateField (:85), OTPInput (:78). **No size axis, fixed height**: TimeField (:114), SelectBox (48pt :109), Autocomplete (48pt :110), FieldButton (56/48pt :63), ColorField (52pt :57), PaymentCardField (52pt :107), Mentions (40pt :72). (SearchField's 64pt is a deliberate design constant, :101 — exempt.) A form mixing TextInput + SelectBox + DateField cannot be uniformly `.small`. | Ant Input/Select/Picker: `size: large/medium/small` with fixed heights (verified API table); HeroUI `size sm/md/lg`. | **P0** | Uniform `func size(_ s: TextInputSize) -> Self` on every field-shaped component → `.scaledControlHeight(s.height)`, precedence `explicit ?? fieldDefaults.size ?? componentDefault` (template: `TextInput.swift:202`). PR per component. | cited inline |
+| C2 | **InputNumber** | Bespoke `large()` boolean → 40/48pt — neither on the ramp; never aligns with a `.small` (44) TextInput beside it. | Ant InputNumber `size` = Input sizes. | **P1** | `size(_ s: TextInputSize)`; `@available(*, deprecated)` shim `large()` → `.size(.large)`. | `Molecules/InputNumber.swift:61, 114, 260` |
+| C3 | **Chip** | `ChipSize` = `small/large`, padding-only — no enforced min-height/hit target; mixed-content chips misalign. | HeroUI Chip `sm/md/lg` fixed heights. | P2 | Per-case `minHeight` via `scaledControlHeight`; add `.medium`. | `Atoms/Chip.swift:9-22` |
+| C4 | **Checkbox / RadioButton glyphs** | `controlSize.checkboxSide`: mini/small → 20, *everything else* → 24 — `.large`/`.extraLarge` silently no-op. | HeroUI Checkbox `sm/md/lg` = 3 box sizes. | P2 | Extend mapping (`.large/.extraLarge → 28`); keep `customSize` escape hatch. | `Molecules/Checkbox.swift:13-18` |
+| C5 | **Size-vocabulary booleans** | `ScoreBadge.large()` (`Atoms/ScoreBadge.swift:213` in surface dump), `InputNumber.large()` (C2), `Steps.small()` (`Molecules/Steps.swift:777` surface) — boolean size toggles instead of the kit's size-enum vocabulary. | Ant uses `size` enums everywhere. | P2 | Deprecate-and-forward each to a size enum (`ScoreBadgeSize`, `TextInputSize`, `StepsSize`) for a uniform axis name. | cited inline |
+
+---
+
+## D. Missing slots
+
+| # | Component | Gap | Reference | Sev | API to add | Source |
+|---|---|---|---|---|---|---|
+| D1 | **Checkbox / RadioButton** | Label is `String?` init arg only — no `.label { }` slot (canonical slot vocabulary already reserves the name). | Checkbox/Radio children are nodes. | P2 | `func label<V: View>(@ViewBuilder _ content: () -> V) -> Self` storing `SlotContent`. | `Molecules/Checkbox.swift:63-69, 93-97` |
+| D2 | **Tooltip** | String-only API (`func tooltip(...)` :240/:257); no content slot. | HeroUI/Ant Tooltip content node. | P2 | `func tooltip<C: View>(isPresented:…, @ViewBuilder content:)` overload reusing bubble chrome. | `Molecules/Tooltip.swift:134, 240-257` |
+| D3 | **Callout** | No `.leading{}/.trailing{}` — sibling InfoBanner has both (`InfoBanner.swift:200-207`); asymmetric alert APIs. | Ant Alert `icon`/`action` nodes; HeroUI `startContent/endContent`. | P2 | Mirror InfoBanner's slot pair. | `Organisms/Callout.swift:125-143` |
+| D4 | **EmptyState** | Actions are string+closure only; no `.actions { }` slot. Also carries raw-token knobs — `iconForeground(_ c: Color?)` :125, `imageMaxHeight(CGFloat)` :124, `iconCircleSize(CGFloat)` :129 (token overloads exist alongside; see G5). | Ant Empty children node; HeroUI Pro action nodes. | P2 | `.actions { }` SlotContent slot (ResultView precedent — it already has `.icon{}/.content{}/.extra{}`, `Organisms/ResultView.swift:1449-1451` surface). | `Organisms/EmptyState.swift:130-131` |
+| D5 | **Timeline** | No custom-dot slot — `Steps` has `.marker { }` (`Molecules/Steps.swift:779` surface), Timeline only `axis/mode/reversed/pending`. | Ant Timeline custom `dot` per item. | P2 | `func marker<V: View>(@ViewBuilder _ content: @escaping (Item, Int) -> V) -> Self` — Steps precedent. | `Organisms/Timeline.swift:1551-1554` (surface) |
+| D6 | **NotificationCard** | No action-button axis — surface is `message/date/unread/variant/onClose/leading/surface/cornerRadius/elevation`; a notification can't carry "View"/"Undo". | Ant notification `actions` (verified API); HeroUI Pro notification CTA row. | P2 | `func action(_ title: String, onAction: @escaping () -> Void) -> Self` (Callout/InfoBanner pattern) + optional secondary. | `Organisms/NotificationCard.swift:1385-1393` (surface) |
+| D7 | **KanbanBoard** (new, #249) | Zero chainable appearance modifiers — card slot lives in `init` ✓ but no `columnWidth`, `spacing`, or accent axes; `KanbanColumn` takes `accent:` as an **init arg** (violates house rule 3: modifiers = appearance). | Ant Pro Board / HeroUI Pro kanban expose column sizing. | P2 | `func columnWidth(_ w: KanbanColumnWidth) -> Self` (enum, not CGFloat), `func spacing(_ key: Theme.SpacingKey) -> Self`; move column accent to a modifier or document the model-arg exception. | `Organisms/KanbanBoard.swift:23, 33-41` |
+| D8 | **EmojiReactionButton** (new, #249) | Zero appearance modifiers (controlled/uncontrolled inits only ✓). No size/accent axis. | HeroUI Pro reaction chips have sizes. | P2 | `func size(_ s: ChipSize) -> Self`, `func accent(_ c: SemanticColor?) -> Self`. | `Molecules/EmojiReactionButton.swift:17-35` |
+
+---
+
+## E. Missing states / variants / behavior axes
+
+| # | Component | Gap | Reference | Sev | API to add | Source |
+|---|---|---|---|---|---|---|
+| E1 | **Entire library — no read-only axis** | `grep -ri readonly Sources/ThemeKit` → 0 hits. `.disabled(_:)` is the only off switch and it dims to `textDisabled` + changes a11y semantics — wrong for review/summary screens. | HeroUI `isReadOnly` on all inputs; Ant `readOnly` on Input/InputNumber. | **P0** | Kit-wide environment axis: `public func readOnly(_ on: Bool = true) -> some View` → `EnvironmentValues.isReadOnly`; fields keep normal chrome, suppress editing/focus/clear, keep VoiceOver value. Infra PR + per-field adoption PRs. | verified absent (repo grep 2026-07-10) |
+| E2 | **Required indicator — 8 components** | `.required()` only on TextInput (:485), MultiLineTextInput (:227), ControlRow (:153). Missing: Select, SelectBox, DateField, TimeField, InputNumber, OTPInput, RadioGroup, CheckboxGroup — all already render `InputLabel`-style headers that support `.required(_:)` (`InputLabel.swift:53`). | HeroUI `isRequired`; Ant Form required mark. | **P1** | Same `required(_ on: Bool = true)` modifier per component → forward to `InputLabel`; honor `FieldDefaults.requiredIndicator` (F4) from day one. | verified per component (`grep "func required"`) |
+| E3 | **`.validate` rollout — 6 components** | The `ValidationRule` engine exists and is wired only into TextInput (`TextInput.swift:528-541`). OTPInput, InputNumber, DateField, TimeField, Autocomplete, PaymentCardField expose `errorText`/`infoMessages` but no `.validate(_:on:)`. | Ant Form rules per field; HeroUI `validate`. | P2 | `func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self` per component, reusing the TextInput plumbing. (Deliberately deferred earlier as design-intensive — schedule as feature work, wave 3.) | `Molecules/TextInput.swift:528-541`; absence verified in each file's surface |
+| E4 | **Checkbox** | No `lineThrough` label treatment when checked. | HeroUI Checkbox `lineThrough`. | P2 | `func lineThrough(_ on: Bool = true) -> Self` → `.strikethrough(isChecked)`. | `Molecules/Checkbox.swift:93-97` |
+| E5 | **RadioGroup / CheckboxGroup** | Group-level `title` ✓ (`RadioGroup.swift:48-54`), `infoMessages` ✓, but no group-level `description`. | Ant/HeroUI group `description`. | P2 | `func description(_ text: String?) -> Self` → `HelperText` under the title. | `RadioGroup.swift:51-56`; `CheckboxGroup.swift:60-65` |
+| E6 | **Autocomplete** | No `clearable`, no `loading`, no validation axes (surface: `placeholder/maxResults/debounce/suggestionEnabled/onSearch/a11yID`). | Ant AutoComplete `allowClear/status`; HeroUI Autocomplete `isClearable/isLoading/isInvalid`. | P2 | `clearable(_:)` + `loading(_:)` + `infoMessages(_:)` — copy Select's implementations (`Select.swift:309-321`). | `Molecules/Autocomplete.swift:307-313` (surface) |
+| E7 | **Cascader** | Only `placeholder/changeOnSelect`. No `searchable`, `clearable`, `optionEnabled`, validation. | Ant Cascader `showSearch/allowClear/disabled options/status` (verified pattern from Select API). | P2 | Port the Select/TreeSelect axes: `searchable(_:)`, `clearable(_:)`, `nodeEnabled(_:)`, `infoMessages(_:)`. | `Molecules/Cascader.swift:327-328` (surface) |
+| E8 | **Transfer** | Only `titles(_:_:)`. No per-list search, no item-disable predicate. | Ant Transfer `showSearch`, `disabled`, per-item disable. | P2 | `searchable(_:)` + `itemEnabled(_ predicate:)` (kit-standard `isOptionEnabled` idiom). | `Molecules/Transfer.swift:852` (surface) |
+| E9 | **ToggleGroup** | Only `optionDescription/a11yID`. Missing `optionEnabled` (CheckboxGroup has it), `accent`, `axis`. | Ant/HeroUI group axes. | P2 | Port the three standard group modifiers. | `Molecules/ToggleGroup.swift:845-846` (surface) |
+| E10 | **MultiLineTextInput** | Missing `helperText(_:)` and `warningText(_:)` — TextInput has both (:511, :517); the two text editors have asymmetric message APIs. | Ant TextArea shares Input's API. | P2 | Add both modifiers routing through the same `HelperText`/`InfoMessageList` path. | `Molecules/MultiLineTextInput.swift:507-516` (surface; absence verified) |
+| E11 | **InputNumber** | `Int`-only binding — no decimal values, no `precision`/`formatter`. | Ant InputNumber: decimal + `precision/formatter/parser`. | P2 | `InputNumber<V: BinaryFloatingPoint>` overload or a `Decimal` init + `func precision(_ digits: Int) -> Self`; keep Int init. | `Molecules/InputNumber.swift:470-479` (surface) |
+| E12 | **Rating** | No clear-on-re-tap. | Ant Rate `allowClear` (tap current value → 0). | P2 | `func allowClear(_ on: Bool = true) -> Self`. | `Atoms/Rating.swift:190-199` (surface) |
+| E13 | **MultiSelect** | `maxTags` caps the *display*; no selection-count limit. | Ant Select `maxCount` (verified API). | P2 | `func maxSelection(_ count: Int?) -> Self` — disable unselected options at the cap. | `Molecules/MultiSelect.swift:525` |
+| E14 | **Tag** | No `closable/onClose` — FilterChip has `closable` (`Molecules/Chips.swift:351`), Tag needs the `.trailing{}` slot hand-rolled. | Ant Tag `closable + onClose`. | P2 | `func closable(_ onClose: @escaping () -> Void) -> Self` rendering the kit `CloseButton`. | `Atoms/Tag.swift:262-269` (surface) |
+| E15 | **Avatar** | No border ring axis. | HeroUI `isBordered`; Ant Avatar ring via style. | P2 | `func bordered(_ on: Bool = true, accent: SemanticColor? = nil) -> Self` (token stroke). | `Atoms/Avatar.swift:14-25` (surface) |
+| E16 | **Splitter** | Horizontal only (`bounds(min:max:)` is the whole surface). | Ant Splitter supports vertical layout + collapsible panels. | P2 | `func vertical(_ on: Bool = true) -> Self` (kit-standard axis name, cf. Space/Flex); optional `collapsible(_:)`. | `Molecules/Splitter.swift:758` (surface) |
+
+---
+
+## F. Provider / defaults incompleteness
+
+| # | Surface | Gap | Reference | Sev | API to add | Source |
+|---|---|---|---|---|---|---|
+| F1 | **FeedbackDefaults** | 3 knobs only. Hardcoded in the host: **edge offset** (`.padding(.md)` :504 — Ant `top/bottom: 24` config), **inter-toast spacing** (`VStack(spacing: .sm)` :490), **insert/remove animation** (`Motion.base.spring` :414), **swipe-to-dismiss** always-on, fixed 60/120pt (:559-563), **no pause-on-drag** (auto-dismiss `.task` keeps running mid-swipe :567-572 — Ant `pauseOnHover: true` default), **no timeout progress** (Ant `showProgress`), **no haptic on show** (zero `Haptics` calls in Feedback.swift), **notification layer pinned `.top`** (:409). | Ant `notification.config({placement, top/bottom, duration, maxCount, showProgress, pauseOnHover})` — verified; HeroUI ToastProvider (`toastOffset`, `disableAnimation`, `shouldShowTimeoutProgress`). | **P1** | Extend `FeedbackDefaults` (optional fields, existing merge semantics): `toastOffset: Theme.SpacingKey?`, `toastSpacing: Theme.SpacingKey?`, `toastMotion: Motion?`, `swipeToDismiss: Bool?`, `showsTimeoutProgress: Bool?`, `hapticsOnShow: Bool?`, `notificationPosition: ToastPosition?`. Pause-on-drag is a bug-grade fix regardless. | `Organisms/FeedbackDefaults.swift:29-36`; `Organisms/Feedback.swift:414, 490, 504, 559-572, 409` |
+| F2 | **ToastPosition** | `case top, bottom` only. | Ant: 6 placements (verified); HeroUI: 6. | P2 | Additive logical cases (`.topLeading/.topTrailing/.bottomLeading/.bottomTrailing`) → overlay alignments; RTL-safe names. | `Organisms/Feedback.swift:74` |
+| F3 | **ComponentDefaults adoption** | Consumed by only **5 travel organisms** (RoomCard, StickyBookingBar, PriceAlertCard, AncillaryCard, AgentPriceRow — repo grep). Core ignores it: ThemeButton hardcodes `color = .primary` (:34) and shape radius (:187); Card/Chip/Badge likewise. "Set the app accent once" doesn't re-tint the button family. | Ant `ConfigProvider` / `HeroUIProvider` cascade everywhere. | **P1** | Resolve `explicit ?? componentDefaults.accent ?? .primary` (5-organism precedent) in ThemeButton, Chip, Badge, Card, FloatingActionButton, SegmentedControl. PR per component. | `ComponentDefaults.swift:18-27`; `ThemeButton.swift:34, 187` |
+| F4 | **FieldDefaults.requiredIndicator** | Honored only by TextInput + MultiLineTextInput (repo grep); ControlRow renders the asterisk directly and ignores the default. | Provider defaults apply uniformly. | P2 | Read `\.fieldDefaults.requiredIndicator` in ControlRow + all E2 adopters. | `ControlRow.swift:70-71` |
+| F5 | **FieldDefaults breadth** | Only `size/messagesAnimated/requiredIndicator`. No subtree default for `clearable` or `ValidationTrigger`. (Field *variant* is already covered by `.fieldStyle(_:)` env ✓ — Ant Input `variant` maps to Default/Muted/Underlined FieldStyles, `FieldStyle.swift:138-151`.) | Ant ConfigProvider input config. | P2 | `clearable: Bool?`, `validationTrigger: ValidationTrigger?` with the existing merge pattern. | `FieldDefaults.swift:24-44` |
+| F6 | **Feedback barriers vs Backdrop** | Loading/confirm scrims are raw `bgTertiary.opacity(0.3/0.4)` — not the shared `Backdrop` atom / `bgBackdrop` token from infra unit 2; two backdrop colors in one host, neither themable. | Provider-level overlay consistency. | P2 | Replace both with `Backdrop`. | `Organisms/Feedback.swift:429, 512` |
+
+---
+
+## G. A11y / RTL / Dynamic Type / token hygiene
+
+| # | Component | Gap | Sev | Fix | Source |
+|---|---|---|---|---|---|
+| G1 | **TextInput** | Field row pinned with raw `.frame(height: effectiveSize.height)` — clips floating label + value at accessibility type sizes. Its own family already uses `scaledControlHeight` (SearchBar :205, Select :143, DateField :143, SelectBox, Autocomplete, TreeSelect, MultiSelect, TimeField). | **P1** | One line: `.scaledControlHeight(effectiveSize.height)`. | `Molecules/TextInput.swift:329` |
+| G2 | **ColorField / FieldButton / Mentions** | Fixed unscaled heights (52 / 56–48 / 40pt); no `scaledControlHeight` or documented `dynamicTypeClamp` (OTPInput clamps correctly, `OTPInput.swift:136`). | P2 | `scaledControlHeight` — folds into their C1 size PRs. | `ColorField.swift:57`, `FieldButton.swift:63`, `Mentions.swift:72` |
+| G3 | **RTL-unmirrored glyphs** | `chevron.right/left`, `arrow.right` without `.mirrorsInRTL()`: `TreeView.swift:48`, `DatePriceStrip.swift:151,153`, `PriceTrendChart.swift:121,125`, `RecentSearchRow.swift:59` (its :97 chevron *does* mirror). Correct precedents: `Dropdown.swift:433`, `TreeSelect.swift:177`, `Pagination.swift:139`, `SearchBar.swift:148`, `SuggestionRow.swift:107`. | P2 | Add `.mirrorsInRTL()` at the 6 sites. | cited inline |
+| G4 | **A1 design note** | Leading-control ControlRow must keep the single-a11y-element contract (`.accessibilityHidden(true)` on the indicator, :80). | — | Folded into A1. | `ControlRow.swift:80` |
+| G5 | **Raw-Color/CGFloat modifier batch** (token-hygiene deprecations; each has or needs a token twin) | `Badge.badgeColor(_ Color?)` :207 + `gradient(_ [Color]?)` :209; `RadioButton.fillColor(_ Color?)` :184; `AmenityGrid.tint(_ Color?)` :128 (semantic twin at :129 ✓); `PriceHistogram.accent(_ Color?)` :106 (twin ✓); `EmptyState.iconForeground/Background(_ Color?)` :125,:127 (twins ✓); `Card.contentPadding(_ CGFloat)` :153 (no `SpacingKey` twin — SurfaceView has one, `Atoms/SurfaceView.swift:251`); `Checkbox.customSize(_ CGFloat)` :185 (documented escape hatch — keep); `LoyaltyCard.gradient(_ [Color]?)` (surface :1365). | P2 | Where a token twin exists: `@available(*, deprecated, message: "Use the token overload")`. Where missing (Card.contentPadding): add `contentPadding(_ key: Theme.SpacingKey)` first, then deprecate. One batch PR. | cited inline |
+
+---
+
+## Coverage Index — every component reviewed
+
+Legend: **✓** = surveyed, no gap worth opening (parity adequate for its role) ·
+**Gxx/…** = gap IDs above · *(support)* = models/style-protocol/layout file, no
+public component surface. Survey basis: full modifier-surface extraction (all files)
++ targeted deep reads.
+
+**Atoms (56):**
+AnimatedImage ✓ · Aura ✓ · Avatar E15 · Backdrop ✓ · Badge G5 · Barcode ✓ ·
+BorderBeam ✓ · Chip C3 · ChipStyle *(support)* · CloseButton ✓ · CodeBlock ✓ ·
+ColorSwatch ✓ · Confetti ✓ · CornerRadiusModifier *(support)* · CountBadge ✓ ·
+CountdownTimer ✓ · DividerView ✓ · FareFeatureRow ✓ · FlightStatusBadge ✓ ·
+GaugeView ✓ · HelperText B1 · Icon ✓ · IconTile G5-adjacent (CGFloat sizes; token
+twins exist) · Indicator ✓ · InlineText ✓ (the fix vehicle) · InputLabel B4 · Join ✓ ·
+Kbd ✓ · Mask ✓ · MeterStyle *(support)* · PointsBadge ✓ · PriceTag ✓ · ProgressBar ✓ ·
+QRCode ✓ · RadialProgress ✓ · Rating E12 · RemoteImage ✓ · RollingNumber ✓ ·
+ScoreBadge C5 · SearchBadge ✓ · SeatCell *(support)* · ShareButton ✓ · Skeleton ✓ ·
+SkeletonGroup ✓ · Spinner ✓ · StatusDot ✓ · SurfaceView ✓ · Swap ✓ · SwapButton ✓ ·
+Tag E14 · TextLink ✓ · TextRotate ✓ · TiltCard ✓ · Title ✓ · TrendChip ✓ (new #249) ·
+Watermark ✓
+
+**Molecules (104):**
+Affix ✓ · AmenityGrid G5 · AnchorNav ✓ · Autocomplete C1 E6 · Breadcrumbs ✓ ·
+ButtonGroup ✓ · Buttons/Buttons ✓ (presets; `helperText`+`confirmsSuccess` already
+rich) · Buttons/ButtonSize *(support)* · Buttons/ThemeButton A7 F3 ·
+CalendarView ✓ · CalendarYearPicker ✓ (new) · Cascader E7 · Charts/AreaChart ✓ (new) ·
+Charts/BarChart ✓ · Charts/ChartModels *(support)* · Charts/ChartSupport *(support)* ·
+Charts/DonutChart ✓ · Charts/LineChart ✓ · Checkbox A2 B8 C4 D1 E4 G5(customSize kept) ·
+CheckboxGroup A5 A6 E5 · Chips ✓ (FilterChip closable ✓, emptyContent slot ✓) ·
+ColorArea ✓ (new) · ColorField C1 G2 · ColorModels *(support)* · ColorSlider ✓ (new) ·
+ColorSwatchPicker ✓ (new) · ColumnsGrid ✓ · ControlRow A1 B1(consumer) E2✓(has) F4 ·
+CurrencyPicker ✓ · DateField C1 E2 E3 · DatePriceStrip G3 · Dropdown ✓ ·
+EmojiReactionButton D8 (new) · FieldButton C1 G2 · Fieldset ✓ · FieldStyle *(support;
+= Ant `variant` ✓)* · FileInput ✓ · FilterGroup ✓ · FilterRow ✓ · Flex ✓ ·
+FlightRoute ✓ · FlowLayout *(support)* · GuestSelector ✓ · HoverCard ✓ (new) ·
+InputNumber C2 E2 E3 E11 · InstallmentPicker ✓ · InstallmentSelector ✓ · LayoverRow ✓ ·
+MapPriceMarker ✓ · Masonry ✓ · Mentions C1 G2 · MultiLineTextInput E10 (size ✓) ·
+MultiSelect C1 E13 · OTPInput C1 E2 E3 · Pagination ✓ · PassengerRow ✓ ·
+PaymentCardField C1 E3 · PriceBreakdown ✓ · PriceHistogram G5 · PriceTrendChart G3 ·
+ProgressIndicator ✓ · QuantityStepper ✓ (thin but role-adequate; 44pt targets shipped) ·
+RadioButton A3 B8 D1 G5 · RadioGroup A4 B7 E5 · RangeSlider ✓ · RecentSearchRow G3 ·
+ScrollShadow ✓ · ScrubGallery ✓ · SearchBar C1 · SearchField ✓ (64pt exempt) ·
+SearchSummary ✓ · SeatLegend ✓ · SegmentedControl ✓ · Select E2 (size ✓ loading ✓) ·
+SelectBox C1 E2 · SelectStyle *(support)* · Slider ✓ · SmartSuggestion ✓ ·
+SortSummaryBar ✓ · Space ✓ · Splitter E16 · Stat ✓ · StatStyle *(support)* ·
+StepperRow ✓ · Steps C5 · SuggestionRow ✓ · TableCells *(support, new)* ·
+TextInput E1 G1 B1 (gold standard otherwise) · TextInputFormatter *(support)* ·
+ThemeContextMenu ✓ (new) · ThemeController ✓ · ThemeToggle ✓ · TimeField C1 E2 E3 ·
+ToggleGroup E9 · Tooltip B9 D2 · Transfer E8 · TreeSelect ✓ · TreeView G3 ·
+TripTypeToggle ✓ · ValidationRule *(support)*
+
+**Organisms (87):**
+Accordion ✓ · AccordionGroup ✓ · ActionBar ✓ (new) · Agenda ✓ (new) · AgentPriceRow ✓ ·
+AlertToast B5 · AnchoredPopover ✓ · AncillaryCard ✓ · BarStyle *(support)* · BlogCard ✓ ·
+BoardingPass ✓ · BottomSheet ✓ · BrowserFrame ✓ · ButtonDock ✓ · Callout B3 D3 ·
+Card G5 (contentPadding) · CardStack ✓ · CardStyle *(support)* · Carousel ✓ ·
+ChatBubble ✓ · ColorPickerPanel ✓ (new) · CommandPalette ✓ (new) · Counter ✓ · Coupon ✓ ·
+DataTable ✓ (row-selection/sort deliberately out of scope — tracked in
+HEROUI_NATIVE_AUDIT) · DestinationCard ✓ · Dialog ✓ · Diff ✓ · Drawer ✓ ·
+EmptyState B2 D4 G5 · FareFamilyCard ✓ · FareSummary ✓ · Feedback F1 F2 F6 B6 ·
+FeedbackDefaults F1 · FilterBar ✓ · FilterList ✓ · FlightCard ✓ · FlightListItem ✓ ·
+FlightListItemStyle *(support)* · FlightResultRow ✓ · FlightTicketCard ✓ ·
+FloatingActionButton F3 · Footer ✓ · Gallery ✓ · Hero ✓ · HotelResultCard ✓ ·
+ImageCollage ✓ · InfoBanner ✓ (the exemplar) · KanbanBoard D7 (new) · KeyValueTable ✓ ·
+ListRow ✓ · ListRowStyle *(support)* · ListView ✓ · LocationCard ✓ · LoyaltyCard G5 ·
+MapCallout ✓ · MenuCard ✓ · NavigationBar ✓ · NotificationCard D6 · PageHeader ✓ ·
+PageHeaderStyle *(support)* · PagingCarousel ✓ · PhoneFrame ✓ · Popconfirm ✓ ·
+PriceAlertCard ✓ · PromoBanner ✓ · RatingSummary ✓ · ResultView ✓ · ReviewCard ✓ ·
+RoomCard ✓ · SeatMap ✓ · SeatMapModels *(support)* · SegmentedTabBar ✓ ·
+SelectionCards ✓ · SheetHeader ✓ · Sidebar ✓ · StickyBookingBar ✓ · ThemePicker ✓ ·
+TicketStub ✓ · Timeline D5 · Toast ✓ · ToastStyle *(support)* · Tour ✓ · Upload ✓ ·
+VideoPlayerView ✓ · WindowFrame ✓
+
+---
+
+## Implementation waves (PR-sized, sequenced)
+
+Every unit: additive, copy-on-write, token-fed; verify via `#Preview` matrix +
+`xcrun simctl launch <bundle> -startTab 0 -openDemo "<Component>"`.
+
+### Wave 0 — Quick wins (7 tiny PRs, effort S each)
+1. **G1** TextInput `.scaledControlHeight` (1 line).
+2. **G3** RTL mirror batch (6 sites, 1 PR).
+3. **F1-bug** Toast pause-on-drag (`FeedbackToastRow`: suspend the `.task` timer while `dragProgress > 0`).
+4. **F4** ControlRow honors `fieldDefaults.requiredIndicator`.
+5. **F6** Feedback barriers → `Backdrop` atom.
+6. **A1** `ControlRow.controlPlacement(_: HorizontalEdge)`.
+7. **E10** MultiLineTextInput `helperText`/`warningText` parity.
+
+### Wave 1 — Field size unification (12 PRs, S–M each) — the P0
+`func size(_ s: TextInputSize) -> Self` + `scaledControlHeight` + `explicit ??
+fieldDefaults.size ?? default` on: SearchBar, DateField, TimeField, OTPInput,
+SelectBox, Autocomplete, FieldButton, ColorField, PaymentCardField, Mentions,
+MultiSelect, and **InputNumber** (C2, with deprecated `large()` shim). G2 folds in.
+
+### Wave 2 — Read-only axis (1 infra PR + ~12 adoption PRs, M) — the other P0
+ADR first (interaction with `.disabled`, focus, clear/reveal buttons, a11y traits),
+then `\.isReadOnly` + `.readOnly(_:)`, then adopt: TextInput, MultiLineTextInput,
+Select, SelectBox, DateField, TimeField, InputNumber, OTPInput, Checkbox,
+RadioButton, ThemeToggle, ControlRow.
+
+### Wave 3 — Required + validation completion (8 + 6 PRs, S each)
+**E2** `required(_:)` on Select, SelectBox, DateField, TimeField, InputNumber,
+OTPInput, RadioGroup, CheckboxGroup (each reading F4's default). **E3** `.validate`
+on OTPInput, InputNumber, DateField, TimeField, Autocomplete, PaymentCardField.
+
+### Wave 4 — Rich text links (1 atom PR + 6 adopter PRs, S each)
+**B1** `HelperText.links(_:)` first (free upgrade for TextInput/ControlRow), then
+B2 EmptyState, B3 Callout, B4 InputLabel, B5 AlertToast + B6 presenter forwarding,
+B7 RadioGroup-via-HelperText.
+
+### Wave 5 — Control placement + label slots (5 PRs, S–M)
+A2–A5 `controlPlacement(_:)` across Checkbox/RadioButton/RadioGroup/CheckboxGroup
+(+ A6 CheckboxGroup `.axis`), D1 `.label { }` slots, E4 `lineThrough`, E5 group
+descriptions, C4 glyph-size mapping — grouped per component.
+
+### Wave 6 — Provider expansion (3 PRs, M)
+**F1** FeedbackDefaults knobs + host plumbing (token-fed: `SpacingKey` offsets/gaps,
+`Motion` animation, Reduce-Motion-gated; haptics off by default). **F2** ToastPosition
+corner cases. **F5** FieldDefaults `clearable`/`validationTrigger`. Then **F3**
+ComponentDefaults adoption: ThemeButton, Chip, Badge, Card, FloatingActionButton,
+SegmentedControl (PR per component).
+
+### Wave 7 — Long-tail flexibility (batched small PRs, S each)
+A7 ThemeButton `spinnerPlacement` · D2 Tooltip content slot · D3 Callout slots ·
+D4 EmptyState `.actions{}` · D5 Timeline `.marker{}` · D6 NotificationCard `.action` ·
+D7 KanbanBoard axes · D8 EmojiReactionButton axes · E6 Autocomplete · E7 Cascader ·
+E8 Transfer · E9 ToggleGroup · E11 InputNumber decimals · E12 Rating `allowClear` ·
+E13 MultiSelect `maxSelection` · E14 Tag `closable` · E15 Avatar `bordered` ·
+E16 Splitter `vertical` · C3 Chip min-heights · C5 size-boolean deprecations.
+
+### Wave 8 — Token-hygiene deprecations (1 batch PR, S)
+**G5**: deprecate raw-`Color`/`CGFloat` twins toward token overloads; add the missing
+`Card.contentPadding(_ key: Theme.SpacingKey)` first.
+
+---
+
+*Audited 2026-07-10 against `main` @ `3cf0721`. All `file:line` references verified by
+direct read or extracted modifier-surface dump. Ant Design API tables for Input,
+Button, Select, notification fetched from ant.design 2026-07-10; HeroUI behavior from
+heroui.com / heroui.pro component APIs.*

--- a/Sources/ThemeKit/Components/Atoms/Avatar.swift
+++ b/Sources/ThemeKit/Components/Atoms/Avatar.swift
@@ -83,6 +83,8 @@ public struct Avatar: View {
     private var shape: AvatarShape = .circle
     private var presence: StatusKind?
     private var presencePulse: Bool = false
+    private var isBordered: Bool = false
+    private var borderAccent: SemanticColor?
 
     public init(_ content: AvatarContent) {   // R1 — content only
         self.content = content
@@ -130,6 +132,14 @@ public struct Avatar: View {
         }
         .frame(width: dim, height: dim)
         .clipShape(clip)
+        // Border ring (HeroUI `isBordered`): drawn after the clip so it sits on
+        // top of image content; token stroke — the semantic accent's solid when
+        // set, else the primary border token.
+        .overlay {
+            if isBordered {
+                clip.stroke(borderAccent?.solid ?? theme.border(.borderPrimary), lineWidth: 2)
+            }
+        }
         .overlay(alignment: .bottomTrailing) { presenceDot }
         // One element for VoiceOver; callers override with `.accessibilityLabel`.
         // The presence dot's spoken status survives the collapse as the value,
@@ -268,6 +278,14 @@ public extension Avatar {
     /// Circle (default) or rounded square.
     func shape(_ s: AvatarShape) -> Self { copy { $0.shape = s } }
 
+    /// Draws a token stroke ring around the avatar (HeroUI `isBordered`) —
+    /// e.g. to mark the active speaker or lift a photo off a busy surface.
+    /// `accent` tints the ring from the semantic palette; `nil` (default)
+    /// uses the primary border token.
+    func bordered(_ on: Bool = true, accent: SemanticColor? = nil) -> Self {
+        copy { $0.isBordered = on; $0.borderAccent = accent }
+    }
+
     /// Corner presence dot (online / away / busy …); `nil` hides it.
     func presence(_ kind: StatusKind?, pulse: Bool = false) -> Self {
         copy { $0.presence = kind; $0.presencePulse = pulse }
@@ -368,6 +386,13 @@ public extension AvatarGroup {
             Avatar(.initials("NE")).fill(.soft)   // no accent → neutral soft
             Avatar(.initials("SO")).accent(.success)   // solid, for contrast
         }
+        // Border ring: default border token, semantic accent, and on a photo.
+        HStack(spacing: 12) {
+            Avatar(.initials("BR")).bordered()
+            Avatar(.initials("AC")).accent(.success).fill(.soft).bordered(accent: .success)
+            Avatar(.remote(URL(string: "https://i.pravatar.cc/96"))).bordered(accent: .primary)
+            Avatar(.icon("person.fill")).shape(.square).bordered(accent: .warning)
+        }
         AvatarGroup([.initials("AB"), .initials("CD"), .initials("EF"), .icon("person.fill"), .initials("GH"), .initials("IJ")]).maxVisible(4)
         AvatarGroup([.initials("AB"), .initials("CD"), .initials("EF")]).accent(.info).fill(.soft)
         // a11y: each avatar is one VoiceOver element — initials are spoken when
@@ -386,6 +411,7 @@ public extension AvatarGroup {
         PreviewCase("Remote")   { Avatar(.remote(URL(string: "https://i.pravatar.cc/96"))) }
         PreviewCase("Remote fallback") { Avatar(.remote(URL(string: "https://invalid.invalid/broken.png"), fallback: .initials("FB"))).accent(.warning) }
         PreviewCase("Soft fill") { Avatar(.initials("SO")).accent(.success).fill(.soft) }
+        PreviewCase("Bordered") { Avatar(.initials("BR")).bordered(accent: .success) }
         PreviewCase("Group +N") { AvatarGroup([.initials("AB"), .initials("CD"), .initials("EF"), .initials("GH"), .initials("IJ")]).maxVisible(3) }
     }
 }

--- a/Sources/ThemeKit/Components/Atoms/Badge.swift
+++ b/Sources/ThemeKit/Components/Atoms/Badge.swift
@@ -205,7 +205,15 @@ public extension Badge {
     /// Overrides the text/foreground color (otherwise derived from style + variant).
     @available(*, deprecated, message: "Use badgeStyle(_:) with a semantic BadgeStyle (plus variant(_:)) instead of a raw color.")
     func badgeColor(_ color: Color?) -> Self { copy { $0.textColor = color } }
-    /// Fills the badge with a horizontal gradient instead of the style background.
+    /// Fills the badge with a horizontal gradient of semantic tokens (each
+    /// hue's solid shade) instead of the style background; `nil` restores it.
+    func gradient(_ colors: [SemanticColor]?) -> Self { copy { $0.gradient = colors?.map(\.solid) } }
+    /// Raw-color gradient (back-compat); prefer the token-bound overload.
+    /// Disfavored so member-shorthand literals like `[.purple, .pink]` —
+    /// valid as both `[Color]` and `[SemanticColor]` — resolve to the token
+    /// overload instead of being ambiguous.
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Use gradient(_: [SemanticColor]?) — the token-bound overload.")
     func gradient(_ colors: [Color]?) -> Self { copy { $0.gradient = colors } }
     /// Lifts the badge off the surface with a subtle drop shadow.
     func highlighted(_ on: Bool = true) -> Self { copy { $0.highlighted = on } }
@@ -238,6 +246,12 @@ private struct BadgeHighlight: ViewModifier {
             Badge("Medium").badgeStyle(.info).size(.medium)
             Badge("Large").badgeStyle(.info).size(.large)
             Badge("Rounded").badgeStyle(.success).badgeShape(.rounded)
+        }
+        // G5 — token gradient twin (solid shades of semantic hues); `.solid`
+        // variant keeps the on-solid foreground over the gradient fill.
+        HStack {
+            Badge("Pro").gradient([.purple, .pink]).variant(.solid)
+            Badge("Deal").gradient([.primary, .turquoise]).variant(.solid)
         }
     }
     .padding()

--- a/Sources/ThemeKit/Components/Atoms/Chip.swift
+++ b/Sources/ThemeKit/Components/Atoms/Chip.swift
@@ -7,18 +7,31 @@
 import SwiftUI
 
 public enum ChipSize {
-    case small, large
+    case small, medium, large
 
     var verticalPadding: CGFloat {
         switch self {
         case .small: return Theme.SpacingKey.sm.value   // 8
+        case .medium: return 10                          // ramp midpoint (no token between sm and 12)
         case .large: return 12
         }
     }
     var horizontalPadding: CGFloat {
         switch self {
         case .small: return 12
+        case .medium: return 14                          // ramp midpoint
         case .large: return Theme.SpacingKey.md.value   // 16
+        }
+    }
+    /// Enforced capsule min-height per tier (HeroUI Chip `sm/md/lg` fixed
+    /// heights) so mixed-content chips align on a row; `.large` reaches the
+    /// 44pt hit target. Applied via `scaledControlHeight`, so Dynamic Type
+    /// still grows the capsule instead of clipping.
+    var minHeight: CGFloat {
+        switch self {
+        case .small: return 36
+        case .medium: return 40
+        case .large: return 44
         }
     }
 }
@@ -115,13 +128,18 @@ public struct Chip: View {
             }
         }
         .frame(maxWidth: expandsHorizontally ? .infinity : nil)
+        // Enforce the tier's min-height from inside the style's padding, so the
+        // capsule (content + 2 × verticalPadding) lands on the ChipSize ramp
+        // (C3) — for custom `ChipStyle`s the content still carries the floor.
+        .scaledControlHeight(size.minHeight - size.verticalPadding * 2)
     }
 }
 
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension Chip {
-    /// Control size: small / large.
+    /// Control size: small / medium / large — drives paddings and the enforced
+    /// min-height ramp (36 / 40 / 44pt at the default text size).
     func size(_ s: ChipSize) -> Self { copy { $0.size = s } }
     /// How a selected chip is filled: tonal / solid. A shorthand for the
     /// built-in ``TonalChipStyle`` / ``SolidChipStyle`` — it overrides the
@@ -170,6 +188,13 @@ public extension Chip {
             Chip("Icon", isSelected: .constant(true)).icon("checkmark")
             Chip("Large", isSelected: .constant(false)).size(.large)
             Chip("Disabled", isSelected: .constant(false)).disabled(true)
+        }
+        // C3 — size ramp with enforced min-heights: mixed-content chips align.
+        HStack(alignment: .center) {
+            Chip("Small", isSelected: .constant(false)).size(.small)
+            Chip("Medium", isSelected: .constant(false)).size(.medium)
+            Chip("Medium + icon", isSelected: .constant(true)).size(.medium).icon("star")
+            Chip("Large", isSelected: .constant(false)).size(.large)
         }
         // Environment ChipStyle + slots: `.chipStyle(.solid)` on the container
         // resolves to `SolidChipStyle` via the `View` extension, so both chips

--- a/Sources/ThemeKit/Components/Atoms/HelperText.swift
+++ b/Sources/ThemeKit/Components/Atoms/HelperText.swift
@@ -32,6 +32,7 @@ public struct HelperText: View {
     private var hasError = false
     private var hidesOnError = false
     private var accessibilityID: String? = nil
+    private var links: [(substring: String, action: () -> Void)] = []
 
     public init(_ text: String) {   // R1 — content only
         self.text = text
@@ -40,14 +41,26 @@ public struct HelperText: View {
     public var body: some View {
         Group {
             if !(hasError && hidesOnError) {   // hidden so a field-error line can take its place
-                Text(text)
-                    .textStyle(.bodySm400)
-                    .foregroundStyle(color)
+                content
                     .a11y(A11yElement.Field.message, in: accessibilityID)
                     .transition(.opacity)
             }
         }
         .animation(motion, value: hasError)
+    }
+
+    /// Plain `Text` by default; `InlineText` when `.links(_:)` supplied a
+    /// substring→action map, so "agree to the *Terms*" copy can carry anchors.
+    @ViewBuilder private var content: some View {
+        if links.isEmpty {
+            Text(text)
+                .textStyle(.bodySm400)
+                .foregroundStyle(color)
+        } else {
+            InlineText(text, links: links)
+                .inlineStyle(.bodySm400)
+                .color(color)
+        }
     }
 
     private var color: Color {
@@ -66,6 +79,11 @@ public extension HelperText {
     /// Remove the helper text entirely while `hasError` is set, so a field-error
     /// line can take its place (maps HeroUI `hideOnInvalid`).
     func hidesOnError(_ on: Bool = true) -> Self { copy { $0.hidesOnError = on } }
+
+    /// Turn substrings of the text into inline tappable links (rendered via
+    /// `InlineText`) — e.g. `HelperText("Agree to the Terms").links([("Terms", open)])`.
+    /// (HeroUI/Ant descriptions are nodes; this is the string-surface idiom.)
+    func links(_ links: [(substring: String, action: () -> Void)]) -> Self { copy { $0.links = links } }
 
     /// Namespaced accessibility identifier for UI tests
     /// (the text gets `"<id>.message"`).

--- a/Sources/ThemeKit/Components/Atoms/InputLabel.swift
+++ b/Sources/ThemeKit/Components/Atoms/InputLabel.swift
@@ -16,6 +16,7 @@ public struct InputLabel: View {
     private var isRequired = false
     private var hasInfo = false
     private var hasError = false
+    private var links: [(substring: String, action: () -> Void)] = []
 
     private let text: String
 
@@ -25,9 +26,13 @@ public struct InputLabel: View {
 
     public var body: some View {
         HStack(spacing: 4) {
-            Text(text)
-                .textStyle(.labelSm600)
-                .foregroundStyle(textColor)
+            Group {
+                if links.isEmpty {
+                    Text(text).textStyle(.labelSm600).foregroundStyle(textColor)
+                } else {
+                    InlineText(text, links: links).inlineStyle(.labelSm600).color(textColor)
+                }
+            }
             if isRequired {
                 Text("*").textStyle(.labelSm600)
                     .foregroundStyle(isEnabled ? theme.foreground(.systemcolorsFgError) : theme.text(.textDisabled))
@@ -51,6 +56,10 @@ public struct InputLabel: View {
 public extension InputLabel {
     /// Append a required asterisk after the label text.
     func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
+
+    /// Turn substrings of the label into inline tappable links (rendered via
+    /// `InlineText`) — e.g. a labeled consent with a linked policy name.
+    func links(_ links: [(substring: String, action: () -> Void)]) -> Self { copy { $0.links = links } }
 
     /// Show a trailing info glyph.
     func hasInfo(_ on: Bool = true) -> Self { copy { $0.hasInfo = on } }

--- a/Sources/ThemeKit/Components/Atoms/Rating.swift
+++ b/Sources/ThemeKit/Components/Atoms/Rating.swift
@@ -30,6 +30,7 @@ public struct Rating: View {
     private var maxValue: Int = 5
     private var size: CGFloat = 16
     private var allowHalf: Bool = false
+    private var allowClear: Bool = false
     private var systemImage: String = "star"
     private var sentiment: String? = nil
     private var onRate: ((Double) -> Void)? = nil
@@ -196,10 +197,16 @@ public struct Rating: View {
     private func tapTargets(for index: Int) -> some View {
         HStack(spacing: 0) {
             Color.clear.contentShape(Rectangle())
-                .onTapGesture { onRate?(allowHalf ? Double(index) - 0.5 : Double(index)) }
+                .onTapGesture { rate(allowHalf ? Double(index) - 0.5 : Double(index)) }
             Color.clear.contentShape(Rectangle())
-                .onTapGesture { onRate?(Double(index)) }
+                .onTapGesture { rate(Double(index)) }
         }
+    }
+
+    /// Routes a tap through the clear-on-repeat rule: re-tapping the current
+    /// value resets to 0 when `allowClear` is on (Ant Rate `allowClear`).
+    private func rate(_ newValue: Double) {
+        onRate?(allowClear && value == newValue ? 0 : newValue)
     }
 
     private func color(for index: Int) -> Color {
@@ -229,6 +236,10 @@ public extension Rating {
     func starSize(_ points: CGFloat) -> Self { copy { $0.size = points } }
     /// Enables half-step interaction (and half-star tap targets).
     func allowHalf(_ on: Bool = true) -> Self { copy { $0.allowHalf = on } }
+    /// Re-tapping the current value clears the rating to 0 (Ant Rate
+    /// `allowClear`) — interactive star layout only; VoiceOver users reach 0
+    /// through the adjustable decrement as before.
+    func allowClear(_ on: Bool = true) -> Self { copy { $0.allowClear = on } }
     /// Overrides the SF Symbol used for the glyph (default "star").
     func symbol(_ systemImage: String) -> Self { copy { $0.systemImage = systemImage } }
     /// Sentiment word for the `.rateNumberText` layout (otherwise score-derived).
@@ -253,6 +264,7 @@ public extension Rating {
                 Rating(value: 4.3).countLabel("(128)")                                   // continuous fill
                 Rating(value: 4.3).layout(.numberRate).countLabel("1,284 reviews").onReviewTap {}  // numeric + tappable review
                 Rating(value: v).allowHalf().onRate { v = $0 }                            // interactive
+                Rating(value: v).allowClear().onRate { v = $0 }                           // re-tap current value → 0
                 Rating(value: 3).symbol("heart")
             }
             .padding()

--- a/Sources/ThemeKit/Components/Atoms/RollingNumber.swift
+++ b/Sources/ThemeKit/Components/Atoms/RollingNumber.swift
@@ -52,7 +52,12 @@ public extension RollingNumber {
 
     /// Raw digit color override (back-compat); prefer `accent(_:)`.
     @available(*, deprecated, message: "Use accent(_:) with a SemanticColor token.")
-    func color(_ c: Color?) -> Self { copy { $0.color = c } }
+    func color(_ c: Color?) -> Self { colorOverride(c) }
+
+    /// Module-internal raw digit color (mirrors `Icon.colorOverride`), so
+    /// in-package call sites needing a theme-token `Color` stay off the
+    /// deprecated `color(_:)` without changing behavior.
+    internal func colorOverride(_ c: Color?) -> Self { copy { $0.color = c } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self

--- a/Sources/ThemeKit/Components/Atoms/ScoreBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/ScoreBadge.swift
@@ -6,6 +6,12 @@
 
 import SwiftUI
 
+/// Size tiers for ``ScoreBadge`` — the kit's uniform size-enum vocabulary
+/// (replaces the boolean `large()` toggle, C5).
+public enum ScoreBadgeSize: Sendable {
+    case small, large
+}
+
 /// Atom. A numeric rating score in a filled rounded box (e.g. "9.0").
 public struct ScoreBadge: View {
     @Environment(\.theme) private var theme
@@ -13,12 +19,12 @@ public struct ScoreBadge: View {
     private let score: Double
 
     // Appearance — mutated only through the modifiers below (R2).
-    private var large: Bool
+    private var size: ScoreBadgeSize
     private var accent: SemanticColor?
 
     public init(_ score: Double, large: Bool = false) {
         self.score = score
-        self.large = large
+        self.size = large ? .large : .small
     }
 
     /// Fill — the accent's solid role when set, else the stock turquoise token.
@@ -26,12 +32,14 @@ public struct ScoreBadge: View {
     /// Content on the fill — auto-contrasting on a custom accent.
     private var content: Color { accent.map { $0.onSolid } ?? theme.foreground(.fgSecondary) }
 
+    private var isLarge: Bool { size == .large }
+
     public var body: some View {
         Text(String(format: "%.1f", score))
-            .textStyle(large ? .labelMd700 : .labelSm700)
+            .textStyle(isLarge ? .labelMd700 : .labelSm700)
             .foregroundStyle(content)
-            .padding(.horizontal, large ? Theme.SpacingKey.sm.value : Theme.SpacingKey.xs.value)
-            .frame(minWidth: large ? 40 : 32, minHeight: large ? 32 : 24)
+            .padding(.horizontal, isLarge ? Theme.SpacingKey.sm.value : Theme.SpacingKey.xs.value)
+            .frame(minWidth: isLarge ? 40 : 32, minHeight: isLarge ? 32 : 24)
             .background(fill,
                        in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous))
             // Give the bare number context: VoiceOver reads "Score: 9.0".
@@ -44,8 +52,11 @@ public struct ScoreBadge: View {
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension ScoreBadge {
-    /// Larger box + type — the chainable twin of the init's `large:` flag.
-    func large(_ on: Bool = true) -> Self { copy { $0.large = on } }
+    /// Size tier: small (default) / large — the kit's uniform size-enum axis.
+    func size(_ s: ScoreBadgeSize) -> Self { copy { $0.size = s } }
+    /// Larger box + type — the boolean twin of the init's `large:` flag.
+    @available(*, deprecated, message: "Use size(_:) with a ScoreBadgeSize.")
+    func large(_ on: Bool = true) -> Self { size(on ? .large : .small) }
     /// Token-fed fill override (content auto-contrasts); `nil` keeps the
     /// stock turquoise token.
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
@@ -63,7 +74,7 @@ public extension ScoreBadge {
         ScoreBadge(8.5)
         ScoreBadge(9.8, large: true)
         ScoreBadge(7.4).accent(.warning)
-        ScoreBadge(9.2).large().accent(.success)
+        ScoreBadge(9.2).size(.large).accent(.success)   // C5 — size enum axis
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Atoms/Tag.swift
+++ b/Sources/ThemeKit/Components/Atoms/Tag.swift
@@ -26,6 +26,7 @@ public struct Tag: View {
     private var size: ChipSize = .small
     private var leadingSlot: AnyView?
     private var trailingSlot: AnyView?
+    private var onClose: (() -> Void)?
 
     @Environment(\.theme) private var theme
 
@@ -52,6 +53,17 @@ public struct Tag: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel(String(themeKit: "Remove \(text)"))
             }
+            if let onClose {
+                // The kit CloseButton atom (Ant Tag `closable` + `onClose`).
+                // Its 44pt hit slop is bigger than the tag: the fixed frame
+                // clamps the *visual* footprint to the mini/small circle while
+                // the hit target overflows the capsule (nothing clips it).
+                CloseButton(action: onClose)
+                    .plain()
+                    .controlSize(size == .small ? .mini : .small)
+                    .frame(width: closeButtonSide, height: closeButtonSide)
+                    .accessibilityLabel(String(themeKit: "Remove \(text)"))
+            }
         }
         .foregroundStyle(foreground)
         .padding(.horizontal, horizontalPadding)
@@ -76,6 +88,9 @@ public struct Tag: View {
     // Fixed glyph constants for the icon/remove shorthands (no semantic token).
     private var iconGlyphSize: CGFloat { size == .small ? 12 : 14 }
     private var removeGlyphSize: CGFloat { size == .small ? 10 : 12 }
+    /// Visual side of the composed `CloseButton` — matches its mini/small
+    /// circle diameters so the capsule stays tag-sized.
+    private var closeButtonSide: CGFloat { size == .small ? 24 : 28 }
 
     private var foreground: Color {
         if let semantic {
@@ -153,6 +168,13 @@ public extension Tag {
 
     /// Add a hairline border to a soft/solid tag (Ant `bordered`). Outline is always bordered.
     func bordered(_ on: Bool = true) -> Self { copy { $0.bordered = on } }
+
+    /// Make the tag removable, appending the kit ``CloseButton`` after the
+    /// text/trailing slot (Ant Tag `closable` + `onClose`) — the modifier twin
+    /// of the `onRemove:` init argument, rendering the standard dismiss atom
+    /// (muted glyph + full hit slop) instead of the bare glyph. Pairs best
+    /// with the soft / outline variants, where the muted glyph stays legible.
+    func closable(_ onClose: @escaping () -> Void) -> Self { copy { $0.onClose = onClose } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -241,6 +263,12 @@ public extension CheckableTag {
             Tag("Boosted").leading { Image(systemName: "sparkles").font(.system(size: 12)) }
             Tag("Deploys", onRemove: {}).trailing { Text("12").textStyle(.labelSm700) }
         }
+        // Closable: the kit CloseButton atom (vs the bare onRemove glyph).
+        HStack {
+            Tag("Filter").closable {}
+            Tag("Nonstop").tagStyle(.info).closable {}
+            Tag("Large").size(.large).closable {}
+        }
         CheckableTagRow()
     }
     .padding()
@@ -266,6 +294,7 @@ private struct CheckableTagRow: View {
         PreviewCase("Large")     { Tag("Filter", onRemove: {}).size(.large) }
         PreviewCase("Leading slot")  { Tag("Online").leading { StatusDot(.online) } }
         PreviewCase("Trailing slot") { Tag("Deploys", onRemove: {}).trailing { Text("12").textStyle(.labelSm700) } }
+        PreviewCase("Closable (CloseButton)") { Tag("Filter").closable {} }
         PreviewCase("Long text") { Tag("a-very-long-keyword-value-here") }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
+++ b/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
@@ -19,7 +19,9 @@ public struct Autocomplete: View {
     @Environment(\.theme) private var theme
     /// The field chrome (fill + border), swappable via `.fieldStyle(_:)`.
     @Environment(\.fieldStyle) private var fieldStyle
-
+    @Environment(\.fieldDefaults) private var fieldDefaults
+    /// Read-only subtree axis (set with `.readOnly(_:)`) — normal chrome, no editing.
+    @Environment(\.isReadOnly) private var isReadOnly
 
     /// Where suggestions come from.
     private enum Source {
@@ -41,6 +43,24 @@ public struct Autocomplete: View {
     private var isSuggestionEnabled: ((String) -> Bool)? = nil
     private var onSearch: ((String) -> Void)? = nil
     private var accessibilityID: String? = nil
+    /// Clear affordance — on by default (Autocomplete's classic behavior);
+    /// `.clearable(false)` hides it (Select-parity axis, E6).
+    private var allowClear = true
+    /// Caller-driven loading state (async option fetch outside the built-in provider).
+    private var externalLoading = false
+    private var infoMessages: [InfoMessage] = []
+    /// Explicit `.size(_:)` preset — wins over the subtree `FieldDefaults.size`.
+    private var explicitSize: TextInputSize?
+    /// `.required()` — asterisk on the label + ", required" in the a11y label.
+    private var isRequired = false
+
+    // Declarative validation (daisyUI Validator) — TextInput's plumbing: rules
+    // run against the bound text at `validationTrigger`; failures merge into
+    // the rendered messages, driving the border state automatically.
+    private var validationRules: [ValidationRule] = []
+    private var validationTrigger: ValidationTrigger = .editingEnd
+    private var onValidation: ((Bool) -> Void)?
+    @State private var validationMessages: [InfoMessage] = []
 
     @FocusState private var isFocused: Bool
     @State private var results: [String] = []
@@ -85,23 +105,62 @@ public struct Autocomplete: View {
     private func suggestionEnabled(_ suggestion: String) -> Bool { isSuggestionEnabled?(suggestion) ?? true }
 
     private var showsDropdown: Bool {
-        isFocused && !text.isEmpty && (isLoading || !results.isEmpty || isEmptyResult)
+        isFocused && !isReadOnly && !text.isEmpty && (isLoading || !results.isEmpty || isEmptyResult)
     }
 
     private var isEmptyResult: Bool { !isLoading && results.isEmpty }
 
+    /// Explicit `infoMessages(_:)` plus any current `validate(_:on:)` failures.
+    private var messages: [InfoMessage] { infoMessages + validationMessages }
+    private var dominant: InfoMessage.Kind? { messages.dominantKind }
+    private var hasError: Bool { dominant == .error }
+    private var hasWarning: Bool { dominant == .warning }
+    /// Explicit `.size(_:)` → subtree `FieldDefaults.size` → the classic scaled 48pt.
+    private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }
+    /// Whether `.required()` renders its asterisk (`FieldDefaults.requiredIndicator`;
+    /// the accessibility ", required" suffix is unaffected).
+    private var showsRequiredIndicator: Bool { fieldDefaults.requiredIndicator ?? true }
+    private var showsSpinner: Bool { isLoading || externalLoading }
+    private var showsClear: Bool { allowClear && !text.isEmpty && isEnabled && !isReadOnly }
+    private var a11yLabel: String {
+        let base = label ?? placeholder
+        return isRequired ? base + ", " + String(themeKit: "required") : base
+    }
+
+    /// Runs the declared rules (first failure only, via `Validator`);
+    /// publishes the result and reports validity.
+    private func runValidation(_ value: String) {
+        guard !validationRules.isEmpty else { return }
+        let failures = Validator.validate(value, validationRules)
+        if failures != validationMessages { validationMessages = failures }
+        onValidation?(!failures.contains { $0.kind == .error })
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
-            if let label { InputLabel(label) }
+            if let label { InputLabel(label).required(isRequired && showsRequiredIndicator).hasError(hasError) }
 
             fieldBox
 
             if showsDropdown { dropdown }
+
+            if !messages.isEmpty {
+                InfoMessageList(messages)
+                    .a11y(A11yElement.Field.message, in: accessibilityID)
+            }
         }
         .onAppear { update(for: text) }
         .onDebouncedChange(of: text, for: debounce) { value in
             update(for: value)
             onSearch?(value)
+        }
+        // `.live` validates every change; other triggers re-validate once a
+        // failure is visible so the error clears as the user fixes it.
+        .onChange(of: text) { _, value in
+            if validationTrigger == .live || !validationMessages.isEmpty { runValidation(value) }
+        }
+        .onChange(of: isFocused) { _, now in
+            if !now, validationTrigger == .editingEnd { runValidation(text) }   // validate on blur
         }
     }
 
@@ -114,39 +173,46 @@ public struct Autocomplete: View {
             TextField(placeholder, text: $text)
                 .textStyle(.bodyBase400)
                 .foregroundStyle(theme.text(.textPrimary))
-                .tint(theme.foreground(.fgHero))
+                // Caret / selection tint follows the validation state.
+                .tint(theme.foreground(hasError ? .systemcolorsFgError : .fgHero))
                 .focused($isFocused)
                 .disabled(!isEnabled)
+                // Read-only keeps the normal chrome + VoiceOver value but
+                // blocks focus/editing (E1 — distinct from `.disabled`).
+                .allowsHitTesting(!isReadOnly)
+                .onSubmit { runValidation(text) }   // submit is the strongest trigger
                 .a11y(A11yElement.Field.field, in: accessibilityID)
-                .accessibilityLabel(label ?? placeholder)
-            if isLoading {
+                .accessibilityLabel(a11yLabel)
+            if showsSpinner {
                 Spinner().size(IconSize.sm.value).lineWidth(2)
-            } else if !text.isEmpty {
+            } else if showsClear {
                 Button { text = "" } label: {
                     Icon(systemName: "xmark.circle.fill").size(.sm).color(theme.text(.textTertiary))
                 }
                 .buttonStyle(.plain)
+                .a11y(A11yElement.Field.clear, in: accessibilityID)
+                .accessibilityLabel(String(themeKit: "Clear"))
             }
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
-        .scaledControlHeight(48)
+        .scaledControlHeight(effectiveSize?.height ?? 48)
     }
 
     /// The field row wrapped in the active ``FieldStyle`` chrome (fill + border).
     /// Configuration mapping: `isFocused` ← the field's `@FocusState`;
-    /// `isEnabled` ← `\.isEnabled`; `hasError` / `hasWarning` are `false`
-    /// (Autocomplete has no validation concept); `size` is `.medium` —
-    /// Autocomplete has no `TextInputSize` axis (its fixed 48pt control height
-    /// lives in the content and matches no preset).
+    /// `isEnabled` ← `\.isEnabled`; `hasError` / `hasWarning` follow the dominant
+    /// message kind (explicit `infoMessages` + validation failures). With no
+    /// explicit `.size(_:)` and no subtree `FieldDefaults.size` the height stays
+    /// the classic scaled 48pt (nominal `.medium`), carried by the content.
     @ViewBuilder
     private var fieldBox: some View {
         fieldStyle.makeBody(configuration: FieldStyleConfiguration(
             content: AnyView(fieldCore),
             isFocused: isFocused,
             isEnabled: isEnabled,
-            hasError: false,
-            hasWarning: false,
-            size: .medium
+            hasError: hasError,
+            hasWarning: hasWarning,
+            size: effectiveSize ?? .medium
         ))
     }
 
@@ -239,6 +305,39 @@ public extension Autocomplete {
     /// Fires with the query text on each (debounced) change.
     func onSearch(_ action: ((String) -> Void)?) -> Self { copy { $0.onSearch = action } }
 
+    /// Control-height preset. An explicit size wins over the subtree
+    /// `FieldDefaults.size` default (`explicit ?? fieldDefaults.size ?? 48pt`).
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
+
+    /// Show a trailing clear button while the field has text (on by default —
+    /// Autocomplete's classic behavior; pass `false` to hide it).
+    func clearable(_ on: Bool = true) -> Self { copy { $0.allowClear = on } }
+
+    /// Shows a loading spinner in place of the clear button (caller-driven
+    /// async option fetch; the built-in async provider spins automatically).
+    func loading(_ on: Bool = true) -> Self { copy { $0.externalLoading = on } }
+
+    /// Validation / info messages rendered under the field (drives the border state).
+    func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }
+
+    /// Marks the field required: an error-token asterisk on the label (honoring
+    /// `FieldDefaults.requiredIndicator`) and ", required" in the a11y label.
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
+
+    /// Declarative validation (daisyUI Validator): `rules` run against the bound
+    /// text at `trigger` (`.editingEnd` on blur, `.live` per keystroke, `.submit`
+    /// on return). Failures merge into the rendered messages and border state.
+    ///
+    ///     Autocomplete("City", text: $city, suggestions: cities)
+    ///         .validate([.required(), .minLength(2)])
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
+        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    }
+
+    /// Reports validity after each `validate(_:on:)` pass — `true` when no
+    /// error-severity failure is present.
+    func onValidation(_ handler: @escaping (Bool) -> Void) -> Self { copy { $0.onValidation = handler } }
+
     /// Sets the accessibility-identifier namespace for this component (its
     /// sub-elements get `"<id>.<element>"`).
     func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
@@ -254,14 +353,27 @@ public extension Autocomplete {
     struct Demo: View {
         @State var text = ""
         @State var underlined = ""
+        @State var validated = ""
+        let cities = ["Istanbul", "Izmir", "Izmit", "Ankara", "Antalya", "Bursa"]
         var body: some View {
             VStack(spacing: 16) {
-                Autocomplete("Destination", text: $text,
-                             suggestions: ["Istanbul", "Izmir", "Izmit", "Ankara", "Antalya", "Bursa"])
+                Autocomplete("Destination", text: $text, suggestions: cities)
                 // Same field, underlined chrome via the ambient FieldStyle.
-                Autocomplete("Destination", text: $underlined,
-                             suggestions: ["Istanbul", "Izmir", "Izmit", "Ankara", "Antalya", "Bursa"])
+                Autocomplete("Destination", text: $underlined, suggestions: cities)
                     .fieldStyle(.underlined)
+                // Required + validation + loading spinner (E6 axes).
+                Autocomplete("City", text: $validated, suggestions: cities)
+                    .required()
+                    .validate([.required(), .minLength(2)])
+                Autocomplete("Fetching", text: $text, suggestions: cities)
+                    .loading()
+                // Read-only: normal chrome + value, no editing or clear (E1).
+                Autocomplete("Origin (read-only)", text: .constant("Istanbul"), suggestions: cities)
+                    .readOnly()
+                // Size ramp — explicit `.size(_:)` wins over `FieldDefaults.size`.
+                Autocomplete("Small", text: $text, suggestions: cities).size(.small)
+                Autocomplete("Large", text: $text, suggestions: cities).size(.large)
+                    .clearable(false)
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
@@ -29,17 +29,27 @@ public enum ButtonShape: String, CaseIterable {
 public struct ThemeButton: View {
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
+    @Environment(\.componentDefaults) private var componentDefaults
 
     // Appearance/state — mutated only through the modifiers below (R2).
-    private var color: SemanticColor = .primary
+    /// Explicit `.color(_:)`; `nil` defers to the subtree `componentDefaults`
+    /// accent, then `.primary` (provider cascade, F3).
+    private var explicitColor: SemanticColor?
     private var variant: ButtonVariant = .solid
     private var size: ButtonSize = .medium
     private var shape: ButtonShape = .rounded
     private var isFullWidth = false
     private var isLoading = false
+    /// When set, `.loading(_:)` keeps the label and shows the spinner on this
+    /// edge instead of replacing the content (A7).
+    private var spinnerEdge: HorizontalEdge?
     private var leadingSystemImage: String?
     private var trailingSystemImage: String?
     private var accessibilityID: String?
+
+    /// The resolved semantic color: explicit modifier ?? subtree
+    /// `componentDefaults.accent` ?? `.primary`.
+    private var color: SemanticColor { explicitColor ?? componentDefaults.accent ?? .primary }
 
     private let title: String?
     private let action: () -> Void
@@ -118,17 +128,31 @@ public struct ThemeButton: View {
         }
     }
 
+    /// `true` while the spinner should render *alongside* the label
+    /// (`spinnerPlacement` set) instead of replacing it. Icon-only buttons
+    /// always replace — there is no label to keep.
+    private var spinnerInline: Bool { isLoading && spinnerEdge != nil && !isIconOnly }
+
+    /// The inline loading spinner, sized down to sit next to the label text.
+    private var inlineSpinner: some View {
+        ProgressView().tint(foreground).controlSize(.small)
+    }
+
     @ViewBuilder
     private var content: some View {
-        if isLoading {
+        if isLoading && !spinnerInline {
             ProgressView().tint(foreground)
         } else if let customLabel {
             // Slot content gets the same environment the built-in label gets:
             // the size's type ramp (child Texts inherit the font) and — via the
             // shared `.foregroundStyle(foreground)` applied in `body` — the
             // variant's token foreground.
-            customLabel
-                .textStyle(size.textStyle)
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                if spinnerInline && spinnerEdge == .leading { inlineSpinner }
+                customLabel
+                    .textStyle(size.textStyle)
+                if spinnerInline && spinnerEdge == .trailing { inlineSpinner }
+            }
         } else if isIconOnly {
             // Icon-only: render the single provided glyph (leading takes
             // precedence), no label.
@@ -137,6 +161,7 @@ public struct ThemeButton: View {
             }
         } else {
             HStack(spacing: Theme.SpacingKey.xs.value) {
+                if spinnerInline && spinnerEdge == .leading { inlineSpinner }
                 if let leadingSystemImage {
                     Image(systemName: leadingSystemImage).font(.system(size: size.fontSize, weight: .semibold))
                 }
@@ -149,6 +174,7 @@ public struct ThemeButton: View {
                 if let trailingSystemImage {
                     Image(systemName: trailingSystemImage).font(.system(size: size.fontSize, weight: .semibold))
                 }
+                if spinnerInline && spinnerEdge == .trailing { inlineSpinner }
             }
         }
     }
@@ -197,8 +223,10 @@ public extension ThemeButton {
     /// Visual treatment: solid / soft / outline / ghost / link.
     func variant(_ v: ButtonVariant) -> Self { copy { $0.variant = v } }
 
-    /// Semantic color token driving the fill/accent ladder (R4).
-    func color(_ c: SemanticColor) -> Self { copy { $0.color = c } }
+    /// Semantic color token driving the fill/accent ladder (R4). When not set,
+    /// the button reads the subtree ``ComponentDefaults`` accent (set once with
+    /// `.componentDefaults(accent:)`), falling back to `.primary`.
+    func color(_ c: SemanticColor) -> Self { copy { $0.explicitColor = c } }
 
     /// Control size: xxsmall … large.
     func size(_ s: ButtonSize) -> Self { copy { $0.size = s } }
@@ -209,8 +237,17 @@ public extension ThemeButton {
     /// Stretch to the available width.
     func fullWidth(_ on: Bool = true) -> Self { copy { $0.isFullWidth = on } }
 
-    /// Swap the label for a spinner and block taps while `on`.
+    /// Show the loading spinner and block taps while `on`. By default the
+    /// spinner replaces the label; combine with ``spinnerPlacement(_:)`` to
+    /// keep the label and show the spinner alongside it.
     func loading(_ on: Bool = true) -> Self { copy { $0.isLoading = on } }
+
+    /// Keep the label while loading and render the spinner beside it on the
+    /// given edge (HeroUI `spinnerPlacement="start"/"end"`; Ant Button
+    /// `loading: { icon }`). Without it, `.loading(_:)` swaps the whole label
+    /// for the spinner. Icon-only (circle/square) buttons always swap.
+    /// RTL-safe — `HorizontalEdge` follows the layout direction.
+    func spinnerPlacement(_ edge: HorizontalEdge) -> Self { copy { $0.spinnerEdge = edge } }
 
     /// Leading and/or trailing SF Symbol. On a circle/square button the leading
     /// glyph (or the trailing one if no leading) becomes the icon.
@@ -409,6 +446,21 @@ extension ButtonSize {
             }
             ThemeButton("Block button") {}.color(.primary).fullWidth()
             ThemeButton("Loading") {}.color(.primary).fullWidth().loading()
+
+            // spinnerPlacement: the label stays while loading (HeroUI
+            // spinnerPlacement / Ant loading.icon).
+            HStack {
+                ThemeButton("Saving") {}.loading().spinnerPlacement(.leading)
+                ThemeButton("Uploading") {}.variant(.soft).loading().spinnerPlacement(.trailing)
+            }
+
+            // ComponentDefaults cascade: no explicit .color(_:) → the subtree
+            // accent re-tints the button; an explicit color still wins.
+            HStack {
+                ThemeButton("Subtree accent") {}
+                ThemeButton("Explicit wins") {}.color(.error)
+            }
+            .componentDefaults(accent: .turquoise)
 
             // Custom label slot — icon + text + badge composition; inherits the
             // size's textStyle and the variant's foreground like the built-in label.

--- a/Sources/ThemeKit/Components/Molecules/Cascader.swift
+++ b/Sources/ThemeKit/Components/Molecules/Cascader.swift
@@ -29,54 +29,118 @@ public struct CascaderOption: Identifiable, Sendable {
 
 public struct Cascader: View {
     @Environment(\.theme) private var theme
+    @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
+    /// Read-only subtree axis (set with `.readOnly(_:)`) — normal chrome, no picking.
+    @Environment(\.isReadOnly) private var isReadOnly
 
     private let options: [CascaderOption]
     @Binding private var selection: [String]
     // Appearance — mutated only through the modifiers below.
     private var placeholder: String = String(themeKit: "Select")
     private var changeOnSelect = false
+    private var allowClear = false
+    private var isSearchable = false
+    private var isNodeEnabled: ((CascaderOption) -> Bool)?
+    private var infoMessages: [InfoMessage] = []
 
     @State private var open = false
     @State private var browse: [String] = []
+    @State private var query = ""
 
     public init(_ options: [CascaderOption], selection: Binding<[String]>) {   // R1
         self.options = options
         self._selection = selection
     }
 
+    private var dominant: InfoMessage.Kind? { infoMessages.dominantKind }
+    private var hasError: Bool { dominant == .error }
+    private var hasWarning: Bool { dominant == .warning }
+    private var showsClear: Bool { allowClear && !selection.isEmpty && isEnabled && !isReadOnly }
+    private func nodeEnabled(_ node: CascaderOption) -> Bool { isNodeEnabled?(node) ?? true }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             field
-            if open { columns }
+            if open { panel }
+            if !infoMessages.isEmpty { InfoMessageList(infoMessages) }
         }
         .animation(.snappy(duration: 0.2), value: open)
         .animation(.snappy(duration: 0.2), value: browse)
     }
 
+    /// Field border follows the dominant message kind, then the open state —
+    /// same token order as the shared `FieldStyle` chrome.
+    private var borderColor: Color {
+        if hasError { return theme.border(.systemcolorsBorderError) }
+        if hasWarning { return theme.border(.systemcolorsBorderWarning) }
+        return theme.border(open ? .borderHero : .borderPrimary)
+    }
+
     private var field: some View {
-        Button {
-            open.toggle()
-            if open { browse = selection }
-        } label: {
-            HStack(spacing: Theme.SpacingKey.sm.value) {
-                Text(pathLabel(selection) ?? placeholder)
-                    .textStyle(.bodyBase400)
-                    .foregroundStyle(selection.isEmpty ? theme.text(.textTertiary) : theme.text(.textPrimary))
-                Spacer(minLength: Theme.SpacingKey.sm.value)
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(theme.text(.textTertiary))
-                    .rotationEffect(.degrees(open ? 180 : 0))
+        ZStack(alignment: .trailing) {
+            Button {
+                // Read-only keeps the normal chrome + VoiceOver value but never
+                // opens the columns (E1 — distinct from `.disabled`).
+                guard !isReadOnly else { return }
+                open.toggle()
+                if open { browse = selection; query = "" }
+            } label: {
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    Text(pathLabel(selection) ?? placeholder)
+                        .textStyle(.bodyBase400)
+                        .foregroundStyle(selection.isEmpty ? theme.text(.textTertiary) : theme.text(.textPrimary))
+                    Spacer(minLength: Theme.SpacingKey.sm.value)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(showsClear ? .clear : theme.text(.textTertiary))
+                        .rotationEffect(.degrees(open ? 180 : 0))
+                }
+                .padding(.horizontal, Theme.SpacingKey.md.value)
+                .scaledControlHeight(44)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
+                .overlay(RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value)
+                    .strokeBorder(borderColor, lineWidth: open || hasError || hasWarning ? 2 : 1))
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, Theme.SpacingKey.md.value)
-            .frame(height: 44)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
-            .overlay(RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value)
-                .strokeBorder(theme.border(open ? .borderHero : .borderPrimary), lineWidth: open ? 2 : 1))
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .accessibilityValue(pathLabel(selection) ?? "")
+
+            if showsClear {
+                Button { selection = []; browse = [] } label: {
+                    Icon(systemName: "xmark.circle.fill").size(.sm).color(theme.text(.textTertiary))
+                }
+                .buttonStyle(.plain)
+                .padding(.trailing, Theme.SpacingKey.md.value)
+                .accessibilityLabel(String(themeKit: "Clear"))
+            }
         }
-        .buttonStyle(.plain)
+    }
+
+    /// The open dropdown: an optional search header (Ant `showSearch`), then
+    /// either the level columns or — while a query is typed — a flat list of
+    /// matched leaf paths.
+    private var panel: some View {
+        VStack(spacing: 0) {
+            if isSearchable {
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    Icon(systemName: "magnifyingglass").size(.sm).color(theme.text(.textTertiary))
+                    TextField(String(themeKit: "Search"), text: $query)
+                        .textStyle(.bodyBase400)
+                        .tint(theme.foreground(.fgHero))
+                }
+                .padding(.horizontal, Theme.SpacingKey.md.value)
+                .scaledControlHeight(44)
+                DividerView().size(.small)
+            }
+            if isSearchable && !query.isEmpty {
+                searchResults
+            } else {
+                columns
+            }
+        }
+        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value))
+        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value).strokeBorder(theme.border(.borderPrimary), lineWidth: 1))
     }
 
     private var columns: some View {
@@ -91,8 +155,6 @@ public struct Cascader: View {
             }
         }
         .frame(maxHeight: 220)
-        .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value))
-        .overlay(RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value).strokeBorder(theme.border(.borderPrimary), lineWidth: 1))
     }
 
     private func column(_ opts: [CascaderOption], level: Int) -> some View {
@@ -100,6 +162,7 @@ public struct Cascader: View {
             VStack(spacing: 0) {
                 ForEach(opts) { opt in
                     let onPath = level < browse.count && browse[level] == opt.value
+                    let enabled = nodeEnabled(opt)
                     Button { pick(opt, level: level) } label: {
                         HStack(spacing: Theme.SpacingKey.xs.value) {
                             Text(opt.label)
@@ -109,6 +172,7 @@ public struct Cascader: View {
                             if !opt.isLeaf {
                                 Image(systemName: "chevron.right").font(.system(size: 10, weight: .semibold))
                                     .foregroundStyle(theme.text(.textTertiary))
+                                    .mirrorsInRTL()
                             }
                         }
                         .padding(.horizontal, Theme.SpacingKey.sm.value)
@@ -118,10 +182,69 @@ public struct Cascader: View {
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .disabled(!enabled)
+                    .opacity(enabled ? 1 : 0.4)
                 }
             }
         }
         .frame(width: 150)
+    }
+
+    // MARK: Search (Ant `showSearch`)
+
+    /// Leaf paths whose joined label matches `query`, skipping any path that
+    /// crosses a `nodeEnabled(_:)`-disabled node.
+    private var matchedPaths: [[CascaderOption]] {
+        var out: [[CascaderOption]] = []
+        func walk(_ opts: [CascaderOption], _ prefix: [CascaderOption]) {
+            for opt in opts {
+                guard nodeEnabled(opt) else { continue }
+                let path = prefix + [opt]
+                if opt.isLeaf {
+                    let joined = path.map(\.label).joined(separator: " / ")
+                    if joined.localizedCaseInsensitiveContains(query) { out.append(path) }
+                } else {
+                    walk(opt.children, path)
+                }
+            }
+        }
+        walk(options, [])
+        return out
+    }
+
+    private var searchResults: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 0) {
+                let paths = matchedPaths
+                if paths.isEmpty {
+                    Text(String(themeKit: "No results"))
+                        .textStyle(.bodySm400)
+                        .foregroundStyle(theme.text(.textTertiary))
+                        .padding(.horizontal, Theme.SpacingKey.md.value)
+                        .padding(.vertical, Theme.SpacingKey.sm.value)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    ForEach(Array(paths.enumerated()), id: \.offset) { _, path in
+                        Button {
+                            selection = path.map(\.value)
+                            browse = selection
+                            open = false
+                            query = ""
+                        } label: {
+                            Text(path.map(\.label).joined(separator: " / "))
+                                .textStyle(.bodySm400)
+                                .foregroundStyle(theme.text(.textPrimary))
+                                .padding(.horizontal, Theme.SpacingKey.md.value)
+                                .frame(height: 36)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .frame(maxHeight: 220)
     }
 
     /// The option lists to show, one per open level.
@@ -137,6 +260,7 @@ public struct Cascader: View {
     }
 
     private func pick(_ opt: CascaderOption, level: Int) {
+        guard nodeEnabled(opt) else { return }
         browse = Array(browse.prefix(level)) + [opt.value]
         if opt.isLeaf {
             selection = browse
@@ -166,6 +290,16 @@ public extension Cascader {
     func placeholder(_ text: String) -> Self { copy { $0.placeholder = text } }
     /// Commit the path at every level, not only on a leaf (Ant `changeOnSelect`).
     func changeOnSelect(_ on: Bool = true) -> Self { copy { $0.changeOnSelect = on } }
+    /// Show a trailing clear button when a path is selected (Ant `allowClear`).
+    func clearable(_ on: Bool = true) -> Self { copy { $0.allowClear = on } }
+    /// Add a search field atop the dropdown; typing filters to a flat list of
+    /// matching leaf paths (Ant `showSearch`).
+    func searchable(_ on: Bool = true) -> Self { copy { $0.isSearchable = on } }
+    /// Per-node enable predicate; disabled nodes are greyed, unselectable, and
+    /// excluded from search results (kit-standard `optionEnabled` idiom).
+    func nodeEnabled(_ predicate: ((CascaderOption) -> Bool)?) -> Self { copy { $0.isNodeEnabled = predicate } }
+    /// Validation / info messages rendered under the field (drives the border state).
+    func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {
         var c = self
@@ -177,15 +311,30 @@ public extension Cascader {
 #Preview {
     struct Demo: View {
         @State private var path: [String] = []
+        @State private var searched: [String] = ["de", "be", "mitte"]
         let options = [
-            CascaderOption("tr", label: "Türkiye", children: [
-                CascaderOption("34", label: "İstanbul", children: [
-                    CascaderOption("kadikoy", label: "Kadıköy"), CascaderOption("besiktas", label: "Beşiktaş")]),
-                CascaderOption("06", label: "Ankara", children: [CascaderOption("cankaya", label: "Çankaya")])]),
-            CascaderOption("de", label: "Deutschland", children: [
+            CascaderOption("us", label: "United States", children: [
+                CascaderOption("ca", label: "California", children: [
+                    CascaderOption("sf", label: "San Francisco"), CascaderOption("la", label: "Los Angeles")]),
+                CascaderOption("ny", label: "New York", children: [CascaderOption("bk", label: "Brooklyn")])]),
+            CascaderOption("de", label: "Germany", children: [
                 CascaderOption("be", label: "Berlin", children: [CascaderOption("mitte", label: "Mitte")])]),
         ]
-        var body: some View { Cascader(options, selection: $path).placeholder("Region").padding() }
+        var body: some View {
+            VStack(spacing: 16) {
+                Cascader(options, selection: $path).placeholder("Region")
+                // Searchable + clearable, with a disabled branch (E7 axes).
+                Cascader(options, selection: $searched)
+                    .searchable().clearable()
+                    .nodeEnabled { $0.value != "ny" }
+                // Validation message drives the error border.
+                Cascader(options, selection: $path)
+                    .infoMessages(path.isEmpty ? [InfoMessage("Pick a region", kind: .error)] : [])
+                // Read-only: normal chrome + value, columns suppressed (E1).
+                Cascader(options, selection: $searched).clearable().readOnly()
+            }
+            .padding()
+        }
     }
     return Demo().environment(Theme.shared)
 }

--- a/Sources/ThemeKit/Components/Molecules/Checkbox.swift
+++ b/Sources/ThemeKit/Components/Molecules/Checkbox.swift
@@ -8,12 +8,13 @@ import SwiftUI
 
 extension ControlSize {
     /// Square side for checkbox / radio glyphs — maps the native control size to
-    /// ThemeKit's Figma "Control Items" metrics (Small 20 / Medium 24). Driven by
-    /// the native `.controlSize(_:)` cascade (default `.regular` → 24).
+    /// ThemeKit's Figma "Control Items" metrics (Small 20 / Medium 24 / Large 28).
+    /// Driven by the native `.controlSize(_:)` cascade (default `.regular` → 24).
     var checkboxSide: CGFloat {
         switch self {
         case .mini, .small: return 20
-        default: return 24   // .regular (default) / .large / .extraLarge
+        case .large, .extraLarge: return 28   // C4 — HeroUI `lg` box size
+        default: return 24   // .regular (default)
         }
     }
 }
@@ -55,6 +56,10 @@ public struct Checkbox: View {
     private var alignment: VerticalAlignment = .center
     private var accent: SemanticColor?
     private var accessibilityID: String?
+    private var controlPlacement: HorizontalEdge = .leading   // A2
+    private var customLabel: SlotContent?                     // D1 — `.label { }` slot
+    private var lineThrough = false                           // E4
+    @Environment(\.isReadOnly) private var isReadOnly         // E1
 
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -86,20 +91,23 @@ public struct Checkbox: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
             Button {
+                guard !isReadOnly else { return }   // E1 — VoiceOver activation is not hit-tested
                 isChecked.toggle()
             } label: {
                 HStack(alignment: alignment, spacing: Theme.SpacingKey.sm.value) {
-                    box
-                    if let label {
-                        Text(label)
-                            .textStyle(.bodyBase400)
-                            .foregroundStyle(isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
+                    if controlPlacement == .leading {
+                        box
+                        labelView
+                    } else {
+                        labelView
+                        box
                     }
                 }
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .disabled(!isEnabled)
+            .allowsHitTesting(!isReadOnly)   // E1 — normal chrome, toggling blocked
             .a11y(A11yElement.Control.checkbox, in: accessibilityID)
             .accessibilityLabel(label ?? "")
             .accessibilityValue(isIndeterminate ? String(themeKit: "mixed") : (isChecked ? String(themeKit: "selected") : String(themeKit: "not selected")))
@@ -108,6 +116,20 @@ public struct Checkbox: View {
             if !infoMessages.isEmpty {
                 InfoMessageList(infoMessages).a11y(A11yElement.Field.message, in: accessibilityID)
             }
+        }
+    }
+
+    /// Built-in string label, or the `.label { }` slot when set (D1/B8). Both
+    /// inherit the `lineThrough` treatment while checked (E4).
+    @ViewBuilder private var labelView: some View {
+        if let customLabel {
+            customLabel
+                .strikethrough(lineThrough && isChecked)
+        } else if let label {
+            Text(label)
+                .textStyle(.bodyBase400)
+                .strikethrough(lineThrough && isChecked)
+                .foregroundStyle(isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
         }
     }
 
@@ -181,6 +203,22 @@ public extension Checkbox {
     /// Vertical alignment of the box against a multi-line label.
     func alignment(_ a: VerticalAlignment) -> Self { copy { $0.alignment = a } }
 
+    /// Which side of the label the box sits on: `.leading` (default) or
+    /// `.trailing`. RTL-safe — `HorizontalEdge` follows the layout direction.
+    /// (ControlRow `controlPlacement` vocabulary; A2.)
+    func controlPlacement(_ edge: HorizontalEdge) -> Self { copy { $0.controlPlacement = edge } }
+
+    /// Replaces the built-in text label with custom content (the canonical
+    /// `.label { }` slot). The slot inherits the surrounding text environment
+    /// and the `lineThrough()` treatment; pass the string init arg too if the
+    /// control should keep a VoiceOver label.
+    func label<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.customLabel = SlotContent(content) }
+    }
+
+    /// Strikes the label through while checked (HeroUI Checkbox `lineThrough`).
+    func lineThrough(_ on: Bool = true) -> Self { copy { $0.lineThrough = on } }
+
     /// Overrides the box side length, bypassing the native `.controlSize` metric.
     func customSize(_ side: CGFloat?) -> Self { copy { $0.customSize = side } }
 
@@ -211,6 +249,19 @@ public extension Checkbox {
         Checkbox(isChecked: .constant(true)).disabled(true)
         Checkbox("Success accent", isChecked: .constant(true)).accent(.success)
         Checkbox("Warning accent", isChecked: .constant(true)).accent(.warning)
+        Checkbox("Large box", isChecked: .constant(true)).controlSize(.large)          // C4
+        Checkbox("Box on the trailing side", isChecked: .constant(true))
+            .controlPlacement(.trailing)                                               // A2
+        Checkbox("Buy milk", isChecked: .constant(true)).lineThrough()                 // E4
+        Checkbox("Terms", isChecked: .constant(false))
+            .label {                                                                   // D1
+                HStack(spacing: Theme.SpacingKey.xs.value) {
+                    Text("I accept the")
+                    Text("Terms of Service").underline().fontWeight(.semibold)
+                }
+                .textStyle(.bodyBase400)
+            }
+        Checkbox("Read-only (tap does nothing)", isChecked: .constant(true)).readOnly() // E1
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Molecules/CheckboxGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/CheckboxGroup.swift
@@ -21,7 +21,11 @@ public struct CheckboxGroup<Option: Hashable>: View {
     private var infoMessages: [InfoMessage] = []
     private var selectAllTitle: String?
     private var isOptionEnabled: ((Option) -> Bool)?
+    private var groupDescription: String?                     // E5
+    private var axis: Axis = .vertical                        // A6
+    private var controlPlacement: HorizontalEdge = .leading   // A5 — forwarded to rows
     private var accessibilityID: String? = nil
+    @Environment(\.isReadOnly) private var isReadOnly         // E1 — rows own the tap
 
     public init(
         title: String? = nil,
@@ -61,49 +65,91 @@ public struct CheckboxGroup<Option: Hashable>: View {
             if let title {
                 Text(title).textStyle(.labelMd600).foregroundStyle(titleColor)
             }
+            if let groupDescription {
+                HelperText(groupDescription)   // E5 — group-level supporting text
+            }
             if let selectAllTitle {
-                Button(action: toggleAll) {
+                Button {
+                    guard !isReadOnly else { return }   // E1 — VoiceOver activation is not hit-tested
+                    toggleAll()
+                } label: {
                     HStack(spacing: Theme.SpacingKey.sm.value) {
-                        Checkbox(isChecked: .constant(allSelected)).indeterminate(someSelected)
-                        Text(selectAllTitle)
-                            .textStyle(.labelBase600)
-                            .foregroundStyle(theme.text(.textPrimary))
-                        Spacer()
+                        if controlPlacement == .leading {   // A5 — group-level placement
+                            Checkbox(isChecked: .constant(allSelected)).indeterminate(someSelected)
+                            selectAllLabel(selectAllTitle)
+                            Spacer()
+                        } else {
+                            selectAllLabel(selectAllTitle)
+                            Spacer()
+                            Checkbox(isChecked: .constant(allSelected)).indeterminate(someSelected)
+                        }
                     }
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .disabled(selectableOptions.isEmpty)
+                .allowsHitTesting(!isReadOnly)   // E1 — normal chrome, toggling blocked
                 .opacity(isEnabled ? 1 : 0.4)
                 .accessibilityLabel(selectAllTitle)
                 .accessibilityAddTraits(allSelected ? .isSelected : [])
                 DividerView().size(.small)
             }
-            ForEach(Array(options.enumerated()), id: \.element) { index, option in
-                let isOn = selection.contains(option)
-                let enabled = optionEnabled(option)
-                Button {
-                    if isOn { selection.remove(option) } else { selection.insert(option) }
-                } label: {
-                    HStack(spacing: Theme.SpacingKey.sm.value) {
-                        Checkbox(isChecked: .constant(isOn))
-                        Text(label(option))
-                            .textStyle(.bodyBase400)
-                            .foregroundStyle(theme.text(.textPrimary))
-                        Spacer()
-                    }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(!enabled)
-                .opacity(enabled ? 1 : 0.4)
-                .a11y("option.\(index)", in: accessibilityID)
-                .accessibilityLabel(label(option))
-                .accessibilityAddTraits(isOn ? .isSelected : [])
-            }
+            optionsContainer
             if !infoMessages.isEmpty {
                 InfoMessageList(infoMessages).a11y(A11yElement.Field.message, in: accessibilityID)
             }
+        }
+    }
+
+    private func selectAllLabel(_ title: String) -> some View {
+        Text(title)
+            .textStyle(.labelBase600)
+            .foregroundStyle(theme.text(.textPrimary))
+    }
+
+    /// Lays the option rows out along `axis` (A6 — HStack/VStack mirror for RTL
+    /// automatically; copies RadioGroup's `.axis(_:)` container).
+    @ViewBuilder private var optionsContainer: some View {
+        switch axis {
+        case .horizontal:
+            HStack(alignment: .top, spacing: Theme.SpacingKey.md.value) { optionRows }
+        case .vertical:
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) { optionRows }
+        }
+    }
+
+    private var optionRows: some View {
+        ForEach(Array(options.enumerated()), id: \.element) { index, option in
+            let isOn = selection.contains(option)
+            let enabled = optionEnabled(option)
+            let box = Checkbox(isChecked: .constant(isOn))
+            let rowLabel = Text(label(option))
+                .textStyle(.bodyBase400)
+                .foregroundStyle(theme.text(.textPrimary))
+            Button {
+                guard !isReadOnly else { return }   // E1 — VoiceOver activation is not hit-tested
+                if isOn { selection.remove(option) } else { selection.insert(option) }
+            } label: {
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    if controlPlacement == .leading {   // A5 — group-level placement
+                        box
+                        rowLabel
+                        if axis == .vertical { Spacer() }
+                    } else {
+                        rowLabel
+                        if axis == .vertical { Spacer() }
+                        box
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!enabled)
+            .allowsHitTesting(!isReadOnly)   // E1 — normal chrome, toggling blocked
+            .opacity(enabled ? 1 : 0.4)
+            .a11y("option.\(index)", in: accessibilityID)
+            .accessibilityLabel(label(option))
+            .accessibilityAddTraits(isOn ? .isSelected : [])
         }
     }
 }
@@ -112,8 +158,16 @@ public struct CheckboxGroup<Option: Hashable>: View {
     struct Demo: View {
         @State var sel: Set<String> = ["Wifi"]
         var body: some View {
-            CheckboxGroup(title: "Amenities", options: ["Wifi", "Pool", "Parking", "Breakfast"], selection: $sel) { $0 }
-                .padding()
+            VStack(alignment: .leading, spacing: 24) {
+                CheckboxGroup(title: "Amenities", options: ["Wifi", "Pool", "Parking", "Breakfast"], selection: $sel) { $0 }
+                CheckboxGroup(title: "Horizontal", options: ["Wifi", "Pool", "Parking"], selection: $sel) { $0 }
+                    .axis(.horizontal)                                                  // A6
+                CheckboxGroup(title: "Trailing boxes", options: ["Wifi", "Pool", "Parking"], selection: $sel) { $0 }
+                    .controlPlacement(.trailing)                                        // A5
+                    .selectAll("All amenities")
+                    .description("Filters apply to all room types.")                    // E5
+            }
+            .padding()
         }
     }
     return Demo()
@@ -127,6 +181,20 @@ public extension CheckboxGroup {
 
     /// Adds a "select all" master row with the given title (nil hides it).
     func selectAll(_ title: String?) -> Self { copy { $0.selectAllTitle = title } }
+
+    /// Group-level supporting text rendered under the title via `HelperText`
+    /// (Ant/HeroUI group `description`; E5).
+    func description(_ text: String?) -> Self { copy { $0.groupDescription = text } }
+
+    /// Layout axis of the option rows: `.vertical` (default) or `.horizontal`.
+    /// (Ant `Checkbox.Group` / HeroUI `orientation`; A6.) The "select all"
+    /// master row always keeps its own line above the options.
+    func axis(_ a: Axis) -> Self { copy { $0.axis = a } }
+
+    /// Which side of each row's label the box sits on: `.leading` (default)
+    /// or `.trailing`, forwarded to every option row and the "select all" row.
+    /// RTL-safe — `HorizontalEdge` follows the layout direction. (A5.)
+    func controlPlacement(_ edge: HorizontalEdge) -> Self { copy { $0.controlPlacement = edge } }
 
     /// Per-option enablement predicate (nil enables every option).
     func optionEnabled(_ predicate: ((Option) -> Bool)?) -> Self { copy { $0.isOptionEnabled = predicate } }

--- a/Sources/ThemeKit/Components/Molecules/ColorField.swift
+++ b/Sources/ThemeKit/Components/Molecules/ColorField.swift
@@ -12,24 +12,32 @@ public struct ColorField: View {
     @Environment(\.theme) private var theme
     /// The field chrome (fill + border), swappable via `.fieldStyle(_:)`.
     @Environment(\.fieldStyle) private var fieldStyle
+    @Environment(\.fieldDefaults) private var fieldDefaults
     @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
+    /// Read-only subtree axis (set with `.readOnly(_:)`) — normal chrome, no editing.
+    @Environment(\.isReadOnly) private var isReadOnly
 
     private let label: String
     @Binding private var selection: Color
 
     // Appearance — mutated only through the modifiers below (R2).
     private var supportsOpacity: Bool = true
+    /// Explicit `.size(_:)` preset — wins over the subtree `FieldDefaults.size`.
+    private var explicitSize: TextInputSize?
 
     public init(_ label: String, selection: Binding<Color>) {   // R1 — content + binding
         self.label = label
         self._selection = selection
     }
 
+    /// Explicit `.size(_:)` → subtree `FieldDefaults.size` → the classic 52pt.
+    private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }
+
     /// The field chrome is delegated to the active ``FieldStyle``. Mapping: the
     /// system color well never drives keyboard focus, so `isFocused` is always
     /// `false`; there is no validation axis, so `hasError`/`hasWarning` are
-    /// `false`; `size` is `.medium` — ColorField has no `TextInputSize` axis
-    /// (the row keeps its fixed 52pt height in the content).
+    /// `false`. With no explicit `.size(_:)` and no subtree `FieldDefaults.size`
+    /// the row keeps its classic scaled 52pt height (nominal `.medium`).
     public var body: some View {
         fieldStyle.makeBody(configuration: FieldStyleConfiguration(
             content: AnyView(row),
@@ -37,7 +45,7 @@ public struct ColorField: View {
             isEnabled: isEnabled,
             hasError: false,
             hasWarning: false,
-            size: .medium
+            size: effectiveSize ?? .medium
         ))
     }
 
@@ -51,10 +59,14 @@ public struct ColorField: View {
             Spacer(minLength: 0)
             ColorPicker("", selection: $selection, supportsOpacity: supportsOpacity)
                 .labelsHidden()
+                // Read-only keeps the swatch + normal chrome but never opens
+                // the system picker (E1 — distinct from `.disabled`).
+                .allowsHitTesting(!isReadOnly)
                 .accessibilityLabel(label)
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
-        .frame(height: 52)
+        // Scales with Dynamic Type (G2); a size preset remaps the height (C1).
+        .scaledControlHeight(effectiveSize?.height ?? 52)
     }
 }
 
@@ -63,6 +75,10 @@ public struct ColorField: View {
 public extension ColorField {
     /// Whether the color well lets the user adjust opacity (defaults to true).
     func supportsOpacity(_ on: Bool = true) -> Self { copy { $0.supportsOpacity = on } }
+
+    /// Control-height preset. An explicit size wins over the subtree
+    /// `FieldDefaults.size` default (`explicit ?? fieldDefaults.size ?? 52pt`).
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -79,6 +95,11 @@ public extension ColorField {
                 ColorField("Brand color", selection: $color)
                 // Swapped chrome: underlined field, same behavior.
                 ColorField("Accent color", selection: $color).fieldStyle(.underlined)
+                // Size ramp — explicit `.size(_:)` wins over `FieldDefaults.size`.
+                ColorField("Small", selection: $color).size(.small)
+                ColorField("Large", selection: $color).size(.large)
+                // Read-only: swatch + normal chrome, picker suppressed (E1).
+                ColorField("Theme color (read-only)", selection: $color).readOnly()
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/ControlRow.swift
+++ b/Sources/ThemeKit/Components/Molecules/ControlRow.swift
@@ -40,6 +40,7 @@ public struct ControlRow: View {
 
     // Appearance/validation — mutated only through the modifiers below (R2).
     private var description: String?
+    private var descriptionLinks: [(substring: String, action: () -> Void)] = []
     private var control: ControlRowControl = .toggle
     private var customIndicator: AnyView?
     private var isRequired = false
@@ -109,6 +110,7 @@ public struct ControlRow: View {
             if let description {
                 HelperText(description)
                     .hasError(hasError)
+                    .links(descriptionLinks)
             }
         }
     }
@@ -154,6 +156,12 @@ public struct ControlRow: View {
 public extension ControlRow {
     /// Supporting text rendered under the label.
     func description(_ text: String?) -> Self { copy { $0.description = text } }
+
+    /// Supporting text with inline tappable links — e.g.
+    /// `.description("By checking this you accept the Terms.", links: [("Terms", openTerms)])`.
+    func description(_ text: String?, links: [(substring: String, action: () -> Void)]) -> Self {
+        copy { $0.description = text; $0.descriptionLinks = links }
+    }
 
     /// Which boolean control renders: `.toggle` (default), `.checkbox`, or
     /// `.radio`. Ignored when a custom `indicator` is set.

--- a/Sources/ThemeKit/Components/Molecules/ControlRow.swift
+++ b/Sources/ThemeKit/Components/Molecules/ControlRow.swift
@@ -46,7 +46,9 @@ public struct ControlRow: View {
     private var hasError = false
     private var errorText: String?
     private var accessibilityID: String?
+    private var controlPlacement: HorizontalEdge = .trailing
 
+    @Environment(\.fieldDefaults) private var fieldDefaults
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
@@ -66,18 +68,15 @@ public struct ControlRow: View {
                 withAnimation(motion) { isOn.toggle() }
             } label: {
                 HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
-                    VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
-                        InputLabel(title)
-                            .required(isRequired)
-                            .hasError(hasError)
-                        if let description {
-                            HelperText(description)
-                                .hasError(hasError)
-                        }
+                    if controlPlacement == .leading {
+                        indicator.accessibilityHidden(true)   // the row is the single a11y element
+                        labelBlock
+                        Spacer(minLength: 0)
+                    } else {
+                        labelBlock
+                        Spacer(minLength: Theme.SpacingKey.sm.value)
+                        indicator.accessibilityHidden(true)
                     }
-                    Spacer(minLength: Theme.SpacingKey.sm.value)
-                    indicator
-                        .accessibilityHidden(true)   // the row is the single a11y element
                 }
                 .contentShape(Rectangle())
             }
@@ -99,9 +98,26 @@ public struct ControlRow: View {
         .animation(motion, value: showsError)
     }
 
-    /// Trailing boolean control: the custom slot when set, else the archetype
-    /// from `control(_:)` — all driven by the same `isOn` binding, so a tap on
-    /// the indicator and a tap on the row stay in sync.
+    /// The label + optional description column. The required asterisk is gated
+    /// by the subtree `FieldDefaults.requiredIndicator` default (F4) — the field
+    /// stays required for a11y/validation even when the glyph is suppressed.
+    private var labelBlock: some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
+            InputLabel(title)
+                .required(showsRequiredIndicator)
+                .hasError(hasError)
+            if let description {
+                HelperText(description)
+                    .hasError(hasError)
+            }
+        }
+    }
+
+    private var showsRequiredIndicator: Bool { isRequired && (fieldDefaults.requiredIndicator ?? true) }
+
+    /// The boolean control: the custom slot when set, else the archetype from
+    /// `control(_:)` — all driven by the same `isOn` binding, so a tap on the
+    /// indicator and a tap on the row stay in sync.
     @ViewBuilder
     private var indicator: some View {
         if let customIndicator {
@@ -139,9 +155,13 @@ public extension ControlRow {
     /// Supporting text rendered under the label.
     func description(_ text: String?) -> Self { copy { $0.description = text } }
 
-    /// Which boolean control renders in the trailing slot: `.toggle` (default),
-    /// `.checkbox`, or `.radio`. Ignored when a custom `indicator` is set.
+    /// Which boolean control renders: `.toggle` (default), `.checkbox`, or
+    /// `.radio`. Ignored when a custom `indicator` is set.
     func control(_ kind: ControlRowControl) -> Self { copy { $0.control = kind } }
+
+    /// Which side the control sits on: `.trailing` (default, switch-row style)
+    /// or `.leading` (control-first, checkbox/radio style).
+    func controlPlacement(_ edge: HorizontalEdge) -> Self { copy { $0.controlPlacement = edge } }
 
     /// Replaces the built-in control with a custom trailing indicator view.
     /// The row press still toggles `isOn`; keep the slot purely visual.
@@ -190,6 +210,10 @@ public extension ControlRow {
                     .a11yID("terms")
                 ControlRow("Remember me", isOn: $remember)
                     .control(.radio)
+                ControlRow("Leading checkbox", isOn: $marketing)
+                    .control(.checkbox)
+                    .controlPlacement(.leading)   // A1 — control on the left
+                    .description("The control sits on the leading edge, checkbox/radio style.")
                 ControlRow("Marketing emails", isOn: $marketing)
                     .description("Occasional product updates and offers.")
                     .disabled(true)

--- a/Sources/ThemeKit/Components/Molecules/DateField.swift
+++ b/Sources/ThemeKit/Components/Molecules/DateField.swift
@@ -82,7 +82,8 @@ public struct DateField: View {
     /// DateField has no `TextInputSize` modifier of its own; the subtree
     /// `FieldDefaults.size` maps onto its control height (nil keeps the
     /// component's classic scaled 48pt / nominal `.medium`).
-    private var effectiveSize: TextInputSize? { fieldDefaults.size }
+    private var explicitSize: TextInputSize?
+    private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }
     /// Message rows animate only when the subtree `FieldDefaults.messagesAnimated`
     /// opts in (DateField historically snaps) — still gated by `microAnimations`
     /// + Reduce Motion.
@@ -260,6 +261,10 @@ public struct DateField: View {
 public extension DateField {
     /// Placeholder shown while no date is selected.
     func placeholder(_ text: String) -> Self { copy { $0.placeholder = text } }
+
+    /// Control-height preset. An explicit size wins over the subtree
+    /// `FieldDefaults.size` default.
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
 
     /// Restrict the picker to a selectable date range.
     func range(_ range: ClosedRange<Date>?) -> Self { copy { $0.range = range } }

--- a/Sources/ThemeKit/Components/Molecules/DatePriceStrip.swift
+++ b/Sources/ThemeKit/Components/Molecules/DatePriceStrip.swift
@@ -196,6 +196,7 @@ public struct DatePriceStrip: View {
         Button { action?() } label: {
             Image(systemName: name).font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(theme.foreground(.fgHero))
+                .mirrorsInRTL()
                 .frame(width: 30, height: 30)
                 .background(theme.background(.bgSecondaryLight), in: Circle())
         }

--- a/Sources/ThemeKit/Components/Molecules/EmojiReactionButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/EmojiReactionButton.swift
@@ -23,6 +23,10 @@ public struct EmojiReactionButton: View {
     /// Base count of *other* reactions; the current user's reaction adds one.
     private let count: Int
 
+    // Appearance — mutated only through the modifiers below (R2).
+    private var size: ChipSize = .small
+    private var accent: SemanticColor?
+
     @ControllableState private var reacted: Bool
     @State private var pop = false
 
@@ -40,21 +44,54 @@ public struct EmojiReactionButton: View {
 
     private var displayCount: Int { count + (reacted ? 1 : 0) }
 
+    // Size ramp — shares Chip's `ChipSize` vocabulary; `.small` reproduces the
+    // original metrics exactly. Fixed glyph constants (no semantic token).
+    private var emojiPointSize: CGFloat {
+        switch size {
+        case .small: return 15
+        case .medium: return 17
+        case .large: return 19
+        }
+    }
+    private var countPointSize: CGFloat {
+        switch size {
+        case .small: return 13
+        case .medium: return 14
+        case .large: return 15
+        }
+    }
+    private var verticalPadding: CGFloat {
+        switch size {
+        case .small: return 5
+        case .medium: return 7
+        case .large: return 9
+        }
+    }
+    private var horizontalPadding: CGFloat {
+        size == .large ? Theme.SpacingKey.md.value : Theme.SpacingKey.sm.value
+    }
+
+    /// Chroma when reacted — the semantic accent when set, else the stock hero
+    /// treatment (unchanged default).
+    private var reactedFill: Color { accent?.soft ?? SemanticColor.primary.soft }
+    private var reactedBorder: Color { accent?.border ?? theme.border(.borderHero) }
+    private var reactedCount: Color { accent?.accent ?? theme.text(.textHero) }
+
     public var body: some View {
         Button(action: toggle) {
             HStack(spacing: 5) {
                 Text(emoji)
-                    .font(.system(size: 15))
+                    .font(.system(size: emojiPointSize))
                     .scaleEffect(pop ? 1.35 : 1)
                 RollingNumber(displayCount)
-                    .size(13)
+                    .size(countPointSize)
                     .weight(.semibold)
-                    .color(reacted ? theme.text(.textHero) : theme.text(.textSecondary))
+                    .colorOverride(reacted ? reactedCount : theme.text(.textSecondary))
             }
-            .padding(.horizontal, Theme.SpacingKey.sm.value)
-            .padding(.vertical, 5)
-            .background(reacted ? SemanticColor.primary.soft : theme.background(.bgSecondaryLight), in: Capsule())
-            .overlay(Capsule().stroke(reacted ? theme.border(.borderHero) : .clear, lineWidth: 1))
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(reacted ? reactedFill : theme.background(.bgSecondaryLight), in: Capsule())
+            .overlay(Capsule().stroke(reacted ? reactedBorder : .clear, lineWidth: 1))
         }
         .buttonStyle(.plain)
         .accessibilityLabel(Text(String(themeKit: "React with \(emoji), \(displayCount) reactions")))
@@ -73,14 +110,40 @@ public struct EmojiReactionButton: View {
     }
 }
 
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension EmojiReactionButton {
+    /// Control size: small (default) / medium / large — shares Chip's
+    /// ``ChipSize`` vocabulary and drives the emoji/count sizes and paddings.
+    func size(_ s: ChipSize) -> Self { copy { $0.size = s } }
+
+    /// Semantic tint for the reacted state (soft fill, border and count);
+    /// `nil` (default) keeps the stock hero treatment.
+    func accent(_ c: SemanticColor?) -> Self { copy { $0.accent = c } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
 #Preview {
     struct Demo: View {
         @State var liked = false
         var body: some View {
-            HStack(spacing: 10) {
-                EmojiReactionButton("👍", count: 12, isReacted: $liked)
-                EmojiReactionButton("🎉", count: 4, initiallyReacted: true)
-                EmojiReactionButton("🔥", count: 0)
+            VStack(spacing: 16) {
+                HStack(spacing: 10) {
+                    EmojiReactionButton("👍", count: 12, isReacted: $liked)
+                    EmojiReactionButton("🎉", count: 4, initiallyReacted: true)
+                    EmojiReactionButton("🔥", count: 0)
+                }
+                // D8 — size ramp + semantic accent for the reacted state.
+                HStack(spacing: 10) {
+                    EmojiReactionButton("👍", count: 3, initiallyReacted: true).size(.medium)
+                    EmojiReactionButton("❤️", count: 9, initiallyReacted: true).size(.large).accent(.error)
+                    EmojiReactionButton("✅", count: 2, initiallyReacted: true).accent(.success)
+                }
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/FieldButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/FieldButton.swift
@@ -14,8 +14,11 @@ import SwiftUI
 public struct FieldButton: View {
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
+    /// Read-only subtree axis (set with `.readOnly(_:)`) — normal chrome, no action.
+    @Environment(\.isReadOnly) private var isReadOnly
     /// The field chrome (fill + border), swappable via `.fieldStyle(_:)`.
     @Environment(\.fieldStyle) private var fieldStyle
+    @Environment(\.fieldDefaults) private var fieldDefaults
 
     private let value: String
     private let action: () -> Void
@@ -24,17 +27,26 @@ public struct FieldButton: View {
     private var systemImage: String?
     private var trailingSystemImage: String? = "chevron.down"
     private var isPlaceholder = false
+    /// Explicit `.size(_:)` preset — wins over the subtree `FieldDefaults.size`.
+    private var explicitSize: TextInputSize?
 
     public init(_ value: String, action: @escaping () -> Void) {   // R1
         self.value = value
         self.action = action
     }
 
+    /// Explicit `.size(_:)` → subtree `FieldDefaults.size` → the classic
+    /// 56pt (labelled) / 48pt height.
+    private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }
+
     public var body: some View {
-        Button(action: action) {
+        // Read-only keeps the normal (non-dimmed) chrome and the VoiceOver
+        // label/value but never runs the action (E1 — distinct from `.disabled`).
+        Button { if !isReadOnly { action() } } label: {
             fieldBox
         }
         .buttonStyle(.plain)
+        .allowsHitTesting(!isReadOnly)
         .accessibilityLabel("\(fieldLabel.map { $0 + ", " } ?? "")\(value)")
         .accessibilityAddTraits(.isButton)
     }
@@ -60,16 +72,18 @@ public struct FieldButton: View {
             }
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
-        .frame(height: fieldLabel != nil ? 56 : 48)
+        // Scales with Dynamic Type (G2); an explicit/subtree size preset remaps
+        // the classic 56pt (labelled) / 48pt heights onto the family ramp (C1).
+        .scaledControlHeight(effectiveSize?.height ?? (fieldLabel != nil ? 56 : 48))
         .frame(maxWidth: .infinity)
     }
 
     /// The trigger row wrapped in the active ``FieldStyle`` chrome (fill + border).
     /// Configuration mapping: FieldButton has no focus / open-popover state and no
     /// validation axis, so `isFocused` / `hasError` / `hasWarning` are always
-    /// false; `isEnabled` comes from the environment (`.disabled(_:)`). `size` is
-    /// nominal `.medium` — FieldButton has no `TextInputSize` axis; its 48/56pt
-    /// (labelled) height stays carried by the content.
+    /// false; `isEnabled` comes from the environment (`.disabled(_:)`). With no
+    /// explicit `.size(_:)` and no subtree `FieldDefaults.size` the height stays
+    /// the classic 48/56pt (nominal `.medium`), carried by the content.
     private var fieldBox: some View {
         fieldStyle.makeBody(configuration: FieldStyleConfiguration(
             content: AnyView(fieldCore),
@@ -77,7 +91,7 @@ public struct FieldButton: View {
             isEnabled: isEnabled,
             hasError: false,
             hasWarning: false,
-            size: .medium
+            size: effectiveSize ?? .medium
         ))
     }
 }
@@ -93,6 +107,9 @@ public extension FieldButton {
     func trailing(_ systemName: String?) -> Self { copy { $0.trailingSystemImage = systemName } }
     /// Renders the value in the muted placeholder colour (nothing chosen yet).
     func placeholder(_ on: Bool = true) -> Self { copy { $0.isPlaceholder = on } }
+    /// Control-height preset. An explicit size wins over the subtree
+    /// `FieldDefaults.size` default (`explicit ?? fieldDefaults.size ?? 56/48pt`).
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -107,6 +124,11 @@ public extension FieldButton {
         FieldButton("Select a date") { }.icon("calendar").placeholder()
         // Underlined chrome via the shared FieldStyle hook.
         FieldButton("Business class") { }.label("Cabin").fieldStyle(.underlined)
+        // Size ramp — explicit `.size(_:)` wins over `FieldDefaults.size`.
+        FieldButton("Small trigger") { }.size(.small)
+        FieldButton("Large trigger") { }.label("Room").size(.large)
+        // Read-only: normal chrome, action suppressed (E1).
+        FieldButton("1 Room · 2 Guests") { }.label("Occupancy").readOnly()
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Molecules/InputNumber.swift
+++ b/Sources/ThemeKit/Components/Molecules/InputNumber.swift
@@ -12,31 +12,50 @@ import SwiftUI
 /// Reference: Ant Design `InputNumber` / Chakra `NumberInput` — the value is
 /// directly editable (type a number, clamped to `range` on commit), steppers move
 /// by `step`, and an optional `unit` suffix labels the value (e.g. "guest", "$").
-/// The field chrome (fill + border) is a swappable ``FieldStyle`` set with
-/// `.fieldStyle(_:)`.
+/// Binds to `Int` (the classic form counter) or, per Ant's decimal support, to
+/// `Double` with a `.precision(_:)` fraction-digit axis (E11). Sits on the field
+/// family's `TextInputSize` ramp via `.size(_:)` (C2). The field chrome (fill +
+/// border) is a swappable ``FieldStyle`` set with `.fieldStyle(_:)`.
 public struct InputNumber: View {
     @Environment(\.theme) private var theme
     /// The field chrome (fill + border), swappable via `.fieldStyle(_:)`.
     @Environment(\.fieldStyle) private var fieldStyle
 
-    @Binding private var value: Int
-    private let range: ClosedRange<Int>
+    /// Canonical internal value — the `Int` init bridges its binding onto this
+    /// (E11: one body serves both integer and decimal callers).
+    @Binding private var value: Double
+    private let range: ClosedRange<Double>
 
     // Appearance/state/config — mutated only through the modifiers below (R2).
     private var label: String?
-    private var step: Int = 1
+    private var step: Double = 1
     private var unit: String?
     private var hint: String?
     private var errorText: String?
     private var accessibilityID: String?
-    /// Set only by the `.large(_:)` modifier — an explicit choice wins over the
-    /// subtree `FieldDefaults.size` default (`nil` falls back to it).
-    private var large: Bool?
+    /// Set only by the `.size(_:)` modifier — an explicit size wins over the
+    /// subtree `FieldDefaults.size` default (C2: `explicitSize ?? fieldDefaults.size`;
+    /// with neither set, the field keeps its original 40pt height).
+    private var explicitSize: TextInputSize?
     private var editable: Bool = true
     private var hasInfo: Bool = false
-    private var onChange: ((Int) -> Void)?
+    /// Fraction digits shown / kept when committing (E11). 0 = integer behavior.
+    private var fractionDigits: Int = 0
+    private var onChange: ((Double) -> Void)?
+
+    /// Marks the field as required: asterisk after the label + ", required"
+    /// appended to the accessibility label (E2, HeroUI `isRequired`).
+    private var isRequired = false
+
+    // Declarative validation (E3, TextInput parity): rules run against the
+    // field's text at `validationTrigger`; the first failure renders as an
+    // `InfoMessageList` row and drives the error border.
+    private var validationRules: [ValidationRule] = []
+    private var validationTrigger: ValidationTrigger = .editingEnd
+    @State private var validationMessages: [InfoMessage] = []
 
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.isReadOnly) private var isReadOnly   // E1 — set by `.readOnly(_:)`
     @Environment(\.fieldDefaults) private var fieldDefaults
 
     @FocusState private var isFocused: Bool
@@ -48,23 +67,56 @@ public struct InputNumber: View {
         range: ClosedRange<Int> = 0...99
     ) {   // R1
         self.label = label
-        self._value = value
-        self.range = range
+        self._value = Binding(
+            get: { Double(value.wrappedValue) },
+            set: { value.wrappedValue = Int($0.rounded()) }
+        )
+        self.range = Double(range.lowerBound)...Double(range.upperBound)
         self._textValue = State(initialValue: String(value.wrappedValue))
     }
 
-    private var hasError: Bool { errorText != nil }
-    /// InputNumber's size axis is binary (regular 40pt / large 48pt); the
-    /// subtree `FieldDefaults.size == .large` maps onto the large height when
-    /// `.large(_:)` wasn't set explicitly.
-    private var isLarge: Bool { large ?? (fieldDefaults.size == .large) }
-    private var height: CGFloat { isLarge ? 48 : 40 }
+    /// Decimal-value overload (E11, Ant InputNumber decimal support). Shows two
+    /// fraction digits by default; tune with `.precision(_:)`.
+    public init(
+        _ label: String? = nil,
+        value: Binding<Double>,
+        range: ClosedRange<Double> = 0...99
+    ) {   // R1
+        self.label = label
+        self._value = value
+        self.range = range
+        self.fractionDigits = 2
+        self._textValue = State(initialValue: Self.format(value.wrappedValue, fractionDigits: 2))
+    }
+
+    /// `errorText` plus any validation failures (computed merge, TextInput idiom).
+    private var messages: [InfoMessage] {
+        var messages = validationMessages
+        if let errorText { messages.append(InfoMessage(errorText, kind: .error)) }
+        return messages
+    }
+    private var hasError: Bool { messages.dominantKind == .error }
+    private var hasWarning: Bool { messages.dominantKind == .warning }
+    /// Explicit `.size(_:)` → subtree `FieldDefaults.size` → `nil` (the field's
+    /// own 40pt default height, kept for source-visual compatibility). C2.
+    private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }
+    private var height: CGFloat { effectiveSize?.height ?? 40 }
+    /// Whether `.required()` renders its asterisk (`FieldDefaults.requiredIndicator`;
+    /// the accessibility ", required" suffix is unaffected).
+    private var showsRequiredIndicator: Bool { fieldDefaults.requiredIndicator ?? true }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
             if let label {
                 HStack(spacing: 4) {
                     Text(label).textStyle(.labelSm600).foregroundStyle(labelColor)
+                    if isRequired && showsRequiredIndicator {
+                        // Same treatment as `InputLabel.required()` — error-token asterisk.
+                        Text(verbatim: "*")
+                            .textStyle(.labelSm600)
+                            .foregroundStyle(theme.foreground(.systemcolorsFgError))
+                            .accessibilityHidden(true)   // spoken via the field's label suffix
+                    }
                     if hasInfo {
                         Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(theme.text(.textTertiary))
                     }
@@ -73,62 +125,83 @@ public struct InputNumber: View {
 
             fieldBox
                 .a11y(A11yElement.Control.stepper, in: accessibilityID)
-                .accessibilityValue("\(value)")
+                .accessibilityValue(displayText)
 
-            if let message = errorText ?? hint {
+            if !validationMessages.isEmpty {
+                // Structured messages (`.validate(_:on:)`) — family-standard list.
+                InfoMessageList(messages)
+                    .a11y(A11yElement.Field.message, in: accessibilityID)
+            } else if let message = errorText ?? hint {
                 Text(message)
                     .textStyle(.bodySm400)
                     .foregroundStyle(hasError ? theme.foreground(.systemcolorsFgError) : theme.text(.textTertiary))
             }
         }
+        .onAppear {
+            // Normalize the initial text to the resolved precision (the `@State`
+            // seed predates the `.precision(_:)` modifier).
+            if !isFocused { textValue = format(value) }
+        }
         .onChange(of: value) { _, newValue in
             // Reflect stepper / external changes back into the editable text.
-            let normalized = String(newValue)
+            let normalized = format(newValue)
             if textValue != normalized && !isFocused { textValue = normalized }
         }
         .onChange(of: textValue) { _, newText in
             // Live-apply a valid in-range entry; full clamp happens on commit.
-            guard editable, let parsed = Self.parse(newText, range: range) else { return }
+            defer {
+                // `.live` validates every change; other triggers re-validate once
+                // a failure is visible so the error clears as the user fixes it.
+                if validationTrigger == .live || !validationMessages.isEmpty { runValidation(newText) }
+            }
+            guard editable, let parsed = parseValue(newText) else { return }
             let clamped = Self.clamp(parsed, to: range)
             if clamped == parsed, clamped != value { value = clamped; onChange?(clamped) }
         }
         .onChange(of: isFocused) { _, focused in
-            if !focused { commit() }
+            if !focused {
+                commit()
+                if validationTrigger == .editingEnd { runValidation(textValue) }   // validate on blur
+            }
         }
     }
 
     /// The composed stepper row (− / value / +), sized — everything the active
-    /// ``FieldStyle`` receives as `configuration.content`.
+    /// ``FieldStyle`` receives as `configuration.content`. E1: read-only keeps
+    /// the value with the normal chrome but drops the stepper affordances.
     private var fieldCore: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
-            stepper("minus", label: String(themeKit: "Decrease"), enabled: value > range.lowerBound) {
-                setValue(value - step)
+            if !isReadOnly {
+                stepper("minus", label: String(themeKit: "Decrease"), enabled: value > range.lowerBound) {
+                    setValue(value - step)
+                }
             }
             middle
                 .frame(maxWidth: .infinity)
-            stepper("plus", label: String(themeKit: "Increase"), enabled: value < range.upperBound) {
-                setValue(value + step)
+            if !isReadOnly {
+                stepper("plus", label: String(themeKit: "Increase"), enabled: value < range.upperBound) {
+                    setValue(value + step)
+                }
             }
         }
         .padding(.horizontal, Theme.SpacingKey.xs.value)
-        .frame(height: height)
+        .scaledControlHeight(height)   // C2/G2 — scales with Dynamic Type
     }
 
     /// The stepper row wrapped in the active ``FieldStyle`` chrome (fill + border).
     /// Configuration mapping: the editable text field's focus drives `isFocused`;
-    /// `errorText` drives `hasError` (InputNumber has no warning axis, so
-    /// `hasWarning` is always false). `size` is nominal `.medium` — InputNumber
-    /// has no `TextInputSize` axis; its 40/48pt (`large`) height stays carried by
-    /// the content. The subtree `FieldDefaults.size` is reported when set, so
-    /// size-keyed styles stay consistent across a defaulted form.
+    /// `errorText` / validation failures drive `hasError` / `hasWarning`. `size`
+    /// reports the resolved `TextInputSize` axis (C2: `.size(_:)` →
+    /// `FieldDefaults.size` → nominal `.medium` while unset, in which case the
+    /// row keeps its own 40pt height).
     private var fieldBox: some View {
         fieldStyle.makeBody(configuration: FieldStyleConfiguration(
             content: AnyView(fieldCore),
             isFocused: isFocused,
             isEnabled: isEnabled,
             hasError: hasError,
-            hasWarning: false,
-            size: fieldDefaults.size ?? .medium
+            hasWarning: hasWarning,
+            size: effectiveSize ?? .medium
         ))
     }
 
@@ -140,13 +213,19 @@ public struct InputNumber: View {
                     .multilineTextAlignment(.center)
                     .focused($isFocused)
                     .disabled(!isEnabled)
+                    // E1 — read-only: normal (non-dimmed) value + VoiceOver value,
+                    // but the field can't be tapped into. NOT `.disabled` (dims).
+                    .allowsHitTesting(!isReadOnly)
                     .submitLabel(.done)
-                    .onSubmit { commit() }
-                    .numericKeyboard(allowsNegative: range.lowerBound < 0)
+                    .onSubmit {
+                        commit()
+                        runValidation(textValue)   // submit is the strongest trigger — always validate
+                    }
+                    .numericKeyboard(allowsNegative: range.lowerBound < 0, allowsDecimals: fractionDigits > 0)
                     .a11y(A11yElement.Field.field, in: accessibilityID)
-                    .accessibilityLabel(label ?? String(themeKit: "Value"))
+                    .accessibilityLabel(accessibleLabel)
             } else {
-                Text("\(value)")
+                Text(displayText)
             }
             if let unit {
                 Text(unit)
@@ -174,16 +253,50 @@ public struct InputNumber: View {
         .accessibilityLabel(label)
     }
 
-    private func setValue(_ new: Int) {
-        let clamped = Self.clamp(new, to: range)
+    private var accessibleLabel: String {
+        let base = label ?? String(themeKit: "Value")
+        return isRequired ? base + ", " + String(themeKit: "required") : base
+    }
+
+    private var displayText: String { format(value) }
+    private func format(_ v: Double) -> String { Self.format(v, fractionDigits: fractionDigits) }
+
+    /// Rounds to the declared precision (whole numbers when `fractionDigits == 0`).
+    private func quantize(_ v: Double) -> Double {
+        guard fractionDigits > 0 else { return v.rounded() }
+        let scale = pow(10.0, Double(fractionDigits))
+        return (v * scale).rounded() / scale
+    }
+
+    /// Integer parsing while `fractionDigits == 0` (legacy digits-only semantics),
+    /// decimal parsing otherwise.
+    private func parseValue(_ text: String) -> Double? {
+        guard fractionDigits > 0 else {
+            return Self.parseInteger(text, allowsNegative: range.lowerBound < 0).map(Double.init)
+        }
+        return Self.parseDecimal(text, allowsNegative: range.lowerBound < 0)
+    }
+
+    private func setValue(_ new: Double) {
+        let clamped = Self.clamp(quantize(new), to: range)
         if clamped != value { value = clamped; onChange?(clamped) }
-        textValue = String(clamped)
+        textValue = format(clamped)
     }
 
     private func commit() {
-        let clamped = Self.clamp(Self.parse(textValue, range: range) ?? value, to: range)
+        let clamped = Self.clamp(quantize(parseValue(textValue) ?? value), to: range)
         if clamped != value { value = clamped; onChange?(clamped) }
-        textValue = String(clamped)
+        textValue = format(clamped)
+    }
+
+    // MARK: Declarative validation (E3, TextInput parity)
+
+    /// Runs the declared rules against the field's text (first failure only,
+    /// via `Validator`) and publishes the result.
+    private func runValidation(_ text: String) {
+        guard !validationRules.isEmpty else { return }
+        let failures = Validator.validate(text, validationRules)
+        if failures != validationMessages { validationMessages = failures }
     }
 
     private var labelColor: Color {
@@ -197,23 +310,51 @@ public struct InputNumber: View {
         min(max(value, range.lowerBound), range.upperBound)
     }
 
+    /// Constrains a decimal `value` to `range` (E11 counterpart of the Int overload).
+    static func clamp(_ value: Double, to range: ClosedRange<Double>) -> Double {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+
     /// Parses user text into an Int, keeping only digits (and a leading minus when
     /// the range admits negatives). Returns nil for empty / non-numeric input.
     static func parse(_ text: String, range: ClosedRange<Int>) -> Int? {
-        let negative = range.lowerBound < 0 && text.trimmingCharacters(in: .whitespaces).hasPrefix("-")
+        parseInteger(text, allowsNegative: range.lowerBound < 0)
+    }
+
+    /// Digits-only integer parsing core (optional leading minus).
+    static func parseInteger(_ text: String, allowsNegative: Bool) -> Int? {
+        let negative = allowsNegative && text.trimmingCharacters(in: .whitespaces).hasPrefix("-")
         let digits = text.filter(\.isNumber)
         guard !digits.isEmpty, let magnitude = Int(digits) else { return nil }
         return negative ? -magnitude : magnitude
     }
+
+    /// Parses user text into a decimal value (E11), accepting both `.` and `,`
+    /// as the fraction separator and keeping a leading minus when allowed.
+    /// Returns nil for empty / non-numeric input.
+    static func parseDecimal(_ text: String, allowsNegative: Bool) -> Double? {
+        let negative = allowsNegative && text.trimmingCharacters(in: .whitespaces).hasPrefix("-")
+        let filtered = text
+            .replacingOccurrences(of: ",", with: ".")
+            .filter { $0.isNumber || $0 == "." }
+        guard !filtered.isEmpty, filtered != ".", let magnitude = Double(filtered) else { return nil }
+        return negative ? -magnitude : magnitude
+    }
+
+    /// Renders `value` with the given fraction digits (whole-number string when 0).
+    static func format(_ value: Double, fractionDigits: Int) -> String {
+        guard fractionDigits > 0 else { return String(Int(value.rounded())) }
+        return value.formatted(.number.precision(.fractionLength(fractionDigits)).grouping(.never))
+    }
 }
 
 private extension View {
-    /// Numeric keyboard (iOS only). Uses a punctuation keyboard when negatives are
-    /// allowed so the user can type a leading minus.
+    /// Numeric keyboard (iOS only). Decimal entry gets a decimal pad; ranges that
+    /// admit negatives use a punctuation keyboard so the user can type a minus.
     @ViewBuilder
-    func numericKeyboard(allowsNegative: Bool) -> some View {
+    func numericKeyboard(allowsNegative: Bool, allowsDecimals: Bool) -> some View {
         #if os(iOS)
-        self.keyboardType(allowsNegative ? .numbersAndPunctuation : .numberPad)
+        self.keyboardType(allowsNegative ? .numbersAndPunctuation : (allowsDecimals ? .decimalPad : .numberPad))
         #else
         self
         #endif
@@ -225,11 +366,26 @@ private extension View {
         @State var a = 1
         @State var b = 1
         @State var price = 500
+        @State var weight = 22.5
+        @State var rate = 0.125
         var body: some View {
             VStack(spacing: 16) {
-                InputNumber("Adults", value: $a, range: 1...9).unit("guest").hint("Type or step.").large()
+                InputNumber("Adults", value: $a, range: 1...9).unit("guest").hint("Type or step.").size(.large)
                 InputNumber("Children", value: $b).errorText("Too many")
                 InputNumber("Max price", value: $price, range: 0...10000).step(50).unit("$")
+                // Family size ramp (C2) — aligns with a `.small` TextInput beside it.
+                InputNumber("Rooms", value: $b, range: 1...5).size(.small)
+                // Decimal binding + precision (E11).
+                InputNumber("Weight", value: $weight, range: 0...32).step(0.5).unit("kg")
+                InputNumber("Rate", value: $rate, range: 0...1).step(0.005).precision(3)
+                // Required indicator (E2) + declarative validation (E3).
+                InputNumber("Guests", value: $a, range: 1...9)
+                    .required()
+                    .validate([.required(), .custom(String(themeKit: "Even numbers only")) { (Int($0) ?? 0).isMultiple(of: 2) }])
+                // Read-only (E1): normal chrome + value, steppers hidden, typing blocked.
+                InputNumber("Nights (submitted)", value: .constant(3), range: 1...30)
+                    .unit("nights")
+                    .readOnly()
                 // Underlined chrome via the shared FieldStyle hook.
                 InputNumber("Nights", value: $a, range: 1...30)
                     .fieldStyle(.underlined)
@@ -244,7 +400,14 @@ private extension View {
 
 public extension InputNumber {
     /// Increment/decrement applied by the − / + steppers.
-    func step(_ s: Int) -> Self { copy { $0.step = s } }
+    func step(_ s: Int) -> Self { copy { $0.step = Double(s) } }
+
+    /// Decimal increment/decrement applied by the − / + steppers (E11).
+    func step(_ s: Double) -> Self { copy { $0.step = s } }
+
+    /// Fraction digits shown and kept on commit (E11, Ant `precision`). The
+    /// decimal init defaults to 2; the `Int` init stays at 0 (whole numbers).
+    func precision(_ digits: Int) -> Self { copy { $0.fractionDigits = max(0, digits) } }
 
     /// Trailing unit suffix labelling the value (e.g. "guest", "$").
     func unit(_ u: String?) -> Self { copy { $0.unit = u } }
@@ -255,9 +418,31 @@ public extension InputNumber {
     /// Error text + error styling; takes precedence over `hint`.
     func errorText(_ text: String?) -> Self { copy { $0.errorText = text } }
 
-    /// Use the larger (48pt) field height. An explicit choice wins over the
-    /// subtree `FieldDefaults.size` default (`.large` maps onto this height).
-    func large(_ on: Bool = true) -> Self { copy { $0.large = on } }
+    /// Control height on the field family's `TextInputSize` ramp (C2). An
+    /// explicit size wins over the subtree `FieldDefaults.size` default; with
+    /// neither set the field keeps its original 40pt height.
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
+
+    /// Marks the field as required: renders an error-token asterisk after the
+    /// label (the `InputLabel` treatment, honoring the subtree
+    /// `FieldDefaults.requiredIndicator`) and appends ", required" to the
+    /// field's accessibility label (E2, HeroUI `isRequired`).
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
+
+    /// Declarative validation (E3, TextInput parity): evaluates `rules` against
+    /// the field's text at `trigger` and feeds the first failure into the
+    /// message list / error styling automatically.
+    ///
+    ///     InputNumber("Guests", value: $count)
+    ///         .validate([.required()], on: .editingEnd)
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
+        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    }
+
+    /// Legacy binary height (regular 40pt / large 48pt), superseded by the
+    /// field family's size ramp.
+    @available(*, deprecated, message: "Use .size(.large) — InputNumber now sits on the TextInputSize ramp (C2)")
+    func large(_ on: Bool = true) -> Self { on ? size(.large) : self }
 
     /// Whether the value can be typed (default true); `false` shows it read-only
     /// with steppers still active.
@@ -267,7 +452,11 @@ public extension InputNumber {
     func hasInfo(_ on: Bool = true) -> Self { copy { $0.hasInfo = on } }
 
     /// Fires with the clamped value whenever it changes (stepper / type / commit).
-    func onValueChange(_ action: ((Int) -> Void)?) -> Self { copy { $0.onChange = action } }
+    /// Decimal-bound fields receive the value rounded to whole numbers here —
+    /// observe the `Double` binding itself for full precision.
+    func onValueChange(_ action: ((Int) -> Void)?) -> Self {
+        copy { $0.onChange = action.map { handler in { handler(Int($0.rounded())) } } }
+    }
 
     /// Sets the accessibility-identifier namespace for this component (its
     /// sub-elements get `"<id>.<element>"`).

--- a/Sources/ThemeKit/Components/Molecules/Mentions.swift
+++ b/Sources/ThemeKit/Components/Molecules/Mentions.swift
@@ -25,12 +25,17 @@ public struct MentionOption: Identifiable, Sendable {
 
 public struct Mentions: View {
     @Environment(\.theme) private var theme
+    @Environment(\.fieldDefaults) private var fieldDefaults
+    /// Read-only subtree axis (set with `.readOnly(_:)`) — normal chrome, no editing.
+    @Environment(\.isReadOnly) private var isReadOnly
 
     @Binding private var text: String
     private let options: [MentionOption]
     // Appearance — mutated only through the modifiers below.
     private var prefix: Character = "@"
     private var placeholder: String = ""
+    /// Explicit `.size(_:)` preset — wins over the subtree `FieldDefaults.size`.
+    private var explicitSize: TextInputSize?
 
     @State private var query: String?
 
@@ -39,19 +44,25 @@ public struct Mentions: View {
         self.options = options
     }
 
+    /// Explicit `.size(_:)` → subtree `FieldDefaults.size` → the classic 40pt rows.
+    private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
             TextField(placeholder, text: $text, axis: .vertical)
                 .textFieldStyle(.plain)
                 .textStyle(.bodyBase400)
                 .lineLimit(3...6)
+                // Read-only keeps the normal chrome + VoiceOver value but
+                // blocks focus/editing (E1 — distinct from `.disabled`).
+                .allowsHitTesting(!isReadOnly)
                 .padding(Theme.SpacingKey.md.value)
                 .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
                 .overlay(RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value)
                     .strokeBorder(theme.border(query == nil ? .borderPrimary : .borderHero), lineWidth: query == nil ? 1 : 2))
                 .onChange(of: text) { query = activeQuery() }
 
-            if query != nil, !filtered.isEmpty {
+            if query != nil, !filtered.isEmpty, !isReadOnly {
                 suggestions
             }
         }
@@ -69,7 +80,9 @@ public struct Mentions: View {
                         Spacer(minLength: 0)
                     }
                     .padding(.horizontal, Theme.SpacingKey.md.value)
-                    .frame(height: 40)
+                    // Scales with Dynamic Type (G2); a size preset remaps the
+                    // suggestion-row control height onto the family ramp (C1).
+                    .scaledControlHeight(effectiveSize?.height ?? 40)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .contentShape(Rectangle())
                 }
@@ -114,6 +127,10 @@ public extension Mentions {
     func prefix(_ character: Character) -> Self { copy { $0.prefix = character } }
     /// Placeholder shown when empty.
     func placeholder(_ text: String) -> Self { copy { $0.placeholder = text } }
+    /// Control-height preset for the suggestion rows (the editor itself is
+    /// multi-line and grows with content). An explicit size wins over the
+    /// subtree `FieldDefaults.size` default (`explicit ?? fieldDefaults.size ?? 40pt`).
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {
         var c = self
@@ -127,7 +144,17 @@ public extension Mentions {
         @State private var text = "Great work "
         let people = [MentionOption("ada", label: "Ada Lovelace"), MentionOption("alan", label: "Alan Turing"),
                       MentionOption("grace", label: "Grace Hopper")]
-        var body: some View { Mentions(text: $text, options: people).placeholder("Write a note…").padding() }
+        var body: some View {
+            VStack(spacing: 16) {
+                Mentions(text: $text, options: people).placeholder("Write a note…")
+                // Larger suggestion rows via the family size ramp (C1).
+                Mentions(text: $text, options: people).size(.medium)
+                // Read-only: normal chrome + text, editing/suggestions suppressed (E1).
+                Mentions(text: .constant("Thanks @ada for the review"), options: people)
+                    .readOnly()
+            }
+            .padding()
+        }
     }
     return Demo().environment(Theme.shared)
 }

--- a/Sources/ThemeKit/Components/Molecules/MultiLineTextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiLineTextInput.swift
@@ -26,6 +26,7 @@ public struct MultiLineTextInput: View {
     @Binding private var text: String
     private let label: String
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.isReadOnly) private var isReadOnly   // E1 — set by `.readOnly(_:)`
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.fieldDefaults) private var fieldDefaults
@@ -131,7 +132,7 @@ public struct MultiLineTextInput: View {
         // External focus bridge (TextInput parity): a `true` write focuses the
         // editor; blurring resets the external binding so the owner stays in sync.
         .onChange(of: externalFocus?.wrappedValue ?? false) { _, want in
-            if want && !isFocused { isFocused = true }
+            if want && !isFocused && !isReadOnly { isFocused = true }   // E1 — no programmatic focus either
         }
         .onChange(of: isFocused) { _, now in
             if !now, externalFocus?.wrappedValue == true { externalFocus?.wrappedValue = false }
@@ -153,6 +154,9 @@ public struct MultiLineTextInput: View {
                 .scrollContentBackground(.hidden)
                 .padding(8)
                 .disabled(!isEnabled)
+                // E1 — read-only: normal (non-dimmed) chrome + VoiceOver value,
+                // but the editor can't be tapped into. NOT `.disabled` (dims).
+                .allowsHitTesting(!isReadOnly)
                 .a11y(A11yElement.Field.field, in: accessibilityID)
                 .accessibilityLabel(isRequired ? label + ", " + String(themeKit: "required") : label)
                 .accessibilityValue(text)
@@ -288,6 +292,10 @@ public extension MultiLineTextInput {
                     .errorText(showError ? "This field is required." : nil)
                     .fieldStyle(.muted)
                 Button(showError ? "Hide error" : "Show error") { showError.toggle() }
+                // Read-only (E1): normal chrome + value, editing blocked.
+                MultiLineTextInput("Submitted review", text: .constant("Great stay, would book again."))
+                    .size(.xsmall)
+                    .readOnly()
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/MultiLineTextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiLineTextInput.swift
@@ -34,6 +34,8 @@ public struct MultiLineTextInput: View {
     private var placeholder: String = ""
     private var characterLimit: Int?
     private var errorText: String?
+    private var helperText: String?
+    private var warningText: String?
     private var infoMessages: [InfoMessage] = []
     /// Set only by the `.size(_:)` modifier — an explicit size wins over the
     /// subtree `FieldDefaults.size` default (`explicitSize ?? fieldDefaults.size ?? .medium`).
@@ -66,6 +68,8 @@ public struct MultiLineTextInput: View {
     private var messages: [InfoMessage] {
         var messages = infoMessages
         if let errorText { messages.append(InfoMessage(errorText, kind: .error)) }
+        if let warningText { messages.append(InfoMessage(warningText, kind: .warning)) }
+        if let helperText { messages.append(InfoMessage(helperText, kind: .info)) }
         return messages
     }
     private var dominant: InfoMessage.Kind? { messages.dominantKind }
@@ -228,6 +232,14 @@ public extension MultiLineTextInput {
 
     /// Convenience error message appended as an `.error` `InfoMessage`.
     func errorText(_ text: String?) -> Self { copy { $0.errorText = text } }
+
+    /// Convenience hint appended to the message list as an `.info` `InfoMessage`
+    /// (parity with `TextInput.helperText`).
+    func helperText(_ text: String?) -> Self { copy { $0.helperText = text } }
+
+    /// Convenience warning appended to the message list as a `.warning` `InfoMessage`
+    /// (parity with `TextInput.warningText`).
+    func warningText(_ text: String?) -> Self { copy { $0.warningText = text } }
 
     /// Validation / hint messages rendered beneath the editor.
     func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }

--- a/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
@@ -30,6 +30,8 @@ public struct MultiSelect<Option: Hashable>: View {
     private var searchable: Bool = true
     private var allowClear: Bool = true
     private var maxTagCount: Int? = nil
+    /// Selection-count cap (E13, Ant `maxCount`); `nil` = unlimited.
+    private var maxSelection: Int? = nil
     private var isLoading: Bool = false
     private var accessibilityID: String? = nil
     @Environment(\.isEnabled) private var isEnabled
@@ -68,7 +70,16 @@ public struct MultiSelect<Option: Hashable>: View {
     private var selectedOptions: [Option] { options.filter { selection.contains($0) } }
     private var visibleTags: [Option] { Self.tagLayout(selected: selectedOptions, maxTagCount: maxTagCount).visible }
     private var overflowCount: Int { Self.tagLayout(selected: selectedOptions, maxTagCount: maxTagCount).overflow }
-    private func optionEnabled(_ option: Option) -> Bool { isOptionEnabled?(option) ?? true }
+    /// Whether the selection is at its `maxSelection(_:)` cap (E13).
+    private var atSelectionCap: Bool {
+        guard let maxSelection, maxSelection > 0 else { return false }
+        return selection.count >= maxSelection
+    }
+    /// A row is selectable when its predicate allows it AND — at the cap —
+    /// it's already selected (so it can still be deselected).
+    private func optionEnabled(_ option: Option) -> Bool {
+        (isOptionEnabled?(option) ?? true) && (selection.contains(option) || !atSelectionCap)
+    }
 
     /// Splits selected options into the chips to render and the "+N" overflow count.
     static func tagLayout(selected: [Option], maxTagCount: Int?) -> (visible: [Option], overflow: Int) {
@@ -223,7 +234,11 @@ public struct MultiSelect<Option: Hashable>: View {
     }
 
     private func toggle(_ opt: Option) {
-        if selection.contains(opt) { selection.remove(opt) } else { selection.insert(opt) }
+        if selection.contains(opt) {
+            selection.remove(opt)
+        } else if !atSelectionCap {   // E13 — VoiceOver activation isn't hit-tested
+            selection.insert(opt)
+        }
     }
 }
 
@@ -259,6 +274,11 @@ public extension MultiSelect {
     /// Caps the visible selected-tag chips, collapsing the rest into a "+N" tag.
     func maxTags(_ count: Int?) -> Self { copy { $0.maxTagCount = count } }
 
+    /// Caps how many options can be selected (E13, Ant `maxCount`). At the cap
+    /// the remaining unselected rows are disabled until something is deselected;
+    /// `nil` (default) = unlimited. Display-only chip capping stays `maxTags(_:)`.
+    func maxSelection(_ count: Int?) -> Self { copy { $0.maxSelection = count } }
+
     /// Shows a loading spinner in place of the chevron (async option fetch).
     func loading(_ on: Bool = true) -> Self { copy { $0.isLoading = on } }
 
@@ -287,6 +307,9 @@ public extension MultiSelect {
         var body: some View {
             VStack(spacing: 16) {
                 MultiSelect("Cities", options: cities, selection: $picks) { $0 }
+                // Selection cap (E13): at 3 picks the remaining rows disable.
+                MultiSelect("Up to 3 cities", options: cities, selection: $picks) { $0 }
+                    .maxSelection(3)
                 // Descriptions + custom leading content, driven by a
                 // controlled isExpanded binding.
                 MultiSelect("Channels", options: ["Email", "Push", "SMS"], selection: $channels, isExpanded: $channelsOpen) { $0 }

--- a/Sources/ThemeKit/Components/Molecules/OTPInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/OTPInput.swift
@@ -75,7 +75,8 @@ public struct OTPInput: View {
     /// OTPInput has no `TextInputSize` modifier of its own; the subtree
     /// `FieldDefaults.size` maps onto the digit-cell height (`nil` keeps the
     /// classic 56pt `.medium` cell).
-    private var effectiveSize: TextInputSize { fieldDefaults.size ?? .medium }
+    private var explicitSize: TextInputSize?
+    private var effectiveSize: TextInputSize { explicitSize ?? fieldDefaults.size ?? .medium }
     /// Message rows animate when micro-animations are on and the subtree default
     /// doesn't turn message motion off (Reduce Motion still wins inside MicroMotion).
     private var messagesAnimated: Bool { micro && (fieldDefaults.messagesAnimated ?? true) }
@@ -386,6 +387,10 @@ public extension OTPInput {
     /// Per-slot placeholder: each empty, non-caret box shows the character at
     /// its position (e.g. `"------"` or `"000000"`) in the tertiary text tone.
     func placeholder(_ text: String) -> Self { copy { $0.placeholderText = text } }
+
+    /// Control-height preset. An explicit size wins over the subtree
+    /// `FieldDefaults.size` default.
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
 
     /// Mask the entered digits (password-style dots) instead of showing them.
     func secure(_ on: Bool = true) -> Self { copy { $0.isSecure = on } }

--- a/Sources/ThemeKit/Components/Molecules/PaymentCardField.swift
+++ b/Sources/ThemeKit/Components/Molecules/PaymentCardField.swift
@@ -42,7 +42,10 @@ public struct PaymentCardField: View {
     /// holder) is its own field box, so the whole box chroma belongs to
     /// `FieldStyle`, not `CardStyle`.
     @Environment(\.fieldStyle) private var fieldStyle
+    @Environment(\.fieldDefaults) private var fieldDefaults
     @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
+    /// Read-only subtree axis (set with `.readOnly(_:)`) — normal chrome, no editing.
+    @Environment(\.isReadOnly) private var isReadOnly
 
     /// Which of the four field rows currently holds keyboard focus.
     private enum FieldRole: Hashable { case number, expiry, cvv, holder }
@@ -57,6 +60,17 @@ public struct PaymentCardField: View {
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
     private var numberPlaceholder = "Card number"
     private var holderPlaceholder = "Cardholder name"
+    /// Explicit `.size(_:)` preset — wins over the subtree `FieldDefaults.size`.
+    private var explicitSize: TextInputSize?
+    private var infoMessages: [InfoMessage] = []
+
+    // Declarative validation (daisyUI Validator) — rules run against the
+    // *card number* text at `validationTrigger`; failures merge into the
+    // rendered messages, driving the rows' error border automatically.
+    private var validationRules: [ValidationRule] = []
+    private var validationTrigger: ValidationTrigger = .editingEnd
+    private var onValidation: ((Bool) -> Void)?
+    @State private var validationMessages: [InfoMessage] = []
 
     public init(number: Binding<String>, expiry: Binding<String>, cvv: Binding<String>) {   // R1
         self._number = number
@@ -67,6 +81,22 @@ public struct PaymentCardField: View {
     private var brand: CardBrand { CardBrand.detect(number) }
     private var accentBase: Color { (accent ?? .primary).base }
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous) }
+    /// Explicit `.size(_:)` → subtree `FieldDefaults.size` → the classic 52pt rows.
+    private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }
+    /// Explicit `infoMessages(_:)` plus any current `validate(_:on:)` failures.
+    private var messages: [InfoMessage] { infoMessages + validationMessages }
+    private var dominant: InfoMessage.Kind? { messages.dominantKind }
+    private var hasError: Bool { dominant == .error }
+    private var hasWarning: Bool { dominant == .warning }
+
+    /// Runs the declared rules over the card-number text (first failure only,
+    /// via `Validator`); publishes the result and reports validity.
+    private func runValidation(_ value: String) {
+        guard !validationRules.isEmpty else { return }
+        let failures = Validator.validate(value, validationRules)
+        if failures != validationMessages { validationMessages = failures }
+        onValidation?(!failures.contains { $0.kind == .error })
+    }
 
     public var body: some View {
         VStack(spacing: Theme.SpacingKey.sm.value) {
@@ -82,6 +112,16 @@ public struct PaymentCardField: View {
             if let holder {
                 fieldBox(.holder) { field(holder, holderPlaceholder, role: .holder) { $0 } }
             }
+            if !messages.isEmpty { InfoMessageList(messages) }
+        }
+        // `.live` validates every number change; other triggers re-validate once
+        // a failure is visible so the error clears as the user fixes it.
+        .onChange(of: number) { _, value in
+            if validationTrigger == .live || !validationMessages.isEmpty { runValidation(value) }
+        }
+        // `.editingEnd` / `.submit` fire when the number row loses focus.
+        .onChange(of: focused) { old, now in
+            if old == .number, now != .number, validationTrigger != .live { runValidation(number) }
         }
     }
 
@@ -102,16 +142,18 @@ public struct PaymentCardField: View {
 
     /// One field row wrapped in the active ``FieldStyle`` chrome (fill + border).
     /// Mapping: `isFocused` is true for the row whose editor holds focus;
-    /// `hasError`/`hasWarning` are always `false` (this component has no
-    /// validation axis); `size` is `.medium` — the rows have no `TextInputSize`
-    /// axis (they keep their fixed 52pt min-height in the content). A custom
+    /// `hasError`/`hasWarning` follow the dominant message kind (explicit
+    /// `infoMessages` + validation failures — group-level, so every row recolors).
+    /// With no explicit `.size(_:)` and no subtree `FieldDefaults.size` the rows
+    /// keep their classic scaled 52pt min-height (nominal `.medium`). A custom
     /// `surface(_:)` key (anything other than the default `.bgBase`) is painted
     /// inside the content so the modifier keeps working; with the default key the
     /// fill is left entirely to the style.
     private func fieldBox<Content: View>(_ role: FieldRole, @ViewBuilder _ content: () -> Content) -> some View {
         let row = content()
             .padding(.horizontal, Theme.SpacingKey.md.value)
-            .frame(minHeight: 52)
+            // Scales with Dynamic Type (G2); a size preset remaps the height (C1).
+            .scaledControlHeight(effectiveSize?.height ?? 52)
             .frame(maxWidth: .infinity, alignment: .leading)
         return fieldStyle.makeBody(configuration: FieldStyleConfiguration(
             content: surfaceKey == .bgWhite
@@ -119,9 +161,9 @@ public struct PaymentCardField: View {
                 : AnyView(row.background(theme.background(surfaceKey), in: shape)),
             isFocused: focused == role,
             isEnabled: isEnabled,
-            hasError: false,
-            hasWarning: false,
-            size: .medium
+            hasError: hasError,
+            hasWarning: hasWarning,
+            size: effectiveSize ?? .medium
         ))
     }
 
@@ -138,6 +180,9 @@ public struct PaymentCardField: View {
         .focused($focused, equals: role)
         .textStyle(.bodyBase400)
         .foregroundStyle(theme.text(.textPrimary))
+        // Read-only keeps the normal chrome + values but blocks focus/editing
+        // on every row (E1 — distinct from `.disabled`).
+        .allowsHitTesting(!isReadOnly)
         .applyKeyboard(keyboard)
         .onChange(of: binding.wrappedValue) { _, new in
             let f = format(new)
@@ -193,6 +238,28 @@ public extension PaymentCardField {
         copy { if let number { $0.numberPlaceholder = number }; if let holder { $0.holderPlaceholder = holder } }
     }
 
+    /// Control-height preset for every row. An explicit size wins over the
+    /// subtree `FieldDefaults.size` default (`explicit ?? fieldDefaults.size ?? 52pt`).
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
+
+    /// Validation / info messages rendered under the group (drives the rows' border state).
+    func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }
+
+    /// Declarative validation (daisyUI Validator): `rules` run against the
+    /// **card number** text (as displayed, space-grouped) at `trigger` —
+    /// `.editingEnd`/`.submit` when the number row loses focus, `.live` per
+    /// keystroke. Failures merge into the rendered messages and border state.
+    ///
+    ///     PaymentCardField(number: $num, expiry: $exp, cvv: $cvv)
+    ///         .validate([.required(), .minLength(19, "Enter the full card number")])
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
+        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    }
+
+    /// Reports validity after each `validate(_:on:)` pass — `true` when no
+    /// error-severity failure is present.
+    func onValidation(_ handler: @escaping (Bool) -> Void) -> Self { copy { $0.onValidation = handler } }
+
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
         mutate(&c)
@@ -212,6 +279,15 @@ public extension PaymentCardField {
                 // Swapped chrome: every field row picks up the underlined style.
                 PaymentCardField(number: $num, expiry: $exp, cvv: $cvv)
                     .fieldStyle(.underlined)
+                // Declarative validation over the card number (E3).
+                PaymentCardField(number: $num, expiry: $exp, cvv: $cvv)
+                    .validate([.required(), .minLength(19, "Enter the full card number")])
+                // Size ramp — explicit `.size(_:)` wins over `FieldDefaults.size`.
+                PaymentCardField(number: $num, expiry: $exp, cvv: $cvv).size(.small)
+                // Read-only: values + normal chrome, editing suppressed (E1).
+                PaymentCardField(number: .constant("4111 1111 1111 1111"),
+                                 expiry: .constant("12/29"), cvv: .constant("123"))
+                    .readOnly()
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/PriceTrendChart.swift
+++ b/Sources/ThemeKit/Components/Molecules/PriceTrendChart.swift
@@ -128,6 +128,7 @@ public struct PriceTrendChart: View {
     private func chevron(_ name: String, _ action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: name).font(.system(size: 13, weight: .semibold)).foregroundStyle(theme.foreground(.fgHero))
+                .mirrorsInRTL()
                 .frame(width: 28, height: 28).background(theme.background(.bgSecondaryLight), in: Circle())
         }.buttonStyle(.plain)
     }

--- a/Sources/ThemeKit/Components/Molecules/RadioButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioButton.swift
@@ -62,6 +62,9 @@ public struct RadioButton: View {
     private var accent: SemanticColor?
     private var verticalAlignment: VerticalAlignment = .center
     private var accessibilityID: String?
+    private var controlPlacement: HorizontalEdge = .leading   // A3
+    private var customLabel: SlotContent?                     // D1 — `.label { }` slot
+    @Environment(\.isReadOnly) private var isReadOnly         // E1
 
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -87,25 +90,23 @@ public struct RadioButton: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
             Button {
+                guard !isReadOnly else { return }   // E1 — VoiceOver activation is not hit-tested
                 if type == .check { isSelected.toggle() } else { isSelected = true }
             } label: {
                 HStack(alignment: verticalAlignment, spacing: gap.value) {
-                    Circle()
-                        .fill(filled ? fillColor : .clear)
-                        .overlay(Circle().strokeBorder(stroke, lineWidth: 1.5))
-                        .frame(width: controlSize.checkboxSide, height: controlSize.checkboxSide)
-                        .overlay(indicator.transition(.scale(scale: 0.6).combined(with: .opacity)))
-                        .animation(motion, value: isSelected)
-                    if let label {
-                        Text(label)
-                            .textStyle(.bodyBase400)
-                            .foregroundStyle(isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
+                    if controlPlacement == .leading {
+                        control
+                        labelView
+                    } else {
+                        labelView
+                        control
                     }
                 }
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .disabled(!isEnabled)
+            .allowsHitTesting(!isReadOnly)   // E1 — normal chrome, toggling blocked
             .a11y(A11yElement.Control.radio, in: accessibilityID)
             .accessibilityLabel(label ?? "")
             .accessibilityValue(isSelected ? String(themeKit: "selected") : String(themeKit: "not selected"))
@@ -114,6 +115,27 @@ public struct RadioButton: View {
             if !infoMessages.isEmpty {
                 InfoMessageList(infoMessages).a11y(A11yElement.Field.message, in: accessibilityID)
             }
+        }
+    }
+
+    /// The radio glyph itself (extracted so `controlPlacement` can branch order).
+    private var control: some View {
+        Circle()
+            .fill(filled ? fillColor : .clear)
+            .overlay(Circle().strokeBorder(stroke, lineWidth: 1.5))
+            .frame(width: controlSize.checkboxSide, height: controlSize.checkboxSide)
+            .overlay(indicator.transition(.scale(scale: 0.6).combined(with: .opacity)))
+            .animation(motion, value: isSelected)
+    }
+
+    /// Built-in string label, or the `.label { }` slot when set (D1/B8).
+    @ViewBuilder private var labelView: some View {
+        if let customLabel {
+            customLabel
+        } else if let label {
+            Text(label)
+                .textStyle(.bodyBase400)
+                .foregroundStyle(isEnabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
         }
     }
 
@@ -193,6 +215,18 @@ public extension RadioButton {
     /// Vertical alignment of the radio against a multi-line label.
     func alignment(_ a: VerticalAlignment) -> Self { copy { $0.verticalAlignment = a } }
 
+    /// Which side of the label the radio sits on: `.leading` (default) or
+    /// `.trailing`. RTL-safe — `HorizontalEdge` follows the layout direction.
+    /// (ControlRow `controlPlacement` vocabulary; A3.)
+    func controlPlacement(_ edge: HorizontalEdge) -> Self { copy { $0.controlPlacement = edge } }
+
+    /// Replaces the built-in text label with custom content (the canonical
+    /// `.label { }` slot). The slot inherits the surrounding text environment;
+    /// pass the string init arg too if the control should keep a VoiceOver label.
+    func label<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.customLabel = SlotContent(content) }
+    }
+
     /// Sets the accessibility-identifier namespace for this component (its
     /// sub-elements get `"<id>.<element>"`).
     func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
@@ -213,6 +247,18 @@ public extension RadioButton {
         RadioButton("Remember me", isSelected: .constant(true)).type(.check).radioStyle(.inner).gap(.medium)
         RadioButton("Success accent", isSelected: .constant(true)).accent(.success)
         RadioButton("Error accent", isSelected: .constant(true)).type(.check).accent(.error)
+        RadioButton("Large radio", isSelected: .constant(true)).controlSize(.large)     // C4
+        RadioButton("Radio on the trailing side", isSelected: .constant(true))
+            .controlPlacement(.trailing)                                                // A3
+        RadioButton("Card payment", isSelected: .constant(true))
+            .label {                                                                    // D1
+                HStack(spacing: Theme.SpacingKey.xs.value) {
+                    Image(systemName: "creditcard")
+                    Text("Card payment").fontWeight(.semibold)
+                }
+                .textStyle(.bodyBase400)
+            }
+        RadioButton("Read-only (tap does nothing)", isSelected: .constant(true)).readOnly() // E1
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
@@ -21,9 +21,12 @@ public struct RadioGroup<Option: Hashable>: View {
     private var infoMessages: [InfoMessage] = []
     private var isOptionEnabled: ((Option) -> Bool)?
     private var description: (Option) -> String? = { _ in nil }
+    private var groupDescription: String?                     // E5
     private var accent: SemanticColor?
     private var axis: Axis = .vertical
+    private var controlPlacement: HorizontalEdge = .leading   // A4 — forwarded to rows
     private var accessibilityID: String? = nil
+    @Environment(\.isReadOnly) private var isReadOnly         // E1 — rows own the tap
 
     public init(
         title: String? = nil,
@@ -52,6 +55,9 @@ public struct RadioGroup<Option: Hashable>: View {
             if let title {
                 Text(title).textStyle(.labelMd600).foregroundStyle(titleColor)
             }
+            if let groupDescription {
+                HelperText(groupDescription)   // E5 — group-level supporting text
+            }
             optionsContainer
             if !infoMessages.isEmpty {
                 InfoMessageList(infoMessages).a11y(A11yElement.Field.message, in: accessibilityID)
@@ -73,29 +79,38 @@ public struct RadioGroup<Option: Hashable>: View {
         ForEach(Array(options.enumerated()), id: \.element) { index, option in
             let enabled = optionEnabled(option)
             let description = description(option)
+            let radio = RadioButton(isSelected: .constant(selection == option)).accent(accent)
+            let labelBlock = VStack(alignment: .leading, spacing: 2) {
+                Text(label(option))
+                    .textStyle(.bodyBase400)
+                    .foregroundStyle(theme.text(.textPrimary))
+                if let description {
+                    Text(description)
+                        .textStyle(.bodySm400)
+                        .foregroundStyle(theme.text(.textSecondary))
+                }
+            }
             Button {
+                guard !isReadOnly else { return }   // E1 — VoiceOver activation is not hit-tested
                 selection = option
             } label: {
                 // Top-align the radio against the label block when supporting text is present.
                 HStack(alignment: description == nil ? .center : .top, spacing: Theme.SpacingKey.sm.value) {
-                    RadioButton(isSelected: .constant(selection == option))
-                        .accent(accent)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(label(option))
-                            .textStyle(.bodyBase400)
-                            .foregroundStyle(theme.text(.textPrimary))
-                        if let description {
-                            Text(description)
-                                .textStyle(.bodySm400)
-                                .foregroundStyle(theme.text(.textSecondary))
-                        }
+                    if controlPlacement == .leading {   // A4 — group-level placement
+                        radio
+                        labelBlock
+                        if axis == .vertical { Spacer() }
+                    } else {
+                        labelBlock
+                        if axis == .vertical { Spacer() }
+                        radio
                     }
-                    if axis == .vertical { Spacer() }
                 }
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .disabled(!enabled)
+            .allowsHitTesting(!isReadOnly)   // E1 — normal chrome, selection blocked
             .opacity(enabled ? 1 : 0.4)
             .a11y("option.\(index)", in: accessibilityID)
             .accessibilityLabel(label(option))
@@ -203,6 +218,9 @@ public struct RadioButtonGroup<Option: Hashable>: View {
                     .accent(.success)
                 RadioGroup(title: "Horizontal", options: ["Economy", "Business", "First"], selection: $sel) { $0 }
                     .axis(.horizontal)
+                RadioGroup(title: "Trailing radios", options: ["Economy", "Business", "First"], selection: $sel) { $0 }
+                    .controlPlacement(.trailing)                                        // A4
+                    .description("Fares are per passenger, taxes included.")            // E5
                 RadioButtonGroup(options: ["Day", "Week", "Month"], selection: $seg) { $0 }
                 RadioButtonGroup(options: ["Day", "Week", "Month"], selection: $seg) { $0 }
                     .groupStyle(.outline).fullWidth()
@@ -224,6 +242,15 @@ public extension RadioGroup {
 
     /// Supporting text rendered under each row's label (return nil for none).
     func optionDescription(_ description: @escaping (Option) -> String?) -> Self { copy { $0.description = description } }
+
+    /// Group-level supporting text rendered under the title via `HelperText`
+    /// (Ant/HeroUI group `description`; E5). Distinct from `optionDescription`.
+    func description(_ text: String?) -> Self { copy { $0.groupDescription = text } }
+
+    /// Which side of each row's label the radio sits on: `.leading` (default)
+    /// or `.trailing`, forwarded to every option row. RTL-safe —
+    /// `HorizontalEdge` follows the layout direction. (A4.)
+    func controlPlacement(_ edge: HorizontalEdge) -> Self { copy { $0.controlPlacement = edge } }
 
     /// Semantic tint forwarded to every radio's selected fill/border; `nil`
     /// (default) uses the hero tokens. (HeroUI item variant / daisyUI `radio-{color}`.)

--- a/Sources/ThemeKit/Components/Molecules/RecentSearchRow.swift
+++ b/Sources/ThemeKit/Components/Molecules/RecentSearchRow.swift
@@ -56,7 +56,7 @@ public struct RecentSearchRow: View {
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 6) {
                         Text(from).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
-                        Image(systemName: roundTrip ? "arrow.left.arrow.right" : "arrow.right").font(.system(size: 12, weight: .semibold)).foregroundStyle(theme.text(.textTertiary))
+                        Image(systemName: roundTrip ? "arrow.left.arrow.right" : "arrow.right").font(.system(size: 12, weight: .semibold)).foregroundStyle(theme.text(.textTertiary)).mirrorsInRTL()
                         Text(to).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
                     }
                     if let caption { Text(caption).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(1) }

--- a/Sources/ThemeKit/Components/Molecules/SearchBar.swift
+++ b/Sources/ThemeKit/Components/Molecules/SearchBar.swift
@@ -134,7 +134,8 @@ public struct SearchBar: View {
     /// SearchBar has no `TextInputSize` modifier of its own; the subtree
     /// `FieldDefaults.size` maps onto its control height (the classic fixed
     /// 44pt equals `.small`, which stays the default).
-    private var effectiveSize: TextInputSize { fieldDefaults.size ?? .small }
+    private var explicitSize: TextInputSize?
+    private var effectiveSize: TextInputSize { explicitSize ?? fieldDefaults.size ?? .small }
     /// Message rows animate when micro-animations are on and the subtree default
     /// doesn't turn message motion off (Reduce Motion still wins inside MicroMotion).
     private var messagesAnimated: Bool { micro && (fieldDefaults.messagesAnimated ?? true) }
@@ -434,6 +435,10 @@ public struct SearchBar: View {
 public extension SearchBar {
     /// Placeholder shown while the field is empty.
     func placeholder(_ text: String) -> Self { copy { $0.placeholder = text } }
+
+    /// Control-height preset. An explicit size wins over the subtree
+    /// `FieldDefaults.size` default (`explicit ?? fieldDefaults.size ?? .small`).
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
 
     /// Static typeahead suggestions, filtered locally as the user types (classic init only).
     func suggestions(_ items: [String]) -> Self { copy { $0.source = items.isEmpty ? .none : .staticList(items) } }

--- a/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
+++ b/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
@@ -68,6 +68,7 @@ public enum SegmentedSelectionStyle { case thumb, outline, tinted }
 public struct SegmentedControl: View {
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
+    @Environment(\.componentDefaults) private var componentDefaults
 
     private let items: [SegmentItem]
     @Binding private var selection: Int
@@ -77,10 +78,19 @@ public struct SegmentedControl: View {
     private var size: SegmentedSize = .medium
     private var shape: SegmentedShape = .default
     private var selectionStyle: SegmentedSelectionStyle = .thumb
-    private var tintColor: SemanticColor = .primary
+    /// Explicit `.accent(_:)` / `.tinted(_:)` color; `nil` defers to the
+    /// subtree `componentDefaults` accent, then `.primary` (provider cascade, F3).
+    private var tintColor: SemanticColor?
     private var isVertical = false
     private var showsDividers = false
     private var accessibilityID: String? = nil
+
+    /// The resolved tint for the `.tinted` / `.outline` selection styles:
+    /// explicit modifier ?? subtree `componentDefaults.accent` ?? `.primary`.
+    private var resolvedTint: SemanticColor { tintColor ?? componentDefaults.accent ?? .primary }
+    /// `true` while nothing (explicit or provider) re-tints the control — the
+    /// stock hero chroma applies, keeping the default look pixel-identical.
+    private var usesStockTint: Bool { tintColor == nil && componentDefaults.accent == nil }
 
     @State private var hovered: Int?
     @Namespace private var pill
@@ -110,7 +120,7 @@ public struct SegmentedControl: View {
 
     /// The track fill — the tint's soft wash for `.tinted`, else the neutral base.
     private var trackFill: Color {
-        selectionStyle == .tinted ? tintColor.soft : theme.background(.bgBase)
+        selectionStyle == .tinted ? resolvedTint.soft : theme.background(.bgBase)
     }
 
     public var body: some View {
@@ -188,8 +198,10 @@ public struct SegmentedControl: View {
                 thumbShape.fill(theme.background(.bgWhite)).themeShadow(.soft)
                     .matchedGeometryEffect(id: "pill", in: pill)
             case .outline:
-                thumbShape.fill(SemanticColor.primary.soft)
-                    .overlay(thumbShape.stroke(theme.border(.borderHero), lineWidth: 2))
+                // Stock hue keeps the historical hero-border chroma exactly;
+                // an explicit/provider accent re-tints the pill + stroke.
+                thumbShape.fill(resolvedTint.soft)
+                    .overlay(thumbShape.stroke(usesStockTint ? theme.border(.borderHero) : resolvedTint.border, lineWidth: 2))
                     .matchedGeometryEffect(id: "pill", in: pill)
             case .tinted:
                 EmptyView()   // no thumb — the soft track + hero foreground carry selection
@@ -207,7 +219,7 @@ public struct SegmentedControl: View {
         guard enabled else { return theme.text(.textDisabled) }
         guard isActive else { return theme.text(.textSecondary) }
         // The tinted style follows its base color's accent; others use the hero.
-        return selectionStyle == .tinted ? tintColor.accent : theme.text(.textHero)
+        return selectionStyle == .tinted ? resolvedTint.accent : theme.text(.textHero)
     }
 }
 
@@ -228,12 +240,20 @@ public extension SegmentedControl {
     /// Draw a hairline between adjacent segments — pair with `.tinted()` / `.shape(.round)`
     /// for the design-system icon toggle (chart / grid switch).
     func dividers(_ on: Bool = true) -> Self { copy { $0.showsDividers = on } }
-    /// The thumbless soft-track selection style, tinted with a base `color`
-    /// (default hero): the track uses `color.soft`, the active option `color.accent`.
-    /// Shortcut for `.selectionStyle(.tinted)` with a color.
-    func tinted(_ color: SemanticColor = .primary) -> Self {
+    /// The thumbless soft-track selection style, tinted with a base `color`:
+    /// the track uses `color.soft`, the active option `color.accent`. `nil`
+    /// (default) defers to the subtree ``ComponentDefaults`` accent, then the
+    /// hero primary. Shortcut for `.selectionStyle(.tinted)` with a color.
+    func tinted(_ color: SemanticColor? = nil) -> Self {
         copy { $0.selectionStyle = .tinted; $0.tintColor = color }
     }
+
+    /// Semantic tint for the `.tinted` / `.outline` selection styles (standard
+    /// accent vocabulary); `nil` (default) defers to the subtree
+    /// ``ComponentDefaults`` accent (set once with
+    /// `.componentDefaults(accent:)`), then `.primary`. The stock `.thumb`
+    /// style keeps its neutral chroma.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.tintColor = color } }
     /// Sets the accessibility-identifier namespace for this component.
     func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
 
@@ -261,6 +281,14 @@ public extension SegmentedControl {
                     SegmentedControl([SegmentItem(icon: "list.bullet"), SegmentItem(icon: "square.grid.2x2"),
                                       SegmentItem(icon: "map")], selection: $c).fullWidth(false)
                     SegmentedControl(["A", "B", "C"], selection: $d).vertical().fullWidth(false)
+                    // F3 — provider cascade: no explicit accent → the subtree
+                    // componentDefaults re-tints .tinted/.outline; explicit wins.
+                    VStack(alignment: .leading, spacing: 8) {
+                        SegmentedControl(["Chart", "Grid"], selection: $a).tinted().dividers().fullWidth(false)
+                        SegmentedControl(["Day", "Week"], selection: $b).selectionStyle(.outline)
+                        SegmentedControl(["On", "Off"], selection: $c).tinted(.success).fullWidth(false)
+                    }
+                    .componentDefaults(accent: .turquoise)
                 }
                 .padding()
             }

--- a/Sources/ThemeKit/Components/Molecules/Select.swift
+++ b/Sources/ThemeKit/Components/Molecules/Select.swift
@@ -42,7 +42,12 @@ public struct Select<Option: Hashable>: View {
     private var describeOption: ((Option) -> String?)? = nil
     private var leadingContent: ((Option) -> AnyView)? = nil
     private var accessibilityID: String? = nil
+    /// Marks the field as required: asterisk after the label + ", required"
+    /// appended to the accessibility label (E2, HeroUI `isRequired`).
+    private var isRequired = false
     @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
+    @Environment(\.isReadOnly) private var isReadOnly // E1 — set by `.readOnly(_:)`
+    @Environment(\.fieldDefaults) private var fieldDefaults
 
     /// Legacy chrome hook — honored only when a custom style was injected with
     /// the (deprecated) `.selectStyle(_:)`. Otherwise chrome comes from `\.fieldStyle`.
@@ -84,7 +89,10 @@ public struct Select<Option: Hashable>: View {
     }
 
     private var hasValue: Bool { selection != nil }
-    private var showsClear: Bool { allowClear && hasValue && isEnabled && !isLoading }
+    private var showsClear: Bool { allowClear && hasValue && isEnabled && !isReadOnly && !isLoading }
+    /// Whether `.required()` renders its asterisk (`FieldDefaults.requiredIndicator`;
+    /// the accessibility ", required" suffix is unaffected).
+    private var showsRequiredIndicator: Bool { fieldDefaults.requiredIndicator ?? true }
     private func optionEnabled(_ option: Option) -> Bool { isOptionEnabled?(option) ?? true }
     private var hasAnyResults: Bool { sections.contains { !filtered($0.options).isEmpty } }
 
@@ -92,7 +100,7 @@ public struct Select<Option: Hashable>: View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
             ZStack(alignment: .trailing) {
                 if searchable {
-                    Button { if isEnabled { open.toggle() } } label: { field }
+                    Button { if isEnabled && !isReadOnly { open.toggle() } } label: { field }
                         .buttonStyle(.plain)
                         .disabled(!isEnabled)
                 } else {
@@ -101,11 +109,15 @@ public struct Select<Option: Hashable>: View {
                 }
                 clearButton
             }
+            // E1 — read-only keeps the normal (non-dimmed) chrome + value +
+            // VoiceOver value, but the menu / panel can't be opened and the
+            // clear button is hidden. Deliberately NOT `.disabled`, which dims.
+            .allowsHitTesting(!isReadOnly)
             .a11y(A11yElement.Select.trigger, in: accessibilityID)
-            .accessibilityLabel(label)
+            .accessibilityLabel(isRequired ? label + ", " + String(themeKit: "required") : label)
             .accessibilityValue(selection.map(optionTitle) ?? "")
 
-            if searchable && open { panel }
+            if searchable && open && !isReadOnly { panel }   // E1 — panel closes under read-only
             if !infoMessages.isEmpty {
                 InfoMessageList(infoMessages).a11y(A11yElement.Field.message, in: accessibilityID)
             }
@@ -119,10 +131,18 @@ public struct Select<Option: Hashable>: View {
     private var fieldContent: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
             ZStack(alignment: .leading) {
-                Text(label)
-                    .textStyle(hasValue ? .labelSm600 : .bodyBase400)
-                    .foregroundStyle(hasValue ? theme.text(.textHero) : theme.text(.textTertiary))
-                    .offset(y: hasValue ? -11 : 0)
+                HStack(spacing: 4) {   // matches the `InputLabel` atom's asterisk gap
+                    Text(label)
+                        .foregroundStyle(hasValue ? theme.text(.textHero) : theme.text(.textTertiary))
+                    if isRequired && showsRequiredIndicator {
+                        // Same treatment as `InputLabel.required()` — error-token asterisk.
+                        Text(verbatim: "*")
+                            .foregroundStyle(theme.foreground(.systemcolorsFgError))
+                            .accessibilityHidden(true)   // spoken via the trigger's label suffix
+                    }
+                }
+                .textStyle(hasValue ? .labelSm600 : .bodyBase400)
+                .offset(y: hasValue ? -11 : 0)
                 if let selection {
                     Text(optionTitle(selection))
                         .textStyle(.bodyBase400)
@@ -314,6 +334,12 @@ public extension Select {
     /// Control height of the trigger field (small / medium / large).
     func size(_ size: TextInputSize) -> Self { copy { $0.size = size } }
 
+    /// Marks the field as required: renders an error-token asterisk after the
+    /// floating label (the `InputLabel` treatment, honoring the subtree
+    /// `FieldDefaults.requiredIndicator`) and appends ", required" to the
+    /// trigger's accessibility label (E2, HeroUI `isRequired`).
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
+
     /// Validation / info messages rendered under the field (drives the border state).
     func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }
 
@@ -377,6 +403,13 @@ public extension Select {
                 // Chrome via the shared FieldStyle axis.
                 Select("Underlined", options: ["Istanbul", "Ankara", "Izmir"], selection: $city) { $0 }
                     .fieldStyle(.underlined)
+                // Required indicator (E2) — asterisk + ", required" for VoiceOver.
+                Select("Departure city", options: ["Istanbul", "Ankara", "Izmir"], selection: $city) { $0 }
+                    .required()
+                // Read-only (E1): normal chrome + value, menu / clear blocked.
+                Select("Cabin", options: ["Economy", "Business"], selection: .constant("Economy")) { $0 }
+                    .clearable()
+                    .readOnly()
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/SelectBox.swift
+++ b/Sources/ThemeKit/Components/Molecules/SelectBox.swift
@@ -25,6 +25,13 @@ public struct SelectBox<Option: Hashable>: View {
     private var errorText: String? = nil
     private var infoMessages: [InfoMessage] = []
     private var accessibilityID: String? = nil
+    /// Set only by the `.size(_:)` modifier — an explicit size wins over the
+    /// subtree `FieldDefaults.size` default (`explicitSize ?? fieldDefaults.size`;
+    /// with neither set, the field keeps its original 48pt height). C1.
+    private var explicitSize: TextInputSize?
+    /// Marks the field as required: asterisk after the label + ", required"
+    /// appended to the accessibility label (E2, HeroUI `isRequired`).
+    private var isRequired = false
     /// Optional external focus (e.g. driven by `FormValidator.focusBinding`).
     /// The native `Menu` cannot be opened programmatically, so a `true` write
     /// renders the `FieldStyle` focus border (drawing the eye to the field);
@@ -34,6 +41,8 @@ public struct SelectBox<Option: Hashable>: View {
     /// title (empty when nothing is selected) when the selection changes.
     private var onEditingEnd: ((String) -> Void)?
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.isReadOnly) private var isReadOnly   // E1 — set by `.readOnly(_:)`
+    @Environment(\.fieldDefaults) private var fieldDefaults
 
     public init(   // R1
         _ label: String? = nil,
@@ -58,11 +67,25 @@ public struct SelectBox<Option: Hashable>: View {
     private var hasError: Bool { messages.dominantKind == .error }
     private var hasWarning: Bool { messages.dominantKind == .warning }
 
+    /// Explicit `.size(_:)` → subtree `FieldDefaults.size` → `nil` (the field's
+    /// own 48pt default height, kept for source-visual compatibility).
+    private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }
+    /// Whether `.required()` renders its asterisk (`FieldDefaults.requiredIndicator`;
+    /// the accessibility ", required" suffix is unaffected).
+    private var showsRequiredIndicator: Bool { fieldDefaults.requiredIndicator ?? true }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
             if let label {
                 HStack(spacing: 4) {
                     Text(label).textStyle(.labelSm600).foregroundStyle(labelColor)
+                    if isRequired && showsRequiredIndicator {
+                        // Same treatment as `InputLabel.required()` — error-token asterisk.
+                        Text(verbatim: "*")
+                            .textStyle(.labelSm600)
+                            .foregroundStyle(theme.foreground(.systemcolorsFgError))
+                            .accessibilityHidden(true)   // spoken via the trigger's label suffix
+                    }
                     Image(systemName: "info.circle").font(.system(size: 11)).foregroundStyle(theme.text(.textTertiary))
                 }
             }
@@ -83,8 +106,11 @@ public struct SelectBox<Option: Hashable>: View {
                 fieldBox
             }
             .disabled(!isEnabled)
+            // E1 — read-only keeps the normal (non-dimmed) chrome + value +
+            // VoiceOver value, but the menu can't be opened. NOT `.disabled` (dims).
+            .allowsHitTesting(!isReadOnly)
             .a11y(A11yElement.Select.trigger, in: accessibilityID)
-            .accessibilityLabel(label ?? "")
+            .accessibilityLabel(isRequired ? (label ?? "") + ", " + String(themeKit: "required") : (label ?? ""))
             .accessibilityValue(selection.map(optionTitle) ?? "")
 
             if !infoMessages.isEmpty {
@@ -106,8 +132,10 @@ public struct SelectBox<Option: Hashable>: View {
     }
 
     /// The composed trigger row — everything a `FieldStyle` receives as
-    /// `configuration.content`. The fixed 48pt control height lives here, so the
-    /// style only supplies the surface (fill + border + corner).
+    /// `configuration.content`. The control height lives here (the family
+    /// `TextInputSize` ramp when a `.size(_:)` / `FieldDefaults.size` is set,
+    /// the original 48pt otherwise), so the style only supplies the surface
+    /// (fill + border + corner).
     private var fieldContent: some View {
         HStack {
             Text(selection.map(optionTitle) ?? placeholder)
@@ -117,7 +145,7 @@ public struct SelectBox<Option: Hashable>: View {
             Icon(systemName: "chevron.down").size(.sm).color(theme.text(.textTertiary))
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
-        .scaledControlHeight(48)
+        .scaledControlHeight(effectiveSize?.height ?? 48)   // C1 — family size ramp
         .frame(maxWidth: .infinity)
     }
 
@@ -125,9 +153,9 @@ public struct SelectBox<Option: Hashable>: View {
     /// mapping: the native `Menu` exposes no open state, so `isFocused` reflects
     /// only the external focus binding (a `FormValidator` focusing this field
     /// renders the focus border; user taps draw no ring, as before); `hasWarning`
-    /// follows the dominant message severity; and — SelectBox having no
-    /// `TextInputSize` axis — `size` maps to `.medium`, purely advisory for
-    /// styles that key off it (the row keeps its own 48pt height).
+    /// follows the dominant message severity; and `size` reports the resolved
+    /// `TextInputSize` axis (`.medium` while unset — advisory for styles that
+    /// key off it; the row then keeps its own 48pt height).
     private var fieldBox: some View {
         fieldStyle.makeBody(configuration: FieldStyleConfiguration(
             content: AnyView(fieldContent),
@@ -135,7 +163,7 @@ public struct SelectBox<Option: Hashable>: View {
             isEnabled: isEnabled,
             hasError: hasError,
             hasWarning: hasWarning,
-            size: .medium
+            size: effectiveSize ?? .medium
         ))
     }
 
@@ -149,6 +177,17 @@ public struct SelectBox<Option: Hashable>: View {
 public extension SelectBox {
     /// Placeholder shown while no option is selected.
     func placeholder(_ text: String) -> Self { copy { $0.placeholder = text } }
+
+    /// Control height on the field family's `TextInputSize` ramp (C1). An
+    /// explicit size wins over the subtree `FieldDefaults.size` default; with
+    /// neither set the field keeps its original 48pt height.
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
+
+    /// Marks the field as required: renders an error-token asterisk after the
+    /// label (the `InputLabel` treatment, honoring the subtree
+    /// `FieldDefaults.requiredIndicator`) and appends ", required" to the
+    /// trigger's accessibility label (E2, HeroUI `isRequired`).
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
 
     /// Helper text rendered under the field (hidden while an error is shown).
     func hint(_ text: String?) -> Self { copy { $0.hint = text } }
@@ -195,6 +234,15 @@ public extension SelectBox {
                 // Chrome via the shared FieldStyle axis.
                 SelectBox("Underlined", options: ["Turkey", "Germany"], selection: $country) { $0 }
                     .fieldStyle(.underlined)
+                // Family size ramp (C1) — aligns with a `.small` TextInput beside it.
+                SelectBox("Compact", options: ["Turkey", "Germany"], selection: $country) { $0 }
+                    .size(.small)
+                // Required indicator (E2) — asterisk + ", required" for VoiceOver.
+                SelectBox("Region", options: ["EMEA", "APAC"], selection: $country) { $0 }
+                    .required()
+                // Read-only (E1): normal chrome + value, menu blocked.
+                SelectBox("Country (submitted)", options: ["Turkey", "Germany"], selection: .constant("Turkey")) { $0 }
+                    .readOnly()
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/Splitter.swift
+++ b/Sources/ThemeKit/Components/Molecules/Splitter.swift
@@ -16,10 +16,10 @@ import SwiftUI
 public struct Splitter<First: View, Second: View>: View {
     @Environment(\.theme) private var theme
 
-    private let axis: Axis
     private let first: First
     private let second: Second
     // Appearance — mutated only through the modifiers below.
+    private var axis: Axis
     private var minFraction: CGFloat = 0.15
     private var maxFraction: CGFloat = 0.85
 
@@ -101,6 +101,12 @@ public extension Splitter {
         copy { $0.minFraction = Swift.max(0, min); $0.maxFraction = Swift.min(1, max) }
     }
 
+    /// Stack the panes vertically (Ant Splitter `layout="vertical"`) — the
+    /// kit-standard axis vocabulary (cf. `SegmentedControl.vertical`) and the
+    /// modifier twin of the `axis:` init argument; `false` restores the
+    /// side-by-side layout.
+    func vertical(_ on: Bool = true) -> Self { copy { $0.axis = on ? .vertical : .horizontal } }
+
     private func copy(_ mutate: (inout Self) -> Void) -> Self {
         var c = self
         mutate(&c)
@@ -110,13 +116,25 @@ public extension Splitter {
 
 #Preview {
     @Previewable @Environment(\.theme) var theme
-    Splitter(.horizontal) {
-        Text("Sidebar").frame(maxWidth: .infinity, maxHeight: .infinity).background(theme.background(.bgElevatorPrimary))
-    } second: {
-        Text("Detail").frame(maxWidth: .infinity, maxHeight: .infinity).background(theme.background(.bgWhite))
+    VStack(spacing: Theme.SpacingKey.md.value) {
+        Splitter(.horizontal) {
+            Text("Sidebar").frame(maxWidth: .infinity, maxHeight: .infinity).background(theme.background(.bgElevatorPrimary))
+        } second: {
+            Text("Detail").frame(maxWidth: .infinity, maxHeight: .infinity).background(theme.background(.bgWhite))
+        }
+        .frame(height: 200)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value))
+
+        // The `.vertical()` modifier twin of `Splitter(.vertical) { … }`.
+        Splitter {
+            Text("Map").frame(maxWidth: .infinity, maxHeight: .infinity).background(theme.background(.bgElevatorPrimary))
+        } second: {
+            Text("List").frame(maxWidth: .infinity, maxHeight: .infinity).background(theme.background(.bgWhite))
+        }
+        .vertical()
+        .frame(height: 200)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value))
     }
-    .frame(height: 240)
-    .clipShape(RoundedRectangle(cornerRadius: 16))
     .padding()
     .environment(Theme.shared)
 }

--- a/Sources/ThemeKit/Components/Molecules/Steps.swift
+++ b/Sources/ThemeKit/Components/Molecules/Steps.swift
@@ -14,6 +14,12 @@ public enum StepState {
     case done, active, todo, error
 }
 
+/// Size tiers for ``Steps`` markers + labels — the kit's uniform size-enum
+/// vocabulary (replaces the boolean `small()` toggle, C5).
+public enum StepsSize: Sendable {
+    case small, medium
+}
+
 /// A horizontal or vertical step / progress indicator with done / active / todo /
 /// error states, an optional progress dot, and tap-to-navigate.
 ///
@@ -42,7 +48,7 @@ public struct Steps: View {
 
     // Appearance — mutated only through the modifiers below (R2).
     private var axis: Axis = .horizontal
-    private var small = false
+    private var size: StepsSize = .medium
     private var progressDot = false
     /// Custom per-step marker (`marker(_:)`); nil renders the stock circle/number.
     private var markerBuilder: ((Step, Int) -> AnyView)? = nil
@@ -52,6 +58,7 @@ public struct Steps: View {
         self.onSelect = onSelect
     }
 
+    private var small: Bool { size == .small }
     private var dotSize: CGFloat { progressDot ? 12 : (small ? 22 : 28) }
 
     public var body: some View {
@@ -227,8 +234,13 @@ public extension Steps {
     /// Layout orientation: horizontal / vertical.
     func axis(_ a: Axis) -> Self { copy { $0.axis = a } }
 
-    /// Compact markers and labels.
-    func small(_ on: Bool = true) -> Self { copy { $0.small = on } }
+    /// Marker + label size: medium (default) / small — the kit's uniform
+    /// size-enum axis.
+    func size(_ s: StepsSize) -> Self { copy { $0.size = s } }
+
+    /// Compact markers and labels — the boolean twin of `size(.small)`.
+    @available(*, deprecated, message: "Use size(_:) with a StepsSize.")
+    func small(_ on: Bool = true) -> Self { size(on ? .small : .medium) }
 
     /// Render minimal progress dots instead of numbered markers (Ant `progressDot`).
     func progressDot(_ on: Bool = true) -> Self { copy { $0.progressDot = on } }
@@ -253,6 +265,8 @@ public extension Steps {
 #Preview {
     VStack(spacing: 40) {
         Steps([.init("Cart", state: .done), .init("Address", description: "Shipping", state: .done), .init("Payment", state: .error), .init("Done", state: .todo)])
+        // C5 — the size-enum axis (compact markers + labels).
+        Steps([.init("Cart", state: .done), .init("Pay", state: .active), .init("Done", state: .todo)]).size(.small)
         Steps([.init("Account", description: "Your details", state: .done), .init("Profile", state: .active), .init("Confirm", state: .todo)]).axis(.vertical)
         // Custom per-step markers; the percent ring still wraps the active step.
         Steps([.init("Cart", state: .done), .init("Pay", state: .active, percent: 0.6), .init("Done", state: .todo)])

--- a/Sources/ThemeKit/Components/Molecules/TextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInput.swift
@@ -326,7 +326,9 @@ public struct TextInput: View {
                 fieldContent
             }
         }
-        .frame(height: effectiveSize.height)
+        // Scales with Dynamic Type (matches the rest of the field family) instead
+        // of a raw fixed height that clips the floating label + value at large sizes.
+        .scaledControlHeight(effectiveSize.height)
     }
 
     /// The field row wrapped in the active ``FieldStyle`` chrome (fill + border).

--- a/Sources/ThemeKit/Components/Molecules/TextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInput.swift
@@ -149,6 +149,7 @@ public struct TextInput: View {
     /// Optional external focus (e.g. driven by `FormValidator.focusBinding`).
     private var externalFocus: Binding<Bool>?
     @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
+    @Environment(\.isReadOnly) private var isReadOnly // E1 — set by `.readOnly(_:)`
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.fieldDefaults) private var fieldDefaults
@@ -217,7 +218,7 @@ public struct TextInput: View {
     private var dominant: InfoMessage.Kind? { messages.dominantKind }
     private var hasError: Bool { dominant == .error }
     private var hasWarning: Bool { dominant == .warning }
-    private var showsClear: Bool { model.allowClear && !text.isEmpty && isEnabled && !model.isSecure }
+    private var showsClear: Bool { model.allowClear && !text.isEmpty && isEnabled && !isReadOnly && !model.isSecure }
 
     private var hasAddons: Bool { model.addonBefore != nil || model.addonAfter != nil }
     private var isOverLimit: Bool { Self.isOverLimit(count: text.count, maxLength: model.maxLength) }
@@ -344,7 +345,7 @@ public struct TextInput: View {
             size: effectiveSize
         ))
         .contentShape(Rectangle())
-        .onTapGesture { if isEnabled { isFocused = true } }
+        .onTapGesture { if isEnabled && !isReadOnly { isFocused = true } }
     }
 
     public var body: some View {
@@ -379,7 +380,7 @@ public struct TextInput: View {
             if validationTrigger == .live || !validationMessages.isEmpty { runValidation(v) }
         }
         .onChange(of: externalFocus?.wrappedValue ?? false) { _, want in
-            if want && !isFocused { isFocused = true }
+            if want && !isFocused && !isReadOnly { isFocused = true }   // E1 — no programmatic focus either
         }
         .onChange(of: isFocused) { _, now in
             if !now, externalFocus?.wrappedValue == true { externalFocus?.wrappedValue = false }
@@ -405,6 +406,9 @@ public struct TextInput: View {
         // Caret / selection tint follows the validation state (HeroUI invalid caret).
         .tint(theme.foreground(hasError ? .systemcolorsFgError : .fgHero))
         .disabled(!isEnabled)
+        // E1 — read-only: normal (non-dimmed) chrome + VoiceOver value, but the
+        // field can't be tapped into. Deliberately NOT `.disabled`, which dims.
+        .allowsHitTesting(!isReadOnly)
         .submitLabel(model.submitLabel)
         .autocorrectionDisabled(model.autocorrectionDisabled)
         .textInputTraits(keyboard: model.keyboardType,
@@ -420,14 +424,16 @@ public struct TextInput: View {
 
     @ViewBuilder
     private var trailingAccessory: some View {
-        if model.isSecure {
+        // E1 — read-only keeps the value chrome but drops the editing
+        // affordances (reveal / clear); a static suffix icon still renders.
+        if model.isSecure && !isReadOnly {
             Button { reveal.toggle() } label: {
                 Icon(systemName: reveal ? "eye.slash" : "eye").size(.sm).color(theme.text(.textTertiary))
             }
             .buttonStyle(.plain)
             .a11y(A11yElement.Field.reveal, in: accessibilityID)
             .accessibilityLabel(reveal ? String(themeKit: "Hide password") : String(themeKit: "Show password"))
-        } else if showsClear || (!text.isEmpty && isFocused && model.suffixSystemImage == nil) {
+        } else if showsClear || (!text.isEmpty && isFocused && !isReadOnly && model.suffixSystemImage == nil) {
             Button { text = "" } label: {
                 Icon(systemName: "xmark.circle.fill").size(.sm).color(theme.text(.textTertiary))
             }
@@ -695,6 +701,10 @@ private extension TextInputCapitalization {
                     .required()
                     .errorText(showError ? "This field is required." : nil)
                 Button(showError ? "Hide error" : "Show error") { showError.toggle() }
+                // Read-only (E1): normal chrome + value, editing / clear blocked.
+                TextInput("Confirmation code", text: .constant("BRX-4821"))
+                    .clearable()
+                    .readOnly()
             }
             .padding()
         }

--- a/Sources/ThemeKit/Components/Molecules/ThemeToggle.swift
+++ b/Sources/ThemeKit/Components/Molecules/ThemeToggle.swift
@@ -25,6 +25,7 @@ public struct ThemeToggle: View {
     @Binding private var isOn: Bool
     @Environment(\.controlSize) private var controlSize
     @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
+    @Environment(\.isReadOnly) private var isReadOnly // E1 — set by `.readOnly(_:)`
 
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -42,6 +43,7 @@ public struct ThemeToggle: View {
 
     public var body: some View {
         Button {
+            guard !isReadOnly else { return }   // E1 — VoiceOver activation is not hit-tested
             withAnimation(motion) { isOn.toggle() }
         } label: {
             Capsule()
@@ -56,6 +58,7 @@ public struct ThemeToggle: View {
         }
         .buttonStyle(PressFeedbackStyle())   // subtle press scale, gated by microAnimations + Reduce Motion
         .disabled(!interactive)
+        .allowsHitTesting(!isReadOnly)   // E1 — normal chrome + VoiceOver value, toggling blocked
         .opacity(isEnabled ? 1 : 0.6)
         .a11y(A11yElement.Control.toggle, in: accessibilityID)
         .accessibilityValue(isOn ? String(themeKit: "on") : String(themeKit: "off"))
@@ -124,6 +127,7 @@ public struct ThemeToggle: View {
         ThemeToggle(isOn: .constant(true)).symbols(on: "checkmark", off: "xmark")
         ThemeToggle(isOn: .constant(true)).loading()
         ThemeToggle(isOn: .constant(true)).disabled(true)
+        ThemeToggle(isOn: .constant(true)).readOnly()   // E1 — normal chrome, tap does nothing
         ThemeToggle(isOn: .constant(true)).accent(.success)
         ThemeToggle(isOn: .constant(true)).accent(.error).controlSize(.small)
         // Track symbols (HeroUI start/end content) — tap to see the crossfade + press scale.

--- a/Sources/ThemeKit/Components/Molecules/TimeField.swift
+++ b/Sources/ThemeKit/Components/Molecules/TimeField.swift
@@ -31,8 +31,11 @@ public enum TimeFieldHourCycle: Equatable, Sendable {
 public struct TimeField: View {
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
+    /// Read-only subtree axis (set with `.readOnly(_:)`) — normal chrome, no editing.
+    @Environment(\.isReadOnly) private var isReadOnly
     /// The field chrome (fill + border), swappable via `.fieldStyle(_:)`.
     @Environment(\.fieldStyle) private var fieldStyle
+    @Environment(\.fieldDefaults) private var fieldDefaults
 
     private let label: String?
     @Binding private var time: Date?
@@ -47,6 +50,18 @@ public struct TimeField: View {
     private var allowClear = false
     private var leadingSystemImage: String? = "clock"
     private var accessibilityID: String?
+    /// Explicit `.size(_:)` preset — wins over the subtree `FieldDefaults.size`.
+    private var explicitSize: TextInputSize?
+    /// `.required()` — asterisk on the label + ", required" in the a11y label.
+    private var isRequired = false
+
+    // Declarative validation (daisyUI Validator) — rules run against the
+    // *displayed* time string at `validationTrigger`; failures merge into the
+    // rendered messages, driving the border state automatically.
+    private var validationRules: [ValidationRule] = []
+    private var validationTrigger: ValidationTrigger = .editingEnd
+    private var onValidation: ((Bool) -> Void)?
+    @State private var validationMessages: [InfoMessage] = []
 
     @Environment(\.locale) private var environmentLocale
     @State private var showPicker = false
@@ -59,34 +74,68 @@ public struct TimeField: View {
     // MARK: - Derived state
 
     private var locale: Locale { explicitLocale ?? environmentLocale }
-    private var dominant: InfoMessage.Kind? { infoMessages.dominantKind }
+    /// Explicit `infoMessages(_:)` plus any current `validate(_:on:)` failures.
+    private var messages: [InfoMessage] { infoMessages + validationMessages }
+    private var dominant: InfoMessage.Kind? { messages.dominantKind }
     private var hasError: Bool { dominant == .error }
     private var hasWarning: Bool { dominant == .warning }
-    private var showsClear: Bool { allowClear && time != nil && isEnabled }
+    private var showsClear: Bool { allowClear && time != nil && isEnabled && !isReadOnly }
     private var displayText: String? {
         time.map { Self.text(for: $0, hourCycle: hourCycle, locale: locale) }
+    }
+    /// Explicit `.size(_:)` → subtree `FieldDefaults.size` → the classic scaled 48pt.
+    private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }
+    /// Whether `.required()` renders its asterisk (`FieldDefaults.requiredIndicator`;
+    /// the accessibility ", required" suffix is unaffected).
+    private var showsRequiredIndicator: Bool { fieldDefaults.requiredIndicator ?? true }
+    private var a11yLabel: String {
+        let base = label ?? String(themeKit: "Time")
+        return isRequired ? base + ", " + String(themeKit: "required") : base
+    }
+
+    /// Runs the declared rules over the displayed time string (first failure
+    /// only, via `Validator`); publishes the result and reports validity.
+    private func runValidation() {
+        guard !validationRules.isEmpty else { return }
+        let failures = Validator.validate(displayText ?? "", validationRules)
+        if failures != validationMessages { validationMessages = failures }
+        onValidation?(!failures.contains { $0.kind == .error })
     }
 
     // MARK: - Body
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
-            if let label { InputLabel(label).hasError(hasError) }
+            if let label {
+                InputLabel(label).required(isRequired && showsRequiredIndicator).hasError(hasError)
+            }
 
             fieldBox
                 .contentShape(Rectangle())
-                .onTapGesture { if isEnabled { showPicker = true } }
+                // Read-only keeps the normal chrome + VoiceOver value but never
+                // opens the picker (E1 — distinct from `.disabled`).
+                .onTapGesture { if isEnabled && !isReadOnly { showPicker = true } }
+                .allowsHitTesting(!isReadOnly)
                 .popover(isPresented: $showPicker) { picker }
                 .a11y(A11yElement.Select.trigger, in: accessibilityID)
-                .accessibilityLabel(label ?? String(themeKit: "Time"))
+                .accessibilityLabel(a11yLabel)
                 .accessibilityValue(displayText ?? "")
                 .accessibilityAddTraits(.isButton)
-                .accessibilityAction { if isEnabled { showPicker = true } }
+                .accessibilityAction { if isEnabled && !isReadOnly { showPicker = true } }
 
-            if !infoMessages.isEmpty {
-                InfoMessageList(infoMessages)
+            if !messages.isEmpty {
+                InfoMessageList(messages)
                     .a11y(A11yElement.Field.message, in: accessibilityID)
             }
+        }
+        // `.live` validates every change; other triggers re-validate once a
+        // failure is visible so the error clears as the user fixes it.
+        .onChange(of: time) { _, _ in
+            if validationTrigger == .live || !validationMessages.isEmpty { runValidation() }
+        }
+        // Dismissing the picker is this field's blur *and* submit moment.
+        .onChange(of: showPicker) { _, now in
+            if !now, validationTrigger != .live { runValidation() }
         }
     }
 
@@ -104,15 +153,15 @@ public struct TimeField: View {
             trailing
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
-        .scaledControlHeight(48)
+        .scaledControlHeight(effectiveSize?.height ?? 48)
         .frame(maxWidth: .infinity)
     }
 
     /// The field row wrapped in the active ``FieldStyle`` chrome (fill + border).
     /// Configuration mapping: the open popover reads as `isFocused`; the dominant
-    /// `infoMessages` kind drives `hasError` / `hasWarning`. `size` is nominal
-    /// `.medium` — `TimeField` has no `TextInputSize` axis; its height stays the
-    /// component's own scaled 48pt, carried by the content.
+    /// message kind drives `hasError` / `hasWarning`. With no explicit `.size(_:)`
+    /// and no subtree `FieldDefaults.size` the height stays the component's
+    /// classic scaled 48pt (nominal `.medium`), carried by the content.
     private var fieldBox: some View {
         fieldStyle.makeBody(configuration: FieldStyleConfiguration(
             content: AnyView(fieldCore),
@@ -120,7 +169,7 @@ public struct TimeField: View {
             isEnabled: isEnabled,
             hasError: hasError,
             hasWarning: hasWarning,
-            size: .medium
+            size: effectiveSize ?? .medium
         ))
     }
 
@@ -235,6 +284,29 @@ public extension TimeField {
     /// Placeholder shown while no time is selected.
     func placeholder(_ text: String) -> Self { copy { $0.placeholder = text } }
 
+    /// Control-height preset. An explicit size wins over the subtree
+    /// `FieldDefaults.size` default (`explicit ?? fieldDefaults.size ?? 48pt`).
+    func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
+
+    /// Marks the field required: an error-token asterisk on the label (honoring
+    /// `FieldDefaults.requiredIndicator`) and ", required" in the a11y label.
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
+
+    /// Declarative validation (daisyUI Validator): `rules` run against the
+    /// *displayed* time string (empty when no time is set) at `trigger` —
+    /// `.editingEnd`/`.submit` fire when the picker is dismissed, `.live` on
+    /// every change. Failures merge into the rendered messages and border state.
+    ///
+    ///     TimeField("Alarm", time: $alarm)
+    ///         .validate([.required("Pick a time")])
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
+        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    }
+
+    /// Reports validity after each `validate(_:on:)` pass — `true` when no
+    /// error-severity failure is present.
+    func onValidation(_ handler: @escaping (Bool) -> Void) -> Self { copy { $0.onValidation = handler } }
+
     /// Restrict the picker to a selectable time range.
     func range(_ range: ClosedRange<Date>?) -> Self { copy { $0.range = range } }
 
@@ -281,6 +353,15 @@ public extension TimeField {
                     .infoMessages(alarm == nil ? [InfoMessage("Pick a time", kind: .error)] : [])
                 // Disabled.
                 TimeField("Locked", time: .constant(.now)).disabled(true)
+                // Read-only: normal chrome + VoiceOver value, no picker/clear (E1).
+                TimeField("Departure (read-only)", time: .constant(.now)).clearable().readOnly()
+                // Required + declarative validation (asterisk, rules on dismiss).
+                TimeField("Check-in", time: $alarm)
+                    .required()
+                    .validate([.required("Pick a check-in time")])
+                // Size ramp — explicit `.size(_:)` wins over `FieldDefaults.size`.
+                TimeField("Small", time: $meeting).size(.small)
+                TimeField("Large", time: $meeting).size(.large)
                 // Underlined chrome via the shared FieldStyle hook.
                 TimeField("Boarding", time: $meeting)
                     .hourCycle(.h24)

--- a/Sources/ThemeKit/Components/Molecules/ToggleGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/ToggleGroup.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// owned by the caller (single Set binding).
 public struct ToggleGroup<Option: Hashable>: View {
     @Environment(\.theme) private var theme
+    @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
 
     private let title: String?
     private let options: [Option]
@@ -18,6 +19,9 @@ public struct ToggleGroup<Option: Hashable>: View {
 
     // Appearance/config — mutated only through the modifiers below (R2).
     private var description: (Option) -> String? = { _ in nil }
+    private var axis: Axis = .vertical
+    private var accent: SemanticColor?
+    private var isOptionEnabled: ((Option) -> Bool)?
     private var accessibilityID: String? = nil
 
     public init(
@@ -32,33 +36,56 @@ public struct ToggleGroup<Option: Hashable>: View {
         self.label = label
     }
 
+    private func optionEnabled(_ option: Option) -> Bool { isEnabled && (isOptionEnabled?(option) ?? true) }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
             if let title {
                 Text(title).textStyle(.labelMd600).foregroundStyle(theme.text(.textPrimary))
             }
-            ForEach(Array(options.enumerated()), id: \.element) { index, option in
-                HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(label(option))
-                            .textStyle(.labelBase600)
-                            .foregroundStyle(theme.text(.textPrimary))
-                        if let description = description(option) {
-                            Text(description)
-                                .textStyle(.bodySm400)
-                                .foregroundStyle(theme.text(.textSecondary))
-                        }
+            optionsContainer
+        }
+    }
+
+    /// Lays the rows out along `axis` (HStack/VStack mirror for RTL automatically).
+    @ViewBuilder private var optionsContainer: some View {
+        switch axis {
+        case .horizontal:
+            HStack(alignment: .top, spacing: Theme.SpacingKey.md.value) { optionRows }
+        case .vertical:
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) { optionRows }
+        }
+    }
+
+    private var optionRows: some View {
+        ForEach(Array(options.enumerated()), id: \.element) { index, option in
+            let enabled = optionEnabled(option)
+            HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label(option))
+                        .textStyle(.labelBase600)
+                        .foregroundStyle(enabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
+                    if let description = description(option) {
+                        Text(description)
+                            .textStyle(.bodySm400)
+                            .foregroundStyle(enabled ? theme.text(.textSecondary) : theme.text(.textDisabled))
                     }
-                    Spacer(minLength: Theme.SpacingKey.sm.value)
-                    ThemeToggle(isOn: Binding(
-                        get: { selection.contains(option) },
-                        set: { isOn in if isOn { selection.insert(option) } else { selection.remove(option) } }
-                    ))
-                    .a11y("option.\(index)", in: accessibilityID)
-                    .accessibilityLabel(label(option))
-                    .accessibilityValue(selection.contains(option) ? String(themeKit: "on") : String(themeKit: "off"))
-                    .accessibilityAddTraits(selection.contains(option) ? .isSelected : [])
                 }
+                // Vertical rows push the switch to the trailing edge; in a
+                // horizontal group each label+switch pair hugs instead.
+                if axis == .vertical {
+                    Spacer(minLength: Theme.SpacingKey.sm.value)
+                }
+                ThemeToggle(isOn: Binding(
+                    get: { selection.contains(option) },
+                    set: { isOn in if isOn { selection.insert(option) } else { selection.remove(option) } }
+                ))
+                .accent(accent)
+                .disabled(!enabled)   // native — R3
+                .a11y("option.\(index)", in: accessibilityID)
+                .accessibilityLabel(label(option))
+                .accessibilityValue(selection.contains(option) ? String(themeKit: "on") : String(themeKit: "off"))
+                .accessibilityAddTraits(selection.contains(option) ? .isSelected : [])
             }
         }
     }
@@ -67,14 +94,36 @@ public struct ToggleGroup<Option: Hashable>: View {
 #Preview {
     struct Demo: View {
         @State var sel: Set<String> = ["push"]
+        @State var horizontal: Set<String> = ["wifi"]
         var body: some View {
-            ToggleGroup(
-                title: "Notifications",
-                options: ["push", "email", "sms"],
-                selection: $sel,
-                label: { ["push": "Push", "email": "Email", "sms": "SMS"][$0] ?? $0 }
-            )
-            .optionDescription { _ in "Lorem ipsum supporting text." }
+            VStack(alignment: .leading, spacing: 32) {
+                ToggleGroup(
+                    title: "Notifications",
+                    options: ["push", "email", "sms"],
+                    selection: $sel,
+                    label: { ["push": "Push", "email": "Email", "sms": "SMS"][$0] ?? $0 }
+                )
+                .optionDescription { _ in "Lorem ipsum supporting text." }
+
+                // E9 — accent + per-option enablement.
+                ToggleGroup(
+                    title: "Privacy",
+                    options: ["analytics", "ads", "tracking"],
+                    selection: $sel,
+                    label: { $0.capitalized }
+                )
+                .accent(.success)
+                .optionEnabled { $0 != "tracking" }
+
+                // E9 — horizontal axis: each label + switch pair hugs.
+                ToggleGroup(
+                    title: "Amenities",
+                    options: ["wifi", "pool"],
+                    selection: $horizontal,
+                    label: { $0.capitalized }
+                )
+                .axis(.horizontal)
+            }
             .padding()
         }
     }
@@ -86,6 +135,19 @@ public struct ToggleGroup<Option: Hashable>: View {
 public extension ToggleGroup {
     /// Supporting text rendered under each row's label (return nil for none).
     func optionDescription(_ description: @escaping (Option) -> String?) -> Self { copy { $0.description = description } }
+
+    /// Per-option enablement predicate — disabled rows dim and their switch
+    /// stops responding (nil enables every option; the kit-standard group
+    /// idiom, cf. `CheckboxGroup.optionEnabled`).
+    func optionEnabled(_ predicate: ((Option) -> Bool)?) -> Self { copy { $0.isOptionEnabled = predicate } }
+
+    /// Semantic track tint forwarded to each row's `ThemeToggle`; `nil`
+    /// (default) keeps the stock hero track.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+
+    /// Lay the rows out along `axis` (vertical default; HStack/VStack mirror
+    /// for RTL automatically — cf. `RadioGroup.axis`).
+    func axis(_ a: Axis) -> Self { copy { $0.axis = a } }
 
     /// Sets the accessibility-identifier namespace for this component (its
     /// sub-elements get `"<id>.<element>"`). Replaces the `accessibilityID:` init param.

--- a/Sources/ThemeKit/Components/Molecules/Transfer.swift
+++ b/Sources/ThemeKit/Components/Molecules/Transfer.swift
@@ -29,8 +29,14 @@ public struct Transfer: View {
     @Binding private var target: Set<String>
     // Appearance — mutated only through the modifiers below.
     private var titles: (String, String) = (String(themeKit: "Source"), String(themeKit: "Target"))
+    private var isSearchable = false
+    /// Per-item enablement predicate (nil enables every item) — the
+    /// kit-standard `optionEnabled` idiom (Ant Transfer per-item `disabled`).
+    private var isItemEnabled: ((TransferItem) -> Bool)?
 
     @State private var checked: Set<String> = []
+    @State private var sourceQuery = ""
+    @State private var targetQuery = ""
 
     public init(_ items: [TransferItem], target: Binding<Set<String>>) {   // R1
         self.items = items
@@ -39,21 +45,28 @@ public struct Transfer: View {
 
     private var source: [TransferItem] { items.filter { !target.contains($0.key) } }
     private var targeted: [TransferItem] { items.filter { target.contains($0.key) } }
-    private var checkedInSource: Bool { source.contains { checked.contains($0.key) } }
-    private var checkedInTarget: Bool { targeted.contains { checked.contains($0.key) } }
+    private var checkedInSource: Bool { source.contains { checked.contains($0.key) && itemEnabled($0) } }
+    private var checkedInTarget: Bool { targeted.contains { checked.contains($0.key) && itemEnabled($0) } }
+
+    private func itemEnabled(_ item: TransferItem) -> Bool { isItemEnabled?(item) ?? true }
+
+    private func filtered(_ items: [TransferItem], query: String) -> [TransferItem] {
+        guard isSearchable, !query.isEmpty else { return items }
+        return items.filter { $0.title.localizedCaseInsensitiveContains(query) }
+    }
 
     public var body: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
-            listBox(titles.0, items: source)
+            listBox(titles.0, items: source, query: $sourceQuery)
             VStack(spacing: Theme.SpacingKey.sm.value) {
                 arrow("chevron.right", label: String(themeKit: "Move to \(titles.1)"), enabled: checkedInSource, action: moveToTarget)
                 arrow("chevron.left", label: String(themeKit: "Move to \(titles.0)"), enabled: checkedInTarget, action: moveToSource)
             }
-            listBox(titles.1, items: targeted)
+            listBox(titles.1, items: targeted, query: $targetQuery)
         }
     }
 
-    private func listBox(_ title: String, items: [TransferItem]) -> some View {
+    private func listBox(_ title: String, items: [TransferItem], query: Binding<String>) -> some View {
         VStack(spacing: 0) {
             HStack {
                 Text(title).textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary))
@@ -66,9 +79,22 @@ public struct Transfer: View {
 
             Rectangle().fill(theme.border(.borderPrimary)).frame(height: 1)
 
+            // Per-list search (Ant Transfer `showSearch`) — the Select-panel idiom.
+            if isSearchable {
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    Icon(systemName: "magnifyingglass").size(.xs).colorOverride(theme.text(.textTertiary))
+                    TextField(String(themeKit: "Search"), text: query)
+                        .textStyle(.bodySm400)
+                        .tint(theme.foreground(.fgHero))
+                }
+                .padding(.horizontal, Theme.SpacingKey.sm.value)
+                .scaledControlHeight(32)
+                Rectangle().fill(theme.border(.borderPrimary)).frame(height: 1)
+            }
+
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 0) {
-                    ForEach(items) { item in row(item) }
+                    ForEach(filtered(items, query: query.wrappedValue)) { item in row(item) }
                 }
             }
             .frame(maxHeight: .infinity)
@@ -81,23 +107,26 @@ public struct Transfer: View {
 
     private func row(_ item: TransferItem) -> some View {
         let isOn = checked.contains(item.key)
+        let enabled = itemEnabled(item)
         return Button {
             if isOn { checked.remove(item.key) } else { checked.insert(item.key) }
         } label: {
             HStack(spacing: Theme.SpacingKey.sm.value) {
                 Image(systemName: isOn ? "checkmark.square.fill" : "square")
                     .font(.system(size: 16))
-                    .foregroundStyle(isOn ? theme.text(.textHero) : theme.text(.textTertiary))
-                Text(item.title).textStyle(.bodySm400).foregroundStyle(theme.text(.textPrimary))
+                    .foregroundStyle(!enabled ? theme.text(.textDisabled) : (isOn ? theme.text(.textHero) : theme.text(.textTertiary)))
+                Text(item.title).textStyle(.bodySm400)
+                    .foregroundStyle(enabled ? theme.text(.textPrimary) : theme.text(.textDisabled))
                 Spacer(minLength: 0)
             }
             .padding(.horizontal, Theme.SpacingKey.sm.value)
             .frame(height: 34)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isOn ? SemanticColor.primary.soft.opacity(0.5) : .clear)
+            .background(isOn && enabled ? SemanticColor.primary.soft.opacity(0.5) : .clear)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .disabled(!enabled)
         .accessibilityAddTraits(isOn ? .isSelected : [])
     }
 
@@ -118,13 +147,13 @@ public struct Transfer: View {
     }
 
     private func moveToTarget() {
-        let moving = source.filter { checked.contains($0.key) }.map(\.key)
+        let moving = source.filter { checked.contains($0.key) && itemEnabled($0) }.map(\.key)
         target.formUnion(moving)
         checked.subtract(moving)
     }
 
     private func moveToSource() {
-        let moving = targeted.filter { checked.contains($0.key) }.map(\.key)
+        let moving = targeted.filter { checked.contains($0.key) && itemEnabled($0) }.map(\.key)
         target.subtract(moving)
         checked.subtract(moving)
     }
@@ -135,6 +164,15 @@ public struct Transfer: View {
 public extension Transfer {
     /// Header labels for the source and target boxes (Ant `titles`).
     func titles(_ source: String, _ target: String) -> Self { copy { $0.titles = (source, target) } }
+
+    /// Show a search field in each list box, filtering its rows by title
+    /// (Ant Transfer `showSearch`).
+    func searchable(_ on: Bool = true) -> Self { copy { $0.isSearchable = on } }
+
+    /// Per-item enablement predicate — disabled rows dim, can't be checked and
+    /// never move (nil enables every item; the kit-standard `optionEnabled`
+    /// idiom, Ant Transfer per-item `disabled`).
+    func itemEnabled(_ predicate: ((TransferItem) -> Bool)?) -> Self { copy { $0.isItemEnabled = predicate } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {
         var c = self
@@ -151,6 +189,23 @@ public extension Transfer {
                      TransferItem("spa", title: "Spa"), TransferItem("park", title: "Parking")]
         var body: some View {
             Transfer(items, target: $target).titles("Available", "Included").padding()
+        }
+    }
+    return Demo().environment(Theme.shared)
+}
+
+#Preview("Searchable + disabled items") {
+    struct Demo: View {
+        @State private var target: Set<String> = ["wifi"]
+        let items = [TransferItem("wifi", title: "Wi-Fi"), TransferItem("bkfst", title: "Breakfast"),
+                     TransferItem("pool", title: "Pool"), TransferItem("gym", title: "Gym"),
+                     TransferItem("spa", title: "Spa"), TransferItem("park", title: "Parking")]
+        var body: some View {
+            Transfer(items, target: $target)
+                .titles("Available", "Included")
+                .searchable()                              // E8 — per-list search
+                .itemEnabled { $0.key != "spa" }           // E8 — disabled rows never move
+                .padding()
         }
     }
     return Demo().environment(Theme.shared)

--- a/Sources/ThemeKit/Components/Molecules/TreeView.swift
+++ b/Sources/ThemeKit/Components/Molecules/TreeView.swift
@@ -48,6 +48,7 @@ public struct TreeView: View {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(theme.text(.textTertiary))
+                    .mirrorsInRTL()
                     .rotationEffect(.degrees(expanded.contains(node.id) ? 90 : 0))
                     .frame(width: 20, height: 20)
                     .opacity(hasChildren ? 1 : 0)

--- a/Sources/ThemeKit/Components/Organisms/Callout.swift
+++ b/Sources/ThemeKit/Components/Organisms/Callout.swift
@@ -68,6 +68,8 @@ public struct Callout: View {
     private var style: CalloutStyle = .plain
     private var showIcon = true
     private var iconOverride: String?
+    private var leadingView: AnyView?
+    private var trailingView: AnyView?
     private var actionTitle: String?
     private var onAction: (() -> Void)?
     private var onClose: (() -> Void)?
@@ -80,11 +82,16 @@ public struct Callout: View {
     }
 
     private var hasAction: Bool { actionTitle != nil && onAction != nil }
-    private var hasTrailing: Bool { hasAction || onClose != nil }
+    private var hasTrailing: Bool { hasAction || onClose != nil || trailingView != nil }
 
     public var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.xs.value) {
-            if showIcon {
+            // Leading indicator: a custom view replaces the stock status icon
+            // entirely (the InfoBanner slot pair, D3); otherwise the glyph,
+            // optionally overridden per-instance via `icon(_:)`.
+            if let leadingView {
+                leadingView
+            } else if showIcon {
                 Image(systemName: iconOverride ?? type.systemImage)
                     .font(.system(size: 14))
                     .accessibilityLabel(type.accessibilityLabel)
@@ -98,6 +105,9 @@ public struct Callout: View {
             }
             if hasTrailing {
                 Spacer(minLength: Theme.SpacingKey.sm.value)
+                if let trailingView {
+                    trailingView
+                }
                 if let actionTitle, let onAction {
                     Button(action: onAction) {
                         Text(actionTitle).textStyle(.labelSm600)
@@ -144,6 +154,21 @@ public extension Callout {
     /// `nil` restores the variant's default.
     func icon(_ systemName: String?) -> Self { copy { $0.iconOverride = systemName } }
 
+    /// Replace the stock status icon with a custom leading view — e.g. a
+    /// `Spinner` for an in-progress note (mirrors `InfoBanner.leading`, D3).
+    /// Wins over `icon(_:)` and `showsIcon(_:)`; inherits the variant's accent
+    /// foreground, so plain glyphs tint correctly with zero configuration.
+    func leading<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.leadingView = AnyView(content()) }
+    }
+
+    /// Custom trailing accessory rendered before the text-link action and the
+    /// dismiss button — e.g. a `Badge` or a small `ThemeButton` (mirrors
+    /// `InfoBanner.trailing`, D3).
+    func trailing<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.trailingView = AnyView(content()) }
+    }
+
     /// Trailing inline action button (title + handler).
     func action(_ title: String, onAction: @escaping () -> Void) -> Self {
         copy { $0.actionTitle = title; $0.onAction = onAction }
@@ -168,6 +193,12 @@ public extension Callout {
         Callout("Lorem ipsum placeholder text.").variant(.neutral).calloutStyle(.soft)
         Callout("Brand-primary emphasis.").variant(.accent).calloutStyle(.soft)
         Callout("Custom glyph via icon override.").variant(.info).icon("bell.badge")
+        // D3 — slot pair mirroring InfoBanner.
+        Callout("Checking availability…").variant(.accent).calloutStyle(.soft)
+            .leading { Spinner().size(14).lineWidth(2).accent(.primary) }
+        Callout("Fare updated a moment ago.").variant(.info).calloutStyle(.soft)
+            .trailing { Badge("New").badgeStyle(.info).size(.small) }
+            .onClose {}
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/Callout.swift
+++ b/Sources/ThemeKit/Components/Organisms/Callout.swift
@@ -73,6 +73,7 @@ public struct Callout: View {
     private var onClose: (() -> Void)?
 
     private let text: String
+    private var links: [(substring: String, action: () -> Void)] = []
 
     public init(_ text: String) {   // R1
         self.text = text
@@ -88,8 +89,13 @@ public struct Callout: View {
                     .font(.system(size: 14))
                     .accessibilityLabel(type.accessibilityLabel)
             }
-            Text(text)
-                .textStyle(.bodySm400)
+            Group {
+                if links.isEmpty {
+                    Text(text).textStyle(.bodySm400)
+                } else {
+                    InlineText(text, links: links).inlineStyle(.bodySm400)
+                }
+            }
             if hasTrailing {
                 Spacer(minLength: Theme.SpacingKey.sm.value)
                 if let actionTitle, let onAction {
@@ -123,6 +129,10 @@ public struct Callout: View {
 public extension Callout {
     /// Semantic status: neutral / info / success / warning / error / accent (drives accent + icon).
     func variant(_ t: CalloutType) -> Self { copy { $0.type = t } }
+
+    /// Turn substrings of the body into inline tappable links (rendered via
+    /// `InlineText`) — API symmetry with `InfoBanner`, which already supports it.
+    func links(_ links: [(substring: String, action: () -> Void)]) -> Self { copy { $0.links = links } }
 
     /// Surface treatment: plain (transparent) or soft (light tinted surface).
     func calloutStyle(_ s: CalloutStyle) -> Self { copy { $0.style = s } }

--- a/Sources/ThemeKit/Components/Organisms/Card.swift
+++ b/Sources/ThemeKit/Components/Organisms/Card.swift
@@ -20,7 +20,13 @@ public struct Card<Content: View>: View {
 
     // Appearance/config — mutated only through the modifiers below (R2).
     private var elevation: CardElevation = .soft
+    /// Raw padding (deprecated escape hatch); `paddingKey` wins when set.
     private var padding: CGFloat = 16
+    /// Token padding (`contentPadding(_ key:)`) — resolved against the
+    /// environment theme so it re-skins with a spacing-scale change.
+    private var paddingKey: Theme.SpacingKey?
+
+    private var resolvedPadding: CGFloat { paddingKey.map { theme.spacing($0) } ?? padding }
     private var subtitle: String?
     private var extraTitle: String?
     private var onExtra: (() -> Void)?
@@ -54,8 +60,8 @@ public struct Card<Content: View>: View {
                 titleHeader
             }
         }
-        .padding(.horizontal, padding)
-        .padding(.top, padding)
+        .padding(.horizontal, resolvedPadding)
+        .padding(.top, resolvedPadding)
         .padding(.bottom, Theme.SpacingKey.sm.value)
     }
 
@@ -87,9 +93,9 @@ public struct Card<Content: View>: View {
         if let footerContent {
             footerContent
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, padding)
+                .padding(.horizontal, resolvedPadding)
                 .padding(.top, Theme.SpacingKey.sm.value)
-                .padding(.bottom, padding)
+                .padding(.bottom, resolvedPadding)
         }
     }
 
@@ -113,7 +119,7 @@ public struct Card<Content: View>: View {
             Group {
                 if isLoading { loadingPlaceholder } else { content() }
             }
-            .padding(padding)
+            .padding(resolvedPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
             if footerContent != nil {
                 DividerView().size(.small)
@@ -149,8 +155,18 @@ public extension Card {
     /// Surface elevation: none / soft / elevated.
     func elevation(_ elevation: CardElevation) -> Self { copy { $0.elevation = elevation } }
 
-    /// Inner content padding (named so it doesn't shadow the native `.padding`).
-    func contentPadding(_ padding: CGFloat) -> Self { copy { $0.padding = padding } }
+    /// Inner content padding by spacing token (named so it doesn't shadow the
+    /// native `.padding`; the `SurfaceView`/`TicketStub` twin) — resolved
+    /// against the environment theme, so it re-skins with a spacing change.
+    func contentPadding(_ key: Theme.SpacingKey) -> Self {
+        copy { $0.paddingKey = key }
+    }
+
+    /// Raw inner content padding (back-compat); prefer the token-bound overload.
+    @available(*, deprecated, message: "Use contentPadding(_: Theme.SpacingKey) — the token-bound overload.")
+    func contentPadding(_ padding: CGFloat) -> Self {
+        copy { $0.padding = padding; $0.paddingKey = nil }
+    }
 
     /// Trailing header action (Ant `extra`) — renders when both title and action are set.
     func extraAction(_ title: String?, action: (() -> Void)? = nil) -> Self {
@@ -264,6 +280,13 @@ public extension View {
                     .foregroundStyle(theme.text(.textSecondary))
             }
             .surface(.bgSecondaryLight)
+
+            // Token content padding (G5): the SpacingKey overload.
+            Card("Compact padding") {
+                Text("Inner padding from the `.sm` spacing token.").textStyle(.bodyBase400)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+            .contentPadding(.sm)
         }
         .padding()
     }

--- a/Sources/ThemeKit/Components/Organisms/EmptyState.swift
+++ b/Sources/ThemeKit/Components/Organisms/EmptyState.swift
@@ -28,6 +28,7 @@ public struct EmptyState: View {
 
     // Appearance/content/actions — mutated only through the modifiers below (R2).
     private var message: String?
+    private var messageLinks: [(substring: String, action: () -> Void)] = []
     private var imageMaxHeight: CGFloat = 160
     private var iconForeground: Color?
     private var iconBackground: Color?
@@ -89,10 +90,18 @@ public struct EmptyState: View {
                         .multilineTextAlignment(.center)
                 }
                 if let message {
-                    Text(message)
-                        .textStyle(.bodyBase400)
-                        .foregroundStyle(theme.text(.textSecondary))
-                        .multilineTextAlignment(.center)
+                    Group {
+                        if messageLinks.isEmpty {
+                            Text(message)
+                                .textStyle(.bodyBase400)
+                                .foregroundStyle(theme.text(.textSecondary))
+                        } else {
+                            InlineText(message, links: messageLinks)
+                                .inlineStyle(.bodyBase400)
+                                .color(theme.text(.textSecondary))
+                        }
+                    }
+                    .multilineTextAlignment(.center)
                 }
             }
 
@@ -119,6 +128,12 @@ public extension EmptyState {
 
     /// Secondary message under the title.
     func message(_ s: String?) -> Self { copy { $0.message = s } }
+
+    /// Message with inline tappable links (rendered via `InlineText`) — e.g.
+    /// `.message("Read the docs.", links: [("docs", openDocs)])`.
+    func message(_ s: String?, links: [(substring: String, action: () -> Void)]) -> Self {
+        copy { $0.message = s; $0.messageLinks = links }
+    }
 
     /// Max height of the custom/animated illustration.
     func imageMaxHeight(_ h: CGFloat) -> Self { copy { $0.imageMaxHeight = h } }

--- a/Sources/ThemeKit/Components/Organisms/EmptyState.swift
+++ b/Sources/ThemeKit/Components/Organisms/EmptyState.swift
@@ -39,6 +39,8 @@ public struct EmptyState: View {
     private var action: (() -> Void)?
     private var secondaryTitle: String?
     private var onSecondary: (() -> Void)?
+    /// Custom actions slot (`.actions { }`); replaces the stock buttons.
+    private var actionsSlot: SlotContent?
 
     public init(_ title: String? = nil) {   // R1 — content; default SF Symbol media
         self.media = .symbol("tray")
@@ -97,15 +99,17 @@ public struct EmptyState: View {
                                 .foregroundStyle(theme.text(.textSecondary))
                         } else {
                             InlineText(message, links: messageLinks)
-                                .inlineStyle(.bodyBase400)
-                                .color(theme.text(.textSecondary))
+                                .inlineStyle(.bodyBase400)   // base color defaults to textSecondary
                         }
                     }
                     .multilineTextAlignment(.center)
                 }
             }
 
-            if buttonTitle != nil || secondaryTitle != nil {
+            if let actionsSlot {
+                // Custom actions replace the stock button stack (D4).
+                actionsSlot
+            } else if buttonTitle != nil || secondaryTitle != nil {
                 VStack(spacing: Theme.SpacingKey.sm.value) {
                     if let buttonTitle, let action {
                         PrimaryButton(buttonTitle, action: action)
@@ -165,6 +169,13 @@ public extension EmptyState {
         copy { $0.secondaryTitle = title; $0.onSecondary = action }
     }
 
+    /// Custom actions slot (the `ResultView.actions` precedent) — arbitrary
+    /// content (a `ButtonGroup`, a link row…) rendered where the stock
+    /// primary/secondary buttons go; when set it replaces them.
+    func actions<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.actionsSlot = SlotContent(content) }
+    }
+
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
         mutate(&c)
@@ -173,9 +184,24 @@ public extension EmptyState {
 }
 
 #Preview {
-    EmptyState("No results found")
-        .icon("magnifyingglass")
-        .message("Try adjusting your search or filters to find what you're looking for.")
-        .primaryAction("Clear filters") {}
+    ScrollView {
+        VStack(spacing: 48) {
+            EmptyState("No results found")
+                .icon("magnifyingglass")
+                .message("Try adjusting your search or filters to find what you're looking for.")
+                .primaryAction("Clear filters") {}
+
+            // D4 — custom `.actions { }` slot replaces the stock buttons.
+            EmptyState("Your trips will appear here")
+                .icon("airplane")
+                .message("Plan your first trip to get started.")
+                .actions {
+                    HStack(spacing: Theme.SpacingKey.sm.value) {
+                        ThemeButton("Search flights") {}.size(.small)
+                        ThemeButton("Explore deals") {}.variant(.ghost).size(.small)
+                    }
+                }
+        }
         .padding()
+    }
 }

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -487,7 +487,7 @@ private struct FeedbackHostModifier: ViewModifier {
             let edge: Edge = position == .top ? .top : .bottom
             // Newest nearest the anchored edge: bottom keeps array order, top reverses.
             let ordered = position == .top ? Array(stack.reversed()) : stack
-            VStack(spacing: Theme.SpacingKey.sm.value) {
+            VStack(spacing: (feedbackDefaults.toastSpacing ?? .sm).value) {
                 ForEach(Array(ordered.enumerated()), id: \.element.id) { index, item in
                     // Depth 0 = the newest toast; ones behind it recede with a
                     // subtle scale + peek offset toward the anchored edge.
@@ -501,7 +501,7 @@ private struct FeedbackHostModifier: ViewModifier {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .center)
-            .padding(Theme.SpacingKey.md.value)
+            .padding((feedbackDefaults.toastOffset ?? .md).value)
         }
     }
 
@@ -554,15 +554,10 @@ private struct FeedbackToastRow: View {
     }
 
     var body: some View {
-        row
-            .themeShadow(.elevated)
-            .dismissDrag(edge: edge,
-                         threshold: .points(60),
-                         progressSpan: 120,
-                         progress: $dragProgress,
-                         onDismiss: onDismiss)
+        swipeableRow
             .opacity(1 - dragProgress)
             .transition(.move(edge: edge).combined(with: .opacity))
+            .onAppear { if feedbackDefaults.hapticsOnShow == true { Haptics.tap() } }
             .task(id: item.id) {
                 guard let duration = effectiveDuration else { return }   // nil = sticky
                 // Pause the auto-dismiss countdown while the user is dragging the
@@ -577,6 +572,21 @@ private struct FeedbackToastRow: View {
                 }
                 onDismiss()
             }
+    }
+
+    /// The row with the swipe-to-dismiss gesture, unless the subtree default
+    /// `FeedbackDefaults.swipeToDismiss` is `false`.
+    @ViewBuilder private var swipeableRow: some View {
+        let base = row.themeShadow(.elevated)
+        if feedbackDefaults.swipeToDismiss ?? true {
+            base.dismissDrag(edge: edge,
+                             threshold: .points(60),
+                             progressSpan: 120,
+                             progress: $dragProgress,
+                             onDismiss: onDismiss)
+        } else {
+            base
+        }
     }
 
     /// Stock `AlertToast`, or the caller-drawn view for custom-content toasts.

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -426,7 +426,7 @@ private struct FeedbackHostModifier: ViewModifier {
     private var loadingLayer: some View {
         if let title = presenter.activeLoading {
             ZStack {
-                theme.background(.bgTertiary).opacity(0.3).ignoresSafeArea()
+                Backdrop(fade: 0.7).ignoresSafeArea()   // shared themable scrim (bgBackdrop token)
                 VStack(spacing: Theme.SpacingKey.sm.value) {
                     Spinner().size(28).lineWidth(3)
                     Text(title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
@@ -509,7 +509,7 @@ private struct FeedbackHostModifier: ViewModifier {
     private var confirmLayer: some View {
         if let confirm = presenter.activeConfirm {
             ZStack {
-                theme.background(.bgTertiary).opacity(0.4)
+                Backdrop()
                     .ignoresSafeArea()
                     .onTapGesture { presenter.dismissConfirm() }
                 DialogCard(
@@ -565,7 +565,16 @@ private struct FeedbackToastRow: View {
             .transition(.move(edge: edge).combined(with: .opacity))
             .task(id: item.id) {
                 guard let duration = effectiveDuration else { return }   // nil = sticky
-                try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+                // Pause the auto-dismiss countdown while the user is dragging the
+                // toast (reading / inspecting it) — Ant `pauseOnHover` semantics.
+                // Previously the fixed sleep fired mid-drag and dismissed the toast.
+                let tick = 0.05
+                var remaining = duration
+                while remaining > 0 {
+                    try? await Task.sleep(nanoseconds: UInt64(tick * 1_000_000_000))
+                    if Task.isCancelled { return }
+                    if dragProgress == 0 { remaining -= tick }
+                }
                 onDismiss()
             }
     }

--- a/Sources/ThemeKit/Components/Organisms/FeedbackDefaults.swift
+++ b/Sources/ThemeKit/Components/Organisms/FeedbackDefaults.swift
@@ -35,10 +35,27 @@ public struct FeedbackDefaults: Equatable {
     /// it). Read ahead of the host's `maxVisibleToasts:` parameter.
     public var maxVisibleToasts: Int?
 
-    public init(toastPosition: ToastPosition? = nil, toastDuration: Double? = nil, maxVisibleToasts: Int? = nil) {
+    /// Inset of the toast stack from its anchored edge (default `.md`). Ant
+    /// `notification.config({ top / bottom })`.
+    public var toastOffset: Theme.SpacingKey?
+    /// Gap between stacked toasts (default `.sm`).
+    public var toastSpacing: Theme.SpacingKey?
+    /// Whether toasts can be swiped away (default `true`). Ant `closable` /
+    /// HeroUI `shouldAllowSwipe`.
+    public var swipeToDismiss: Bool?
+    /// Fire a light haptic when a toast appears (default off).
+    public var hapticsOnShow: Bool?
+
+    public init(toastPosition: ToastPosition? = nil, toastDuration: Double? = nil, maxVisibleToasts: Int? = nil,
+                toastOffset: Theme.SpacingKey? = nil, toastSpacing: Theme.SpacingKey? = nil,
+                swipeToDismiss: Bool? = nil, hapticsOnShow: Bool? = nil) {
         self.toastPosition = toastPosition
         self.toastDuration = toastDuration
         self.maxVisibleToasts = maxVisibleToasts
+        self.toastOffset = toastOffset
+        self.toastSpacing = toastSpacing
+        self.swipeToDismiss = swipeToDismiss
+        self.hapticsOnShow = hapticsOnShow
     }
 }
 
@@ -68,11 +85,19 @@ public extension View {
     /// ```
     func feedbackDefaults(toastPosition: ToastPosition? = nil,
                           toastDuration: Double? = nil,
-                          maxVisibleToasts: Int? = nil) -> some View {
+                          maxVisibleToasts: Int? = nil,
+                          toastOffset: Theme.SpacingKey? = nil,
+                          toastSpacing: Theme.SpacingKey? = nil,
+                          swipeToDismiss: Bool? = nil,
+                          hapticsOnShow: Bool? = nil) -> some View {
         transformEnvironment(\.feedbackDefaults) { d in
             if let toastPosition { d.toastPosition = toastPosition }
             if let toastDuration { d.toastDuration = toastDuration }
             if let maxVisibleToasts { d.maxVisibleToasts = maxVisibleToasts }
+            if let toastOffset { d.toastOffset = toastOffset }
+            if let toastSpacing { d.toastSpacing = toastSpacing }
+            if let swipeToDismiss { d.swipeToDismiss = swipeToDismiss }
+            if let hapticsOnShow { d.hapticsOnShow = hapticsOnShow }
         }
     }
 }

--- a/Sources/ThemeKit/Components/Organisms/FloatingActionButton.swift
+++ b/Sources/ThemeKit/Components/Organisms/FloatingActionButton.swift
@@ -24,11 +24,18 @@ public enum FABShape { case circle, square }
 /// (daisyUI "FAB / Speed Dial".)
 public struct FloatingActionButton: View {
     @Environment(\.theme) private var theme
+    @Environment(\.componentDefaults) private var componentDefaults
 
     // Appearance/state — mutated only through the modifiers below (R2).
     private var shape: FABShape = .circle
-    private var color: SemanticColor = .primary
+    /// Explicit `.accent(_:)`; `nil` defers to the subtree `componentDefaults`
+    /// accent, then `.primary` (provider cascade, F3).
+    private var explicitColor: SemanticColor?
     private var badge: Int?
+
+    /// The resolved semantic color: explicit modifier ?? subtree
+    /// `componentDefaults.accent` ?? `.primary`.
+    private var color: SemanticColor { explicitColor ?? componentDefaults.accent ?? .primary }
 
     private let systemImage: String
     private let actions: [FABAction]
@@ -112,9 +119,11 @@ public extension FloatingActionButton {
     /// Corner treatment of the main button: circle / square.
     func shape(_ s: FABShape) -> Self { copy { $0.shape = s } }
 
-    /// Semantic color token driving the main button's fill (R4); `nil` restores
-    /// the primary default. Standard accent vocabulary (flexibility audit §6).
-    func accent(_ color: SemanticColor?) -> Self { copy { $0.color = color ?? .primary } }
+    /// Semantic color token driving the main button's fill (R4); `nil`
+    /// (default) defers to the subtree ``ComponentDefaults`` accent (set once
+    /// with `.componentDefaults(accent:)`), then `.primary`. Standard accent
+    /// vocabulary (flexibility audit §6).
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.explicitColor = color } }
 
     /// Semantic color token driving the main button's fill (R4).
     @available(*, deprecated, message: "Use accent(_:) with a SemanticColor token.")
@@ -138,4 +147,15 @@ public extension FloatingActionButton {
     ])
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
     .padding()
+}
+
+#Preview("ComponentDefaults accent") {
+    // F3 — no explicit accent: the subtree componentDefaults re-tints the FAB;
+    // an explicit `.accent(_:)` still wins.
+    HStack(spacing: 24) {
+        FloatingActionButton(systemImage: "plus")
+        FloatingActionButton(systemImage: "heart").accent(.error)
+    }
+    .padding()
+    .componentDefaults(accent: .turquoise)
 }

--- a/Sources/ThemeKit/Components/Organisms/KanbanBoard.swift
+++ b/Sources/ThemeKit/Components/Organisms/KanbanBoard.swift
@@ -12,7 +12,25 @@
 
 import SwiftUI
 
-/// One board column. `limit` (when exceeded) turns the count red.
+/// Width tiers for a ``KanbanBoard`` column (Ant Pro Board / HeroUI Pro kanban
+/// column sizing) — an enum, not a raw `CGFloat`, per the token-signature rule.
+public enum KanbanColumnWidth: Sendable {
+    case compact, regular, wide
+
+    /// Fixed column widths — genuine dimensions with no semantic token.
+    var value: CGFloat {
+        switch self {
+        case .compact: return 240
+        case .regular: return 280
+        case .wide: return 320
+        }
+    }
+}
+
+/// One board column. `limit` (when exceeded) turns the count red. `accent` is
+/// column *data* (a status hue travels with the column, like `title`), so it
+/// stays a model argument — the documented exception to the modifiers-only
+/// rule for appearance.
 public struct KanbanColumn<Item: Identifiable & Equatable>: Identifiable {
     public let id: String
     public let title: String
@@ -38,6 +56,10 @@ public struct KanbanBoard<Item: Identifiable & Equatable, CardContent: View>: Vi
     @Binding private var columns: [KanbanColumn<Item>]
     private let card: (Item) -> CardContent
 
+    // Appearance — mutated only through the modifiers below (R2).
+    private var columnWidth: KanbanColumnWidth = .regular
+    private var spacingKey: Theme.SpacingKey = .md
+
     public init(columns: Binding<[KanbanColumn<Item>]>, @ViewBuilder card: @escaping (Item) -> CardContent) {   // R1
         self._columns = columns
         self.card = card
@@ -45,7 +67,7 @@ public struct KanbanBoard<Item: Identifiable & Equatable, CardContent: View>: Vi
 
     public var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(alignment: .top, spacing: Theme.SpacingKey.md.value) {
+            HStack(alignment: .top, spacing: theme.spacing(spacingKey)) {
                 ForEach(columns) { column in
                     columnView(column)
                 }
@@ -82,7 +104,7 @@ public struct KanbanBoard<Item: Identifiable & Equatable, CardContent: View>: Vi
             }
         }
         .padding(Theme.SpacingKey.sm.value)
-        .frame(width: 280, alignment: .top)
+        .frame(width: columnWidth.value, alignment: .top)
         .background(theme.background(.bgSecondaryLight), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
         .dropDestination(for: String.self) { dropped, _ in
             for idString in dropped { move(cardID: idString, toColumn: column.id, before: nil) }
@@ -145,6 +167,23 @@ public struct KanbanBoard<Item: Identifiable & Equatable, CardContent: View>: Vi
     }
 }
 
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension KanbanBoard {
+    /// Column width tier: compact / regular (default) / wide (Ant Pro Board /
+    /// HeroUI Pro kanban column sizing).
+    func columnWidth(_ w: KanbanColumnWidth) -> Self { copy { $0.columnWidth = w } }
+
+    /// Gap between columns by spacing token (default `.md`).
+    func spacing(_ key: Theme.SpacingKey) -> Self { copy { $0.spacingKey = key } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
 #Preview {
     struct Demo: View {
         struct Task: Identifiable, Equatable { let id: Int; let title: String }
@@ -154,12 +193,24 @@ public struct KanbanBoard<Item: Identifiable & Equatable, CardContent: View>: Vi
             .init("Done", items: [Task(id: 4, title: "Ship colors")], accent: .success),
         ]
         var body: some View {
-            KanbanBoard(columns: $columns) { task in
-                Text(task.title)
-                    .textStyle(.labelBase600)
-                    .padding(Theme.SpacingKey.sm.value)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color.white, in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
+            VStack(spacing: 24) {
+                KanbanBoard(columns: $columns) { task in
+                    Text(task.title)
+                        .textStyle(.labelBase600)
+                        .padding(Theme.SpacingKey.sm.value)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.white, in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
+                }
+                // D7 — width tier + token gap axes.
+                KanbanBoard(columns: $columns) { task in
+                    Text(task.title)
+                        .textStyle(.labelBase600)
+                        .padding(Theme.SpacingKey.sm.value)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.white, in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
+                }
+                .columnWidth(.compact)
+                .spacing(.sm)
             }
             .padding(.vertical)
         }

--- a/Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift
@@ -186,7 +186,15 @@ public extension LoyaltyCard {
     func progress(_ value: Double, toNextTier tier: String? = nil) -> Self { copy { $0.progress = value; $0.nextTier = tier } }
     /// A tier SF Symbol (default `seal.fill`).
     func icon(_ systemName: String) -> Self { copy { $0.systemImage = systemName } }
-    /// Overrides the brand gradient.
+    /// Overrides the brand gradient with semantic tokens (each hue's solid
+    /// shade); `nil` restores the theme's primary 600→900 gradient.
+    func gradient(_ colors: [SemanticColor]?) -> Self { copy { $0.gradientOverride = colors?.map(\.solid) } }
+    /// Raw-color gradient override (back-compat); prefer the token-bound
+    /// overload. Disfavored so member-shorthand literals like
+    /// `[.purple, .pink]` — valid as both `[Color]` and `[SemanticColor]` —
+    /// resolve to the token overload instead of being ambiguous.
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Use gradient(_: [SemanticColor]?) — the token-bound overload.")
     func gradient(_ colors: [Color]?) -> Self { copy { $0.gradientOverride = colors } }
     /// A brand logo slot in the top-trailing corner (replaces the tier icon).
     func logo<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.logoSlot = AnyView(content()) } }
@@ -205,10 +213,16 @@ public extension LoyaltyCard {
 }
 
 #Preview {
-    LoyaltyCard(tier: "Gold", points: 8_430)
-        .memberName("Elif Kaya")
-        .progress(0.62, toNextTier: "Platinum")
-        .padding()
+    VStack(spacing: 16) {
+        LoyaltyCard(tier: "Gold", points: 8_430)
+            .memberName("Elif Kaya")
+            .progress(0.62, toNextTier: "Platinum")
+        // G5 — token gradient twin (solid shades of semantic hues).
+        LoyaltyCard(tier: "Emerald", points: 4_120)
+            .memberName("Ada Deniz")
+            .gradient([.success, .turquoise])
+    }
+    .padding()
 }
 
 #Preview("Outlined style (back face)") {

--- a/Sources/ThemeKit/Components/Organisms/MenuCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/MenuCard.swift
@@ -61,7 +61,7 @@ public struct MenuCard: View {
                 }
             }
         }
-        .contentPadding(0)
+        .contentPadding(.none)   // token twin of the deprecated raw 0
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
@@ -29,6 +29,11 @@ public struct NotificationCard<Actions: View>: View {
     private var type: FeedbackKind?
     private var onClose: (() -> Void)?
     private var leadingSlot: AnyView?
+    // Inline CTA row (Ant notification `actions`; Callout/InfoBanner pattern).
+    private var actionTitle: String?
+    private var onAction: (() -> Void)?
+    private var secondaryActionTitle: String?
+    private var onSecondaryAction: (() -> Void)?
     // Shell — token-fed; defaults match the previous `Card`-provided chrome.
     private var surfaceKey: Theme.BackgroundColorKey = .bgWhite
     private var radiusRole: Theme.RadiusRole = .box
@@ -80,11 +85,28 @@ public struct NotificationCard<Actions: View>: View {
                 if let actions {
                     actions.padding(.top, Theme.SpacingKey.xs.value)
                 }
+                if actionTitle != nil || secondaryActionTitle != nil {
+                    HStack(spacing: Theme.SpacingKey.md.value) {
+                        if let actionTitle, let onAction {
+                            Button(action: onAction) {
+                                Text(actionTitle).textStyle(.labelSm600).foregroundStyle(theme.text(.textHero))
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        if let secondaryActionTitle, let onSecondaryAction {
+                            Button(action: onSecondaryAction) {
+                                Text(secondaryActionTitle).textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary))
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.top, Theme.SpacingKey.xs.value)
+                }
             }
             Spacer(minLength: 0)
             if let onClose {
                 Button(action: onClose) {
-                    Icon(systemName: "xmark").size(.xs).color(theme.text(.textTertiary))
+                    Icon(systemName: "xmark").size(.xs).colorOverride(theme.text(.textTertiary))
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(String(themeKit: "Dismiss"))
@@ -100,7 +122,7 @@ public struct NotificationCard<Actions: View>: View {
         if let leadingSlot {
             leadingSlot
         } else {
-            Icon(systemName: iconName).size(.sm).color(iconColor)
+            Icon(systemName: iconName).size(.sm).colorOverride(iconColor)
         }
     }
 }
@@ -128,6 +150,18 @@ public extension NotificationCard {
 
     /// Show a trailing dismiss button invoking `action`.
     func onClose(_ action: (() -> Void)?) -> Self { copy { $0.onClose = action } }
+
+    /// Inline call-to-action under the message — e.g. "View" (Ant notification
+    /// `actions`; the Callout/InfoBanner `action(_:onAction:)` pattern). For
+    /// richer content, compose the `actions:` init slot instead.
+    func action(_ title: String, onAction: @escaping () -> Void) -> Self {
+        copy { $0.actionTitle = title; $0.onAction = onAction }
+    }
+
+    /// Optional secondary inline action rendered after the primary — e.g. "Undo".
+    func secondaryAction(_ title: String, onAction: @escaping () -> Void) -> Self {
+        copy { $0.secondaryActionTitle = title; $0.onSecondaryAction = onAction }
+    }
 
     /// Replace the leading icon region with custom content — an avatar, a brand
     /// mark. Omit to keep the `variant(_:)`-driven bell icon.
@@ -162,6 +196,13 @@ public extension NotificationCard {
         NotificationCard(title: "7 days left until your holiday begins")
             .message("Rixos Sungate")
             .date("November 28, 2024")
+        // D6 — inline action row via the Callout/InfoBanner modifier pattern.
+        NotificationCard(title: "Your price alert dropped")
+            .message("The route you follow is now 12% cheaper.")
+            .variant(.success)
+            .action("View") {}
+            .secondaryAction("Dismiss") {}
+            .onClose {}
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/Timeline.swift
+++ b/Sources/ThemeKit/Components/Organisms/Timeline.swift
@@ -41,6 +41,8 @@ public struct Timeline: View {
     private var axis: Axis = .vertical
     private var mode: TimelineMode = .left
     private var reverse = false
+    /// Custom per-item marker (`marker(_:)`); nil renders the stock dot/icon.
+    private var markerBuilder: ((Item, Int) -> AnyView)? = nil
 
     private let items: [Item]
 
@@ -73,7 +75,7 @@ public struct Timeline: View {
                         if index < ordered.count - 1 {
                             Rectangle().fill(railColor(item)).frame(height: 2).offset(x: 14)
                         }
-                        marker(item)
+                        marker(item, index: index)
                     }
                     if let time = item.time {
                         Text(time).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
@@ -97,7 +99,7 @@ public struct Timeline: View {
                 let isLast = position == displayRows.count - 1
                 switch row {
                 case .item(let item):
-                    verticalRow(position: position, isLast: isLast, marker: marker(item), rail: railColor(item),
+                    verticalRow(position: position, isLast: isLast, marker: marker(item, index: position), rail: railColor(item),
                                 main: { itemMain(item, showTime: mode != .alternate) },
                                 opposite: { oppositeContent(item) })
                 case .pending(let text):
@@ -183,7 +185,19 @@ public struct Timeline: View {
     }
 
     @ViewBuilder
-    private func marker(_ item: Item) -> some View {
+    private func marker(_ item: Item, index: Int) -> some View {
+        if let markerBuilder {
+            // Custom marker (Ant Timeline `dot`): replaces the stock dot/icon,
+            // centered in the same 28pt slot so the rail geometry is unchanged.
+            ZStack { markerBuilder(item, index) }
+                .frame(width: 28, height: 28)
+        } else {
+            stockMarker(item)
+        }
+    }
+
+    @ViewBuilder
+    private func stockMarker(_ item: Item) -> some View {
         let dotColor = item.state == .error
             ? theme.background(.systemcolorsBgError)
             : (item.color?.solid ?? theme.background(.bgHero))
@@ -225,6 +239,15 @@ public extension Timeline {
     /// Trailing loading ("pending") node with its label.
     func pending(_ text: String?) -> Self { copy { $0.pending = text } }
 
+    /// Replace the default dot/icon marker with a custom view, built per item
+    /// from the item and its zero-based display position (Ant Timeline custom
+    /// `dot`; the `Steps.marker(_:)` precedent). The custom view is centered
+    /// in the marker's 28pt slot, so the rail and connectors are unchanged;
+    /// the pending node keeps its stock spinner. Omit for the stock markers.
+    func marker<V: View>(@ViewBuilder _ content: @escaping (Timeline.Item, Int) -> V) -> Self {
+        copy { $0.markerBuilder = { item, index in AnyView(content(item, index)) } }
+    }
+
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
         mutate(&c)
@@ -246,6 +269,18 @@ public extension Timeline {
                 .init(title: "Layover", time: "12:30", description: "Munich (MUC)", systemImage: "clock", state: .active),
                 .init(title: "Arrival", time: "16:45", description: "Barcelona (BCN)", systemImage: "airplane.arrival", state: .todo),
             ]).mode(.alternate)
+
+            // Custom `.marker { }` slot — the Steps precedent; rail unchanged.
+            Timeline([
+                .init(title: "Booked", time: "Mon", state: .done),
+                .init(title: "Checked in", time: "Tue", state: .active),
+                .init(title: "Flight", time: "Wed", state: .todo),
+            ])
+            .marker { item, index in
+                Image(systemName: item.state == .done ? "checkmark.seal.fill" : "\(index + 1).circle.fill")
+                    .font(.system(size: 20))
+                    .foregroundStyle(item.state == .todo ? SemanticColor.neutral.solid : SemanticColor.primary.solid)
+            }
         }
         .padding()
     }

--- a/Sources/ThemeKit/ReadOnly.swift
+++ b/Sources/ThemeKit/ReadOnly.swift
@@ -1,0 +1,44 @@
+//
+//  ReadOnly.swift
+//  ThemeKit
+//  Created by İsa Mercan on 23.06.2026.
+//
+//  A kit-wide read-only axis (HeroUI `isReadOnly` / Ant `readOnly`). Unlike
+//  `.disabled(_:)` — which dims to the disabled token and drops the control from
+//  the a11y value tree — a read-only input keeps its NORMAL chrome and its
+//  VoiceOver value, but suppresses editing, focus and clear/reveal affordances.
+//  It's the right axis for review / summary / confirmation screens where the
+//  data must stay legible and copy-able but not editable.
+//
+//  Components opt in by reading `\.isReadOnly` and gating their editing surface
+//  (make the inner control non-focusable / non-editable, hide clear buttons,
+//  keep the value text and border). Presentation stays identical to the
+//  editable state.
+//
+
+import SwiftUI
+
+private struct IsReadOnlyKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+public extension EnvironmentValues {
+    /// Whether inputs in this subtree are read-only (non-editable but not
+    /// disabled). Read by the field family; set with `.readOnly(_:)`.
+    var isReadOnly: Bool {
+        get { self[IsReadOnlyKey.self] }
+        set { self[IsReadOnlyKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Mark inputs in this subtree read-only: they render their value with the
+    /// normal (non-dimmed) chrome but can't be edited, focused, or cleared.
+    /// VoiceOver still reads the value. Distinct from `.disabled(_:)`.
+    ///
+    ///     ReviewForm()
+    ///         .readOnly(isSubmitted)
+    func readOnly(_ on: Bool = true) -> some View {
+        environment(\.isReadOnly, on)
+    }
+}


### PR DESCRIPTION
Library-wide **flexibility / customization** sweep — adds the missing per-component axes vs **HeroUI Pro + HeroUI core + Ant Design**, from the audit in `HEROUI_STYLE_GAP_AUDIT.md` (46 gaps: 2 P0 · 10 P1 · 34 P2; all 217 files reviewed in a Coverage Index; "survey-before-adding" so already-covered axes are left alone). Everything is additive, copy-on-write, token-fed. `swift build` clean, **267 tests pass**, Demo app builds — at every commit.

## The two P0s
- **Read-only axis** (new) — `\.isReadOnly` environment + `.readOnly(_:)` (`Sources/ThemeKit/ReadOnly.swift`), adopted across the field + control families. Unlike `.disabled`, it keeps normal chrome and the VoiceOver value while blocking editing/focus/clear (HeroUI `isReadOnly` / Ant `readOnly`).
- **Field-size unification** — per-instance `.size(_:)` → `scaledControlHeight` on the whole field family (SearchBar, DateField, TimeField, OTPInput, SelectBox, Autocomplete, FieldButton, ColorField, PaymentCardField, Mentions, MultiSelect, InputNumber, …), precedence `explicit ?? fieldDefaults.size ?? default`. Fixed-height fields now scale with Dynamic Type.

## By wave (7 commits)
- **Wave 0** — ControlRow `.controlPlacement(.leading/.trailing)`, RTL mirror batch, toast **pause-on-drag** bug fix, Backdrop scrims, MLTI helper/warning parity.
- **Wave 4** — inline `.links(_:)` on HelperText / InputLabel / EmptyState / Callout + `ControlRow.description(_:links:)`.
- **Wave 6** — FeedbackDefaults provider knobs (offset, spacing, swipe-to-dismiss, haptics).
- **Waves 1-3** — field-size + read-only + `required`/`validate` rollout + InputNumber decimals/precision + Autocomplete clearable/loading + Cascader searchable/clearable + MultiSelect `maxSelection`.
- **Wave 5** — control placement + `.label{}` slots + `CheckboxGroup.axis` + `lineThrough` + group descriptions + read-only across Checkbox / RadioButton / RadioGroup / CheckboxGroup / ThemeToggle. C4 glyph sizes.
- **Waves 7-8** — 24 long-tail components: Tooltip content slot, Avatar `.bordered`, Tag `.closable`, Splitter `.vertical`, ThemeButton `.spinnerPlacement`, Transfer search/item-disable, ToggleGroup axes, Rating `.allowClear`, Timeline `.marker` slot, NotificationCard `.action`, KanbanBoard `.columnWidth/.spacing`, EmojiReactionButton `.size/.accent`, Callout `.leading/.trailing` slots, EmptyState `.actions` slot, Chip `.medium` + min-heights; **ComponentDefaults accent** adoption (ThemeButton/FAB/SegmentedControl were hardcoded `.primary`); token-hygiene deprecation batch.

## Intended behavior shifts (called out)
- InputNumber `large()` → 64pt (moved onto the family ramp; the one in-repo caller migrated).
- Checkbox/RadioButton `.controlSize(.large)` glyph → 28pt (previously a silent no-op that rendered 24).

## Notes
- The ~40-component remainder was implemented by four `sr-ios-dev` agents on disjoint file sets; the consolidated build was clean on the first try.
- Demo emits 4 deprecation *warnings* (raw-color/padding call sites) — a trivial follow-up; the app builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
