### PR TITLE
chore(demo): clear all pre-existing deprecation warnings in the Demo gallery

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -41,7 +41,7 @@ struct IconDemo: View {
 
     var body: some View {
         ComponentStage("Icon", inspector: [("size", "\(size.rawValue) · \(Int(size.value))")]) {
-            Icon(systemName: symbol).size(size).color(Theme.shared.foreground(.fgHero))
+            Icon(systemName: symbol).size(size).accent(.primary)
         } knobs: {
             TextField("SF Symbol", text: $symbol).textFieldStyle(.roundedBorder).autocorrectionDisabled()
             Picker("Size", selection: $size) { ForEach(IconSize.allCases, id: \.self) { Text($0.rawValue).tag($0) } }.pickerStyle(.segmented)
@@ -195,12 +195,12 @@ struct SelectDemo: View {
     var body: some View {
         ComponentStage("Select", inspector: [("style", filled ? "filled" : "default"), ("selection", city ?? "nil")]) {
             if filled {
-                selectView.selectStyle(.filled)   // custom SelectStyle via .selectStyle(_:)
+                selectView.fieldStyle(.muted)   // filled chrome via the shared .fieldStyle(_:) axis
             } else {
                 selectView
             }
         } knobs: {
-            Toggle("Filled style (.selectStyle)", isOn: $filled)
+            Toggle("Filled style (.fieldStyle)", isOn: $filled)
             Toggle("Searchable (inline panel + sections)", isOn: $searchable)
             Toggle("Required indicator", isOn: $required)
             Toggle("Allow clear", isOn: $clearable)
@@ -341,13 +341,13 @@ struct TooltipDemo: View {
     var body: some View {
         ComponentStage("Tooltip", inspector: [("isPresented", "\(shown)"), ("edge", "\(edge)"), ("content", rich ? "custom view" : "text")]) {
             if rich {
-                Icon(systemName: "info.circle").size(.lg).color(Theme.shared.foreground(.fgHero))
+                Icon(systemName: "info.circle").size(.lg).accent(.primary)
                     .tooltip(isPresented: $shown, edge: edge, style: colored ? .info : nil) {
                         HStack(spacing: 6) { Image(systemName: "wifi"); Text("Free Wi-Fi") }
                     }
                     .padding(60)
             } else {
-                Icon(systemName: "info.circle").size(.lg).color(Theme.shared.foreground(.fgHero))
+                Icon(systemName: "info.circle").size(.lg).accent(.primary)
                     .tooltip("Helpful hint", isPresented: $shown, edge: edge, style: colored ? .info : nil)
                     .padding(60)
             }
@@ -1048,9 +1048,9 @@ struct IndicatorDemo: View {
         ComponentStage("Indicator", inspector: [("kind", kind.rawValue)]) {
             Group {
                 if kind == .dot {
-                    Icon(systemName: "bell").size(.xl).color(Theme.shared.text(.textPrimary)).indicatorDot(position: position)
+                    Icon(systemName: "bell").size(.xl).accent(.neutral).indicatorDot(position: position)
                 } else {
-                    Icon(systemName: "envelope").size(.xl).color(Theme.shared.text(.textPrimary)).indicator(position) { Badge("3").badgeStyle(.error).size(.small) }
+                    Icon(systemName: "envelope").size(.xl).accent(.neutral).indicator(position) { Badge("3").badgeStyle(.error).size(.small) }
                 }
             }
         } knobs: {
@@ -1336,7 +1336,7 @@ struct FABDemo: View {
                 .init(systemImage: "doc", label: "Document", action: { flash("FAB: Document") }),
                 .init(systemImage: "link", label: "Link", action: { flash("FAB: Link") }),
             ] : [], action: { flash("FAB tapped") })
-            .shape(square ? .square : .circle).color(color).badge(badge ? 3 : nil)
+            .shape(square ? .square : .circle).accent(color).badge(badge ? 3 : nil)
             .frame(maxWidth: .infinity, minHeight: 220, alignment: .bottomTrailing)
         } knobs: {
             Toggle("Speed dial", isOn: $speedDial)
@@ -2697,7 +2697,7 @@ struct RollingNumberDemo: View {
     var body: some View {
         ComponentStage("RollingNumber", inspector: [("value", "\(value)")]) {
             VStack(spacing: 16) {
-                RollingNumber(value).size(size).color(Theme.shared.text(.textHero))
+                RollingNumber(value).size(size).accent(.primary)
                 ThemeButton("Roll") { value = Int.random(in: 100...99999); flash("RollingNumber: \(value)") }.icon(leading: "dice")
             }
         } knobs: {

--- a/Demo/Demo/Gallery/Demos/TravelDemos.swift
+++ b/Demo/Demo/Gallery/Demos/TravelDemos.swift
@@ -218,7 +218,7 @@ struct AmenityGridDemo: View {
     private var grid: AmenityGrid {
         var g = AmenityGrid(items).columns(Int(columns)).size(size)
         if useLimit { g = g.limit(Int(limit)) }
-        if tinted { g = g.tint(SemanticColor.purple.base) }
+        if tinted { g = g.tint(.purple) }
         if highlight { g = g.highlighted(["Free Wi-Fi", "Breakfast"]) }
         return g
     }
@@ -312,7 +312,7 @@ struct PriceHistogramDemo: View {
     private var histogram: PriceHistogram {
         var h = PriceHistogram(bins: bins, lowerValue: $low, upperValue: $high, in: 0...5_000)
             .barHeight(barHeight).currency(currency).showsBounds(showsBounds)
-        if accent { h = h.accent(SemanticColor.purple.base) }
+        if accent { h = h.accent(.purple) }
         if showsCount { h = h.resultCount(bins.reduce(0, +)) }
         return h
     }
@@ -1686,7 +1686,7 @@ struct SmartSuggestionDemo: View {
     private let tintNames = ["Success", "Warning", "Info"]
 
     private var banner: SmartSuggestion {
-        var b = SmartSuggestion("The Berlin outbound is 12% cheaper on Sat 13 Sep.").tint(tints[tintIdx])
+        var b = SmartSuggestion("The Berlin outbound is 12% cheaper on Sat 13 Sep.").accent(tints[tintIdx])
         if hasLabel { b = b.label("Smart tip") }
         if action { b = b.action("Apply") { flash("Applied") } } else { b = b.onTap { flash("Tapped") } }
         return b
@@ -1811,7 +1811,7 @@ struct FlightStatusBadgeDemo: View {
         ComponentStage("FlightStatusBadge", inspector: [("status", "\(statuses[idx])")]) {
             FlightStatusBadge(statuses[idx]).solid(solid).time(time ? (statuses[idx] == .delayed ? "+35m" : "13:15") : nil)
         } knobs: {
-            Picker("Status", selection: $idx) { ForEach(statuses.indices, id: \.self) { Text("\(statuses[$0])").tag($0) } }
+            Picker("Status", selection: $idx) { ForEach(statuses.indices, id: \.self) { Text(verbatim: "\(statuses[$0])").tag($0) } }
             Toggle("Solid fill (vs soft)", isOn: $solid)
             Toggle("Trailing time", isOn: $time)
             Text("Semantic colour per status: on-time green · delayed amber · cancelled red.").font(.caption).foregroundStyle(.secondary)


### PR DESCRIPTION
Migrates the **13 pre-existing deprecation warnings** in the Demo gallery to the current token-based APIs, so the Demo app builds warning-free.

### Changes
| Site | Before | After |
|---|---|---|
| Icon (×5) | `.color(Theme.shared.foreground(.fgHero))` / `.color(Theme.shared.text(.textPrimary))` | `.accent(.primary)` / `.accent(.neutral)` |
| RollingNumber | `.color(Theme.shared.text(.textHero))` | `.accent(.primary)` |
| FloatingActionButton | `.color(color)` | `.accent(color)` |
| Select | `.selectStyle(.filled)` | `.fieldStyle(.muted)` (shared FieldStyle axis) |
| AmenityGrid | `.tint(SemanticColor.purple.base)` | `.tint(.purple)` |
| PriceHistogram | `.accent(SemanticColor.purple.base)` | `.accent(.purple)` |
| SmartSuggestion | `.tint(_)` | `.accent(_)` |
| FlightStatusBadge picker | `Text("\(status)")` | `Text(verbatim:)` (drops the LocalizedStringKey interpolation warning) |

Two files touched: `MoreDemos.swift` (9 sites), `TravelDemos.swift` (4 sites). No Sources/library changes.

### Verification
- Demo **BUILD SUCCEEDED** on iPhone 17 sim — **0 deprecation warnings, 0 errors**
- Pre-push gate green: SwiftLint ✓, `swift build` ✓, 267 tests ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)