### PR TITLE
feat(flexibility): F5 field-defaults adoption + gallery knobs for all new axes

### DIFF
--- a/Demo/Demo/Gallery/Demos/AtomDemos.swift
+++ b/Demo/Demo/Gallery/Demos/AtomDemos.swift
@@ -15,6 +15,7 @@ struct AvatarDemo: View {
     @State private var accent: SemanticColor = .primary
     @State private var initials = false
     @State private var square = false
+    @State private var bordered = false
     @State private var group = false
     @State private var numeric = 0.0   // 0 = use enum tier; >0 = custom point size
     @State private var presenceIdx = 1   // 0 = none
@@ -26,14 +27,14 @@ struct AvatarDemo: View {
 
     var body: some View {
         ComponentStage("Avatar", inspector: [
-            ("size", numeric > 0 ? "\(Int(numeric))pt" : "\(Int(size.rawValue))"), ("presence", presences[presenceIdx].0),
+            ("size", numeric > 0 ? "\(Int(numeric))pt" : "\(Int(size.rawValue))"), ("presence", presences[presenceIdx].0), ("bordered", "\(bordered)"),
         ]) {
             if group {
                 AvatarGroup([.initials("AB"), .initials("CD"), .initials("EF"), .icon("person.fill"), .initials("GH"), .initials("IJ")]).size(size).maxVisible(4)
             } else if numeric > 0 {
-                Avatar(initials ? .initials("AB") : .icon("person.fill")).dimension(numeric).accent(accent).shape(square ? .square : .circle).presence(presence, pulse: presence == .online)
+                Avatar(initials ? .initials("AB") : .icon("person.fill")).dimension(numeric).accent(accent).shape(square ? .square : .circle).bordered(bordered, accent: accent).presence(presence, pulse: presence == .online)
             } else {
-                Avatar(initials ? .initials("AB") : .icon("person.fill")).size(size).accent(accent).shape(square ? .square : .circle).presence(presence, pulse: presence == .online)
+                Avatar(initials ? .initials("AB") : .icon("person.fill")).size(size).accent(accent).shape(square ? .square : .circle).bordered(bordered, accent: accent).presence(presence, pulse: presence == .online)
             }
         } knobs: {
             Picker("Presence", selection: $presenceIdx) {
@@ -47,6 +48,7 @@ struct AvatarDemo: View {
                 Text("Primary").tag(SemanticColor.primary); Text("Neutral").tag(SemanticColor.neutral); Text("Purple").tag(SemanticColor.purple)
             }.pickerStyle(.segmented)
             Toggle("Square shape", isOn: $square)
+            Toggle("Bordered ring (accent-tinted)", isOn: $bordered)
             Toggle("Initials", isOn: $initials)
             Toggle("Avatar group (+N)", isOn: $group)
         }
@@ -122,7 +124,7 @@ struct BadgeDemo: View {
 struct ChipDemo: View {
     @State private var selected = true
     @State private var solid = false
-    @State private var large = false
+    @State private var size: ChipSize = .small
     @State private var enabled = true
     @State private var rating = false
     @State private var exists = true
@@ -130,10 +132,10 @@ struct ChipDemo: View {
 
     var body: some View {
         ComponentStage("Chip", inspector: [
-            ("isSelected", "\(selected)"), ("isExist", "\(exists)"), ("isEnabled", "\(enabled)"),
+            ("isSelected", "\(selected)"), ("size", "\(size)"), ("isExist", "\(exists)"), ("isEnabled", "\(enabled)"),
         ]) {
             Chip(exists ? "Recommended" : "Sold out", isSelected: $selected)
-                    .size(large ? .large : .small)
+                    .size(size)
                     .chipStyle(solid ? .solid : .tonal)
                     .rating(rating ? 4.6 : nil)
                     .exists(exists)
@@ -145,7 +147,9 @@ struct ChipDemo: View {
             Toggle("isExist (strike-through when off)", isOn: $exists)
             Toggle("Expands horizontally", isOn: $expands)
             Toggle("Solid style", isOn: $solid)
-            Toggle("Large", isOn: $large)
+            Picker("Size", selection: $size) {
+                Text("Small").tag(ChipSize.small); Text("Medium").tag(ChipSize.medium); Text("Large").tag(ChipSize.large)
+            }.pickerStyle(.segmented)
             Toggle("Enabled", isOn: $enabled)
         }
     }
@@ -189,6 +193,7 @@ struct RatingDemo: View {
     @State private var layoutIdx = 0   // 0 stars, 1 numberRate, 2 rateNumberText
     @State private var interactive = true
     @State private var allowHalf = true
+    @State private var allowClear = false
     @State private var reviewLink = true
     @State private var taps = 0
 
@@ -200,6 +205,7 @@ struct RatingDemo: View {
                 .layout(layout)
                 .countLabel("1,284 reviews")
                 .allowHalf(allowHalf)
+                .allowClear(allowClear)
                 .onRate((interactive && layoutIdx == 0) ? { value = $0; flash("Rating: \(String(format: "%.1f", $0))") } : nil)
                 .onReviewTap(reviewLink ? { taps += 1; flash("Reviews tapped") } : nil)
         } knobs: {
@@ -208,6 +214,7 @@ struct RatingDemo: View {
             Text("Stars: fill/half-tap. Number: value + star. Number+text: score chip + sentiment word.").font(.caption).foregroundStyle(.secondary)
             Toggle("Interactive (tap to rate, stars)", isOn: $interactive)
             Toggle("Allow half", isOn: $allowHalf)
+            Toggle("Clear on re-tap (tap current value → 0)", isOn: $allowClear)
             Toggle("Tappable review count", isOn: $reviewLink)
         }
     }
@@ -230,6 +237,7 @@ struct SpinnerDemo: View {
 struct TagDemo: View {
     @State private var text = "Istanbul"
     @State private var removable = true
+    @State private var closable = false
     @State private var icon = false
     @State private var styleIdx = 0   // 0 = neutral (no style)
     @State private var variant: FillVariant = .soft
@@ -244,14 +252,21 @@ struct TagDemo: View {
         ("turquoise", .turquoise), ("orange", .orange), ("purple", .purple), ("pink", .pink), ("info", .info),
     ]
 
+    /// `.closable(_:)` takes a non-optional closure, so the chain is built here
+    /// and the modifier applied conditionally.
+    private var demoTag: Tag {
+        let tag = Tag(text, onRemove: removable ? { flash("Tag removed") } : nil)
+            .icon(icon ? "mappin" : nil)
+            .tagStyle(styles[styleIdx].1)
+            .variant(variant)
+            .bordered(bordered)
+        return closable ? tag.closable { flash("Tag closed") } : tag
+    }
+
     var body: some View {
-        ComponentStage("Tag", inspector: [("style", styles[styleIdx].0), ("variant", "\(variant)")]) {
+        ComponentStage("Tag", inspector: [("style", styles[styleIdx].0), ("variant", "\(variant)"), ("closable", "\(closable)")]) {
             VStack(spacing: 18) {
-                Tag(text, onRemove: removable ? { flash("Tag removed") } : nil)
-                    .icon(icon ? "mappin" : nil)
-                    .tagStyle(styles[styleIdx].1)
-                    .variant(variant)
-                    .bordered(bordered)
+                demoTag
 
                 // .color(_) — the broader Ant palette
                 FlowLayout(spacing: 6, lineSpacing: 6) {
@@ -272,7 +287,8 @@ struct TagDemo: View {
             Picker("Variant", selection: $variant) {
                 Text("Soft").tag(FillVariant.soft); Text("Solid").tag(FillVariant.solid); Text("Outline").tag(FillVariant.outline)
             }.pickerStyle(.segmented)
-            Toggle("Removable", isOn: $removable)
+            Toggle("Removable (init onRemove, bare glyph)", isOn: $removable)
+            Toggle("Closable (kit CloseButton)", isOn: $closable)
             Toggle("Leading icon", isOn: $icon)
             Toggle("Bordered", isOn: $bordered)
         }
@@ -328,11 +344,12 @@ struct CloseButtonDemo: View {
 struct HelperTextDemo: View {
     @State private var error = false
     @State private var hides = false
+    @State private var links = false
     @State private var enabled = true
 
     var body: some View {
         ComponentStage("HelperText", inspector: [
-            ("hasError", "\(error)"), ("hidesOnError", "\(hides)"), ("isEnabled", "\(enabled)"),
+            ("hasError", "\(error)"), ("hidesOnError", "\(hides)"), ("links", "\(links)"), ("isEnabled", "\(enabled)"),
         ]) {
             VStack(alignment: .leading, spacing: 6) {
                 InputLabel("Password").required().hasError(error)
@@ -342,7 +359,8 @@ struct HelperTextDemo: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(12)
                     .background(RoundedRectangle(cornerRadius: 10).stroke(Theme.shared.border(.borderPrimary)))
-                HelperText("Min. 8 characters, one number.")
+                HelperText(links ? "By continuing you agree to the Terms and Privacy Policy." : "Min. 8 characters, one number.")
+                    .links(links ? [("Terms", { flash("Terms tapped") }), ("Privacy Policy", { flash("Privacy Policy tapped") })] : [])
                     .hasError(error)
                     .hidesOnError(hides)
                     .disabled(!enabled)
@@ -350,6 +368,7 @@ struct HelperTextDemo: View {
         } knobs: {
             Toggle("Error (red helper)", isOn: $error)
             Toggle("Hide on error (yields to a field-error line)", isOn: $hides)
+            Toggle("Inline links (tappable substrings)", isOn: $links)
             Toggle("Enabled", isOn: $enabled)
         }
     }

--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -69,12 +69,15 @@ struct ButtonDemo: View {
 struct CheckboxDemo: View {
     @State private var checked = false
     @State private var indeterminate = false
-    @State private var small = false
+    @State private var sizeIdx = 1   // 0 small (20pt), 1 regular (24pt), 2 large (28pt glyph)
     @State private var enabled = true
     @State private var withLabel = true
     @State private var requiredError = true
     @State private var big = false
     @State private var typeIdx = 0   // 0 plain, 1 inner, 2 customInner
+    @State private var trailing = false
+    @State private var strike = false
+    @State private var readOnly = false
 
     private var type: CheckboxType {
         switch typeIdx {
@@ -97,16 +100,22 @@ struct CheckboxDemo: View {
                     .type(type)
                     .indeterminate(indeterminate)
                     .alignment(.top)
-                    .controlSize(small ? .small : .regular)
+                    .controlPlacement(trailing ? .trailing : .leading)
+                    .lineThrough(strike)
+                    .controlSize(sizeIdx == 0 ? .small : sizeIdx == 2 ? .large : .regular)
                     .disabled(!enabled)
+                    .readOnly(readOnly)
         } knobs: {
             Toggle("Checked", isOn: $checked)
             Toggle("Custom size (32)", isOn: $big)
             Picker("Type", selection: $typeIdx) { Text("Plain").tag(0); Text("Inner").tag(1); Text("Swatch").tag(2) }.pickerStyle(.segmented)
+            Picker("Size", selection: $sizeIdx) { Text("S (20)").tag(0); Text("M (24)").tag(1); Text("L (28)").tag(2) }.pickerStyle(.segmented)
+            Toggle("Trailing control (.controlPlacement)", isOn: $trailing)
+            Toggle("Line-through when checked", isOn: $strike)
             Toggle("Required (error when unchecked)", isOn: $requiredError)
             Toggle("Inline label", isOn: $withLabel)
             Toggle("Indeterminate", isOn: $indeterminate)
-            Toggle("Small", isOn: $small)
+            Toggle("Read-only (blocks toggling, normal chrome)", isOn: $readOnly)
             Toggle("Enabled", isOn: $enabled)
         }
     }
@@ -119,6 +128,8 @@ struct RadioButtonDemo: View {
     @State private var check = false
     @State private var inner = false
     @State private var inlineLabel = true
+    @State private var trailing = false
+    @State private var readOnly = false
 
     var body: some View {
         ComponentStage("RadioButton", inspector: [("type", check ? "check" : "select"), ("style", inner ? "inner" : "plain")]) {
@@ -126,14 +137,18 @@ struct RadioButtonDemo: View {
                     .type(check ? .check : .select)
                     .radioStyle(inner ? .inner : .plain)
                     .gap(.medium)
+                    .controlPlacement(trailing ? .trailing : .leading)
                     .controlSize(small ? .small : .regular)
                     .disabled(!enabled)
+                    .readOnly(readOnly)
         } knobs: {
             Toggle("Selected", isOn: $selected)
             Toggle("Inline label", isOn: $inlineLabel)
+            Toggle("Trailing control (.controlPlacement)", isOn: $trailing)
             Toggle("Check type (toggles)", isOn: $check)
             Toggle("Inner style (check)", isOn: $inner)
             Toggle("Small", isOn: $small)
+            Toggle("Read-only (blocks toggling, normal chrome)", isOn: $readOnly)
             Toggle("Enabled", isOn: $enabled)
         }
     }
@@ -145,19 +160,22 @@ struct ToggleDemo: View {
     @State private var enabled = true
     @State private var loading = false
     @State private var icons = false
+    @State private var readOnly = false
 
     var body: some View {
-        ComponentStage("ThemeToggle", inspector: [("isOn", "\(on)"), ("isLoading", "\(loading)"), ("isEnabled", "\(enabled)")]) {
+        ComponentStage("ThemeToggle", inspector: [("isOn", "\(on)"), ("isLoading", "\(loading)"), ("readOnly", "\(readOnly)")]) {
             ThemeToggle(isOn: $on)
                 .loading(loading)
                 .symbols(on: icons ? "checkmark" : nil, off: icons ? "xmark" : nil)
                 .controlSize(small ? .small : .regular)
                 .disabled(!enabled)
+                .readOnly(readOnly)
         } knobs: {
             Toggle("On", isOn: $on)
             Toggle("Loading", isOn: $loading)
             Toggle("Inner icons", isOn: $icons)
             Toggle("Small", isOn: $small)
+            Toggle("Read-only (blocks toggling, normal chrome)", isOn: $readOnly)
             Toggle("Enabled", isOn: $enabled)
         }
     }
@@ -168,6 +186,8 @@ struct TextInputDemo: View {
     @State private var text = ""
     @State private var mode: Mode = .email
     @State private var loggedIn = false
+    @State private var readOnly = false
+    @State private var sizeIdx = 1   // 0 small, 1 medium, 2 large (TextInputSize ramp)
 
     private var model: TextInputModel {
         switch mode {
@@ -214,11 +234,16 @@ struct TextInputDemo: View {
     }
 
     var body: some View {
-        ComponentStage("TextInput", inspector: [("mode", mode.rawValue), ("value", "\"\(text)\""), ("login", "\(loggedIn)")]) {
-            TextInput(model, text: $text).a11yID(demoA11yID)
+        ComponentStage("TextInput", inspector: [("mode", mode.rawValue), ("value", "\"\(text)\""), ("readOnly", "\(readOnly)")]) {
+            TextInput(model, text: $text)
+                .size([.small, .medium, .large][sizeIdx])
+                .a11yID(demoA11yID)
+                .readOnly(readOnly)
         } knobs: {
             Text("email = keyboard/autofill + validation. password = password-manager autofill. bio = soft limit (exceed 80 → red counter). card/phone/currency = format-as-you-type masks.").font(.caption).foregroundStyle(.secondary)
             Picker("Mode", selection: $mode) { ForEach(Mode.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) } }.pickerStyle(.segmented)
+            Picker("Size", selection: $sizeIdx) { Text("S").tag(0); Text("M").tag(1); Text("L").tag(2) }.pickerStyle(.segmented)
+            Toggle("Read-only (keeps chrome, blocks editing)", isOn: $readOnly)
             Button("Reset") { text = ""; loggedIn = false }
         }
         .onChange(of: mode) { _, _ in text = ""; loggedIn = false }
@@ -389,29 +414,35 @@ struct SegmentedControlDemo: View {
 
 struct InputNumberDemo: View {
     @State private var value = 2
-    @State private var large = true
+    @State private var sizeIdx = 2   // 0 small, 1 medium, 2 large (TextInputSize ramp)
     @State private var showError = false
     @State private var editable = true
     @State private var priceMode = false   // toggles a step:50 + "$" unit config
+    @State private var readOnly = false
+
+    private var size: TextInputSize { [.small, .medium, .large][sizeIdx] }
 
     var body: some View {
-        ComponentStage("InputNumber", inspector: [("value", "\(value)"), ("editable", "\(editable)")]) {
+        ComponentStage("InputNumber", inspector: [("value", "\(value)"), ("editable", "\(editable)"), ("readOnly", "\(readOnly)")]) {
             if priceMode {
                 InputNumber("Max price", value: $value, range: 0...10000).step(50).unit("$")
-                    .hint("Type or step by 50").size(large ? .large : .small)
+                    .hint("Type or step by 50").size(size)
                     .editable(editable)
+                    .readOnly(readOnly)
             } else {
                 InputNumber("Guests", value: $value, range: 1...9).unit("guests")
                     .hint(showError ? nil : "Type a number or use ± ")
-                    .errorText(showError ? "Too many" : nil).size(large ? .large : .small)
+                    .errorText(showError ? "Too many" : nil).size(size)
                     .editable(editable)
+                    .readOnly(readOnly)
             }
         } knobs: {
             Text("editable = type the value directly (Ant InputNumber); ± steps by `step`.").font(.caption).foregroundStyle(.secondary)
             Stepper("Value: \(value)", value: $value, in: 0...10000)
             Toggle("Editable (type to enter)", isOn: $editable)
             Toggle("Price mode (step 50, $)", isOn: $priceMode)
-            Toggle("Large", isOn: $large)
+            Picker("Size", selection: $sizeIdx) { Text("S").tag(0); Text("M").tag(1); Text("L").tag(2) }.pickerStyle(.segmented)
+            Toggle("Read-only (keeps chrome, blocks stepping)", isOn: $readOnly)
             Toggle("Error state", isOn: $showError)
         }
         .onChange(of: priceMode) { _, price in value = price ? 500 : 2 }
@@ -617,16 +648,17 @@ struct SplitterDemo: View {
 
     var body: some View {
         ComponentStage("Splitter", inspector: [("axis", vertical ? "vertical" : "horizontal")]) {
-            Splitter(vertical ? .vertical : .horizontal, initialFraction: 0.4) {
+            Splitter(initialFraction: 0.4) {
                 pane("Pane A", .bgElevatorPrimary)
             } second: {
                 pane("Pane B", .bgWhite)
             }
+            .vertical(vertical)
             .frame(height: 320)
             .clipShape(RoundedRectangle(cornerRadius: 16))
             .overlay(RoundedRectangle(cornerRadius: 16).stroke(theme.border(.borderPrimary), lineWidth: 1))
         } knobs: {
-            Toggle("Vertical", isOn: $vertical)
+            Toggle("Vertical (.vertical())", isOn: $vertical)
             Text("Drag the divider to resize the panes.").font(.caption).foregroundStyle(.secondary)
         }
     }
@@ -641,6 +673,9 @@ struct SplitterDemo: View {
 
 struct CascaderDemo: View {
     @State private var path: [String] = []
+    @State private var searchable = false
+    @State private var clearable = false
+    @State private var readOnly = false
     private let options = [
         CascaderOption("tr", label: "Türkiye", children: [
             CascaderOption("34", label: "İstanbul", children: [
@@ -655,7 +690,13 @@ struct CascaderDemo: View {
     var body: some View {
         ComponentStage("Cascader", inspector: [("path", path.isEmpty ? "—" : path.joined(separator: "/"))]) {
             Cascader(options, selection: $path).placeholder("Select region")
+                .searchable(searchable)
+                .clearable(clearable)
+                .readOnly(readOnly)
         } knobs: {
+            Toggle("Searchable (filter across levels)", isOn: $searchable)
+            Toggle("Clearable (x when selected)", isOn: $clearable)
+            Toggle("Read-only (keeps chrome, blocks opening)", isOn: $readOnly)
             Text("Pick through the columns; selecting a leaf commits the path.").font(.caption).foregroundStyle(.secondary)
         }
     }
@@ -663,14 +704,20 @@ struct CascaderDemo: View {
 
 struct TransferDemo: View {
     @State private var target: Set<String> = ["wifi"]
+    @State private var searchable = false
+    @State private var lockSpa = false
     private let items = [TransferItem("wifi", title: "Wi-Fi"), TransferItem("bkfst", title: "Breakfast"),
                          TransferItem("pool", title: "Pool"), TransferItem("gym", title: "Gym"),
                          TransferItem("spa", title: "Spa"), TransferItem("park", title: "Parking")]
 
     var body: some View {
-        ComponentStage("Transfer", inspector: [("target", "\(target.count) items")]) {
+        ComponentStage("Transfer", inspector: [("target", "\(target.count) items"), ("searchable", "\(searchable)")]) {
             Transfer(items, target: $target).titles("Available", "Included")
+                .searchable(searchable)
+                .itemEnabled(lockSpa ? { $0.key != "spa" } : nil)
         } knobs: {
+            Toggle("Searchable (per-list filter)", isOn: $searchable)
+            Toggle("Disable Spa (.itemEnabled)", isOn: $lockSpa)
             Text("Check items, then move them across with the arrows.").font(.caption).foregroundStyle(.secondary)
         }
     }
@@ -678,13 +725,19 @@ struct TransferDemo: View {
 
 struct MentionsDemo: View {
     @State private var text = "Nice work "
+    @State private var sizeIdx = 1   // 0 small, 1 medium, 2 large (TextInputSize ramp)
+    @State private var readOnly = false
     private let people = [MentionOption("ada", label: "Ada Lovelace"), MentionOption("alan", label: "Alan Turing"),
                           MentionOption("grace", label: "Grace Hopper"), MentionOption("linus", label: "Linus Torvalds")]
 
     var body: some View {
-        ComponentStage("Mentions", inspector: [("chars", "\(text.count)")]) {
+        ComponentStage("Mentions", inspector: [("chars", "\(text.count)"), ("readOnly", "\(readOnly)")]) {
             Mentions(text: $text, options: people).placeholder("Type @ to mention someone…")
+                .size([.small, .medium, .large][sizeIdx])
+                .readOnly(readOnly)
         } knobs: {
+            Picker("Size", selection: $sizeIdx) { Text("S").tag(0); Text("M").tag(1); Text("L").tag(2) }.pickerStyle(.segmented)
+            Toggle("Read-only (keeps chrome, blocks editing)", isOn: $readOnly)
             Text("Type '@' then a name → pick a suggestion; it inserts @value.").font(.caption).foregroundStyle(.secondary)
         }
     }

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -54,12 +54,16 @@ struct InputLabelDemo: View {
     @State private var required = false
     @State private var info = true
     @State private var error = false
+    @State private var link = false
 
     var body: some View {
         ComponentStage("InputLabel", inspector: [("required", "\(required)"), ("hasError", "\(error)")]) {
-            InputLabel(text).required(required).hasInfo(info).hasError(error)
+            InputLabel(link ? "Email (why do we ask?)" : text)
+                .required(required).hasInfo(info).hasError(error)
+                .links(link ? [("why do we ask?", { flash("InputLabel link") })] : [])
         } knobs: {
             TextField("Text", text: $text).textFieldStyle(.roundedBorder)
+            Toggle("Inline tappable link", isOn: $link)
             Toggle("Required", isOn: $required)
             Toggle("Info glyph", isOn: $info)
             Toggle("Error", isOn: $error)
@@ -71,11 +75,11 @@ struct ScoreBadgeDemo: View {
     @State private var score = 9.0
     @State private var large = false
     var body: some View {
-        ComponentStage("ScoreBadge", inspector: [("score", String(format: "%.1f", score))]) {
-            ScoreBadge(score, large: large)
+        ComponentStage("ScoreBadge", inspector: [("score", String(format: "%.1f", score)), ("size", large ? "large" : "small")]) {
+            ScoreBadge(score).size(large ? .large : .small)
         } knobs: {
             HStack { Text("Score"); SwiftUI.Slider(value: $score, in: 0...10, step: 0.1) }
-            Toggle("Large", isOn: $large)
+            Toggle("Large (size axis)", isOn: $large)
         }
     }
 }
@@ -135,20 +139,30 @@ struct SearchBarDemo: View {
     @State private var back = false
     @State private var trailing = true
     @State private var typeahead = true
+    @State private var sizeIdx = 0   // 0 auto, then the TextInputSize ramp
     @State private var recent = ["Istanbul", "Bursa"]
 
     private let cities = ["Istanbul", "Izmir", "Izmit", "Ankara", "Antalya", "Bursa", "Adana"]
+    private var explicitSize: TextInputSize? {
+        switch sizeIdx { case 1: return .xsmall; case 2: return .small; case 3: return .medium; case 4: return .large; default: return nil }
+    }
 
     var body: some View {
-        ComponentStage("SearchBar", inspector: [("text", "\"\(text)\""), ("suggestions", "\(typeahead)"), ("recent", "\(recent.count)")]) {
-            SearchBar(text: $text)
-                .suggestions(typeahead ? cities : [])
-                .recent(typeahead ? recent : [], onClear: typeahead ? { recent = []; flash("Recent cleared") } : nil)
-                .onSelect { flash("Selected: \($0)") }
-                .onCommit { flash("Submit: \($0)") }
-                .backButton(back)
-                .trailingIcon(trailing ? "barcode.viewfinder" : nil)
+        ComponentStage("SearchBar", inspector: [("text", "\"\(text)\""), ("suggestions", "\(typeahead)"), ("size", explicitSize.map { "\($0)" } ?? "auto")]) {
+            {
+                let base = SearchBar(text: $text)
+                    .suggestions(typeahead ? cities : [])
+                    .recent(typeahead ? recent : [], onClear: typeahead ? { recent = []; flash("Recent cleared") } : nil)
+                    .onSelect { flash("Selected: \($0)") }
+                    .onCommit { flash("Submit: \($0)") }
+                    .backButton(back)
+                    .trailingIcon(trailing ? "barcode.viewfinder" : nil)
+                return explicitSize.map { base.size($0) } ?? base
+            }()
         } knobs: {
+            Picker("Size", selection: $sizeIdx) {
+                Text("Auto").tag(0); Text("XS").tag(1); Text("S").tag(2); Text("M").tag(3); Text("L").tag(4)
+            }.pickerStyle(.segmented)
             Toggle("Back button", isOn: $back)
             Toggle("Trailing icon", isOn: $trailing)
             Toggle("Suggestions + recent", isOn: $typeahead)
@@ -162,6 +176,7 @@ struct SelectDemo: View {
     @State private var searchable = false
     @State private var loading = false
     @State private var disableSoldOut = false   // marks "Konya" disabled
+    @State private var required = false
     @State private var filled = false
 
     private var selectView: some View {
@@ -173,6 +188,7 @@ struct SelectDemo: View {
         .clearable(clearable)
         .searchable(searchable)
         .loading(loading)
+        .required(required)
         .optionEnabled(disableSoldOut ? { $0 != "Konya" } : nil)
     }
 
@@ -186,6 +202,7 @@ struct SelectDemo: View {
         } knobs: {
             Toggle("Filled style (.selectStyle)", isOn: $filled)
             Toggle("Searchable (inline panel + sections)", isOn: $searchable)
+            Toggle("Required indicator", isOn: $required)
             Toggle("Allow clear", isOn: $clearable)
             Toggle("Loading (async)", isOn: $loading)
             Toggle("Disable \"Konya\"", isOn: $disableSoldOut)
@@ -200,24 +217,27 @@ struct MultiSelectDemo: View {
     @State private var searchable = true
     @State private var clearable = true
     @State private var capTags = true
+    @State private var capSelection = false
     @State private var enabled = true
     @State private var loading = false
     @State private var disableSoldOut = false   // marks "Adana" disabled
     private let cities = ["Istanbul", "Ankara", "Izmir", "Antalya", "Bursa", "Adana", "Konya"]
 
     var body: some View {
-        ComponentStage("MultiSelect", inspector: [("count", "\(picks.count)"), ("loading", "\(loading)")]) {
+        ComponentStage("MultiSelect", inspector: [("count", "\(picks.count)"), ("maxSelection", capSelection ? "5" : "—")]) {
             MultiSelect("Cities", options: cities, selection: $picks) { $0 }
             .optionEnabled(disableSoldOut ? { $0 != "Adana" } : nil)
             .searchable(searchable)
             .clearable(clearable)
             .maxTags(capTags ? 2 : nil)
+            .maxSelection(capSelection ? 5 : nil)
             .loading(loading)
             .disabled(!enabled)
         } knobs: {
             Toggle("Searchable", isOn: $searchable)
             Toggle("Allow clear", isOn: $clearable)
             Toggle("Max 2 tags (+N)", isOn: $capTags)
+            Toggle("Max 5 selections (cap)", isOn: $capSelection)
             Toggle("Loading (async)", isOn: $loading)
             Toggle("Disable \"Adana\"", isOn: $disableSoldOut)
             Toggle("Enabled", isOn: $enabled)
@@ -230,13 +250,26 @@ struct SelectBoxDemo: View {
     @State private var country: String? = "Turkey"
     @State private var error = false
     @State private var enabled = true
+    @State private var required = false
+    @State private var sizeIdx = 0   // 0 auto, then the TextInputSize ramp
+    private var explicitSize: TextInputSize? {
+        switch sizeIdx { case 1: return .xsmall; case 2: return .small; case 3: return .medium; case 4: return .large; default: return nil }
+    }
     var body: some View {
-        ComponentStage("SelectBox", inspector: [("selection", country ?? "nil"), ("isEnabled", "\(enabled)")]) {
-            SelectBox("Country", options: ["Turkey", "Germany", "France"], selection: $country) { $0 }
-            .hint(error ? nil : "Pick your country")
-            .errorText(error ? "Required" : nil)
+        ComponentStage("SelectBox", inspector: [("selection", country ?? "nil"), ("size", explicitSize.map { "\($0)" } ?? "auto")]) {
+            {
+                let base = SelectBox("Country", options: ["Turkey", "Germany", "France"], selection: $country) { $0 }
+                    .hint(error ? nil : "Pick your country")
+                    .errorText(error ? "Required" : nil)
+                    .required(required)
+                return explicitSize.map { base.size($0) } ?? base
+            }()
             .disabled(!enabled)
         } knobs: {
+            Picker("Size", selection: $sizeIdx) {
+                Text("Auto").tag(0); Text("XS").tag(1); Text("S").tag(2); Text("M").tag(3); Text("L").tag(4)
+            }.pickerStyle(.segmented)
+            Toggle("Required indicator", isOn: $required)
             Toggle("Error state", isOn: $error)
             Toggle("Enabled", isOn: $enabled)
             Button("Clear") { country = nil }
@@ -248,14 +281,20 @@ struct MultiLineDemo: View {
     @State private var text = ""
     @State private var limit = true
     @State private var error = false
+    @State private var helper = false
+    @State private var warning = false
     var body: some View {
         ComponentStage("MultiLineTextInput", inspector: [("count", "\(text.count)")]) {
             MultiLineTextInput("Notes", text: $text)
                 .placeholder("Write something…")
                 .characterLimit(limit ? 200 : nil)
+                .helperText(helper ? "Visible to the support team only." : nil)
+                .warningText(warning ? "Avoid sharing personal data." : nil)
                 .errorText(error ? "Required" : nil)
         } knobs: {
             Toggle("Character limit", isOn: $limit)
+            Toggle("Helper text", isOn: $helper)
+            Toggle("Warning text", isOn: $warning)
             Toggle("Error state", isOn: $error)
         }
     }
@@ -267,17 +306,25 @@ struct OTPDemo: View {
     @State private var error = false
     @State private var secure = false
     @State private var resend = false
+    @State private var sizeIdx = 0   // 0 auto, then the TextInputSize ramp
     @State private var lastComplete = "—"
+    private var explicitSize: TextInputSize? {
+        switch sizeIdx { case 1: return .xsmall; case 2: return .small; case 3: return .medium; case 4: return .large; default: return nil }
+    }
     var body: some View {
-        ComponentStage("OTPInput", inspector: [("code", "\"\(code)\""), ("completed", lastComplete)]) {
+        ComponentStage("OTPInput", inspector: [("code", "\"\(code)\""), ("completed", lastComplete), ("size", explicitSize.map { "\($0)" } ?? "auto")]) {
             {
-                let base = OTPInput(code: $code, onComplete: { lastComplete = $0 })
+                var base = OTPInput(code: $code, onComplete: { lastComplete = $0 })
                     .digitCount(six ? 6 : 4)
                     .secure(secure)
                     .errorText(error ? "Invalid code" : nil)
+                if let explicitSize { base = base.size(explicitSize) }
                 return resend ? base.resend(interval: 30, onResend: { lastComplete = "resent" }) : base
             }()
         } knobs: {
+            Picker("Size", selection: $sizeIdx) {
+                Text("Auto").tag(0); Text("XS").tag(1); Text("S").tag(2); Text("M").tag(3); Text("L").tag(4)
+            }.pickerStyle(.segmented)
             Toggle("6 digits", isOn: $six)
             Toggle("Secure entry", isOn: $secure)
             Toggle("Error state", isOn: $error)
@@ -290,13 +337,23 @@ struct TooltipDemo: View {
     @State private var shown = true
     @State private var edge: TooltipEdge = .top
     @State private var colored = false
+    @State private var rich = false
     var body: some View {
-        ComponentStage("Tooltip", inspector: [("isPresented", "\(shown)"), ("edge", "\(edge)"), ("style", colored ? "info" : "default")]) {
-            Icon(systemName: "info.circle").size(.lg).color(Theme.shared.foreground(.fgHero))
-                .tooltip("Helpful hint", isPresented: $shown, edge: edge, style: colored ? .info : nil)
-                .padding(60)
+        ComponentStage("Tooltip", inspector: [("isPresented", "\(shown)"), ("edge", "\(edge)"), ("content", rich ? "custom view" : "text")]) {
+            if rich {
+                Icon(systemName: "info.circle").size(.lg).color(Theme.shared.foreground(.fgHero))
+                    .tooltip(isPresented: $shown, edge: edge, style: colored ? .info : nil) {
+                        HStack(spacing: 6) { Image(systemName: "wifi"); Text("Free Wi-Fi") }
+                    }
+                    .padding(60)
+            } else {
+                Icon(systemName: "info.circle").size(.lg).color(Theme.shared.foreground(.fgHero))
+                    .tooltip("Helpful hint", isPresented: $shown, edge: edge, style: colored ? .info : nil)
+                    .padding(60)
+            }
         } knobs: {
             Toggle("Presented", isOn: $shown)
+            Toggle("Custom content (icon + text)", isOn: $rich)
             Toggle("Colored (info)", isOn: $colored)
             Picker("Edge", selection: $edge) {
                 Text("Top").tag(TooltipEdge.top)
@@ -328,14 +385,23 @@ struct CheckboxGroupDemo: View {
     @State private var selectAll = true
     @State private var enabled = true
     @State private var disableParking = false
+    @State private var horizontal = false
+    @State private var trailingControl = false
+    @State private var description = false
     private let options = ["Wifi", "Pool", "Parking", "Breakfast"]
     var body: some View {
-        ComponentStage("CheckboxGroup", inspector: [("selected", sel.sorted().joined(separator: ", "))]) {
+        ComponentStage("CheckboxGroup", inspector: [("selected", sel.sorted().joined(separator: ", ")), ("axis", horizontal ? "horizontal" : "vertical")]) {
             CheckboxGroup(title: "Amenities", options: options, selection: $sel) { $0 }
+                .description(description ? "Included with every room." : nil)
                 .selectAll(selectAll ? "Select all" : nil)
                 .optionEnabled(disableParking ? { $0 != "Parking" } : nil)
+                .axis(horizontal ? .horizontal : .vertical)
+                .controlPlacement(trailingControl ? .trailing : .leading)
                 .disabled(!enabled)
         } knobs: {
+            Toggle("Horizontal axis", isOn: $horizontal)
+            Toggle("Trailing control placement", isOn: $trailingControl)
+            Toggle("Group description", isOn: $description)
             Toggle("Select-all (indeterminate)", isOn: $selectAll)
             Toggle("Enabled (whole group)", isOn: $enabled)
             Toggle("Disable “Parking”", isOn: $disableParking)
@@ -349,6 +415,8 @@ struct RadioGroupDemo: View {
     @State private var styleIdx = 0   // 0 stacked, 1 button-solid, 2 button-outline
     @State private var enabled = true
     @State private var disableFirst = false
+    @State private var trailingControl = false
+    @State private var description = false
     private var optionEnabled: ((String) -> Bool)? { disableFirst ? { $0 != "First" } : nil }
 
     var body: some View {
@@ -364,11 +432,17 @@ struct RadioGroupDemo: View {
                     .disabled(!enabled)
             default:
                 RadioGroup(title: "Class", options: ["Economy", "Business", "First"], selection: $sel) { $0 }
+                    .description(description ? "Fares differ by cabin class." : nil)
+                    .controlPlacement(trailingControl ? .trailing : .leading)
                     .optionEnabled(optionEnabled)
                     .disabled(!enabled)
             }
         } knobs: {
             Picker("Style", selection: $styleIdx) { Text("Stacked").tag(0); Text("Button solid").tag(1); Text("Button outline").tag(2) }.pickerStyle(.segmented)
+            if styleIdx == 0 {
+                Toggle("Trailing control placement", isOn: $trailingControl)
+                Toggle("Group description", isOn: $description)
+            }
             Toggle("Enabled (whole group)", isOn: $enabled)
             Toggle("Disable “First” option", isOn: $disableFirst)
             Button("Clear") { sel = nil }
@@ -378,12 +452,21 @@ struct RadioGroupDemo: View {
 
 struct ToggleGroupDemo: View {
     @State private var sel: Set<String> = ["push"]
+    @State private var horizontal = false
+    @State private var accented = false
+    @State private var disableSms = false
     var body: some View {
-        ComponentStage("ToggleGroup", inspector: [("on", sel.sorted().joined(separator: ", "))]) {
+        ComponentStage("ToggleGroup", inspector: [("on", sel.sorted().joined(separator: ", ")), ("axis", horizontal ? "horizontal" : "vertical")]) {
             ToggleGroup(title: "Notifications", options: ["push", "email", "sms"], selection: $sel,
                         label: { ["push": "Push", "email": "Email", "sms": "SMS"][$0] ?? $0 })
-                .optionDescription { _ in "Supporting text." }
+                .optionDescription { _ in horizontal ? nil : "Supporting text." }
+                .optionEnabled(disableSms ? { $0 != "sms" } : nil)
+                .accent(accented ? .success : nil)
+                .axis(horizontal ? .horizontal : .vertical)
         } knobs: {
+            Toggle("Horizontal axis", isOn: $horizontal)
+            Toggle("Accent (success)", isOn: $accented)
+            Toggle("Disable “SMS”", isOn: $disableSms)
             Button("Enable all") { sel = ["push", "email", "sms"] }
         }
     }
@@ -393,24 +476,45 @@ struct AutocompleteDemo: View {
     @State private var text = ""
     @State private var asyncMode = false
     @State private var disableSoldOut = false
+    @State private var clearable = false
+    @State private var externalLoading = false
+    @State private var sizeIdx = 0   // 0 auto, then the TextInputSize ramp
     private let cities = ["Istanbul", "Izmir", "Izmit", "Ankara", "Antalya", "Bursa"]
     private var enabledPredicate: ((String) -> Bool)? {
         disableSoldOut ? { $0 != "Izmit" } : nil
     }
+    private var explicitSize: TextInputSize? {
+        switch sizeIdx { case 1: return .xsmall; case 2: return .small; case 3: return .medium; case 4: return .large; default: return nil }
+    }
     var body: some View {
-        ComponentStage("Autocomplete", inspector: [("text", "\"\(text)\""), ("mode", asyncMode ? "async" : "static"), ("disabled", disableSoldOut ? "Izmit" : "—")]) {
+        ComponentStage("Autocomplete", inspector: [("text", "\"\(text)\""), ("mode", asyncMode ? "async" : "static"), ("size", explicitSize.map { "\($0)" } ?? "auto")]) {
             if asyncMode {
-                Autocomplete("Destination", text: $text, suggest: { query in
-                    try? await Task.sleep(nanoseconds: 400_000_000)   // simulate network
-                    return cities.filter { $0.localizedCaseInsensitiveContains(query) }
-                })
-                .suggestionEnabled(enabledPredicate)
-            } else {
-                Autocomplete("Destination", text: $text, suggestions: cities)
+                {
+                    let base = Autocomplete("Destination", text: $text, suggest: { query in
+                        try? await Task.sleep(nanoseconds: 400_000_000)   // simulate network
+                        return cities.filter { $0.localizedCaseInsensitiveContains(query) }
+                    })
                     .suggestionEnabled(enabledPredicate)
+                    .clearable(clearable)
+                    .loading(externalLoading)
+                    return explicitSize.map { base.size($0) } ?? base
+                }()
+            } else {
+                {
+                    let base = Autocomplete("Destination", text: $text, suggestions: cities)
+                        .suggestionEnabled(enabledPredicate)
+                        .clearable(clearable)
+                        .loading(externalLoading)
+                    return explicitSize.map { base.size($0) } ?? base
+                }()
             }
         } knobs: {
+            Picker("Size", selection: $sizeIdx) {
+                Text("Auto").tag(0); Text("XS").tag(1); Text("S").tag(2); Text("M").tag(3); Text("L").tag(4)
+            }.pickerStyle(.segmented)
             Toggle("Async (remote-style)", isOn: $asyncMode)
+            Toggle("Clearable", isOn: $clearable)
+            Toggle("Loading (external)", isOn: $externalLoading)
             Toggle("Disable “Izmit”", isOn: $disableSoldOut)
             Text("Type to filter suggestions.").font(.footnote).foregroundStyle(.secondary)
         }
@@ -470,9 +574,11 @@ struct EmptyStateDemo: View {
     @State private var customImage = false
     @State private var tintIcon = false
     @State private var animated = false
+    @State private var inlineLink = false
+    @State private var actionsSlot = false
     private let gifURL = URL(string: "https://upload.wikimedia.org/wikipedia/commons/d/d3/Newtons_cradle_animation_book_2.gif")
     var body: some View {
-        ComponentStage("EmptyState", inspector: [("media", animated ? "gif" : customImage ? "custom" : "symbol")]) {
+        ComponentStage("EmptyState", inspector: [("media", animated ? "gif" : customImage ? "custom" : "symbol"), ("actions", actionsSlot ? "slot" : "stock")]) {
             if animated {
                 EmptyState(animatedURL: gifURL, title: "Loading")
                     .imageMaxHeight(140)
@@ -484,19 +590,36 @@ struct EmptyStateDemo: View {
                     .message("You haven't added anything yet.")
                     .primaryAction(hasButton ? "Explore" : nil, action: hasButton ? { flash("EmptyState: Explore") } : nil)
             } else {
-                EmptyState("No results found")
-                    .icon("magnifyingglass")
-                    .iconForeground(tintIcon ? Theme.shared.foreground(.systemcolorsFgWarning) : nil)
-                    .iconBackground(tintIcon ? Theme.shared.background(.systemcolorsBgWarningLight) : nil)
-                    .iconCircleSize(tintIcon ? 104 : 88)
-                    .message("Try adjusting your search or filters.")
-                    .primaryAction(hasButton ? "Clear filters" : nil, action: hasButton ? { flash("EmptyState: Clear filters") } : nil)
-                    .secondaryAction(secondary ? "Learn more" : nil, action: secondary ? { flash("EmptyState: Learn more") } : nil)
+                {
+                    var base = EmptyState("No results found")
+                        .icon("magnifyingglass")
+                        .iconCircleSize(tintIcon ? 104 : 88)
+                    if tintIcon {
+                        base = base.iconForeground(.systemcolorsFgWarning).iconBackground(.systemcolorsBgWarningLight)
+                    }
+                    base = inlineLink
+                        ? base.message("Try adjusting your filters or read the search tips.",
+                                       links: [("search tips", { flash("EmptyState: search tips") })])
+                        : base.message("Try adjusting your search or filters.")
+                    if actionsSlot {
+                        return base.actions {
+                            ButtonGroup(.horizontal) {
+                                SecondaryButton("Learn more") { flash("EmptyState: Learn more") }.size(.small)
+                                PrimaryButton("Clear filters") { flash("EmptyState: Clear filters") }.size(.small)
+                            }
+                        }
+                    }
+                    return base
+                        .primaryAction(hasButton ? "Clear filters" : nil, action: hasButton ? { flash("EmptyState: Clear filters") } : nil)
+                        .secondaryAction(secondary ? "Learn more" : nil, action: secondary ? { flash("EmptyState: Learn more") } : nil)
+                }()
             }
         } knobs: {
             Toggle("Animated illustration (GIF, native)", isOn: $animated)
             Toggle("Custom illustration", isOn: $customImage)
             Toggle("Tinted + larger icon", isOn: $tintIcon)
+            Toggle("Inline tappable link (symbol)", isOn: $inlineLink)
+            Toggle("Actions slot (ButtonGroup)", isOn: $actionsSlot)
             Toggle("Action button", isOn: $hasButton)
             Toggle("Secondary action (symbol)", isOn: $secondary)
         }
@@ -571,11 +694,12 @@ struct ListRowDemo: View {
 struct NotificationDemo: View {
     @State private var unread = true
     @State private var actions = true
+    @State private var inlineAction = false
     @State private var closable = false
     @State private var typed = false
     private var type: FeedbackKind? { typed ? .success : nil }
     var body: some View {
-        ComponentStage("NotificationCard", inspector: [("isUnread", "\(unread)"), ("type", typed ? "success" : "default")]) {
+        ComponentStage("NotificationCard", inspector: [("isUnread", "\(unread)"), ("action", actions ? "slot" : inlineAction ? "inline" : "—")]) {
             if actions {
                 NotificationCard(title: "We Have a Suggestion for Your Holiday") {
                     ButtonGroup(.horizontal) {
@@ -589,16 +713,20 @@ struct NotificationDemo: View {
                 .variant(type)
                 .onClose(closable ? { flash("Notification dismissed") } : nil)
             } else {
-                NotificationCard(title: "We Have a Suggestion for Your Holiday")
-                    .message("24 days left until your Hilton Istanbul reservation.")
-                    .date("December 5, 2024")
-                    .unread(unread)
-                    .variant(type)
-                    .onClose(closable ? { flash("Notification dismissed") } : nil)
+                {
+                    let base = NotificationCard(title: "We Have a Suggestion for Your Holiday")
+                        .message("24 days left until your Hilton Istanbul reservation.")
+                        .date("December 5, 2024")
+                        .unread(unread)
+                        .variant(type)
+                        .onClose(closable ? { flash("Notification dismissed") } : nil)
+                    return inlineAction ? base.action("View") { flash("Notification: View") } : base
+                }()
             }
         } knobs: {
             Toggle("Unread", isOn: $unread)
-            Toggle("Actions", isOn: $actions)
+            Toggle("Actions (custom slot)", isOn: $actions)
+            if !actions { Toggle("Inline action (View)", isOn: $inlineAction) }
             Toggle("Type (success icon)", isOn: $typed)
             Toggle("Closable", isOn: $closable)
         }
@@ -990,14 +1118,17 @@ struct StepsDemo: View {
                          percent: (percent && state == .active) ? 0.6 : nil)
         }
     }
+    @State private var small = false
     var body: some View {
-        ComponentStage("Steps", inspector: [("active", "\(active)"), ("progressDot", "\(progressDot)")]) {
+        ComponentStage("Steps", inspector: [("active", "\(active)"), ("size", small ? "small" : "medium")]) {
             Steps(steps) { active = $0; flash("Step \($0 + 1) selected") }
                 .axis(vertical ? .vertical : .horizontal)
                 .progressDot(progressDot)
+                .size(small ? .small : .medium)
         } knobs: {
             Stepper("Active: \(active)", value: $active, in: 0...3)
             Text("Tip: tap a step to jump to it.").font(.caption).foregroundStyle(.secondary)
+            Toggle("Small size", isOn: $small)
             Toggle("Progress dot", isOn: $progressDot)
             Toggle("Active percent ring (60%)", isOn: $percent)
             Toggle("Error at active", isOn: $error)
@@ -1029,22 +1160,36 @@ struct TimelineDemo: View {
     @State private var horizontal = false
     @State private var mode: TimelineMode = .left
     @State private var reverse = false
+    @State private var customMarkers = false
     private var modeLabel: String {
         switch mode { case .left: return "left"; case .right: return "right"; case .alternate: return "alternate" }
     }
     var body: some View {
-        ComponentStage("Timeline", inspector: [("active", "\(Int(step))"), ("axis", horizontal ? "horizontal" : "vertical"), ("mode", modeLabel), ("reverse", "\(reverse)")]) {
-            Timeline([
-                .init(title: "Order", time: "09:24", systemImage: "cart", state: .done, color: .success),
-                .init(title: "Preparing", time: "09:40", systemImage: "shippingbox", state: Int(step) > 1 ? .done : .active),
-                failed
-                    ? .init(title: "Error", time: "09:45", description: horizontal ? nil : "Try your card again.", state: .error)
-                    : .init(title: "On the way", time: "—", systemImage: "truck.box", state: Int(step) > 2 ? .done : Int(step) == 2 ? .active : .todo),
-            ])
-            .axis(horizontal ? .horizontal : .vertical).mode(mode).reversed(reverse)
-            .pending((!horizontal && pending) ? "Waiting for courier…" : nil)
+        ComponentStage("Timeline", inspector: [("active", "\(Int(step))"), ("axis", horizontal ? "horizontal" : "vertical"), ("mode", modeLabel), ("marker", customMarkers ? "custom" : "stock")]) {
+            {
+                let base = Timeline([
+                    .init(title: "Order", time: "09:24", systemImage: "cart", state: .done, color: .success),
+                    .init(title: "Preparing", time: "09:40", systemImage: "shippingbox", state: Int(step) > 1 ? .done : .active),
+                    failed
+                        ? .init(title: "Error", time: "09:45", description: horizontal ? nil : "Try your card again.", state: .error)
+                        : .init(title: "On the way", time: "—", systemImage: "truck.box", state: Int(step) > 2 ? .done : Int(step) == 2 ? .active : .todo),
+                ])
+                .axis(horizontal ? .horizontal : .vertical).mode(mode).reversed(reverse)
+                .pending((!horizontal && pending) ? "Waiting for courier…" : nil)
+                if customMarkers {
+                    return base.marker { _, index in
+                        Text("\(index + 1)")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 22, height: 22)
+                            .background(Circle().fill(Theme.shared.foreground(.fgHero)))
+                    }
+                }
+                return base
+            }()
         } knobs: {
             Stepper("Active: \(Int(step))", value: $step, in: 0...3)
+            Toggle("Custom markers (numbered)", isOn: $customMarkers)
             Toggle("Horizontal", isOn: $horizontal)
             Toggle("Pending node (vertical)", isOn: $pending)
             Toggle("Error item", isOn: $failed)
@@ -1494,15 +1639,24 @@ struct CommandPaletteDemo: View {
 
 struct EmojiReactionButtonDemo: View {
     @State private var liked = false
+    @State private var size: ChipSize = .small
+    @State private var accented = false
     var body: some View {
-        ComponentStage("EmojiReactionButton", inspector: [("reacted", "\(liked)")]) {
+        ComponentStage("EmojiReactionButton", inspector: [("reacted", "\(liked)"), ("size", "\(size)"), ("accent", accented ? "success" : "default")]) {
             HStack(spacing: 10) {
                 EmojiReactionButton("👍", count: 12, isReacted: $liked)
+                    .size(size).accent(accented ? .success : nil)
                 EmojiReactionButton("🎉", count: 4, initiallyReacted: true)
+                    .size(size).accent(accented ? .success : nil)
                 EmojiReactionButton("🔥", count: 0)
+                    .size(size).accent(accented ? .success : nil)
             }
         } knobs: {
             Toggle("First reacted", isOn: $liked)
+            Picker("Size", selection: $size) {
+                Text("S").tag(ChipSize.small); Text("M").tag(ChipSize.medium); Text("L").tag(ChipSize.large)
+            }.pickerStyle(.segmented)
+            Toggle("Accent (success)", isOn: $accented)
         }
     }
 }
@@ -1628,8 +1782,11 @@ struct KanbanBoardDemo: View {
         .init("In progress", items: [Task(id: 3, title: "Build charts")], accent: .primary, limit: 2),
         .init("Done", items: [Task(id: 4, title: "Ship colors")], accent: .success),
     ]
+    @State private var width: KanbanColumnWidth = .regular
+    @State private var spacingIdx = 1   // 0 sm, 1 md, 2 lg
+    private var spacingKey: Theme.SpacingKey { spacingIdx == 0 ? .sm : spacingIdx == 2 ? .lg : .md }
     var body: some View {
-        ComponentStage("KanbanBoard", inspector: [("columns", "\(columns.count)")]) {
+        ComponentStage("KanbanBoard", inspector: [("columns", "\(columns.count)"), ("width", "\(width)"), ("spacing", "\(spacingKey)")]) {
             KanbanBoard(columns: $columns) { task in
                 Text(task.title)
                     .font(.callout.weight(.semibold))
@@ -1638,7 +1795,16 @@ struct KanbanBoardDemo: View {
                     .background(Color.white, in: RoundedRectangle(cornerRadius: 8))
                     .shadow(color: .black.opacity(0.06), radius: 3, y: 1)
             }
+            .columnWidth(width)
+            .spacing(spacingKey)
             .frame(height: 380)
+        } knobs: {
+            Picker("Column width", selection: $width) {
+                Text("Compact").tag(KanbanColumnWidth.compact); Text("Regular").tag(KanbanColumnWidth.regular); Text("Wide").tag(KanbanColumnWidth.wide)
+            }.pickerStyle(.segmented)
+            Picker("Column spacing", selection: $spacingIdx) {
+                Text("sm").tag(0); Text("md").tag(1); Text("lg").tag(2)
+            }.pickerStyle(.segmented)
         }
     }
 }
@@ -1651,6 +1817,11 @@ struct DateFieldDemo: View {
     @State private var clearable = true
     @State private var enabled = true
     @State private var error = false
+    @State private var required = false
+    @State private var sizeIdx = 0   // 0 auto, then the TextInputSize ramp
+    private var explicitSize: TextInputSize? {
+        switch sizeIdx { case 1: return .xsmall; case 2: return .small; case 3: return .medium; case 4: return .large; default: return nil }
+    }
 
     private var style: DateFieldStyle {
         switch styleSel {
@@ -1665,19 +1836,27 @@ struct DateFieldDemo: View {
     private var messages: [InfoMessage] { error ? [InfoMessage("Date is required", kind: .error)] : [] }
 
     var body: some View {
-        ComponentStage("DateField", inspector: [("style", styleSel.rawValue), ("value", date.map { $0.formatted(date: .abbreviated, time: .omitted) } ?? "nil")]) {
-            DateField("Date", date: $date)
+        ComponentStage("DateField", inspector: [("style", styleSel.rawValue), ("size", explicitSize.map { "\($0)" } ?? "auto")]) {
+            {
+                let base = DateField("Date", date: $date)
                     .style(style)
                     .components(withTime ? .dateAndTime : .date)
                     .infoMessages(messages)
                     .clearable(clearable)
+                    .required(required)
                     .icon("calendar")
                     .a11yID("demoDate")
-                    .disabled(!enabled)
+                return explicitSize.map { base.size($0) } ?? base
+            }()
+            .disabled(!enabled)
         } knobs: {
             Text("style = display format (custom = \"EEE, d MMM\"). Tap the field to open the themed picker.").font(.caption).foregroundStyle(.secondary)
             Picker("Style", selection: $styleSel) { ForEach(Style.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) } }
+            Picker("Size", selection: $sizeIdx) {
+                Text("Auto").tag(0); Text("XS").tag(1); Text("S").tag(2); Text("M").tag(3); Text("L").tag(4)
+            }.pickerStyle(.segmented)
             Toggle("With time", isOn: $withTime)
+            Toggle("Required indicator", isOn: $required)
             Toggle("Clearable", isOn: $clearable)
             Toggle("Error message", isOn: $error)
             Toggle("Enabled", isOn: $enabled)
@@ -1693,6 +1872,11 @@ struct TimeFieldDemo: View {
     @State private var clearable = true
     @State private var enabled = true
     @State private var error = false
+    @State private var required = false
+    @State private var sizeIdx = 0   // 0 auto, then the TextInputSize ramp
+    private var explicitSize: TextInputSize? {
+        switch sizeIdx { case 1: return .xsmall; case 2: return .small; case 3: return .medium; case 4: return .large; default: return nil }
+    }
 
     private var cycle: TimeFieldHourCycle {
         switch cycleSel {
@@ -1704,19 +1888,27 @@ struct TimeFieldDemo: View {
     private var messages: [InfoMessage] { error ? [InfoMessage("Time is required", kind: .error)] : [] }
 
     var body: some View {
-        ComponentStage("TimeField", inspector: [("hourCycle", cycleSel.rawValue), ("value", time.map { $0.formatted(date: .omitted, time: .shortened) } ?? "nil")]) {
-            TimeField("Time", time: $time)
-                .hourCycle(cycle)
-                .minuteInterval(interval)
-                .infoMessages(messages)
-                .clearable(clearable)
-                .icon("clock")
-                .a11yID("demoTime")
-                .disabled(!enabled)
+        ComponentStage("TimeField", inspector: [("hourCycle", cycleSel.rawValue), ("size", explicitSize.map { "\($0)" } ?? "auto")]) {
+            {
+                let base = TimeField("Time", time: $time)
+                    .hourCycle(cycle)
+                    .minuteInterval(interval)
+                    .infoMessages(messages)
+                    .clearable(clearable)
+                    .required(required)
+                    .icon("clock")
+                    .a11yID("demoTime")
+                return explicitSize.map { base.size($0) } ?? base
+            }()
+            .disabled(!enabled)
         } knobs: {
             Text("hourCycle = locale / 12h / 24h. minuteInterval snaps the wheel. Tap the field to open the themed picker.").font(.caption).foregroundStyle(.secondary)
             Picker("Hour cycle", selection: $cycleSel) { ForEach(Cycle.allCases, id: \.self) { Text($0.rawValue).tag($0) } }
+            Picker("Size", selection: $sizeIdx) {
+                Text("Auto").tag(0); Text("XS").tag(1); Text("S").tag(2); Text("M").tag(3); Text("L").tag(4)
+            }.pickerStyle(.segmented)
             Stepper("Minute interval: \(interval)", value: $interval, in: 1...30, step: 5)
+            Toggle("Required indicator", isOn: $required)
             Toggle("Clearable", isOn: $clearable)
             Toggle("Error message", isOn: $error)
             Toggle("Enabled", isOn: $enabled)
@@ -1863,6 +2055,7 @@ struct ThemeButtonDemo: View {
     @State private var icon = false
     @State private var trailingIcon = false
     @State private var loading = false
+    @State private var spinnerIdx = 0   // 0 replace label, 1 leading, 2 trailing
 
     private var iconOnly: Bool { shape == .circle || shape == .square }
 
@@ -1870,11 +2063,14 @@ struct ThemeButtonDemo: View {
         ComponentStage("ThemeButton", inspector: [
             ("color", color.rawValue), ("variant", variant.rawValue), ("shape", shape.rawValue), ("size", "\(size)"),
         ]) {
-            ThemeButton(iconOnly ? nil : "Button") { flash("ThemeButton tapped") }
-                .icon(leading: ((icon || iconOnly) && !trailingIcon) ? "star.fill" : nil,
-                      trailing: ((icon || iconOnly) && trailingIcon) ? "star.fill" : nil)
-                .color(color).variant(variant).size(size).shape(shape)
-                .fullWidth(block && !iconOnly).loading(loading)
+            {
+                let base = ThemeButton(iconOnly ? nil : "Button") { flash("ThemeButton tapped") }
+                    .icon(leading: ((icon || iconOnly) && !trailingIcon) ? "star.fill" : nil,
+                          trailing: ((icon || iconOnly) && trailingIcon) ? "star.fill" : nil)
+                    .color(color).variant(variant).size(size).shape(shape)
+                    .fullWidth(block && !iconOnly).loading(loading)
+                return spinnerIdx == 0 ? base : base.spinnerPlacement(spinnerIdx == 1 ? .leading : .trailing)
+            }()
         } knobs: {
             Picker("Color", selection: $color) { ForEach(SemanticColor.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) } }
             Picker("Variant", selection: $variant) { ForEach(ButtonVariant.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) } }
@@ -1886,6 +2082,9 @@ struct ThemeButtonDemo: View {
             Toggle("Leading icon", isOn: $icon)
             Toggle("Trailing icon position", isOn: $trailingIcon)
             Toggle("Loading", isOn: $loading)
+            Picker("Spinner placement", selection: $spinnerIdx) {
+                Text("Replace").tag(0); Text("Start").tag(1); Text("End").tag(2)
+            }.pickerStyle(.segmented)
         }
     }
 }

--- a/Demo/Demo/Gallery/Demos/OrganismDemos.swift
+++ b/Demo/Demo/Gallery/Demos/OrganismDemos.swift
@@ -44,6 +44,9 @@ struct CalloutDemo: View {
     @State private var showIcon = true
     @State private var action = false
     @State private var closable = false
+    @State private var inlineLink = false
+    @State private var leadingSlot = false
+    @State private var trailingSlot = false
     @State private var dismissed = false
 
     var body: some View {
@@ -52,12 +55,16 @@ struct CalloutDemo: View {
                 Button("Reset") { dismissed = false }.buttonStyle(.plain).foregroundStyle(Theme.shared.foreground(.fgHero))
             } else {
                 {
-                    let base = Callout("Lorem ipsum placeholder text.")
+                    var base = Callout(inlineLink ? "Your changes were saved. View the summary for details." : "Lorem ipsum placeholder text.")
                         .variant(type)
                         .calloutStyle(soft ? .soft : .plain)
                         .showsIcon(showIcon)
+                        .links(inlineLink ? [("summary", { flash("Callout link: summary") })] : [])
                         .onClose(closable ? { dismissed = true } : nil)
-                    return action ? base.action("Undo") { flash("Callout action") } : base
+                    if action { base = base.action("Undo") { flash("Callout action") } }
+                    if leadingSlot { base = base.leading { Spinner() } }
+                    if trailingSlot { base = base.trailing { Badge("New") } }
+                    return base
                 }()
             }
         } knobs: {
@@ -66,6 +73,9 @@ struct CalloutDemo: View {
             }
             Toggle("Soft surface", isOn: $soft)
             Toggle("Show icon", isOn: $showIcon)
+            Toggle("Inline tappable link", isOn: $inlineLink)
+            Toggle("Leading slot (Spinner)", isOn: $leadingSlot)
+            Toggle("Trailing slot (Badge)", isOn: $trailingSlot)
             Toggle("Action (Undo)", isOn: $action)
             Toggle("Closable", isOn: $closable)
         }

--- a/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
+++ b/Sources/ThemeKit/Components/Molecules/Autocomplete.swift
@@ -44,8 +44,11 @@ public struct Autocomplete: View {
     private var onSearch: ((String) -> Void)? = nil
     private var accessibilityID: String? = nil
     /// Clear affordance — on by default (Autocomplete's classic behavior);
-    /// `.clearable(false)` hides it (Select-parity axis, E6).
-    private var allowClear = true
+    /// `.clearable(false)` hides it (Select-parity axis, E6). Set only by the
+    /// `.clearable(_:)` modifier, so the subtree `FieldDefaults.clearable` can
+    /// fill the default without overriding an explicit per-field choice (F5):
+    /// `explicitClearable ?? fieldDefaults.clearable ?? true`.
+    private var explicitClearable: Bool?
     /// Caller-driven loading state (async option fetch outside the built-in provider).
     private var externalLoading = false
     private var infoMessages: [InfoMessage] = []
@@ -55,10 +58,12 @@ public struct Autocomplete: View {
     private var isRequired = false
 
     // Declarative validation (daisyUI Validator) — TextInput's plumbing: rules
-    // run against the bound text at `validationTrigger`; failures merge into
-    // the rendered messages, driving the border state automatically.
+    // run against the bound text at `effectiveValidationTrigger`; failures merge
+    // into the rendered messages, driving the border state automatically.
     private var validationRules: [ValidationRule] = []
-    private var validationTrigger: ValidationTrigger = .editingEnd
+    /// Set only by an explicit `on:` argument to `validate(_:on:)`; `nil` falls
+    /// back to `FieldDefaults.validationTrigger`, then `.editingEnd` (F5).
+    private var explicitValidationTrigger: ValidationTrigger?
     private var onValidation: ((Bool) -> Void)?
     @State private var validationMessages: [InfoMessage] = []
 
@@ -121,7 +126,13 @@ public struct Autocomplete: View {
     /// the accessibility ", required" suffix is unaffected).
     private var showsRequiredIndicator: Bool { fieldDefaults.requiredIndicator ?? true }
     private var showsSpinner: Bool { isLoading || externalLoading }
-    private var showsClear: Bool { allowClear && !text.isEmpty && isEnabled && !isReadOnly }
+    /// Explicit `.clearable(_:)` → subtree `FieldDefaults.clearable` → on (Autocomplete's classic default, F5).
+    private var effectiveClearable: Bool { explicitClearable ?? fieldDefaults.clearable ?? true }
+    /// Explicit `on:` argument → subtree `FieldDefaults.validationTrigger` → `.editingEnd` (F5).
+    private var effectiveValidationTrigger: ValidationTrigger {
+        explicitValidationTrigger ?? fieldDefaults.validationTrigger ?? .editingEnd
+    }
+    private var showsClear: Bool { effectiveClearable && !text.isEmpty && isEnabled && !isReadOnly }
     private var a11yLabel: String {
         let base = label ?? placeholder
         return isRequired ? base + ", " + String(themeKit: "required") : base
@@ -157,10 +168,10 @@ public struct Autocomplete: View {
         // `.live` validates every change; other triggers re-validate once a
         // failure is visible so the error clears as the user fixes it.
         .onChange(of: text) { _, value in
-            if validationTrigger == .live || !validationMessages.isEmpty { runValidation(value) }
+            if effectiveValidationTrigger == .live || !validationMessages.isEmpty { runValidation(value) }
         }
         .onChange(of: isFocused) { _, now in
-            if !now, validationTrigger == .editingEnd { runValidation(text) }   // validate on blur
+            if !now, effectiveValidationTrigger == .editingEnd { runValidation(text) }   // validate on blur
         }
     }
 
@@ -310,8 +321,9 @@ public extension Autocomplete {
     func size(_ s: TextInputSize) -> Self { copy { $0.explicitSize = s } }
 
     /// Show a trailing clear button while the field has text (on by default —
-    /// Autocomplete's classic behavior; pass `false` to hide it).
-    func clearable(_ on: Bool = true) -> Self { copy { $0.allowClear = on } }
+    /// Autocomplete's classic behavior; pass `false` to hide it). An explicit
+    /// call wins over the subtree `FieldDefaults.clearable` default (F5).
+    func clearable(_ on: Bool = true) -> Self { copy { $0.explicitClearable = on } }
 
     /// Shows a loading spinner in place of the clear button (caller-driven
     /// async option fetch; the built-in async provider spins automatically).
@@ -327,11 +339,13 @@ public extension Autocomplete {
     /// Declarative validation (daisyUI Validator): `rules` run against the bound
     /// text at `trigger` (`.editingEnd` on blur, `.live` per keystroke, `.submit`
     /// on return). Failures merge into the rendered messages and border state.
+    /// Omitting `on:` follows the subtree `FieldDefaults.validationTrigger`
+    /// default, then `.editingEnd` (F5); an explicit trigger always wins.
     ///
     ///     Autocomplete("City", text: $city, suggestions: cities)
     ///         .validate([.required(), .minLength(2)])
-    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
-        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger? = nil) -> Self {
+        copy { $0.validationRules = rules; if let trigger { $0.explicitValidationTrigger = trigger } }
     }
 
     /// Reports validity after each `validate(_:on:)` pass — `true` when no

--- a/Sources/ThemeKit/Components/Molecules/Cascader.swift
+++ b/Sources/ThemeKit/Components/Molecules/Cascader.swift
@@ -32,13 +32,18 @@ public struct Cascader: View {
     @Environment(\.isEnabled) private var isEnabled   // R3 — set natively by `.disabled(_:)`
     /// Read-only subtree axis (set with `.readOnly(_:)`) — normal chrome, no picking.
     @Environment(\.isReadOnly) private var isReadOnly
+    /// Subtree field-family defaults (F5) — fills `clearable` when not set explicitly.
+    @Environment(\.fieldDefaults) private var fieldDefaults
 
     private let options: [CascaderOption]
     @Binding private var selection: [String]
     // Appearance — mutated only through the modifiers below.
     private var placeholder: String = String(themeKit: "Select")
     private var changeOnSelect = false
-    private var allowClear = false
+    /// Set only by the `.clearable(_:)` modifier, so the subtree
+    /// `FieldDefaults.clearable` can fill the default without overriding an
+    /// explicit per-field choice (F5): `explicitClearable ?? fieldDefaults.clearable ?? false`.
+    private var explicitClearable: Bool?
     private var isSearchable = false
     private var isNodeEnabled: ((CascaderOption) -> Bool)?
     private var infoMessages: [InfoMessage] = []
@@ -55,7 +60,9 @@ public struct Cascader: View {
     private var dominant: InfoMessage.Kind? { infoMessages.dominantKind }
     private var hasError: Bool { dominant == .error }
     private var hasWarning: Bool { dominant == .warning }
-    private var showsClear: Bool { allowClear && !selection.isEmpty && isEnabled && !isReadOnly }
+    /// Explicit `.clearable(_:)` → subtree `FieldDefaults.clearable` → off (F5).
+    private var effectiveClearable: Bool { explicitClearable ?? fieldDefaults.clearable ?? false }
+    private var showsClear: Bool { effectiveClearable && !selection.isEmpty && isEnabled && !isReadOnly }
     private func nodeEnabled(_ node: CascaderOption) -> Bool { isNodeEnabled?(node) ?? true }
 
     public var body: some View {
@@ -291,7 +298,8 @@ public extension Cascader {
     /// Commit the path at every level, not only on a leaf (Ant `changeOnSelect`).
     func changeOnSelect(_ on: Bool = true) -> Self { copy { $0.changeOnSelect = on } }
     /// Show a trailing clear button when a path is selected (Ant `allowClear`).
-    func clearable(_ on: Bool = true) -> Self { copy { $0.allowClear = on } }
+    /// An explicit call wins over the subtree `FieldDefaults.clearable` default (F5).
+    func clearable(_ on: Bool = true) -> Self { copy { $0.explicitClearable = on } }
     /// Add a search field atop the dropdown; typing filters to a flat list of
     /// matching leaf paths (Ant `showSearch`).
     func searchable(_ on: Bool = true) -> Self { copy { $0.isSearchable = on } }

--- a/Sources/ThemeKit/Components/Molecules/DateField.swift
+++ b/Sources/ThemeKit/Components/Molecules/DateField.swift
@@ -48,17 +48,22 @@ public struct DateField: View {
     private var explicitLocale: Locale?
     private var components: DateFieldComponents = .date
     private var infoMessages: [InfoMessage] = []
-    private var allowClear = false
+    /// Set only by the `.clearable(_:)` modifier, so the subtree
+    /// `FieldDefaults.clearable` can fill the default without overriding an
+    /// explicit per-field choice (F5): `explicitClearable ?? fieldDefaults.clearable ?? false`.
+    private var explicitClearable: Bool?
     private var leadingSystemImage: String?
     private var accessibilityID: String?
     /// `.required()` — asterisk on the label + ", required" in the a11y label.
     private var isRequired = false
 
     // Declarative validation (daisyUI Validator) — rules run against the
-    // *displayed* date string at `validationTrigger`; failures merge into the
-    // rendered messages, driving the border state automatically.
+    // *displayed* date string at `effectiveValidationTrigger`; failures merge
+    // into the rendered messages, driving the border state automatically.
     private var validationRules: [ValidationRule] = []
-    private var validationTrigger: ValidationTrigger = .editingEnd
+    /// Set only by an explicit `on:` argument to `validate(_:on:)`; `nil` falls
+    /// back to `FieldDefaults.validationTrigger`, then `.editingEnd` (F5).
+    private var explicitValidationTrigger: ValidationTrigger?
     private var onValidation: ((Bool) -> Void)?
     @State private var validationMessages: [InfoMessage] = []
 
@@ -87,7 +92,13 @@ public struct DateField: View {
     private var dominant: InfoMessage.Kind? { messages.dominantKind }
     private var hasError: Bool { dominant == .error }
     private var hasWarning: Bool { dominant == .warning }
-    private var showsClear: Bool { allowClear && date != nil && isEnabled }
+    /// Explicit `.clearable(_:)` → subtree `FieldDefaults.clearable` → off (F5).
+    private var effectiveClearable: Bool { explicitClearable ?? fieldDefaults.clearable ?? false }
+    /// Explicit `on:` argument → subtree `FieldDefaults.validationTrigger` → `.editingEnd` (F5).
+    private var effectiveValidationTrigger: ValidationTrigger {
+        explicitValidationTrigger ?? fieldDefaults.validationTrigger ?? .editingEnd
+    }
+    private var showsClear: Bool { effectiveClearable && date != nil && isEnabled }
     private var displayText: String? {
         date.map { Self.text(for: $0, style: style, locale: locale, components: components) }
     }
@@ -149,7 +160,7 @@ public struct DateField: View {
         // `.live` validates every change; other triggers re-validate once a
         // failure is visible so the error clears as the user fixes it.
         .onChange(of: date) { _, _ in
-            if validationTrigger == .live || !validationMessages.isEmpty { runValidation() }
+            if effectiveValidationTrigger == .live || !validationMessages.isEmpty { runValidation() }
         }
         // External focus bridge (TextInput parity, popover-flavored): a `true`
         // write opens the picker; dismissing it resets the external binding.
@@ -160,7 +171,7 @@ public struct DateField: View {
         .onChange(of: showPicker) { _, now in
             if !now, externalFocus?.wrappedValue == true { externalFocus?.wrappedValue = false }
             if !now { onEditingEnd?(displayText ?? "") }   // form-wiring hook (`.field(_:in:)`)
-            if !now, validationTrigger != .live { runValidation() }
+            if !now, effectiveValidationTrigger != .live { runValidation() }
         }
     }
 
@@ -311,11 +322,13 @@ public extension DateField {
     /// *displayed* date string (empty when no date is set) at `trigger` —
     /// `.editingEnd`/`.submit` fire when the picker is dismissed, `.live` on
     /// every change. Failures merge into the rendered messages and border state.
+    /// Omitting `on:` follows the subtree `FieldDefaults.validationTrigger`
+    /// default, then `.editingEnd` (F5); an explicit trigger always wins.
     ///
     ///     DateField("Check-in", date: $checkIn)
     ///         .validate([.required("Pick a check-in date")])
-    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
-        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger? = nil) -> Self {
+        copy { $0.validationRules = rules; if let trigger { $0.explicitValidationTrigger = trigger } }
     }
 
     /// Reports validity after each `validate(_:on:)` pass — `true` when no
@@ -337,8 +350,9 @@ public extension DateField {
     /// Validation / info messages rendered under the field (drives the border state).
     func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }
 
-    /// Show a trailing clear button when a date is set.
-    func clearable(_ on: Bool = true) -> Self { copy { $0.allowClear = on } }
+    /// Show a trailing clear button when a date is set. An explicit call wins
+    /// over the subtree `FieldDefaults.clearable` default (F5).
+    func clearable(_ on: Bool = true) -> Self { copy { $0.explicitClearable = on } }
 
     /// Drive focus from outside (e.g. `FormValidator.focusBinding`). DateField's
     /// focus analog is its picker popover: a `true` write opens the picker (which

--- a/Sources/ThemeKit/Components/Molecules/InputNumber.swift
+++ b/Sources/ThemeKit/Components/Molecules/InputNumber.swift
@@ -48,10 +48,12 @@ public struct InputNumber: View {
     private var isRequired = false
 
     // Declarative validation (E3, TextInput parity): rules run against the
-    // field's text at `validationTrigger`; the first failure renders as an
-    // `InfoMessageList` row and drives the error border.
+    // field's text at `effectiveValidationTrigger`; the first failure renders
+    // as an `InfoMessageList` row and drives the error border.
     private var validationRules: [ValidationRule] = []
-    private var validationTrigger: ValidationTrigger = .editingEnd
+    /// Set only by an explicit `on:` argument to `validate(_:on:)`; `nil` falls
+    /// back to `FieldDefaults.validationTrigger`, then `.editingEnd` (F5).
+    private var explicitValidationTrigger: ValidationTrigger?
     @State private var validationMessages: [InfoMessage] = []
 
     @Environment(\.isEnabled) private var isEnabled
@@ -104,6 +106,10 @@ public struct InputNumber: View {
     /// Whether `.required()` renders its asterisk (`FieldDefaults.requiredIndicator`;
     /// the accessibility ", required" suffix is unaffected).
     private var showsRequiredIndicator: Bool { fieldDefaults.requiredIndicator ?? true }
+    /// Explicit `on:` argument → subtree `FieldDefaults.validationTrigger` → `.editingEnd` (F5).
+    private var effectiveValidationTrigger: ValidationTrigger {
+        explicitValidationTrigger ?? fieldDefaults.validationTrigger ?? .editingEnd
+    }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
@@ -152,7 +158,7 @@ public struct InputNumber: View {
             defer {
                 // `.live` validates every change; other triggers re-validate once
                 // a failure is visible so the error clears as the user fixes it.
-                if validationTrigger == .live || !validationMessages.isEmpty { runValidation(newText) }
+                if effectiveValidationTrigger == .live || !validationMessages.isEmpty { runValidation(newText) }
             }
             guard editable, let parsed = parseValue(newText) else { return }
             let clamped = Self.clamp(parsed, to: range)
@@ -161,7 +167,7 @@ public struct InputNumber: View {
         .onChange(of: isFocused) { _, focused in
             if !focused {
                 commit()
-                if validationTrigger == .editingEnd { runValidation(textValue) }   // validate on blur
+                if effectiveValidationTrigger == .editingEnd { runValidation(textValue) }   // validate on blur
             }
         }
     }
@@ -431,12 +437,14 @@ public extension InputNumber {
 
     /// Declarative validation (E3, TextInput parity): evaluates `rules` against
     /// the field's text at `trigger` and feeds the first failure into the
-    /// message list / error styling automatically.
+    /// message list / error styling automatically. Omitting `on:` follows the
+    /// subtree `FieldDefaults.validationTrigger` default, then `.editingEnd`
+    /// (F5); an explicit trigger always wins.
     ///
     ///     InputNumber("Guests", value: $count)
     ///         .validate([.required()], on: .editingEnd)
-    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
-        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger? = nil) -> Self {
+        copy { $0.validationRules = rules; if let trigger { $0.explicitValidationTrigger = trigger } }
     }
 
     /// Legacy binary height (regular 40pt / large 48pt), superseded by the

--- a/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
@@ -28,13 +28,19 @@ public struct MultiSelect<Option: Hashable>: View {
     private var describeOption: ((Option) -> String?)? = nil
     private var leadingContent: ((Option) -> AnyView)? = nil
     private var searchable: Bool = true
-    private var allowClear: Bool = true
+    /// Set only by the `.clearable(_:)` modifier, so the subtree
+    /// `FieldDefaults.clearable` can fill the default without overriding an
+    /// explicit per-field choice (F5): `explicitClearable ?? fieldDefaults.clearable ?? true`
+    /// (clear is on by default, matching a tag picker).
+    private var explicitClearable: Bool?
     private var maxTagCount: Int? = nil
     /// Selection-count cap (E13, Ant `maxCount`); `nil` = unlimited.
     private var maxSelection: Int? = nil
     private var isLoading: Bool = false
     private var accessibilityID: String? = nil
     @Environment(\.isEnabled) private var isEnabled
+    /// Subtree field-family defaults (F5) — fills `clearable` when not set explicitly.
+    @Environment(\.fieldDefaults) private var fieldDefaults
 
     @State private var open = false
     @State private var query = ""
@@ -66,6 +72,8 @@ public struct MultiSelect<Option: Hashable>: View {
 
     private var hasError: Bool { infoMessages.dominantKind == .error }
     private var hasWarning: Bool { infoMessages.dominantKind == .warning }
+    /// Explicit `.clearable(_:)` → subtree `FieldDefaults.clearable` → on (tag-picker default, F5).
+    private var effectiveClearable: Bool { explicitClearable ?? fieldDefaults.clearable ?? true }
 
     private var selectedOptions: [Option] { options.filter { selection.contains($0) } }
     private var visibleTags: [Option] { Self.tagLayout(selected: selectedOptions, maxTagCount: maxTagCount).visible }
@@ -150,7 +158,7 @@ public struct MultiSelect<Option: Hashable>: View {
                 }
             }
             Spacer(minLength: 0)
-            if allowClear && !selection.isEmpty && isEnabled && !isLoading {
+            if effectiveClearable && !selection.isEmpty && isEnabled && !isLoading {
                 Button { selection.removeAll() } label: {
                     Icon(systemName: "xmark.circle.fill").size(.sm).color(theme.text(.textTertiary))
                 }
@@ -268,8 +276,9 @@ public extension MultiSelect {
     /// Whether the dropdown shows a search field (default true).
     func searchable(_ on: Bool = true) -> Self { copy { $0.searchable = on } }
 
-    /// Whether a clear-all button is offered (default true).
-    func clearable(_ on: Bool = true) -> Self { copy { $0.allowClear = on } }
+    /// Whether a clear-all button is offered (default true). An explicit call
+    /// wins over the subtree `FieldDefaults.clearable` default (F5).
+    func clearable(_ on: Bool = true) -> Self { copy { $0.explicitClearable = on } }
 
     /// Caps the visible selected-tag chips, collapsing the rest into a "+N" tag.
     func maxTags(_ count: Int?) -> Self { copy { $0.maxTagCount = count } }

--- a/Sources/ThemeKit/Components/Molecules/OTPInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/OTPInput.swift
@@ -50,10 +50,12 @@ public struct OTPInput: View {
     private var onResend: (() -> Void)?
 
     // Declarative validation (daisyUI Validator) — rules run against the entered
-    // code at `validationTrigger`; failures merge into the rendered messages,
-    // fanning the error state out to every digit cell automatically.
+    // code at `effectiveValidationTrigger`; failures merge into the rendered
+    // messages, fanning the error state out to every digit cell automatically.
     private var validationRules: [ValidationRule] = []
-    private var validationTrigger: ValidationTrigger = .editingEnd
+    /// Set only by an explicit `on:` argument to `validate(_:on:)`; `nil` falls
+    /// back to `FieldDefaults.validationTrigger`, then `.editingEnd` (F5).
+    private var explicitValidationTrigger: ValidationTrigger?
     private var onValidation: ((Bool) -> Void)?
     @State private var validationMessages: [InfoMessage] = []
 
@@ -98,6 +100,10 @@ public struct OTPInput: View {
     /// Message rows animate when micro-animations are on and the subtree default
     /// doesn't turn message motion off (Reduce Motion still wins inside MicroMotion).
     private var messagesAnimated: Bool { micro && (fieldDefaults.messagesAnimated ?? true) }
+    /// Explicit `on:` argument → subtree `FieldDefaults.validationTrigger` → `.editingEnd` (F5).
+    private var effectiveValidationTrigger: ValidationTrigger {
+        explicitValidationTrigger ?? fieldDefaults.validationTrigger ?? .editingEnd
+    }
 
     /// Keeps only the characters allowed by `characters` (digits by default)
     /// and caps the length (extracted for testing).
@@ -179,7 +185,7 @@ public struct OTPInput: View {
                         // validate at completion (the OTP's editing-end/submit
                         // moment) and re-validate once a failure is visible so
                         // the error clears as the user retypes.
-                        if validationTrigger == .live || !validationMessages.isEmpty
+                        if effectiveValidationTrigger == .live || !validationMessages.isEmpty
                             || sanitized.count == digitCount {
                             runValidation()
                         }
@@ -434,12 +440,14 @@ public extension OTPInput {
     /// entered code at `trigger` — `.editingEnd`/`.submit` fire when the last
     /// box fills (the OTP's completion moment), `.live` on every keystroke.
     /// Failures merge into the rendered messages, fanning the error state out
-    /// to every digit cell.
+    /// to every digit cell. Omitting `on:` follows the subtree
+    /// `FieldDefaults.validationTrigger` default, then `.editingEnd` (F5);
+    /// an explicit trigger always wins.
     ///
     ///     OTPInput(code: $code)
     ///         .validate([.minLength(6, "Enter all 6 digits")])
-    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
-        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger? = nil) -> Self {
+        copy { $0.validationRules = rules; if let trigger { $0.explicitValidationTrigger = trigger } }
     }
 
     /// Reports validity after each `validate(_:on:)` pass — `true` when no

--- a/Sources/ThemeKit/Components/Molecules/PaymentCardField.swift
+++ b/Sources/ThemeKit/Components/Molecules/PaymentCardField.swift
@@ -65,10 +65,12 @@ public struct PaymentCardField: View {
     private var infoMessages: [InfoMessage] = []
 
     // Declarative validation (daisyUI Validator) — rules run against the
-    // *card number* text at `validationTrigger`; failures merge into the
-    // rendered messages, driving the rows' error border automatically.
+    // *card number* text at `effectiveValidationTrigger`; failures merge into
+    // the rendered messages, driving the rows' error border automatically.
     private var validationRules: [ValidationRule] = []
-    private var validationTrigger: ValidationTrigger = .editingEnd
+    /// Set only by an explicit `on:` argument to `validate(_:on:)`; `nil` falls
+    /// back to `FieldDefaults.validationTrigger`, then `.editingEnd` (F5).
+    private var explicitValidationTrigger: ValidationTrigger?
     private var onValidation: ((Bool) -> Void)?
     @State private var validationMessages: [InfoMessage] = []
 
@@ -83,6 +85,10 @@ public struct PaymentCardField: View {
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous) }
     /// Explicit `.size(_:)` → subtree `FieldDefaults.size` → the classic 52pt rows.
     private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }
+    /// Explicit `on:` argument → subtree `FieldDefaults.validationTrigger` → `.editingEnd` (F5).
+    private var effectiveValidationTrigger: ValidationTrigger {
+        explicitValidationTrigger ?? fieldDefaults.validationTrigger ?? .editingEnd
+    }
     /// Explicit `infoMessages(_:)` plus any current `validate(_:on:)` failures.
     private var messages: [InfoMessage] { infoMessages + validationMessages }
     private var dominant: InfoMessage.Kind? { messages.dominantKind }
@@ -117,11 +123,11 @@ public struct PaymentCardField: View {
         // `.live` validates every number change; other triggers re-validate once
         // a failure is visible so the error clears as the user fixes it.
         .onChange(of: number) { _, value in
-            if validationTrigger == .live || !validationMessages.isEmpty { runValidation(value) }
+            if effectiveValidationTrigger == .live || !validationMessages.isEmpty { runValidation(value) }
         }
         // `.editingEnd` / `.submit` fire when the number row loses focus.
         .onChange(of: focused) { old, now in
-            if old == .number, now != .number, validationTrigger != .live { runValidation(number) }
+            if old == .number, now != .number, effectiveValidationTrigger != .live { runValidation(number) }
         }
     }
 
@@ -249,11 +255,13 @@ public extension PaymentCardField {
     /// **card number** text (as displayed, space-grouped) at `trigger` —
     /// `.editingEnd`/`.submit` when the number row loses focus, `.live` per
     /// keystroke. Failures merge into the rendered messages and border state.
+    /// Omitting `on:` follows the subtree `FieldDefaults.validationTrigger`
+    /// default, then `.editingEnd` (F5); an explicit trigger always wins.
     ///
     ///     PaymentCardField(number: $num, expiry: $exp, cvv: $cvv)
     ///         .validate([.required(), .minLength(19, "Enter the full card number")])
-    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
-        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger? = nil) -> Self {
+        copy { $0.validationRules = rules; if let trigger { $0.explicitValidationTrigger = trigger } }
     }
 
     /// Reports validity after each `validate(_:on:)` pass — `true` when no

--- a/Sources/ThemeKit/Components/Molecules/Select.swift
+++ b/Sources/ThemeKit/Components/Molecules/Select.swift
@@ -33,7 +33,10 @@ public struct Select<Option: Hashable>: View {
 
     // Appearance/config — mutated only through the modifiers below (R2).
     private var placeholder: String = "Select"
-    private var allowClear: Bool = false
+    /// Set only by the `.clearable(_:)` modifier, so the subtree
+    /// `FieldDefaults.clearable` can fill the default without overriding an
+    /// explicit per-field choice (F5): `explicitClearable ?? fieldDefaults.clearable ?? false`.
+    private var explicitClearable: Bool?
     private var searchable: Bool = false
     private var size: TextInputSize = .medium
     private var infoMessages: [InfoMessage] = []
@@ -89,7 +92,9 @@ public struct Select<Option: Hashable>: View {
     }
 
     private var hasValue: Bool { selection != nil }
-    private var showsClear: Bool { allowClear && hasValue && isEnabled && !isReadOnly && !isLoading }
+    /// Explicit `.clearable(_:)` → subtree `FieldDefaults.clearable` → off (F5).
+    private var effectiveClearable: Bool { explicitClearable ?? fieldDefaults.clearable ?? false }
+    private var showsClear: Bool { effectiveClearable && hasValue && isEnabled && !isReadOnly && !isLoading }
     /// Whether `.required()` renders its asterisk (`FieldDefaults.requiredIndicator`;
     /// the accessibility ", required" suffix is unaffected).
     private var showsRequiredIndicator: Bool { fieldDefaults.requiredIndicator ?? true }
@@ -325,8 +330,9 @@ public extension Select {
     /// Placeholder shown while no option is selected.
     func placeholder(_ text: String) -> Self { copy { $0.placeholder = text } }
 
-    /// Show a trailing clear button when an option is selected.
-    func clearable(_ on: Bool = true) -> Self { copy { $0.allowClear = on } }
+    /// Show a trailing clear button when an option is selected. An explicit
+    /// call wins over the subtree `FieldDefaults.clearable` default (F5).
+    func clearable(_ on: Bool = true) -> Self { copy { $0.explicitClearable = on } }
 
     /// Use the searchable inline panel instead of the native menu.
     func searchable(_ on: Bool = true) -> Self { copy { $0.searchable = on } }

--- a/Sources/ThemeKit/Components/Molecules/TextInput.swift
+++ b/Sources/ThemeKit/Components/Molecules/TextInput.swift
@@ -146,6 +146,14 @@ public struct TextInput: View {
     /// parameter is indistinguishable from the `.medium` default, so it yields
     /// to `FieldDefaults`; use `.size(_:)` to pin a size against the defaults.
     private var explicitSize: TextInputSize?
+    /// Set only by the `.clearable(_:)` modifier. Detects "explicitly set" so
+    /// the subtree `FieldDefaults.clearable` can fill the default without
+    /// overriding an explicit per-field choice (F5):
+    /// `explicitClearable ?? fieldDefaults.clearable ?? model.allowClear`.
+    /// Like `size`, the (init-era) `TextInputModel.allowClear` parameter is
+    /// indistinguishable from the `false` default, so it yields to
+    /// `FieldDefaults`; use `.clearable(_:)` to pin it against the defaults.
+    private var explicitClearable: Bool?
     /// Optional external focus (e.g. driven by `FormValidator.focusBinding`).
     private var externalFocus: Binding<Bool>?
     @Environment(\.isEnabled) private var isEnabled   // set natively by `.disabled(_:)`
@@ -171,11 +179,14 @@ public struct TextInput: View {
     private var warningText: String?
 
     // Declarative validation (daisyUI Validator, see `ValidationRule.swift`):
-    // rules run at `validationTrigger` and their first failure is merged into
-    // `messages`, driving the existing error styling automatically.
+    // rules run at `effectiveValidationTrigger` and their first failure is merged
+    // into `messages`, driving the existing error styling automatically.
     private var validationRules: [ValidationRule] = []
     private var validationCheck: ((String) -> String?)?
-    private var validationTrigger: ValidationTrigger = .editingEnd
+    /// Set only by an explicit `on:` argument to `validate(_:on:)`; `nil` falls
+    /// back to the subtree `FieldDefaults.validationTrigger`, then `.editingEnd`
+    /// (F5): `explicitValidationTrigger ?? fieldDefaults.validationTrigger ?? .editingEnd`.
+    private var explicitValidationTrigger: ValidationTrigger?
     private var onValidation: ((Bool) -> Void)?
     /// Internal editing-end hook (form wiring): fires with the current text when
     /// the field loses focus — regardless of the component's own validation setup.
@@ -207,6 +218,12 @@ public struct TextInput: View {
     /// Message rows animate when micro-animations are on and the subtree default
     /// doesn't turn message motion off (Reduce Motion still wins inside MicroMotion).
     private var messagesAnimated: Bool { micro && (fieldDefaults.messagesAnimated ?? true) }
+    /// Explicit `.clearable(_:)` → subtree `FieldDefaults.clearable` → the model's default (F5).
+    private var effectiveClearable: Bool { explicitClearable ?? fieldDefaults.clearable ?? model.allowClear }
+    /// Explicit `on:` argument → subtree `FieldDefaults.validationTrigger` → `.editingEnd` (F5).
+    private var effectiveValidationTrigger: ValidationTrigger {
+        explicitValidationTrigger ?? fieldDefaults.validationTrigger ?? .editingEnd
+    }
     /// `infoMessages` plus the helper/error/warning conveniences (computed merge).
     private var messages: [InfoMessage] {
         var messages = model.infoMessages + validationMessages
@@ -218,7 +235,7 @@ public struct TextInput: View {
     private var dominant: InfoMessage.Kind? { messages.dominantKind }
     private var hasError: Bool { dominant == .error }
     private var hasWarning: Bool { dominant == .warning }
-    private var showsClear: Bool { model.allowClear && !text.isEmpty && isEnabled && !isReadOnly && !model.isSecure }
+    private var showsClear: Bool { effectiveClearable && !text.isEmpty && isEnabled && !isReadOnly && !model.isSecure }
 
     private var hasAddons: Bool { model.addonBefore != nil || model.addonAfter != nil }
     private var isOverLimit: Bool { Self.isOverLimit(count: text.count, maxLength: model.maxLength) }
@@ -377,14 +394,14 @@ public struct TextInput: View {
             if v != text { text = v }
             // `.live` validates every change; other triggers re-validate once a
             // failure is visible so the error clears as the user fixes it.
-            if validationTrigger == .live || !validationMessages.isEmpty { runValidation(v) }
+            if effectiveValidationTrigger == .live || !validationMessages.isEmpty { runValidation(v) }
         }
         .onChange(of: externalFocus?.wrappedValue ?? false) { _, want in
             if want && !isFocused && !isReadOnly { isFocused = true }   // E1 — no programmatic focus either
         }
         .onChange(of: isFocused) { _, now in
             if !now, externalFocus?.wrappedValue == true { externalFocus?.wrappedValue = false }
-            if !now, validationTrigger == .editingEnd { runValidation(text) }   // validate on blur
+            if !now, effectiveValidationTrigger == .editingEnd { runValidation(text) }   // validate on blur
             if !now { onEditingEnd?(text) }   // form-wiring hook (`.field(_:in:)`)
         }
     }
@@ -495,8 +512,9 @@ public extension TextInput {
     /// Masks input as a password field with a reveal toggle.
     func secure(_ on: Bool = true) -> Self { copy { $0.model.isSecure = on } }
 
-    /// Show a trailing clear button while the field has text.
-    func clearable(_ on: Bool = true) -> Self { copy { $0.model.allowClear = on } }
+    /// Show a trailing clear button while the field has text. An explicit call
+    /// wins over the subtree `FieldDefaults.clearable` default (F5).
+    func clearable(_ on: Bool = true) -> Self { copy { $0.model.allowClear = on; $0.explicitClearable = on } }
 
     /// Caps input at `max` characters; a soft limit (`hardLimit: false`) allows overflow and flags the counter instead.
     func maxLength(_ max: Int?, hardLimit: Bool = true) -> Self {
@@ -529,19 +547,22 @@ public extension TextInput {
 
     /// Declarative validation (daisyUI Validator): evaluates `rules` at
     /// `trigger` and feeds the first failure into the message list / error
-    /// styling automatically — no hand-managed `infoMessages`.
+    /// styling automatically — no hand-managed `infoMessages`. Omitting `on:`
+    /// (`nil`) follows the subtree `FieldDefaults.validationTrigger` default,
+    /// falling back to `.editingEnd` (F5); an explicit trigger always wins.
     ///
     ///     TextInput("Email", text: $email)
     ///         .validate([.required(), .email()], on: .editingEnd)
-    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
-        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger? = nil) -> Self {
+        copy { $0.validationRules = rules; if let trigger { $0.explicitValidationTrigger = trigger } }
     }
 
     /// Closure form of `validate(_:on:)` for dynamic failure messages:
     /// return the error text, or `nil` when the value passes. Runs after the
-    /// rule array (if both are declared).
-    func validate(on trigger: ValidationTrigger = .editingEnd, _ check: @escaping (String) -> String?) -> Self {
-        copy { $0.validationCheck = check; $0.validationTrigger = trigger }
+    /// rule array (if both are declared). Omitting `on:` follows the subtree
+    /// `FieldDefaults.validationTrigger` default, then `.editingEnd` (F5).
+    func validate(on trigger: ValidationTrigger? = nil, _ check: @escaping (String) -> String?) -> Self {
+        copy { $0.validationCheck = check; if let trigger { $0.explicitValidationTrigger = trigger } }
     }
 
     /// Reports validity after each `validate(_:on:)` pass — `true` when no
@@ -655,6 +676,32 @@ private extension TextInputCapitalization {
     }
 }
 #endif
+
+#Preview("Field defaults: clearable + validationTrigger (F5)") {
+    struct Demo: View {
+        @State var name = "Alex"
+        @State var code = "SAVE20"
+        @State var email = ""
+        var body: some View {
+            VStack(spacing: 16) {
+                Text("fieldDefaults(clearable: true, validationTrigger: .live)")
+                    .textStyle(.labelSm600)
+                // No per-instance .clearable() — inherits the subtree default → shows ×.
+                TextInput("Full name", text: $name)
+                // Explicit .clearable(false) wins over the subtree default → no ×.
+                TextInput("Promo code", text: $code)
+                    .clearable(false)
+                // validate(...) without on: — inherits .live from the subtree default,
+                // so the error appears while typing instead of on blur.
+                TextInput("Email", text: $email)
+                    .validate([.required(), .email()])
+            }
+            .padding()
+            .fieldDefaults(clearable: true, validationTrigger: .live)
+        }
+    }
+    return Demo()
+}
 
 #Preview {
     struct Demo: View {

--- a/Sources/ThemeKit/Components/Molecules/TimeField.swift
+++ b/Sources/ThemeKit/Components/Molecules/TimeField.swift
@@ -47,7 +47,10 @@ public struct TimeField: View {
     private var hourCycle: TimeFieldHourCycle = .locale
     private var explicitLocale: Locale?
     private var infoMessages: [InfoMessage] = []
-    private var allowClear = false
+    /// Set only by the `.clearable(_:)` modifier, so the subtree
+    /// `FieldDefaults.clearable` can fill the default without overriding an
+    /// explicit per-field choice (F5): `explicitClearable ?? fieldDefaults.clearable ?? false`.
+    private var explicitClearable: Bool?
     private var leadingSystemImage: String? = "clock"
     private var accessibilityID: String?
     /// Explicit `.size(_:)` preset — wins over the subtree `FieldDefaults.size`.
@@ -56,10 +59,12 @@ public struct TimeField: View {
     private var isRequired = false
 
     // Declarative validation (daisyUI Validator) — rules run against the
-    // *displayed* time string at `validationTrigger`; failures merge into the
-    // rendered messages, driving the border state automatically.
+    // *displayed* time string at `effectiveValidationTrigger`; failures merge
+    // into the rendered messages, driving the border state automatically.
     private var validationRules: [ValidationRule] = []
-    private var validationTrigger: ValidationTrigger = .editingEnd
+    /// Set only by an explicit `on:` argument to `validate(_:on:)`; `nil` falls
+    /// back to `FieldDefaults.validationTrigger`, then `.editingEnd` (F5).
+    private var explicitValidationTrigger: ValidationTrigger?
     private var onValidation: ((Bool) -> Void)?
     @State private var validationMessages: [InfoMessage] = []
 
@@ -79,7 +84,13 @@ public struct TimeField: View {
     private var dominant: InfoMessage.Kind? { messages.dominantKind }
     private var hasError: Bool { dominant == .error }
     private var hasWarning: Bool { dominant == .warning }
-    private var showsClear: Bool { allowClear && time != nil && isEnabled && !isReadOnly }
+    /// Explicit `.clearable(_:)` → subtree `FieldDefaults.clearable` → off (F5).
+    private var effectiveClearable: Bool { explicitClearable ?? fieldDefaults.clearable ?? false }
+    /// Explicit `on:` argument → subtree `FieldDefaults.validationTrigger` → `.editingEnd` (F5).
+    private var effectiveValidationTrigger: ValidationTrigger {
+        explicitValidationTrigger ?? fieldDefaults.validationTrigger ?? .editingEnd
+    }
+    private var showsClear: Bool { effectiveClearable && time != nil && isEnabled && !isReadOnly }
     private var displayText: String? {
         time.map { Self.text(for: $0, hourCycle: hourCycle, locale: locale) }
     }
@@ -131,11 +142,11 @@ public struct TimeField: View {
         // `.live` validates every change; other triggers re-validate once a
         // failure is visible so the error clears as the user fixes it.
         .onChange(of: time) { _, _ in
-            if validationTrigger == .live || !validationMessages.isEmpty { runValidation() }
+            if effectiveValidationTrigger == .live || !validationMessages.isEmpty { runValidation() }
         }
         // Dismissing the picker is this field's blur *and* submit moment.
         .onChange(of: showPicker) { _, now in
-            if !now, validationTrigger != .live { runValidation() }
+            if !now, effectiveValidationTrigger != .live { runValidation() }
         }
     }
 
@@ -296,11 +307,13 @@ public extension TimeField {
     /// *displayed* time string (empty when no time is set) at `trigger` —
     /// `.editingEnd`/`.submit` fire when the picker is dismissed, `.live` on
     /// every change. Failures merge into the rendered messages and border state.
+    /// Omitting `on:` follows the subtree `FieldDefaults.validationTrigger`
+    /// default, then `.editingEnd` (F5); an explicit trigger always wins.
     ///
     ///     TimeField("Alarm", time: $alarm)
     ///         .validate([.required("Pick a time")])
-    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger = .editingEnd) -> Self {
-        copy { $0.validationRules = rules; $0.validationTrigger = trigger }
+    func validate(_ rules: [ValidationRule], on trigger: ValidationTrigger? = nil) -> Self {
+        copy { $0.validationRules = rules; if let trigger { $0.explicitValidationTrigger = trigger } }
     }
 
     /// Reports validity after each `validate(_:on:)` pass — `true` when no
@@ -322,8 +335,9 @@ public extension TimeField {
     /// Validation / info messages rendered under the field (drives the border state).
     func infoMessages(_ messages: [InfoMessage]) -> Self { copy { $0.infoMessages = messages } }
 
-    /// Show a trailing clear button when a time is set.
-    func clearable(_ on: Bool = true) -> Self { copy { $0.allowClear = on } }
+    /// Show a trailing clear button when a time is set. An explicit call wins
+    /// over the subtree `FieldDefaults.clearable` default (F5).
+    func clearable(_ on: Bool = true) -> Self { copy { $0.explicitClearable = on } }
 
     /// Leading SF Symbol shown inside the field (defaults to `clock`; pass `nil` to hide).
     func icon(_ systemImage: String?) -> Self { copy { $0.leadingSystemImage = systemImage } }

--- a/Sources/ThemeKit/FieldDefaults.swift
+++ b/Sources/ThemeKit/FieldDefaults.swift
@@ -36,15 +36,18 @@ public struct FieldDefaults: Equatable {
     /// hiding the asterisk never hides the semantics from VoiceOver.
     public var requiredIndicator: Bool?
     /// Whether fields show a trailing clear (×) affordance while non-empty
-    /// (Ant ConfigProvider input `allowClear`). Provider field only for now —
-    /// the field family adopts it in a follow-up; a field's own explicit
-    /// clearable modifier will still win over this subtree default.
+    /// (Ant ConfigProvider input `allowClear`). Read by TextInput, Select,
+    /// DateField, TimeField, Autocomplete, Cascader, and MultiSelect; a field's
+    /// own explicit `.clearable(_:)` still wins over this subtree default, and
+    /// `nil` keeps each component's own default (off for most; Autocomplete and
+    /// MultiSelect stay on by default).
     public var clearable: Bool?
     /// Default `ValidationTrigger` for rule-driven validation — when
     /// `TextInput.validate(_:)`-style calls omit their `on:` argument
-    /// (`.live` / `.editingEnd` / `.submit`). Provider field only for now —
-    /// the field family adopts it in a follow-up; an explicit per-field `on:`
-    /// argument will still win over this subtree default.
+    /// (`.live` / `.editingEnd` / `.submit`). Read by TextInput, DateField,
+    /// TimeField, Autocomplete, InputNumber, PaymentCardField, and OTPInput;
+    /// an explicit per-field `on:` argument still wins over this subtree
+    /// default, and `nil` keeps the family's `.editingEnd` default.
     public var validationTrigger: ValidationTrigger?
 
     public init(size: TextInputSize? = nil, messagesAnimated: Bool? = nil, requiredIndicator: Bool? = nil,


### PR DESCRIPTION
The last two deferred items from the flexibility sweep.

**F5 adoption** — the field family now READS the FieldDefaults provider fields added in #254 (precedence `explicit ?? fieldDefaults.X ?? default`):
- `clearable`: TextInput, Select, DateField, TimeField, Cascader, Autocomplete, MultiSelect.
- `validationTrigger`: TextInput, DateField, TimeField, Autocomplete, InputNumber, PaymentCardField, OTPInput (`validate(_:on:)` trigger is now optional → inherits the subtree default; explicit case wins; source-compatible).

**Gallery knobs** — ~35 demos now expose the flexibility-sweep axes as deep-linkable knobs (Avatar bordered, Tag closable, Chip size, control placement/lineThrough/size/read-only, field size/required/validate/clearable, Splitter vertical, Tooltip content, Callout/EmptyState links+slots, Timeline marker, Kanban axes, ThemeButton spinner, EmojiReaction size/accent, …). Also migrated the EmptyState raw-color demos to token overloads.

Additive; swift build clean; 267 tests pass; Demo BUILD SUCCEEDED. Built by 4 parallel sr-ios-dev agents on disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)