### PR TITLE
feat(flexibility): tail — required/validate, feedback links + provider knobs, snapshots

### DIFF
--- a/Demo/Demo/Examples/HotelResultsView.swift
+++ b/Demo/Demo/Examples/HotelResultsView.swift
@@ -141,6 +141,6 @@ struct HotelCard: View {
                 .padding()
             }
         }
-        .contentPadding(0)
+        .contentPadding(.none)
     }
 }

--- a/Demo/Demo/Gallery/Demos/AtomDemos.swift
+++ b/Demo/Demo/Gallery/Demos/AtomDemos.swift
@@ -100,7 +100,7 @@ struct BadgeDemo: View {
                 .badgeStyle(style).variant(variant).size(size)
                 .icon(icon ? "star.fill" : nil)
                 .badgeShape(pill ? .pill : .rounded)
-                .gradient(gradient ? [SemanticColor.primary.base, SemanticColor.purple.base] : nil)
+                .gradient(gradient ? [SemanticColor.primary, SemanticColor.purple] : nil)
                 .highlighted(highlighted)
         } knobs: {
             TextField("Text", text: $text).textFieldStyle(.roundedBorder)

--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -398,12 +398,12 @@ struct InputNumberDemo: View {
         ComponentStage("InputNumber", inspector: [("value", "\(value)"), ("editable", "\(editable)")]) {
             if priceMode {
                 InputNumber("Max price", value: $value, range: 0...10000).step(50).unit("$")
-                    .hint("Type or step by 50").large(large)
+                    .hint("Type or step by 50").size(large ? .large : .small)
                     .editable(editable)
             } else {
                 InputNumber("Guests", value: $value, range: 1...9).unit("guests")
                     .hint(showError ? nil : "Type a number or use ± ")
-                    .errorText(showError ? "Too many" : nil).large(large)
+                    .errorText(showError ? "Too many" : nil).size(large ? .large : .small)
                     .editable(editable)
             }
         } knobs: {
@@ -778,6 +778,7 @@ struct ControlRowDemo: View {
     @State private var validate = true
     @State private var custom = false
     @State private var enabled = true
+    @State private var leading = false
 
     private var control: ControlRowControl { controlIdx == 0 ? .toggle : controlIdx == 2 ? .radio : .checkbox }
     private var error: Bool { validate && !accepted }
@@ -801,10 +802,12 @@ struct ControlRowDemo: View {
                     .required(required)
                     .hasError(error)
                     .errorText("This field is required.")
+                    .controlPlacement(leading ? .leading : .trailing)
                     .disabled(!enabled)
             }
         } knobs: {
             Picker("Control", selection: $controlIdx) { Text("Toggle").tag(0); Text("Checkbox").tag(1); Text("Radio").tag(2) }.pickerStyle(.segmented)
+            Toggle("Leading control (.controlPlacement)", isOn: $leading)
             Toggle("Description", isOn: $description)
             Toggle("Required asterisk", isOn: $required)
             Toggle("Validate (error until on)", isOn: $validate)

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -421,7 +421,7 @@ struct AutocompleteDemo: View {
 
 struct CardDemo: View {
     @State private var elevation: CardElevation = .soft
-    @State private var padding = 16.0
+    @State private var padding: Theme.SpacingKey = .base
     @State private var tappable = false
     @State private var header = true
     @State private var loading = false
@@ -457,7 +457,9 @@ struct CardDemo: View {
             Toggle("Loading (skeleton)", isOn: $loading)
             Toggle("Tappable (press feedback)", isOn: $tappable)
             Picker("Elevation", selection: $elevation) { Text("None").tag(CardElevation.none); Text("Soft").tag(CardElevation.soft); Text("Elevated").tag(CardElevation.elevated) }.pickerStyle(.segmented)
-            HStack { Text("Padding"); SwiftUI.Slider(value: $padding, in: 0...32, step: 4) }
+            Picker("Padding", selection: $padding) {
+                ForEach([Theme.SpacingKey.none, .xs, .sm, .md, .base, .lg], id: \.self) { Text($0.rawValue).tag($0) }
+            }
         }
     }
 }

--- a/Demo/Demo/Gallery/Demos/TravelDemos.swift
+++ b/Demo/Demo/Gallery/Demos/TravelDemos.swift
@@ -520,7 +520,7 @@ struct LoyaltyCardDemo: View {
         var c = LoyaltyCard(tier: tier, points: Int(points)).unit(unit).animatesValue(animates)
         if memberName { c = c.memberName("Elif Kaya") }
         if progress { c = c.progress(progressValue, toNextTier: "Platinum") }
-        if gradientOverride { c = c.gradient([SemanticColor.purple.base, SemanticColor.pink.base]) }
+        if gradientOverride { c = c.gradient([SemanticColor.purple, SemanticColor.pink]) }
         if logo {
             c = c.logo { Image(systemName: "airplane.circle.fill").font(.title3).foregroundStyle(.white) }
         } else {

--- a/Sources/ThemeKit/Components/Molecules/CheckboxGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/CheckboxGroup.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// Selection state is owned by the caller (single Set binding — no per-row state).
 public struct CheckboxGroup<Option: Hashable>: View {
     @Environment(\.theme) private var theme
+    @Environment(\.fieldDefaults) private var fieldDefaults   // F4 — requiredIndicator default
 
     private let title: String?
     private let options: [Option]
@@ -24,6 +25,8 @@ public struct CheckboxGroup<Option: Hashable>: View {
     private var groupDescription: String?                     // E5
     private var axis: Axis = .vertical                        // A6
     private var controlPlacement: HorizontalEdge = .leading   // A5 — forwarded to rows
+    /// `.required()` — group-level asterisk after the title (E2).
+    private var isRequired = false
     private var accessibilityID: String? = nil
     @Environment(\.isReadOnly) private var isReadOnly         // E1 — rows own the tap
 
@@ -63,7 +66,19 @@ public struct CheckboxGroup<Option: Hashable>: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
             if let title {
-                Text(title).textStyle(.labelMd600).foregroundStyle(titleColor)
+                // E2 — group-level required mark: the group has no `InputLabel`,
+                // so render the same error-token asterisk manually (the
+                // MultiLineTextInput treatment), honoring `FieldDefaults.requiredIndicator`.
+                HStack(spacing: 2) {
+                    Text(title).foregroundStyle(titleColor)
+                    if isRequired && (fieldDefaults.requiredIndicator ?? true) {
+                        Text(verbatim: "*")
+                            .foregroundStyle(theme.foreground(.systemcolorsFgError))
+                            .accessibilityHidden(true)   // spoken via the title's label suffix
+                    }
+                }
+                .textStyle(.labelMd600)
+                .accessibilityLabel(isRequired ? title + ", " + String(themeKit: "required") : title)
             }
             if let groupDescription {
                 HelperText(groupDescription)   // E5 — group-level supporting text
@@ -166,6 +181,8 @@ public struct CheckboxGroup<Option: Hashable>: View {
                     .controlPlacement(.trailing)                                        // A5
                     .selectAll("All amenities")
                     .description("Filters apply to all room types.")                    // E5
+                CheckboxGroup(title: "Required group", options: ["Wifi", "Pool"], selection: $sel) { $0 }
+                    .required()                                                         // E2
             }
             .padding()
         }
@@ -185,6 +202,11 @@ public extension CheckboxGroup {
     /// Group-level supporting text rendered under the title via `HelperText`
     /// (Ant/HeroUI group `description`; E5).
     func description(_ text: String?) -> Self { copy { $0.groupDescription = text } }
+
+    /// Marks the whole group required: an error-token asterisk after the title
+    /// (honoring `FieldDefaults.requiredIndicator`) and ", required" in the
+    /// title's a11y label. (E2 — HeroUI `isRequired`, Ant required mark.)
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
 
     /// Layout axis of the option rows: `.vertical` (default) or `.horizontal`.
     /// (Ant `Checkbox.Group` / HeroUI `orientation`; A6.) The "select all"

--- a/Sources/ThemeKit/Components/Molecules/DateField.swift
+++ b/Sources/ThemeKit/Components/Molecules/DateField.swift
@@ -51,6 +51,16 @@ public struct DateField: View {
     private var allowClear = false
     private var leadingSystemImage: String?
     private var accessibilityID: String?
+    /// `.required()` — asterisk on the label + ", required" in the a11y label.
+    private var isRequired = false
+
+    // Declarative validation (daisyUI Validator) — rules run against the
+    // *displayed* date string at `validationTrigger`; failures merge into the
+    // rendered messages, driving the border state automatically.
+    private var validationRules: [ValidationRule] = []
+    private var validationTrigger: ValidationTrigger = .editingEnd
+    private var onValidation: ((Bool) -> Void)?
+    @State private var validationMessages: [InfoMessage] = []
 
     /// Optional external focus (e.g. driven by `FormValidator.focusBinding`).
     /// DateField's focus analog is its picker popover: a `true` write opens the
@@ -72,7 +82,9 @@ public struct DateField: View {
     // MARK: - Derived state
 
     private var locale: Locale { explicitLocale ?? environmentLocale }
-    private var dominant: InfoMessage.Kind? { infoMessages.dominantKind }
+    /// Explicit `infoMessages(_:)` plus any current `validate(_:on:)` failures.
+    private var messages: [InfoMessage] { infoMessages + validationMessages }
+    private var dominant: InfoMessage.Kind? { messages.dominantKind }
     private var hasError: Bool { dominant == .error }
     private var hasWarning: Bool { dominant == .warning }
     private var showsClear: Bool { allowClear && date != nil && isEnabled }
@@ -88,42 +100,67 @@ public struct DateField: View {
     /// opts in (DateField historically snaps) — still gated by `microAnimations`
     /// + Reduce Motion.
     private var messagesAnimated: Bool { micro && (fieldDefaults.messagesAnimated ?? false) }
+    /// Whether `.required()` renders its asterisk (`FieldDefaults.requiredIndicator`;
+    /// the accessibility ", required" suffix is unaffected).
+    private var showsRequiredIndicator: Bool { fieldDefaults.requiredIndicator ?? true }
+    private var a11yLabel: String {
+        // Fall back to a generic field name — never "" (which would blank the
+        // control's name) and never the placeholder. The chosen date is carried
+        // by accessibilityValue.
+        let base = label ?? String(themeKit: "Date")
+        return isRequired ? base + ", " + String(themeKit: "required") : base
+    }
+
+    /// Runs the declared rules over the displayed date string (first failure
+    /// only, via `Validator`); publishes the result and reports validity.
+    private func runValidation() {
+        guard !validationRules.isEmpty else { return }
+        let failures = Validator.validate(displayText ?? "", validationRules)
+        if failures != validationMessages { validationMessages = failures }
+        onValidation?(!failures.contains { $0.kind == .error })
+    }
 
     // MARK: - Body
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
-            if let label { InputLabel(label).hasError(hasError) }
+            if let label {
+                InputLabel(label).required(isRequired && showsRequiredIndicator).hasError(hasError)
+            }
 
             fieldBox
                 .contentShape(Rectangle())
                 .onTapGesture { if isEnabled { showPicker = true } }
                 .popover(isPresented: $showPicker) { picker }
                 .a11y(A11yElement.Select.trigger, in: accessibilityID)
-                // Fall back to a generic field name — never "" (which would blank the
-                // control's name) and never the placeholder. The chosen date is carried
-                // by accessibilityValue.
-                .accessibilityLabel(label ?? String(themeKit: "Date"))
+                .accessibilityLabel(a11yLabel)
                 .accessibilityValue(displayText ?? "")
                 .accessibilityAddTraits(.isButton)
                 .accessibilityAction { if isEnabled { showPicker = true } }
 
-            if !infoMessages.isEmpty {
-                InfoMessageList(infoMessages)
+            if !messages.isEmpty {
+                InfoMessageList(messages)
                     .a11y(A11yElement.Field.message, in: accessibilityID)
             }
         }
         // Message rows animate only when `fieldDefaults(messagesAnimated: true)`
         // opts this field family in; `microAnimations` + Reduce Motion still win.
-        .animation(MicroMotion.animation(.fast, enabled: messagesAnimated, reduceMotion: reduceMotion), value: infoMessages)
+        .animation(MicroMotion.animation(.fast, enabled: messagesAnimated, reduceMotion: reduceMotion), value: messages)
+        // `.live` validates every change; other triggers re-validate once a
+        // failure is visible so the error clears as the user fixes it.
+        .onChange(of: date) { _, _ in
+            if validationTrigger == .live || !validationMessages.isEmpty { runValidation() }
+        }
         // External focus bridge (TextInput parity, popover-flavored): a `true`
         // write opens the picker; dismissing it resets the external binding.
         .onChange(of: externalFocus?.wrappedValue ?? false) { _, want in
             if want && !showPicker && isEnabled { showPicker = true }
         }
+        // Dismissing the picker is this field's blur *and* submit moment.
         .onChange(of: showPicker) { _, now in
             if !now, externalFocus?.wrappedValue == true { externalFocus?.wrappedValue = false }
             if !now { onEditingEnd?(displayText ?? "") }   // form-wiring hook (`.field(_:in:)`)
+            if !now, validationTrigger != .live { runValidation() }
         }
     }
 
@@ -147,7 +184,7 @@ public struct DateField: View {
 
     /// The field row wrapped in the active ``FieldStyle`` chrome (fill + border).
     /// Configuration mapping: the open popover reads as `isFocused`; the dominant
-    /// `infoMessages` kind drives `hasError` / `hasWarning`. `size` is nominal
+    /// message kind drives `hasError` / `hasWarning`. `size` is nominal
     /// `.medium` — `DateField` has no `TextInputSize` axis; its height stays the
     /// component's own scaled 48pt, carried by the content — unless the subtree
     /// `FieldDefaults.size` remaps both the height and the reported preset.
@@ -266,6 +303,25 @@ public extension DateField {
     /// `FieldDefaults.size` default.
     func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
 
+    /// Marks the field required: an error-token asterisk on the label (honoring
+    /// `FieldDefaults.requiredIndicator`) and ", required" in the a11y label.
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
+
+    /// Declarative validation (daisyUI Validator): `rules` run against the
+    /// *displayed* date string (empty when no date is set) at `trigger` —
+    /// `.editingEnd`/`.submit` fire when the picker is dismissed, `.live` on
+    /// every change. Failures merge into the rendered messages and border state.
+    ///
+    ///     DateField("Check-in", date: $checkIn)
+    ///         .validate([.required("Pick a check-in date")])
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
+        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    }
+
+    /// Reports validity after each `validate(_:on:)` pass — `true` when no
+    /// error-severity failure is present.
+    func onValidation(_ handler: @escaping (Bool) -> Void) -> Self { copy { $0.onValidation = handler } }
+
     /// Restrict the picker to a selectable date range.
     func range(_ range: ClosedRange<Date>?) -> Self { copy { $0.range = range } }
 
@@ -322,6 +378,10 @@ public extension DateField {
                     .infoMessages(meeting == nil ? [InfoMessage("Pick a time", kind: .error)] : [])
                 // Disabled.
                 DateField("Locked", date: .constant(.now)).disabled(true)
+                // Required + declarative validation (asterisk, rules on dismiss).
+                DateField("Check-out", date: $meeting)
+                    .required()
+                    .validate([.required("Pick a check-out date")])
                 // Underlined chrome via the shared FieldStyle hook.
                 DateField("Departure", date: $checkIn)
                     .icon("calendar")

--- a/Sources/ThemeKit/Components/Molecules/OTPInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/OTPInput.swift
@@ -49,6 +49,14 @@ public struct OTPInput: View {
     private var resendInterval: TimeInterval?
     private var onResend: (() -> Void)?
 
+    // Declarative validation (daisyUI Validator) — rules run against the entered
+    // code at `validationTrigger`; failures merge into the rendered messages,
+    // fanning the error state out to every digit cell automatically.
+    private var validationRules: [ValidationRule] = []
+    private var validationTrigger: ValidationTrigger = .editingEnd
+    private var onValidation: ((Bool) -> Void)?
+    @State private var validationMessages: [InfoMessage] = []
+
     @Binding private var code: String
     private let onComplete: ((String) -> Void)?
 
@@ -62,11 +70,21 @@ public struct OTPInput: View {
         self.onComplete = onComplete
     }
 
-    /// Validation/hint lines: `infoMessages` plus the optional `errorText` (appended as `.error`).
+    /// Validation/hint lines: `infoMessages`, the optional `errorText` (appended
+    /// as `.error`), plus any current `validate(_:on:)` failures.
     private var messages: [InfoMessage] {
         var messages = infoMessages
         if let errorText { messages.append(InfoMessage(errorText, kind: .error)) }
-        return messages
+        return messages + validationMessages
+    }
+
+    /// Runs the declared rules over the entered code (first failure only, via
+    /// `Validator`); publishes the result and reports validity.
+    private func runValidation() {
+        guard !validationRules.isEmpty else { return }
+        let failures = Validator.validate(code, validationRules)
+        if failures != validationMessages { validationMessages = failures }
+        onValidation?(!failures.contains { $0.kind == .error })
     }
 
     private var hasError: Bool { messages.dominantKind == .error }
@@ -156,6 +174,14 @@ public struct OTPInput: View {
                             }
                         } else {
                             lastFired = ""
+                        }
+                        // E3 — `.live` validates every change; other triggers
+                        // validate at completion (the OTP's editing-end/submit
+                        // moment) and re-validate once a failure is visible so
+                        // the error clears as the user retypes.
+                        if validationTrigger == .live || !validationMessages.isEmpty
+                            || sanitized.count == digitCount {
+                            runValidation()
                         }
                     }
                     .a11y(A11yElement.Field.field, in: accessibilityID)
@@ -352,6 +378,9 @@ private struct OTPDigitBox: View {
                 Text("Completed: \(lastComplete)").textStyle(.bodySm400)
                 OTPInput(code: .constant("4321")).digitCount(4).secure()
                 OTPInput(code: .constant("12")).digitCount(4).errorText("Invalid code")
+                // Declarative validation: rules run live against the entered code.
+                OTPInput(code: $code)
+                    .validate([.minLength(6, "Enter all 6 digits")], on: .live)
                 // Swapped chrome: every digit cell picks up the underlined style.
                 OTPInput(code: .constant("98")).digitCount(4).fieldStyle(.underlined)
                 // HeroUI Group/Separator anatomy: 3 + 3 with a dash between.
@@ -400,6 +429,22 @@ public extension OTPInput {
 
     /// Validation / hint messages displayed below the boxes.
     func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }
+
+    /// Declarative validation (daisyUI Validator): `rules` run against the
+    /// entered code at `trigger` — `.editingEnd`/`.submit` fire when the last
+    /// box fills (the OTP's completion moment), `.live` on every keystroke.
+    /// Failures merge into the rendered messages, fanning the error state out
+    /// to every digit cell.
+    ///
+    ///     OTPInput(code: $code)
+    ///         .validate([.minLength(6, "Enter all 6 digits")])
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
+        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    }
+
+    /// Reports validity after each `validate(_:on:)` pass — `true` when no
+    /// error-severity failure is present.
+    func onValidation(_ handler: @escaping (Bool) -> Void) -> Self { copy { $0.onValidation = handler } }
 
     /// Adds a countdown + "resend code" row. `interval` seconds before re-enabling.
     func resend(interval: TimeInterval, onResend: @escaping () -> Void) -> Self {

--- a/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioGroup.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// Selection state is owned by the caller (single optional binding).
 public struct RadioGroup<Option: Hashable>: View {
     @Environment(\.theme) private var theme
+    @Environment(\.fieldDefaults) private var fieldDefaults   // F4 — requiredIndicator default
 
     private let title: String?
     private let options: [Option]
@@ -25,6 +26,8 @@ public struct RadioGroup<Option: Hashable>: View {
     private var accent: SemanticColor?
     private var axis: Axis = .vertical
     private var controlPlacement: HorizontalEdge = .leading   // A4 — forwarded to rows
+    /// `.required()` — group-level asterisk after the title (E2).
+    private var isRequired = false
     private var accessibilityID: String? = nil
     @Environment(\.isReadOnly) private var isReadOnly         // E1 — rows own the tap
 
@@ -53,7 +56,19 @@ public struct RadioGroup<Option: Hashable>: View {
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
             if let title {
-                Text(title).textStyle(.labelMd600).foregroundStyle(titleColor)
+                // E2 — group-level required mark: the group has no `InputLabel`,
+                // so render the same error-token asterisk manually (the
+                // MultiLineTextInput treatment), honoring `FieldDefaults.requiredIndicator`.
+                HStack(spacing: 2) {
+                    Text(title).foregroundStyle(titleColor)
+                    if isRequired && (fieldDefaults.requiredIndicator ?? true) {
+                        Text(verbatim: "*")
+                            .foregroundStyle(theme.foreground(.systemcolorsFgError))
+                            .accessibilityHidden(true)   // spoken via the title's label suffix
+                    }
+                }
+                .textStyle(.labelMd600)
+                .accessibilityLabel(isRequired ? title + ", " + String(themeKit: "required") : title)
             }
             if let groupDescription {
                 HelperText(groupDescription)   // E5 — group-level supporting text
@@ -85,9 +100,10 @@ public struct RadioGroup<Option: Hashable>: View {
                     .textStyle(.bodyBase400)
                     .foregroundStyle(theme.text(.textPrimary))
                 if let description {
-                    Text(description)
-                        .textStyle(.bodySm400)
-                        .foregroundStyle(theme.text(.textSecondary))
+                    // B7 — route through the HelperText atom so option
+                    // descriptions inherit inline links (B1) and the
+                    // disabled/error text tokens for free.
+                    HelperText(description)
                 }
             }
             Button {
@@ -221,6 +237,8 @@ public struct RadioButtonGroup<Option: Hashable>: View {
                 RadioGroup(title: "Trailing radios", options: ["Economy", "Business", "First"], selection: $sel) { $0 }
                     .controlPlacement(.trailing)                                        // A4
                     .description("Fares are per passenger, taxes included.")            // E5
+                RadioGroup(title: "Required group", options: ["Economy", "Business"], selection: $sel) { $0 }
+                    .required()                                                         // E2
                 RadioButtonGroup(options: ["Day", "Week", "Month"], selection: $seg) { $0 }
                 RadioButtonGroup(options: ["Day", "Week", "Month"], selection: $seg) { $0 }
                     .groupStyle(.outline).fullWidth()
@@ -246,6 +264,11 @@ public extension RadioGroup {
     /// Group-level supporting text rendered under the title via `HelperText`
     /// (Ant/HeroUI group `description`; E5). Distinct from `optionDescription`.
     func description(_ text: String?) -> Self { copy { $0.groupDescription = text } }
+
+    /// Marks the whole group required: an error-token asterisk after the title
+    /// (honoring `FieldDefaults.requiredIndicator`) and ", required" in the
+    /// title's a11y label. (E2 — HeroUI `isRequired`, Ant required mark.)
+    func required(_ on: Bool = true) -> Self { copy { $0.isRequired = on } }
 
     /// Which side of each row's label the radio sits on: `.leading` (default)
     /// or `.trailing`, forwarded to every option row. RTL-safe —

--- a/Sources/ThemeKit/Components/Organisms/AlertToast.swift
+++ b/Sources/ThemeKit/Components/Organisms/AlertToast.swift
@@ -79,6 +79,8 @@ public struct AlertToast: View {
     private let title: String
     // Appearance/state — mutated only through the modifiers below (R2).
     private var message: String?
+    /// Tappable substrings of `message` (rendered via `InlineText` when non-empty).
+    private var links: [(substring: String, action: () -> Void)] = []
     private var type: AlertToastType = .info
     private var systemImage: String?
     private var isLoading: Bool = false
@@ -141,7 +143,11 @@ public struct AlertToast: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title).textStyle(.labelBase600)
                 if let message {
-                    Text(message).textStyle(.bodySm400).opacity(0.9)
+                    if links.isEmpty {
+                        Text(message).textStyle(.bodySm400).opacity(0.9)
+                    } else {
+                        InlineText(message, links: links).inlineStyle(.bodySm400)
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -167,7 +173,16 @@ public struct AlertToast: View {
 
 public extension AlertToast {
     /// Secondary line under the title.
-    func message(_ text: String?) -> Self { copy { $0.message = text } }
+    func message(_ text: String?) -> Self { copy { $0.message = text; $0.links = [] } }
+
+    /// Secondary line with tappable inline substrings, rendered via `InlineText`
+    /// (the shipped links idiom — API symmetry with `Callout.links` /
+    /// `HelperText.links`). `InlineText` draws its own body/link tints, so this
+    /// reads best on the light-surface `.neutral` variant or a soft custom
+    /// `ToastStyle`; the trailing `action(_:)` title is unaffected.
+    func message(_ text: String, links: [(substring: String, action: () -> Void)]) -> Self {
+        copy { $0.message = text; $0.links = links }
+    }
 
     /// Status treatment: success / warning / danger / info / neutral / accent
     /// (drives fill + icon).
@@ -202,6 +217,11 @@ public extension AlertToast {
         AlertToast("Pro features unlocked").message("Enjoy the upgrade.").variant(.accent).onClose {}
         AlertToast("Message deleted").variant(.info).action(ToastAction("Undo") {}).onClose {}
         AlertToast("Uploading…").variant(.info).loading()
+        AlertToast("Update available")
+            .message("Read the release notes before installing.",
+                     links: [("release notes", { print("notes") })])
+            .variant(.neutral)
+            .onClose {}
     }
     .padding()
 }

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -70,8 +70,44 @@ public enum FeedbackKind: String, CaseIterable {
     }
 }
 
-/// Which edge the toast stack is anchored to.
-public enum ToastPosition { case top, bottom }
+/// Where the toast stack is anchored: an edge (centered) or a corner. Corner
+/// cases are *logical* — leading/trailing, not left/right — so they mirror
+/// automatically under right-to-left layouts (Ant/HeroUI's 6 placements).
+public enum ToastPosition: CaseIterable {
+    case top, bottom
+    case topLeading, topTrailing, bottomLeading, bottomTrailing
+
+    /// The vertical screen edge this anchor belongs to — drives the insert /
+    /// remove transition direction and the stacking order.
+    var verticalEdge: Edge {
+        switch self {
+        case .top, .topLeading, .topTrailing: return .top
+        case .bottom, .bottomLeading, .bottomTrailing: return .bottom
+        }
+    }
+
+    /// Overlay alignment for this anchor (logical, so RTL-safe by construction).
+    var overlayAlignment: Alignment {
+        switch self {
+        case .top: return .top
+        case .bottom: return .bottom
+        case .topLeading: return .topLeading
+        case .topTrailing: return .topTrailing
+        case .bottomLeading: return .bottomLeading
+        case .bottomTrailing: return .bottomTrailing
+        }
+    }
+
+    /// Horizontal placement of the stack inside its full-width layer:
+    /// edge cases stay centered (the historical look), corners hug their side.
+    var stackAlignment: Alignment {
+        switch self {
+        case .top, .bottom: return .center
+        case .topLeading, .bottomLeading: return .leading
+        case .topTrailing, .bottomTrailing: return .trailing
+        }
+    }
+}
 
 /// Imperative presenter for app-global feedback. A single shared instance is
 /// injected via `.feedbackHost()`; call it from any descendant view.
@@ -143,17 +179,23 @@ public final class FeedbackPresenter {
         /// Whether `duration` was passed explicitly at the call site — `false`
         /// lets the host substitute `FeedbackDefaults.toastDuration` when set.
         let hasExplicitDuration: Bool
+        /// Tappable substrings of `message`; when non-empty the card renders
+        /// the message via `InlineText` (the shipped links idiom).
+        let links: [(substring: String, action: () -> Void)]
         /// When set, the card body renders this instead of the stock icon +
         /// title / message layout; the card chrome and dismissal are shared.
         let custom: AnyView?
 
         init(title: String, message: String?, kind: FeedbackKind, duration: Double,
-             hasExplicitDuration: Bool = true, custom: AnyView? = nil) {
+             hasExplicitDuration: Bool = true,
+             links: [(substring: String, action: () -> Void)] = [],
+             custom: AnyView? = nil) {
             self.title = title
             self.message = message
             self.kind = kind
             self.duration = duration
             self.hasExplicitDuration = hasExplicitDuration
+            self.links = links
             self.custom = custom
         }
     }
@@ -344,6 +386,27 @@ public final class FeedbackPresenter {
                                               duration: 4, hasExplicitDuration: false)
     }
 
+    /// `notify(_:)` with tappable inline substrings in the message — rendered
+    /// via `InlineText` (API symmetry with `Callout.links` / `AlertToast`'s
+    /// `message(_:links:)`). Additive overload; existing `notify` calls are
+    /// untouched.
+    public func notify(_ title: String, message: String,
+                       links: [(substring: String, action: () -> Void)],
+                       kind: FeedbackKind = .info, duration: Double = 4) {
+        activeNotification = NotificationItem(title: title, message: message, kind: kind,
+                                              duration: duration, links: links)
+    }
+
+    /// Links `notify(_:)` without the `duration:` argument — auto-dismisses
+    /// after the subtree default (`.feedbackDefaults(toastDuration:)` when set,
+    /// else 4s).
+    public func notify(_ title: String, message: String,
+                       links: [(substring: String, action: () -> Void)],
+                       kind: FeedbackKind = .info) {
+        activeNotification = NotificationItem(title: title, message: message, kind: kind,
+                                              duration: 4, hasExplicitDuration: false, links: links)
+    }
+
     /// Present a notification card with fully custom body content. Same top-edge
     /// card chrome, close button, transition and auto-dismiss as `notify(_:)`.
     public func notify<Content: View>(duration: Double = 4, @ViewBuilder content: () -> Content) {
@@ -390,6 +453,23 @@ private struct FeedbackHostModifier: ViewModifier {
         feedbackDefaults.toastPosition ?? defaultPosition
     }
 
+    /// Effective anchor for the notification card:
+    /// `FeedbackDefaults.notificationPosition` when set, else the historical
+    /// top edge. (The card spans the full width, so corner anchors matter for
+    /// their vertical edge; the alignment is logical and RTL-safe regardless.)
+    private var effectiveNotificationPosition: ToastPosition {
+        feedbackDefaults.notificationPosition ?? .top
+    }
+
+    /// Insert/remove animation for the toast stack — `FeedbackDefaults.toastMotion`
+    /// when set (else the stock `.base`), as a spring, gated the `MicroMotion`
+    /// way: `nil` (state applies instantly, no motion) when micro-animations
+    /// are off or the system Reduce Motion setting is on.
+    private var toastStackAnimation: Animation? {
+        guard micro && !reduceMotion else { return nil }
+        return (feedbackDefaults.toastMotion ?? .base).spring
+    }
+
     /// HeroUI-style stack depth: each toast behind the newest peeks out by a few
     /// points and recedes at ~0.97 scale per depth step. Fixed chrome constants
     /// (no semantic token exists for a stack-depth transform).
@@ -406,12 +486,16 @@ private struct FeedbackHostModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .environment(presenter)
-            .overlay(alignment: .top) { notificationLayer }
+            .overlay(alignment: effectiveNotificationPosition.overlayAlignment) { notificationLayer }
             .overlay(alignment: .top) { toastLayer(.top) }
             .overlay(alignment: .bottom) { toastLayer(.bottom) }
+            .overlay(alignment: .topLeading) { toastLayer(.topLeading) }
+            .overlay(alignment: .topTrailing) { toastLayer(.topTrailing) }
+            .overlay(alignment: .bottomLeading) { toastLayer(.bottomLeading) }
+            .overlay(alignment: .bottomTrailing) { toastLayer(.bottomTrailing) }
             .overlay { confirmLayer }
             .overlay { loadingLayer }
-            .animation(Motion.base.spring, value: presenter.toasts.map(\.id))
+            .animation(toastStackAnimation, value: presenter.toasts.map(\.id))
             .animation(Motion.base.animation, value: presenter.activeConfirm?.id)
             .animation(Motion.base.animation, value: presenter.activeNotification?.id)
             .animation(Motion.fast.animation, value: presenter.activeLoading)
@@ -450,7 +534,14 @@ private struct FeedbackHostModifier: ViewModifier {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(note.title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
                         if let message = note.message {
-                            Text(message).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                            if note.links.isEmpty {
+                                Text(message).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                            } else {
+                                // Tappable substrings via the shipped links idiom;
+                                // InlineText's default base color is textSecondary,
+                                // matching the plain-message line above.
+                                InlineText(message, links: note.links).inlineStyle(.bodySm400)
+                            }
                         }
                     }
                 }
@@ -465,7 +556,7 @@ private struct FeedbackHostModifier: ViewModifier {
             .background(theme.background(.bgWhite), in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
             .themeShadow(.elevated)
             .padding(Theme.SpacingKey.md.value)
-            .transition(.move(edge: .top).combined(with: .opacity))
+            .transition(.move(edge: effectiveNotificationPosition.verticalEdge).combined(with: .opacity))
             .task(id: note.id) {
                 // Omitted-duration `notify(...)` falls back to the subtree default.
                 let duration = note.hasExplicitDuration
@@ -484,23 +575,26 @@ private struct FeedbackHostModifier: ViewModifier {
     private func toastLayer(_ position: ToastPosition) -> some View {
         let stack = presenter.toasts.filter { ($0.position ?? effectiveDefaultPosition) == position }
         if !stack.isEmpty {
-            let edge: Edge = position == .top ? .top : .bottom
+            let edge = position.verticalEdge
+            let isTop = edge == .top
             // Newest nearest the anchored edge: bottom keeps array order, top reverses.
-            let ordered = position == .top ? Array(stack.reversed()) : stack
+            let ordered = isTop ? Array(stack.reversed()) : stack
             VStack(spacing: (feedbackDefaults.toastSpacing ?? .sm).value) {
                 ForEach(Array(ordered.enumerated()), id: \.element.id) { index, item in
                     // Depth 0 = the newest toast; ones behind it recede with a
                     // subtle scale + peek offset toward the anchored edge.
                     // Static (flat stack) under Reduce Motion / micro-animations off.
-                    let depth = position == .top ? index : ordered.count - 1 - index
+                    let depth = isTop ? index : ordered.count - 1 - index
                     FeedbackToastRow(item: item, edge: edge) { presenter.dismissToast(item.id) }
                         .scaleEffect(depthOn ? pow(stackScale, CGFloat(depth)) : 1,
-                                     anchor: position == .top ? .top : .bottom)
-                        .offset(y: depthOn ? CGFloat(depth) * stackPeek * (position == .top ? -1 : 1) : 0)
+                                     anchor: isTop ? .top : .bottom)
+                        .offset(y: depthOn ? CGFloat(depth) * stackPeek * (isTop ? -1 : 1) : 0)
                         .zIndex(Double(-depth))   // newest draws above what it overlaps
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .center)
+            // Edge anchors stay centered (the historical look); corner anchors
+            // hug their logical side, mirroring under RTL by construction.
+            .frame(maxWidth: .infinity, alignment: position.stackAlignment)
             .padding((feedbackDefaults.toastOffset ?? .md).value)
         }
     }
@@ -538,6 +632,8 @@ private struct FeedbackToastRow: View {
     let edge: Edge
     let onDismiss: () -> Void
 
+    @Environment(\.theme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Read here (inside the view tree) because `FeedbackPresenter.toast(...)`
     /// is called from outside it — the omitted-duration overloads resolve their
     /// effective duration at this host layer.
@@ -547,10 +643,28 @@ private struct FeedbackToastRow: View {
     /// it is dragged toward its anchored edge.
     @State private var dragProgress: Double = 0
 
+    /// 1…0 fraction of the auto-dismiss countdown still remaining — drives the
+    /// timeout progress bar. Updated by the countdown loop itself, so dragging
+    /// pauses the bar together with the timer.
+    @State private var remainingFraction: Double = 1
+
+    /// Fixed chrome: hairline height of the timeout progress bar (no semantic
+    /// token exists for a meter hairline — cf. `stackPeek` above).
+    private let progressBarHeight: CGFloat = 2
+
     /// Explicit `duration:` (including `nil` = sticky) wins; the omitted-argument
     /// overloads fall back to `FeedbackDefaults.toastDuration`, then the stock 2.5s.
     private var effectiveDuration: Double? {
         item.hasExplicitDuration ? item.duration : (feedbackDefaults.toastDuration ?? item.duration)
+    }
+
+    /// HeroUI `shouldShowTimeoutProgress`: opt-in via `FeedbackDefaults`, only
+    /// meaningful when a countdown exists (suppressed for sticky toasts), and
+    /// suppressed under Reduce Motion — it is a continuously animating drain.
+    private var showsTimeoutProgress: Bool {
+        feedbackDefaults.showsTimeoutProgress == true
+            && effectiveDuration != nil
+            && !reduceMotion
     }
 
     var body: some View {
@@ -568,16 +682,39 @@ private struct FeedbackToastRow: View {
                 while remaining > 0 {
                     try? await Task.sleep(nanoseconds: UInt64(tick * 1_000_000_000))
                     if Task.isCancelled { return }
-                    if dragProgress == 0 { remaining -= tick }
+                    if dragProgress == 0 {
+                        remaining -= tick
+                        // Drain the timeout bar from the same countdown so it
+                        // pauses with the timer while the toast is dragged.
+                        if showsTimeoutProgress { remainingFraction = max(0, remaining / duration) }
+                    }
                 }
                 onDismiss()
             }
     }
 
+    /// Thin drain bar along the toast's bottom edge showing how much of the
+    /// auto-dismiss countdown remains. Purely decorative (hidden from
+    /// accessibility); anchored `.leading` so it drains RTL-correctly.
+    @ViewBuilder private var timeoutProgress: some View {
+        if showsTimeoutProgress {
+            Capsule()
+                .fill(item.kind.toastType.foreground(theme).opacity(0.4))
+                .frame(height: progressBarHeight)
+                .scaleEffect(x: max(0, min(1, remainingFraction)), anchor: .leading)
+                .padding(.horizontal, Theme.SpacingKey.sm.value)
+                .padding(.bottom, Theme.SpacingKey.xs.value)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        }
+    }
+
     /// The row with the swipe-to-dismiss gesture, unless the subtree default
     /// `FeedbackDefaults.swipeToDismiss` is `false`.
     @ViewBuilder private var swipeableRow: some View {
-        let base = row.themeShadow(.elevated)
+        let base = row
+            .overlay(alignment: .bottom) { timeoutProgress }
+            .themeShadow(.elevated)
         if feedbackDefaults.swipeToDismiss ?? true {
             base.dismissDrag(edge: edge,
                              threshold: .points(60),

--- a/Sources/ThemeKit/Components/Organisms/FeedbackDefaults.swift
+++ b/Sources/ThemeKit/Components/Organisms/FeedbackDefaults.swift
@@ -46,9 +46,28 @@ public struct FeedbackDefaults: Equatable {
     /// Fire a light haptic when a toast appears (default off).
     public var hapticsOnShow: Bool?
 
+    /// Motion token for the toast stack's insert / remove animation (default
+    /// `.base`, as a spring). Gated the `MicroMotion` way — micro-animations
+    /// off or system Reduce Motion on disable the motion entirely, whatever
+    /// this is set to.
+    public var toastMotion: Motion?
+    /// Show a thin drain bar along each toast's bottom edge while its
+    /// auto-dismiss countdown runs (HeroUI `shouldShowTimeoutProgress`;
+    /// default off). Sticky toasts (`duration: nil`) never show it, and it is
+    /// suppressed under Reduce Motion. It pauses with the countdown while the
+    /// toast is being dragged.
+    public var showsTimeoutProgress: Bool?
+    /// Anchor for the `notify(...)` notification card (default `.top` — the
+    /// historical placement). Corner anchors are logical (leading/trailing),
+    /// so they mirror under RTL; the card spans the full width, so what they
+    /// choose is the vertical edge it slides from.
+    public var notificationPosition: ToastPosition?
+
     public init(toastPosition: ToastPosition? = nil, toastDuration: Double? = nil, maxVisibleToasts: Int? = nil,
                 toastOffset: Theme.SpacingKey? = nil, toastSpacing: Theme.SpacingKey? = nil,
-                swipeToDismiss: Bool? = nil, hapticsOnShow: Bool? = nil) {
+                swipeToDismiss: Bool? = nil, hapticsOnShow: Bool? = nil,
+                toastMotion: Motion? = nil, showsTimeoutProgress: Bool? = nil,
+                notificationPosition: ToastPosition? = nil) {
         self.toastPosition = toastPosition
         self.toastDuration = toastDuration
         self.maxVisibleToasts = maxVisibleToasts
@@ -56,6 +75,9 @@ public struct FeedbackDefaults: Equatable {
         self.toastSpacing = toastSpacing
         self.swipeToDismiss = swipeToDismiss
         self.hapticsOnShow = hapticsOnShow
+        self.toastMotion = toastMotion
+        self.showsTimeoutProgress = showsTimeoutProgress
+        self.notificationPosition = notificationPosition
     }
 }
 
@@ -89,7 +111,10 @@ public extension View {
                           toastOffset: Theme.SpacingKey? = nil,
                           toastSpacing: Theme.SpacingKey? = nil,
                           swipeToDismiss: Bool? = nil,
-                          hapticsOnShow: Bool? = nil) -> some View {
+                          hapticsOnShow: Bool? = nil,
+                          toastMotion: Motion? = nil,
+                          showsTimeoutProgress: Bool? = nil,
+                          notificationPosition: ToastPosition? = nil) -> some View {
         transformEnvironment(\.feedbackDefaults) { d in
             if let toastPosition { d.toastPosition = toastPosition }
             if let toastDuration { d.toastDuration = toastDuration }
@@ -98,24 +123,36 @@ public extension View {
             if let toastSpacing { d.toastSpacing = toastSpacing }
             if let swipeToDismiss { d.swipeToDismiss = swipeToDismiss }
             if let hapticsOnShow { d.hapticsOnShow = hapticsOnShow }
+            if let toastMotion { d.toastMotion = toastMotion }
+            if let showsTimeoutProgress { d.showsTimeoutProgress = showsTimeoutProgress }
+            if let notificationPosition { d.notificationPosition = notificationPosition }
         }
     }
 }
 
-#Preview("Feedback defaults: top edge + 1s duration") {
+#Preview("Feedback defaults: top edge + 2s duration") {
     struct Demo: View {
         @Environment(FeedbackPresenter.self) private var feedback: FeedbackPresenter
         var body: some View {
             VStack(spacing: 12) {
                 ThemeButton("Toast (uses defaults)") {
-                    feedback.toast("Anchored top, gone in 1s", kind: .success)
+                    feedback.toast("Top-anchored, 2s, drain bar", kind: .success)
                 }
                 ThemeButton("Explicit duration wins") {
-                    feedback.toast("Sticky despite the default", kind: .info, duration: nil)
+                    feedback.toast("Sticky despite the default (no drain bar)", kind: .info, duration: nil)
                 }
                 .variant(.outline)
                 ThemeButton("Explicit position wins") {
                     feedback.toast("Bottom despite the default", kind: .neutral, position: .bottom)
+                }
+                .variant(.outline)
+                ThemeButton("Corner toast (.topTrailing)") {
+                    feedback.toast("Anchored to the trailing corner", kind: .accent, position: .topTrailing)
+                }
+                .variant(.outline)
+                ThemeButton("Notification (bottom via default)") {
+                    feedback.notify("Synced", message: "See the sync log for details.",
+                                    links: [("sync log", { print("log") })])
                 }
                 .variant(.outline)
             }
@@ -124,5 +161,7 @@ public extension View {
     }
     return Demo()
         .feedbackHost()
-        .feedbackDefaults(toastPosition: .top, toastDuration: 1, maxVisibleToasts: 2)
+        .feedbackDefaults(toastPosition: .top, toastDuration: 2, maxVisibleToasts: 2,
+                          toastMotion: .slow, showsTimeoutProgress: true,
+                          notificationPosition: .bottom)
 }

--- a/Sources/ThemeKit/FieldDefaults.swift
+++ b/Sources/ThemeKit/FieldDefaults.swift
@@ -35,11 +35,25 @@ public struct FieldDefaults: Equatable {
     /// shown). The ", required" accessibility suffix is spoken regardless, so
     /// hiding the asterisk never hides the semantics from VoiceOver.
     public var requiredIndicator: Bool?
+    /// Whether fields show a trailing clear (×) affordance while non-empty
+    /// (Ant ConfigProvider input `allowClear`). Provider field only for now —
+    /// the field family adopts it in a follow-up; a field's own explicit
+    /// clearable modifier will still win over this subtree default.
+    public var clearable: Bool?
+    /// Default `ValidationTrigger` for rule-driven validation — when
+    /// `TextInput.validate(_:)`-style calls omit their `on:` argument
+    /// (`.live` / `.editingEnd` / `.submit`). Provider field only for now —
+    /// the field family adopts it in a follow-up; an explicit per-field `on:`
+    /// argument will still win over this subtree default.
+    public var validationTrigger: ValidationTrigger?
 
-    public init(size: TextInputSize? = nil, messagesAnimated: Bool? = nil, requiredIndicator: Bool? = nil) {
+    public init(size: TextInputSize? = nil, messagesAnimated: Bool? = nil, requiredIndicator: Bool? = nil,
+                clearable: Bool? = nil, validationTrigger: ValidationTrigger? = nil) {
         self.size = size
         self.messagesAnimated = messagesAnimated
         self.requiredIndicator = requiredIndicator
+        self.clearable = clearable
+        self.validationTrigger = validationTrigger
     }
 }
 
@@ -60,11 +74,15 @@ public extension View {
     /// a field's explicit modifier still overrides.
     func fieldDefaults(size: TextInputSize? = nil,
                        messagesAnimated: Bool? = nil,
-                       requiredIndicator: Bool? = nil) -> some View {
+                       requiredIndicator: Bool? = nil,
+                       clearable: Bool? = nil,
+                       validationTrigger: ValidationTrigger? = nil) -> some View {
         transformEnvironment(\.fieldDefaults) { d in
             if let size { d.size = size }
             if let messagesAnimated { d.messagesAnimated = messagesAnimated }
             if let requiredIndicator { d.requiredIndicator = requiredIndicator }
+            if let clearable { d.clearable = clearable }
+            if let validationTrigger { d.validationTrigger = validationTrigger }
         }
     }
 }

--- a/Tests/ThemeKitTests/Snapshot/FlexibilitySnapshotTests.swift
+++ b/Tests/ThemeKitTests/Snapshot/FlexibilitySnapshotTests.swift
@@ -1,0 +1,98 @@
+//
+//  FlexibilitySnapshotTests.swift
+//  ThemeKitTests
+//
+//  Visual-regression coverage for the flexibility-sweep behavior changes —
+//  control placement, glyph/size shifts, read-only chrome, inline links, and
+//  the long-tail axes — with dark + RTL variants where direction-sensitive.
+//  iOS-only + opt-in (see SnapshotSupport.swift).
+//
+
+#if canImport(UIKit)
+import SnapshotTesting
+import SwiftUI
+import XCTest
+@testable import ThemeKit
+
+@MainActor
+final class FlexibilitySnapshotTests: SnapshotTestCase {
+
+    // MARK: Control placement (A1-A5)
+
+    func testControlRow_leadingVsTrailing() {
+        assertComponentSnapshot(VStack(alignment: .leading, spacing: 16) {
+            ControlRow("Trailing (default)", isOn: .constant(true)).control(.checkbox)
+            ControlRow("Leading control", isOn: .constant(true)).control(.checkbox).controlPlacement(.leading)
+        })
+    }
+    func testControlRow_leading_rtl() {
+        assertComponentSnapshot(
+            ControlRow("Leading control", isOn: .constant(true)).control(.checkbox).controlPlacement(.leading),
+            layoutDirection: .rightToLeft
+        )
+    }
+    func testCheckbox_placementAndLarge() {
+        assertComponentSnapshot(VStack(alignment: .leading, spacing: 12) {
+            Checkbox(isChecked: .constant(true)).controlSize(.large)          // C4: 28pt glyph
+            Checkbox(isChecked: .constant(true)).controlPlacement(.trailing)
+            Checkbox(isChecked: .constant(true)).lineThrough().label { Text("Done") }   // E4 + D1
+        })
+    }
+    func testRadioButton_trailing() {
+        assertComponentSnapshot(RadioButton(isSelected: .constant(true)).controlPlacement(.trailing))
+    }
+
+    // MARK: Field size + read-only (C1, E1)
+
+    func testTextInput_sizeRamp() {
+        assertComponentSnapshot(VStack(spacing: 12) {
+            TextInput("Small", text: .constant("value")).size(.small)
+            TextInput("Large", text: .constant("value")).size(.large)
+        })
+    }
+    func testTextInput_readOnly() {
+        assertComponentSnapshot(
+            TextInput("Email", text: .constant("ada@example.com")).readOnly()
+        )
+    }
+
+    // MARK: Inline links (B1-B4)
+
+    func testHelperText_links() {
+        assertComponentSnapshot(HelperText("By continuing you accept the Terms.").links([("Terms", {})]))
+    }
+    func testCallout_links() {
+        assertComponentSnapshot(Callout("See the docs for details.").links([("docs", {})]))
+    }
+    func testEmptyState_messageLinks() {
+        assertComponentSnapshot(
+            EmptyState("Nothing here").icon("tray").message("Read the guide to get started.", links: [("guide", {})])
+        )
+    }
+
+    // MARK: Long-tail axes (E14/E15, C3, D8)
+
+    func testAvatar_bordered() {
+        assertComponentSnapshot(HStack(spacing: 12) {
+            Avatar(.initials("AB")).bordered()
+            Avatar(.initials("CD")).bordered(accent: .success)
+        })
+    }
+    func testTag_closable() {
+        assertComponentSnapshot(Tag("Istanbul").closable {})
+    }
+    func testChip_sizes() {
+        assertComponentSnapshot(HStack(spacing: 8) {
+            Chip("Small", isSelected: .constant(true)).size(.small)
+            Chip("Medium", isSelected: .constant(true)).size(.medium)
+            Chip("Large", isSelected: .constant(true)).size(.large)
+        })
+    }
+    func testEmojiReactionButton_sizeAccent() {
+        assertComponentSnapshot(HStack(spacing: 10) {
+            EmojiReactionButton("👍", count: 12, initiallyReacted: true).accent(.success)
+            EmojiReactionButton("🔥", count: 3).size(.small)
+        })
+    }
+}
+#endif


### PR DESCRIPTION
Closes the remaining ~10 gaps from HEROUI_STYLE_GAP_AUDIT.md after the main sweep (#252):
- **E2 required**: DateField, RadioGroup, CheckboxGroup (OTPInput skipped — no header label). **E3 validate**: DateField, OTPInput. **B7**: RadioGroup per-option description via HelperText (inherits links).
- **B5** AlertToast.message(_:links:). **B6** Feedback notify(links:). **F2** ToastPosition 4 corner cases (RTL-safe). **F1** remainder: FeedbackDefaults toastMotion / showsTimeoutProgress (drain bar) / notificationPosition. **F5** FieldDefaults clearable/validationTrigger provider fields.
- **Tests**: FlexibilitySnapshotTests (opt-in, iOS) — placement, glyph/size shifts, read-only, links, long-tail with dark/RTL.
- **Demo**: ControlRow placement knob + migrated the 6 sweep-introduced deprecations to token/ramp APIs.

Additive; swift build clean; 267 tests pass; Demo builds. Built by 2 parallel sr-ios-dev agents on disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)