### PR TITLE
feat(travel): ThemeKitTravel domain-edition packaging skeleton (F0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to **ThemeKit** are documented here. The format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — from **1.0.0** on,
 breaking changes bump the **major**.
 
+## [Unreleased]
+
+### Added
+- **`ThemeKitTravel`** library product — the opt-in flight/booking **domain edition** (composition over forking: it wraps the neutral `ThemeKit` catalog rather than re-implementing it). This first drop is the packaging foundation — the SPM target/product plus the edition's own String Catalog (`String(themeKitTravel:)`); the booking-flow components land in follow-ups. **No package trait and no re-export** (mirroring `ThemeKitCalendar`): add `ThemeKitTravel` to a target and write `import ThemeKitTravel` alongside `import ThemeKit` to opt in — a consumer who doesn't compiles nothing from it and downloads the same package. Part of the [#229](https://github.com/isamercan/ThemeKit/issues/229) modular direction (ADR: `THEMEKITTRAVEL_ARCHITECTURE.md`).
+
 ## [1.1.0] - 2026-07-10
 
 **New `ThemeKitCore` product — the token-only theme layer.** The theme engine,

--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,16 @@ let package = Package(
             name: "ThemeKitCalendar",
             targets: ["ThemeKitCalendar"]
         ),
+        // Optional domain edition — the flight/booking component family (#229
+        // modular direction). Depends on the full `ThemeKit` catalog and WRAPS its
+        // neutral primitives into booking-flow organisms. NO trait: the edition has
+        // zero external deps, so a plain optional product already gives perfect
+        // opt-in — a consumer who doesn't add `ThemeKitTravel` to a target compiles
+        // nothing from it and downloads the same package they already download.
+        .library(
+            name: "ThemeKitTravel",
+            targets: ["ThemeKitTravel"]
+        ),
     ],
     // Opt-in traits keep the core resolution truly dependency-free. The DEFAULT
     // set is EMPTY, so a plain `.package(url: "…ThemeKit.git")` resolves the core
@@ -117,6 +127,23 @@ let package = Package(
                 .product(name: "Almanac", package: "Almanac", condition: .when(platforms: [.iOS], traits: ["Calendar"])),
             ]
         ),
+        // Domain edition: the flight/booking family, built on the full catalog.
+        // Composition, not forking — it depends on `ThemeKit` (not just Core) so it
+        // can wrap `TextInput`, `Select`, `DateField`, `FormValidator`, … rather than
+        // re-implement the field family. One-way dependency: Core ← ThemeKit ← Travel;
+        // nothing in `ThemeKit` may name a `ThemeKitTravel` type. No `@_exported`:
+        // consumers import both modules explicitly, mirroring `ThemeKitCalendar`.
+        .target(
+            name: "ThemeKitTravel",
+            dependencies: ["ThemeKit"],
+            resources: [
+                .process("Resources"),
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+                .enableUpcomingFeature("InferIsolatedConformances"),
+            ]
+        ),
         .testTarget(
             name: "ThemeKitTests",
             dependencies: [
@@ -124,6 +151,8 @@ let package = Package(
                 // A couple of tests reach engine internals now living in Core
                 // (`Bundle.themeKit`, `ColorContrast`) via `@testable import ThemeKitCore`.
                 "ThemeKitCore",
+                // The edition rides the same snapshot/a11y/RTL harness (ADR-F1).
+                "ThemeKitTravel",
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ]
         ),

--- a/Sources/ThemeKitTravel/Localization.swift
+++ b/Sources/ThemeKitTravel/Localization.swift
@@ -1,0 +1,41 @@
+//
+//  Localization.swift
+//  ThemeKitTravel
+//
+//  Bridges the edition's own bundled String Catalog (`Localizable.xcstrings`)
+//  into default-argument expressions, mirroring `ThemeKitCore`'s
+//  `String(themeKit:)`. The edition keeps a SEPARATE catalog so its domain
+//  strings (traveler / payment / airport copy) don't crowd the neutral catalog,
+//  and so a consumer who never imports the edition ships none of them.
+//
+//  `Bundle.module` is internal, so it can't appear directly in a *public*
+//  function's default argument. This public initializer wraps the lookup — its
+//  body runs in-module (where `.module` is visible) — so call sites can write
+//  `String(themeKitTravel: "…")` as a default and stay overridable.
+//
+//  Shipped defaults are English (the catalog's source language); consumers can
+//  add their own localizations, and every user-facing string also remains
+//  overridable via API parameters.
+//
+
+import Foundation
+
+public extension String {
+    /// Resolves a default, overridable string from ThemeKitTravel's bundled
+    /// String Catalog, falling back to the English source key.
+    ///
+    /// Note: under a plain `swift build`/`swift test` SwiftPM copies the
+    /// `.xcstrings` verbatim (it doesn't run the catalog compiler), so only the
+    /// English source resolves there. Under Xcode / `xcodebuild` the catalog is
+    /// compiled and all bundled localizations resolve.
+    init(themeKitTravel key: String.LocalizationValue) {
+        self = String(localized: key, bundle: .module)
+    }
+}
+
+extension Bundle {
+    /// The edition's own resource bundle. Exposed (internally, reachable from
+    /// tests via `@testable`) so callers don't collide with `ThemeKitCore`'s
+    /// `Bundle.themeKit` or a consumer module's own synthesized `Bundle.module`.
+    static var themeKitTravel: Bundle { .module }
+}

--- a/Sources/ThemeKitTravel/Resources/Localizable.xcstrings
+++ b/Sources/ThemeKitTravel/Resources/Localizable.xcstrings
@@ -1,0 +1,7 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+
+  },
+  "version" : "1.0"
+}

--- a/Sources/ThemeKitTravel/ThemeKitTravel.swift
+++ b/Sources/ThemeKitTravel/ThemeKitTravel.swift
@@ -1,0 +1,45 @@
+//
+//  ThemeKitTravel.swift
+//  ThemeKitTravel
+//
+//  The ThemeKitTravel domain edition — an opt-in module that packages the
+//  flight/booking component family and WRAPS ThemeKit's neutral primitives
+//  (`TextInput`, `Select`, `DateField`, `FormValidator`, …) into booking-flow
+//  organisms. It follows the #229 modular direction:
+//
+//      ThemeKitCore  (token engine)
+//        └─ ThemeKit  (neutral catalog)
+//             └─ ThemeKitTravel  (domain edition — composition, not forking)
+//
+//  Dependency is strictly one-way (Core ← ThemeKit ← Travel); nothing in
+//  `ThemeKit` may name a `ThemeKitTravel` type. There is deliberately NO
+//  `@_exported import ThemeKit`: consumers import both modules explicitly —
+//
+//      import ThemeKit
+//      import ThemeKitTravel
+//
+//  mirroring `ThemeKitCalendar`, so the neutral namespace is never re-polluted
+//  by a domain edition.
+//
+//  Architecture of record: `THEMEKITTRAVEL_ARCHITECTURE.md` (ADR-F1…F7).
+//
+
+import ThemeKit
+
+/// Namespace + metadata marker for the ThemeKitTravel domain edition.
+///
+/// The type is intentionally lightweight — the edition's surface is its
+/// components and models, not this enum. It exists so a consumer (or a
+/// diagnostic/telemetry line) has a stable, discoverable handle on the edition,
+/// and so the packaging is verifiable before any component ships.
+public enum TravelEdition {
+
+    /// Human-readable edition name.
+    public static let name = "ThemeKitTravel"
+
+    /// The vertical this edition covers. Later clusters (Stay, Transport) join
+    /// the *same* module (never sibling modules — booking renders flight
+    /// components, so siblings would cycle); cluster membership is expressed via
+    /// DocC topics + naming, never folders. Flight ships first.
+    public static let clusters = ["Flight", "Stay", "Transport"]
+}

--- a/Tests/ThemeKitTests/ThemeKitTravelPackagingTests.swift
+++ b/Tests/ThemeKitTests/ThemeKitTravelPackagingTests.swift
@@ -1,0 +1,29 @@
+//
+//  ThemeKitTravelPackagingTests.swift
+//  ThemeKitTests
+//
+//  F0.1 smoke coverage for the ThemeKitTravel domain-edition packaging: the
+//  product links, the edition marker resolves, and the edition's own String
+//  Catalog bundle is wired (so `String(themeKitTravel:)` returns the source key
+//  when unlocalized, which is all a plain `swift test` can assert — see the note
+//  in the edition's Localization.swift).
+//
+
+import XCTest
+@testable import ThemeKitTravel
+
+final class ThemeKitTravelPackagingTests: XCTestCase {
+
+    func testEditionMarkerLinks() {
+        XCTAssertEqual(TravelEdition.name, "ThemeKitTravel")
+        XCTAssertEqual(TravelEdition.clusters.first, "Flight")
+    }
+
+    func testEditionStringCatalogBundleIsWired() {
+        // No key is seeded yet, so the source string round-trips — this proves
+        // `Bundle.themeKitTravel` (the synthesized `.module`) exists and the
+        // `String(themeKitTravel:)` bridge resolves against it rather than trapping.
+        XCTAssertEqual(String(themeKitTravel: "ThemeKitTravel"), "ThemeKitTravel")
+        XCTAssertNotNil(Bundle.themeKitTravel)
+    }
+}


### PR DESCRIPTION
First unit of the **ThemeKitTravel** build plan (`THEMEKITTRAVEL_ARCHITECTURE.md`, ADR-F1) — stands up the opt-in flight/booking **domain edition** as its own SPM product before any component lands. Executes the [#229](https://github.com/isamercan/ThemeKit/issues/229) modular direction.

### What's in
- **`Package.swift`** — new `ThemeKitTravel` library product + target depending on the full `ThemeKit` catalog (composition over forking: wraps `TextInput`/`Select`/`DateField`/`FormValidator` rather than re-implementing them). **No trait, no `@_exported`** (mirrors `ThemeKitCalendar`); one-way dep `Core ← ThemeKit ← Travel`. `ThemeKitTests` gains the edition dep so it rides the same snapshot/a11y/RTL harness.
- **`Sources/ThemeKitTravel/`** — `TravelEdition` namespace/metadata marker + edition String Catalog bridge `String(themeKitTravel:)` / `Bundle.themeKitTravel` over a seeded (empty) `Localizable.xcstrings`, giving the module its own resource bundle separate from the neutral catalog.
- **Tests** — `ThemeKitTravelPackagingTests` smoke-checks the product links and the edition string-catalog bundle is wired.
- **CHANGELOG** — Unreleased entry.

### Deferred to F1.1 (intentional)
`Demo.xcodeproj` product link + `gen_skill.py` second-module teaching — with **zero components** the llms counts (205/34/217/22) are unchanged, so wiring them now is empty churn. They land with the first component that actually imports the edition.

### Verification
- `swift build` — all products compile; `ThemeKitTravel` emits its resource-bundle accessor (bundle synthesized).
- `swift test` — edition packaging tests pass; pre-push gate green (SwiftLint, build, full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)