### PR TITLE
refactor(travel): consolidate neutral flight models into FlightModels.swift (F0.2)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/FareFeatureRow.swift
+++ b/Sources/ThemeKit/Components/Atoms/FareFeatureRow.swift
@@ -9,24 +9,6 @@
 
 import SwiftUI
 
-/// Whether a fare feature is granted, denied, or neutral info.
-public enum FareFeatureStatus: Sendable { case included, excluded, info }
-
-/// A single fare feature / rule line.
-public struct FareFeature: Identifiable, Sendable {
-    public var id: String { "\(systemImage):\(text)" }
-    public let text: String
-    public let systemImage: String
-    public let detail: String?
-    public let status: FareFeatureStatus
-    public init(_ text: String, systemImage: String, detail: String? = nil, status: FareFeatureStatus = .info) {
-        self.text = text
-        self.systemImage = systemImage
-        self.detail = detail
-        self.status = status
-    }
-}
-
 public struct FareFeatureRow: View {
     @Environment(\.theme) private var theme
     private let feature: FareFeature

--- a/Sources/ThemeKit/Components/Atoms/FlightStatusBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/FlightStatusBadge.swift
@@ -13,31 +13,6 @@
 
 import SwiftUI
 
-public enum FlightStatus: String, Sendable, CaseIterable {
-    case onTime, boarding, delayed, gateClosed, departed, arrived, cancelled
-
-    var label: String {
-        switch self {
-        case .onTime: "On time"; case .boarding: "Boarding"; case .delayed: "Delayed"
-        case .gateClosed: "Gate closed"; case .departed: "Departed"; case .arrived: "Arrived"; case .cancelled: "Cancelled"
-        }
-    }
-    var semantic: SemanticColor {
-        switch self {
-        case .onTime, .arrived: .success
-        case .boarding, .departed: .info
-        case .delayed, .gateClosed: .warning
-        case .cancelled: .error
-        }
-    }
-    var icon: String {
-        switch self {
-        case .onTime: "checkmark.circle.fill"; case .boarding: "figure.walk"; case .delayed: "clock.fill"
-        case .gateClosed: "lock.fill"; case .departed: "airplane.departure"; case .arrived: "airplane.arrival"; case .cancelled: "xmark.circle.fill"
-        }
-    }
-}
-
 public struct FlightStatusBadge: View {
     @Environment(\.theme) private var theme
 

--- a/Sources/ThemeKit/Components/Organisms/FareSummary.swift
+++ b/Sources/ThemeKit/Components/Organisms/FareSummary.swift
@@ -11,30 +11,6 @@
 
 import SwiftUI
 
-/// One line of a ``FareSummary``.
-public struct FareLine: Identifiable, Sendable, Equatable, Codable {
-    public enum Kind: String, Sendable, Codable { case item, discount, total }
-    /// Stable, content-derived identity (no per-init `UUID()` churn in `ForEach`).
-    public var id: String { "\(kind.rawValue):\(label)" }
-    let label: String
-    let amount: Decimal
-    let kind: Kind
-    let info: String?
-
-    /// A regular charge (base fare, taxes, a service fee…).
-    public static func item(_ label: String, _ amount: Decimal, info: String? = nil) -> FareLine {
-        .init(label: label, amount: amount, kind: .item, info: info)
-    }
-    /// A saving — rendered green with a leading minus.
-    public static func discount(_ label: String, _ amount: Decimal, info: String? = nil) -> FareLine {
-        .init(label: label, amount: amount, kind: .discount, info: info)
-    }
-    /// The emphasised total — rendered as a hero `PriceTag` under a divider.
-    public static func total(_ label: String, _ amount: Decimal, info: String? = nil) -> FareLine {
-        .init(label: label, amount: amount, kind: .total, info: info)
-    }
-}
-
 /// A token-bound fare breakdown.
 ///
 /// ```swift

--- a/Sources/ThemeKit/Components/Organisms/FlightCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightCard.swift
@@ -15,31 +15,6 @@
 
 import SwiftUI
 
-/// One leg of a multi-leg ``FlightCard`` (outbound, return, connection…).
-public struct FlightLeg: Identifiable, Sendable, Equatable, Codable {
-    /// Stable, content-derived identity (no per-init `UUID()` churn in `ForEach`).
-    public var id: String { "\(origin)-\(destination)@\(Int(departure.timeIntervalSinceReferenceDate))" }
-    public let airline: String
-    public let origin: String
-    public let destination: String
-    public let departure: Date
-    public let arrival: Date
-    public var stops: Int
-    /// Layover summary shown under the path, e.g. `"1 stop · 6h 45m · ESB"`.
-    public var layover: String?
-
-    public init(airline: String, from origin: String, to destination: String,
-                departure: Date, arrival: Date, stops: Int = 0, layover: String? = nil) {
-        self.airline = airline
-        self.origin = origin
-        self.destination = destination
-        self.departure = departure
-        self.arrival = arrival
-        self.stops = stops
-        self.layover = layover
-    }
-}
-
 /// A token-bound flight card — one segment, or a multi-leg itinerary.
 ///
 /// ```swift

--- a/Sources/ThemeKit/Components/Organisms/FlightListItem.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightListItem.swift
@@ -22,24 +22,6 @@
 
 import SwiftUI
 
-/// One purchasable fare option on a flight (fare-family shopping — Delta/THY
-/// style "Basic / Classic / Flex" columns). Rendered by ``FlightListItemStyle``s
-/// that surface multiple prices per flight (e.g. `.fareBoard`).
-public struct FlightFare: Identifiable, Sendable, Equatable {
-    /// Stable, content-derived identity (no per-init `UUID()` churn in `ForEach`).
-    public var id: String { name }
-    public let name: String
-    public let price: Decimal
-    /// SF Symbol names for 1–2 headline perks (e.g. `"suitcase.fill"`).
-    public var perks: [String]
-
-    public init(_ name: String, price: Decimal, perks: [String] = []) {
-        self.name = name
-        self.price = price
-        self.perks = perks
-    }
-}
-
 public struct FlightListItem: View {
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled

--- a/Sources/ThemeKit/Components/Organisms/FlightModels.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightModels.swift
@@ -1,0 +1,124 @@
+//
+//  FlightModels.swift
+//  ThemeKit
+//
+//  The consolidated, brand-neutral flight model vocabulary shared by the flight
+//  family (``FlightCard``, ``FlightListItem``, ``FareSummary``, ``FareFeatureRow``,
+//  ``FlightStatusBadge``…). Models are the *vocabulary*; per-component
+//  configurations slice them for a style. Fully generic — no product/domain
+//  coupling, no view code.
+//
+
+import Foundation
+
+/// A flight status pill's state — on-time / boarding / delayed / gate-closed /
+/// departed / arrived / cancelled. Rendered by ``FlightStatusBadge``.
+public enum FlightStatus: String, Sendable, CaseIterable {
+    case onTime, boarding, delayed, gateClosed, departed, arrived, cancelled
+
+    var label: String {
+        switch self {
+        case .onTime: "On time"; case .boarding: "Boarding"; case .delayed: "Delayed"
+        case .gateClosed: "Gate closed"; case .departed: "Departed"; case .arrived: "Arrived"; case .cancelled: "Cancelled"
+        }
+    }
+    var semantic: SemanticColor {
+        switch self {
+        case .onTime, .arrived: .success
+        case .boarding, .departed: .info
+        case .delayed, .gateClosed: .warning
+        case .cancelled: .error
+        }
+    }
+    var icon: String {
+        switch self {
+        case .onTime: "checkmark.circle.fill"; case .boarding: "figure.walk"; case .delayed: "clock.fill"
+        case .gateClosed: "lock.fill"; case .departed: "airplane.departure"; case .arrived: "airplane.arrival"; case .cancelled: "xmark.circle.fill"
+        }
+    }
+}
+
+/// One leg of a multi-leg ``FlightCard`` (outbound, return, connection…).
+public struct FlightLeg: Identifiable, Sendable, Equatable, Codable {
+    /// Stable, content-derived identity (no per-init `UUID()` churn in `ForEach`).
+    public var id: String { "\(origin)-\(destination)@\(Int(departure.timeIntervalSinceReferenceDate))" }
+    public let airline: String
+    public let origin: String
+    public let destination: String
+    public let departure: Date
+    public let arrival: Date
+    public var stops: Int
+    /// Layover summary shown under the path, e.g. `"1 stop · 6h 45m · ESB"`.
+    public var layover: String?
+
+    public init(airline: String, from origin: String, to destination: String,
+                departure: Date, arrival: Date, stops: Int = 0, layover: String? = nil) {
+        self.airline = airline
+        self.origin = origin
+        self.destination = destination
+        self.departure = departure
+        self.arrival = arrival
+        self.stops = stops
+        self.layover = layover
+    }
+}
+
+/// One purchasable fare option on a flight (fare-family shopping — Delta/THY
+/// style "Basic / Classic / Flex" columns). Rendered by ``FlightListItemStyle``s
+/// that surface multiple prices per flight (e.g. `.fareBoard`).
+public struct FlightFare: Identifiable, Sendable, Equatable {
+    /// Stable, content-derived identity (no per-init `UUID()` churn in `ForEach`).
+    public var id: String { name }
+    public let name: String
+    public let price: Decimal
+    /// SF Symbol names for 1–2 headline perks (e.g. `"suitcase.fill"`).
+    public var perks: [String]
+
+    public init(_ name: String, price: Decimal, perks: [String] = []) {
+        self.name = name
+        self.price = price
+        self.perks = perks
+    }
+}
+
+/// One line of a ``FareSummary``.
+public struct FareLine: Identifiable, Sendable, Equatable, Codable {
+    public enum Kind: String, Sendable, Codable { case item, discount, total }
+    /// Stable, content-derived identity (no per-init `UUID()` churn in `ForEach`).
+    public var id: String { "\(kind.rawValue):\(label)" }
+    let label: String
+    let amount: Decimal
+    let kind: Kind
+    let info: String?
+
+    /// A regular charge (base fare, taxes, a service fee…).
+    public static func item(_ label: String, _ amount: Decimal, info: String? = nil) -> FareLine {
+        .init(label: label, amount: amount, kind: .item, info: info)
+    }
+    /// A saving — rendered green with a leading minus.
+    public static func discount(_ label: String, _ amount: Decimal, info: String? = nil) -> FareLine {
+        .init(label: label, amount: amount, kind: .discount, info: info)
+    }
+    /// The emphasised total — rendered as a hero `PriceTag` under a divider.
+    public static func total(_ label: String, _ amount: Decimal, info: String? = nil) -> FareLine {
+        .init(label: label, amount: amount, kind: .total, info: info)
+    }
+}
+
+/// Whether a fare feature is granted, denied, or neutral info.
+public enum FareFeatureStatus: Sendable { case included, excluded, info }
+
+/// A single fare feature / rule line.
+public struct FareFeature: Identifiable, Sendable {
+    public var id: String { "\(systemImage):\(text)" }
+    public let text: String
+    public let systemImage: String
+    public let detail: String?
+    public let status: FareFeatureStatus
+    public init(_ text: String, systemImage: String, detail: String? = nil, status: FareFeatureStatus = .info) {
+        self.text = text
+        self.systemImage = systemImage
+        self.detail = detail
+        self.status = status
+    }
+}


### PR DESCRIPTION
Unit **F0.2** of the ThemeKitTravel plan (ADR-F7). Relocates the shared flight model vocabulary out of individual component files into one neutral `Sources/ThemeKit/Components/Organisms/FlightModels.swift` — "model = vocabulary, configuration = slice".

**Pure move inside the `ThemeKit` target** — no behavior change, public API byte-identical (API-breakage gate stays green), and it makes F4's 2.0 extraction a clean `git mv`.

Moved (full bodies, conformances, nested types, factories):
- `FlightStatus` (+ `label`/`semantic`/`icon`) ← `FlightStatusBadge.swift`
- `FlightLeg` ← `FlightCard.swift`
- `FlightFare` ← `FlightListItem.swift`
- `FareLine` (+ nested `Kind` + `item`/`discount`/`total` factories) ← `FareSummary.swift`
- `FareFeatureStatus` + `FareFeature` ← `FareFeatureRow.swift`

View/style/modifier extensions stayed with their components. `FlightModels.swift` needs only `import Foundation` — `SemanticColor` resolves module-wide via the `@_exported import ThemeKitCore` in `CoreExports.swift`. `swift build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)