### PR TITLE
feat(travel): edition domain models + FlightDefaults env (F0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ breaking changes bump the **major**.
 ## [Unreleased]
 
 ### Added
+- **`SemanticColor` now conforms to `Sendable`**, and **`CardBrand` now conforms to `Sendable, CaseIterable, Codable`** — additive conformances (no signature change) so `Sendable` value types (e.g. edition environment defaults) can carry a `SemanticColor`, and `CardBrand`-bearing models can be `Codable`.
 - **`ThemeKitTravel`** library product — the opt-in flight/booking **domain edition** (composition over forking: it wraps the neutral `ThemeKit` catalog rather than re-implementing it). This first drop is the packaging foundation — the SPM target/product plus the edition's own String Catalog (`String(themeKitTravel:)`); the booking-flow components land in follow-ups. **No package trait and no re-export** (mirroring `ThemeKitCalendar`): add `ThemeKitTravel` to a target and write `import ThemeKitTravel` alongside `import ThemeKit` to opt in — a consumer who doesn't compiles nothing from it and downloads the same package. Part of the [#229](https://github.com/isamercan/ThemeKit/issues/229) modular direction (ADR: `THEMEKITTRAVEL_ARCHITECTURE.md`).
 
 ## [1.1.0] - 2026-07-10

--- a/Sources/ThemeKit/Components/Molecules/PaymentCardField.swift
+++ b/Sources/ThemeKit/Components/Molecules/PaymentCardField.swift
@@ -14,7 +14,7 @@
 import SwiftUI
 
 /// Card network detected from the number prefix.
-public enum CardBrand: String, Sendable, CaseIterable {
+public enum CardBrand: String, Sendable, CaseIterable, Codable {
     case visa, mastercard, amex, troy, unknown
 
     public var label: String {

--- a/Sources/ThemeKitCore/Theme/SemanticColor.swift
+++ b/Sources/ThemeKitCore/Theme/SemanticColor.swift
@@ -10,7 +10,7 @@
 
 import SwiftUI
 
-public enum SemanticColor: String, CaseIterable {
+public enum SemanticColor: String, CaseIterable, Sendable {
     case primary, neutral, info, success, warning, error
     case turquoise, orange, purple, pink
     /// daisyUI brand colors — backed by additive `palette.secondary/accent.*`

--- a/Sources/ThemeKitTravel/FlightDefaults.swift
+++ b/Sources/ThemeKitTravel/FlightDefaults.swift
@@ -1,0 +1,76 @@
+//
+//  FlightDefaults.swift
+//  ThemeKitTravel
+//
+//  A subtree-level "house style" for flight components — default accent, the SF
+//  Symbol used where no airline logo is provided, and the time/date formats for
+//  schedule-dense components. Set it once with `.flightDefaults(...)`; flight
+//  components read it as their default when the corresponding modifier isn't set
+//  explicitly. Additive and Open/Closed: a per-call modifier still wins.
+//
+//  Resolution order (ADR-F2): explicit per-call argument > `flightDefaults`
+//  > `componentDefaults`/`formatDefaults` > environment natives (`\.locale`)
+//  > the component's own constant.
+//
+//  ```swift
+//  BookingFlow()
+//      .flightDefaults(airlineSymbol: "airplane.circle",
+//                      timeFormat: .dateTime.hour().minute())
+//  ```
+//
+
+import SwiftUI
+import ThemeKit
+
+public struct FlightDefaults: Equatable, Sendable {
+    /// Accent for flight components (falls back to `componentDefaults.accent`,
+    /// then each component's own default — usually the hero foreground token).
+    public var accent: SemanticColor?
+    /// SF Symbol used where no airline logo slot is provided.
+    public var airlineSymbol: String?
+    /// Time format for schedule-dense flight components (FlightTracker,
+    /// TripSearchCard summaries).
+    public var timeFormat: Date.FormatStyle?
+    /// Date format for schedule-dense flight components.
+    public var dateFormat: Date.FormatStyle?
+
+    public init(accent: SemanticColor? = nil,
+                airlineSymbol: String? = nil,
+                timeFormat: Date.FormatStyle? = nil,
+                dateFormat: Date.FormatStyle? = nil) {
+        self.accent = accent
+        self.airlineSymbol = airlineSymbol
+        self.timeFormat = timeFormat
+        self.dateFormat = dateFormat
+    }
+}
+
+private struct FlightDefaultsKey: EnvironmentKey {
+    // Plain `static let` — `FlightDefaults` is `Sendable` (all fields are), so no
+    // `nonisolated(unsafe)` escape hatch is needed (§1.4 revision 2).
+    static let defaultValue = FlightDefaults()
+}
+
+public extension EnvironmentValues {
+    var flightDefaults: FlightDefaults {
+        get { self[FlightDefaultsKey.self] }
+        set { self[FlightDefaultsKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Sets the flight-family defaults for ThemeKitTravel components in this
+    /// subtree. Only the provided fields are set (non-nil merge); a component's
+    /// explicit modifier still overrides.
+    func flightDefaults(accent: SemanticColor? = nil,
+                        airlineSymbol: String? = nil,
+                        timeFormat: Date.FormatStyle? = nil,
+                        dateFormat: Date.FormatStyle? = nil) -> some View {
+        transformEnvironment(\.flightDefaults) { d in
+            if let accent { d.accent = accent }
+            if let airlineSymbol { d.airlineSymbol = airlineSymbol }
+            if let timeFormat { d.timeFormat = timeFormat }
+            if let dateFormat { d.dateFormat = dateFormat }
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Models/FlightSearchModels.swift
+++ b/Sources/ThemeKitTravel/Models/FlightSearchModels.swift
@@ -1,0 +1,141 @@
+//
+//  FlightSearchModels.swift
+//  ThemeKitTravel
+//
+//  Canonical flight-search domain models (ADR-F3 §4.2) — the shared vocabulary
+//  for `AirportPicker`, `CabinClassSelector` and `TripSearchCard`. Value types
+//  only: generic, data-driven, no backend schema. Apps map their own DTOs onto
+//  these; components take them (or flat convenience slices of them) in `init`.
+//
+
+import Foundation
+import ThemeKit
+
+// MARK: - Airport
+
+/// An airport a search leg departs from or arrives at.
+///
+/// Identity is the IATA code — content-derived and stable (no per-init `UUID()`
+/// churn in `ForEach`, matching the `FlightLeg.id` precedent).
+public struct Airport: Identifiable, Sendable, Hashable, Codable {
+    public var id: String { code }
+    /// IATA location code, e.g. `"IST"`.
+    public let code: String
+    /// Full airport name, e.g. `"Istanbul Airport"`.
+    public let name: String
+    /// The city the airport serves.
+    public let city: String
+    /// ISO 3166-1 alpha-2 region code; display names resolve via `Locale`.
+    public let countryCode: String?
+
+    public init(code: String, name: String, city: String, countryCode: String? = nil) {
+        self.code = code
+        self.name = name
+        self.city = city
+        self.countryCode = countryCode
+    }
+}
+
+// MARK: - CabinClass
+
+/// The service cabin a search or fare applies to. Drives `CabinClassSelector`.
+public enum CabinClass: String, CaseIterable, Sendable, Codable {
+    case economy, premiumEconomy, business, first
+
+    /// Localized display name (English source; overridable via the edition catalog).
+    public var label: String {
+        switch self {
+        case .economy: String(themeKitTravel: "Economy")
+        case .premiumEconomy: String(themeKitTravel: "Premium Economy")
+        case .business: String(themeKitTravel: "Business")
+        case .first: String(themeKitTravel: "First")
+        }
+    }
+
+    /// SF Symbol representing the cabin.
+    public var glyph: String {
+        switch self {
+        case .economy: "chair"
+        case .premiumEconomy: "chair.lounge"
+        case .business: "briefcase"
+        case .first: "crown"
+        }
+    }
+}
+
+// MARK: - TripType
+
+/// The itinerary shape of a search. Drives `TripTypeToggle` / `TripSearchCard`.
+public enum TripType: String, CaseIterable, Sendable, Codable {
+    case oneWay, roundTrip, multiCity
+
+    /// Localized display name (English source; overridable via the edition catalog).
+    public var label: String {
+        switch self {
+        case .oneWay: String(themeKitTravel: "One way")
+        case .roundTrip: String(themeKitTravel: "Round trip")
+        case .multiCity: String(themeKitTravel: "Multi-city")
+        }
+    }
+}
+
+// MARK: - PassengerCount
+
+/// How many travelers a search covers. Invariants are self-healing: `adults`
+/// never drops below 1, `children`/`infants` never below 0 — enforced in the
+/// initializer, on direct mutation, and on decode.
+public struct PassengerCount: Sendable, Equatable, Codable {
+    public var adults: Int { didSet { adults = max(1, adults) } }
+    public var children: Int { didSet { children = max(0, children) } }
+    public var infants: Int { didSet { infants = max(0, infants) } }
+
+    public init(adults: Int = 1, children: Int = 0, infants: Int = 0) {
+        self.adults = max(1, adults)
+        self.children = max(0, children)
+        self.infants = max(0, infants)
+    }
+
+    /// All travelers, regardless of age band.
+    public var total: Int { adults + children + infants }
+
+    // Decode routes through the clamping initializer so persisted or hand-made
+    // payloads can't smuggle an invalid count past the invariants.
+    private enum CodingKeys: String, CodingKey { case adults, children, infants }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(adults: try container.decode(Int.self, forKey: .adults),
+                  children: try container.decode(Int.self, forKey: .children),
+                  infants: try container.decode(Int.self, forKey: .infants))
+    }
+}
+
+// MARK: - TripSearchDraft
+
+/// The in-progress state of a flight search — the single value `TripSearchCard`
+/// binds to (`draft: Binding<TripSearchDraft>`). Dates are self-healing: a
+/// return date never precedes the departure date (whichever side is mutated,
+/// the return date is pulled forward to keep the pair ordered).
+public struct TripSearchDraft: Sendable, Equatable {
+    public var tripType: TripType = .roundTrip
+    public var origin: Airport?
+    public var destination: Airport?
+    public var departureDate: Date? { didSet { clampDates() } }
+    /// Meaningful only for `.roundTrip`.
+    public var returnDate: Date? { didSet { clampDates() } }
+    public var passengers: PassengerCount = .init()
+    public var cabin: CabinClass = .economy
+
+    public init() {}
+
+    /// Swaps origin and destination (the round-arrow affordance on search forms).
+    public mutating func swapRoute() {
+        swap(&origin, &destination)
+    }
+
+    private mutating func clampDates() {
+        if let departure = departureDate, let ret = returnDate, ret < departure {
+            returnDate = departure
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Models/FlightStatusModels.swift
+++ b/Sources/ThemeKitTravel/Models/FlightStatusModels.swift
@@ -1,0 +1,51 @@
+//
+//  FlightStatusModels.swift
+//  ThemeKitTravel
+//
+//  Canonical live flight-status model (ADR-F3 §4.2) — consumed by
+//  `FlightTracker`. Wraps the neutral vocabulary rather than re-declaring it:
+//  `FlightLeg` is the canonical leg (scheduled times) and `FlightStatus` is the
+//  7-case atom enum from `FlightStatusBadge`; this adds the day-of-travel
+//  overlay (gates, belts, estimates) on top.
+//
+
+import Foundation
+import ThemeKit
+
+/// Live operational status for one flight leg.
+public struct FlightStatusInfo: Sendable, Equatable {
+    /// The canonical leg — carries the *scheduled* departure/arrival.
+    public var leg: FlightLeg
+    /// Reused 7-case status atom (on-time / boarding / delayed / …).
+    public var status: FlightStatus
+    public var gate: String?
+    public var terminal: String?
+    public var checkInDesk: String?
+    public var baggageBelt: String?
+    /// Estimated departure, vs `leg.departure` (scheduled).
+    public var estimatedDeparture: Date?
+    /// Estimated arrival, vs `leg.arrival` (scheduled).
+    public var estimatedArrival: Date?
+    /// Aircraft type display string, e.g. `"A321neo"`.
+    public var aircraft: String?
+
+    public init(leg: FlightLeg,
+                status: FlightStatus,
+                gate: String? = nil,
+                terminal: String? = nil,
+                checkInDesk: String? = nil,
+                baggageBelt: String? = nil,
+                estimatedDeparture: Date? = nil,
+                estimatedArrival: Date? = nil,
+                aircraft: String? = nil) {
+        self.leg = leg
+        self.status = status
+        self.gate = gate
+        self.terminal = terminal
+        self.checkInDesk = checkInDesk
+        self.baggageBelt = baggageBelt
+        self.estimatedDeparture = estimatedDeparture
+        self.estimatedArrival = estimatedArrival
+        self.aircraft = aircraft
+    }
+}

--- a/Sources/ThemeKitTravel/Models/PassengerModels.swift
+++ b/Sources/ThemeKitTravel/Models/PassengerModels.swift
@@ -1,0 +1,49 @@
+//
+//  PassengerModels.swift
+//  ThemeKitTravel
+//
+//  Canonical traveler-details models (ADR-F3 §4.2) — the value `PassengerForm`
+//  binds to. Generic and data-driven: no airline/agency schema, no document
+//  validation policy (that belongs to the app's rule pack via FormValidator).
+//
+//  Note: `DialCode` is NOT an edition model — it ships neutral alongside
+//  `PhoneField` in `ThemeKit/Molecules` (§1.4 OQ-4), so phone entry is absent here.
+//
+
+import Foundation
+import ThemeKit
+
+// MARK: - PassengerGender
+
+/// Gender as airlines record it on a booking. Drives the form's selector.
+public enum PassengerGender: String, CaseIterable, Sendable, Codable {
+    case female, male, unspecified
+
+    /// Localized display name (English source; overridable via the edition catalog).
+    public var label: String {
+        switch self {
+        case .female: String(themeKitTravel: "Female")
+        case .male: String(themeKitTravel: "Male")
+        case .unspecified: String(themeKitTravel: "Unspecified")
+        }
+    }
+}
+
+// MARK: - PassengerDraft
+
+/// The in-progress state of one traveler's details form. Starts empty; every
+/// field is directly settable so `PassengerForm` can bind row-by-row.
+/// `Codable` so a checkout flow can persist a half-finished traveler.
+public struct PassengerDraft: Sendable, Equatable, Codable {
+    public var givenName = ""
+    public var familyName = ""
+    public var gender: PassengerGender?
+    public var dateOfBirth: Date?
+    /// ISO 3166-1 region code; display names resolve via `Locale`.
+    public var nationality: String?
+    /// Passport or national ID number.
+    public var documentNumber = ""
+    public var documentExpiry: Date?
+
+    public init() {}
+}

--- a/Sources/ThemeKitTravel/Models/PaymentModels.swift
+++ b/Sources/ThemeKitTravel/Models/PaymentModels.swift
@@ -1,0 +1,93 @@
+//
+//  PaymentModels.swift
+//  ThemeKitTravel
+//
+//  Canonical payment-selection models (ADR-F3 §4.2) — consumed by
+//  `PaymentMethodSelector` and `SavedCardsList`. `SavedCard` reuses the neutral
+//  `CardBrand` enum from `PaymentCardField` (F0.4 added `Codable` to it so
+//  `SavedCard`'s `Codable` synthesizes). Generic and data-driven — no PSP schema.
+//
+
+import Foundation
+import ThemeKit
+
+// MARK: - PaymentMethodOption
+
+/// One selectable way to pay — a card, a wallet, or a bank transfer.
+/// Identity is caller-supplied (the app's own method identifier).
+public struct PaymentMethodOption: Identifiable, Sendable, Equatable {
+    /// The family of payment method, used for the default iconography.
+    public enum Kind: String, Sendable, Codable {
+        case card, wallet, transfer
+
+        /// SF Symbol used when the caller doesn't pass one.
+        var defaultSystemImage: String {
+            switch self {
+            case .card: "creditcard"
+            case .wallet: "wallet.pass"
+            case .transfer: "building.columns"
+            }
+        }
+    }
+
+    public let id: String
+    public let kind: Kind
+    public let title: String
+    public var subtitle: String?
+    /// SF Symbol shown beside the title; defaulted per `kind` when omitted.
+    public var systemImage: String
+
+    public init(id: String, kind: Kind, title: String,
+                subtitle: String? = nil, systemImage: String? = nil) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+        self.subtitle = subtitle
+        self.systemImage = systemImage ?? kind.defaultSystemImage
+    }
+}
+
+// MARK: - SavedCard
+
+/// A card on file — brand, masked digits and expiry. `Codable` so an app can
+/// persist its wallet; expiry math stays in the model so every consumer agrees
+/// on when a card stops being offerable.
+public struct SavedCard: Identifiable, Sendable, Equatable, Codable {
+    public let id: String
+    /// Reused from the neutral `PaymentCardField` family.
+    public let brand: CardBrand
+    /// The last four digits, e.g. `"4242"`.
+    public let last4: String
+    public var holder: String?
+    /// 1…12 (clamped); formatted by the consuming component with the env locale.
+    public var expiryMonth: Int?
+    /// Full (`2028`) or two-digit (`28`, treated as 2000-based) year.
+    public var expiryYear: Int?
+
+    public init(id: String, brand: CardBrand, last4: String, holder: String? = nil,
+                expiryMonth: Int? = nil, expiryYear: Int? = nil) {
+        self.id = id
+        self.brand = brand
+        self.last4 = last4
+        self.holder = holder
+        self.expiryMonth = expiryMonth.map { min(12, max(1, $0)) }
+        self.expiryYear = expiryYear
+    }
+
+    /// Whether the card's validity window has passed. A card is valid through the
+    /// last instant of its expiry month; missing expiry data reads as not expired
+    /// (the model can't rule the card out). Pass a fixed `date`/`calendar` for
+    /// deterministic tests.
+    public func isExpired(asOf date: Date = .now, calendar: Calendar = .current) -> Bool {
+        guard let month = expiryMonth, let year = expiryYear else { return false }
+        let fullYear = year < 100 ? year + 2000 : year
+        var components = DateComponents()
+        components.year = fullYear
+        components.month = month
+        components.day = 1
+        guard let firstOfExpiryMonth = calendar.date(from: components),
+              let firstInvalidInstant = calendar.date(byAdding: .month, value: 1, to: firstOfExpiryMonth)
+        else { return false }
+        return date >= firstInvalidInstant
+    }
+}

--- a/Tests/ThemeKitTests/ThemeKitTravelModelTests.swift
+++ b/Tests/ThemeKitTests/ThemeKitTravelModelTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+import ThemeKit
+import ThemeKitTravel
+
+/// Contract tests for the ThemeKitTravel canonical model layer (ADR-F3 §4.2):
+/// `PassengerCount` clamps, `TripSearchDraft` route-swap + date ordering, and
+/// `SavedCard` expiry math + Codable round-trip. All dates are built from fixed
+/// components (UTC Gregorian) — never `Date.now` — so the suite is deterministic.
+final class ThemeKitTravelModelTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// UTC Gregorian, independent of the runner's locale/timezone.
+    private let calendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }()
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        calendar.date(from: DateComponents(year: year, month: month, day: day))!
+    }
+
+    // MARK: - PassengerCount clamps
+
+    func testPassengerCountInitClampsAdultsToMinimumOne() {
+        XCTAssertEqual(PassengerCount(adults: 0).adults, 1)
+        XCTAssertEqual(PassengerCount(adults: -3).adults, 1)
+        XCTAssertEqual(PassengerCount(adults: 2).adults, 2)
+    }
+
+    func testPassengerCountInitClampsChildrenAndInfantsToNonNegative() {
+        let count = PassengerCount(adults: 1, children: -2, infants: -1)
+        XCTAssertEqual(count.children, 0)
+        XCTAssertEqual(count.infants, 0)
+    }
+
+    func testPassengerCountMutationReclamps() {
+        var count = PassengerCount(adults: 2, children: 1, infants: 1)
+        count.adults = 0
+        count.children = -5
+        count.infants = -1
+        XCTAssertEqual(count.adults, 1)
+        XCTAssertEqual(count.children, 0)
+        XCTAssertEqual(count.infants, 0)
+    }
+
+    func testPassengerCountTotalSumsAllBands() {
+        XCTAssertEqual(PassengerCount(adults: 2, children: 3, infants: 1).total, 6)
+        XCTAssertEqual(PassengerCount().total, 1)   // default: 1 adult
+    }
+
+    func testPassengerCountDecodeClampsInvalidPayload() throws {
+        let json = Data(#"{"adults":0,"children":-4,"infants":-1}"#.utf8)
+        let decoded = try JSONDecoder().decode(PassengerCount.self, from: json)
+        XCTAssertEqual(decoded, PassengerCount(adults: 1, children: 0, infants: 0))
+    }
+
+    // MARK: - TripSearchDraft
+
+    func testSwapRouteExchangesOriginAndDestination() {
+        let ist = Airport(code: "IST", name: "Istanbul Airport", city: "Istanbul", countryCode: "TR")
+        let lhr = Airport(code: "LHR", name: "Heathrow Airport", city: "London", countryCode: "GB")
+        var draft = TripSearchDraft()
+        draft.origin = ist
+        draft.destination = lhr
+
+        draft.swapRoute()
+        XCTAssertEqual(draft.origin, lhr)
+        XCTAssertEqual(draft.destination, ist)
+
+        // Swapping with one side empty just moves the value across.
+        draft.destination = nil
+        draft.swapRoute()
+        XCTAssertNil(draft.origin)
+        XCTAssertEqual(draft.destination, lhr)
+    }
+
+    func testSettingReturnDateBeforeDepartureClampsToDeparture() {
+        var draft = TripSearchDraft()
+        draft.departureDate = date(2027, 6, 10)
+        draft.returnDate = date(2027, 6, 5)
+        XCTAssertEqual(draft.returnDate, date(2027, 6, 10))
+    }
+
+    func testMovingDepartureAfterReturnPullsReturnForward() {
+        var draft = TripSearchDraft()
+        draft.departureDate = date(2027, 6, 1)
+        draft.returnDate = date(2027, 6, 4)
+        draft.departureDate = date(2027, 6, 20)
+        XCTAssertEqual(draft.returnDate, date(2027, 6, 20))
+    }
+
+    func testOrderedDatesAreLeftUntouched() {
+        var draft = TripSearchDraft()
+        draft.departureDate = date(2027, 6, 1)
+        draft.returnDate = date(2027, 6, 8)
+        XCTAssertEqual(draft.departureDate, date(2027, 6, 1))
+        XCTAssertEqual(draft.returnDate, date(2027, 6, 8))
+    }
+
+    // MARK: - SavedCard.isExpired
+
+    func testCardExpiredWhenMonthHasPassed() {
+        let card = SavedCard(id: "c1", brand: .visa, last4: "4242", expiryMonth: 3, expiryYear: 2026)
+        // Valid through the last instant of March 2026 — April 1 is expired.
+        XCTAssertTrue(card.isExpired(asOf: date(2026, 4, 1), calendar: calendar))
+        XCTAssertFalse(card.isExpired(asOf: date(2026, 3, 31), calendar: calendar))
+    }
+
+    func testCardNotExpiredForFutureExpiry() {
+        let card = SavedCard(id: "c2", brand: .mastercard, last4: "5100", expiryMonth: 12, expiryYear: 2030)
+        XCTAssertFalse(card.isExpired(asOf: date(2026, 7, 11), calendar: calendar))
+    }
+
+    func testTwoDigitExpiryYearIsTreatedAs2000Based() {
+        let card = SavedCard(id: "c3", brand: .visa, last4: "0001", expiryMonth: 5, expiryYear: 24)
+        XCTAssertTrue(card.isExpired(asOf: date(2026, 1, 1), calendar: calendar))    // 05/24 passed
+        XCTAssertFalse(card.isExpired(asOf: date(2024, 5, 15), calendar: calendar))  // still in-month
+    }
+
+    func testMissingExpiryReadsAsNotExpired() {
+        let card = SavedCard(id: "c4", brand: .amex, last4: "0005")
+        XCTAssertFalse(card.isExpired(asOf: date(2099, 1, 1), calendar: calendar))
+    }
+
+    func testExpiryMonthClampsInto1Through12() {
+        XCTAssertEqual(SavedCard(id: "c5", brand: .visa, last4: "1111", expiryMonth: 0, expiryYear: 2027).expiryMonth, 1)
+        XCTAssertEqual(SavedCard(id: "c6", brand: .visa, last4: "2222", expiryMonth: 13, expiryYear: 2027).expiryMonth, 12)
+    }
+
+    // MARK: - SavedCard Codable round-trip
+
+    func testSavedCardCodableRoundTrip() throws {
+        let card = SavedCard(id: "wallet-1", brand: .troy, last4: "9792",
+                             holder: "Alex Traveler", expiryMonth: 9, expiryYear: 2028)
+        let decoded = try JSONDecoder().decode(SavedCard.self, from: JSONEncoder().encode(card))
+        XCTAssertEqual(decoded, card)
+    }
+}


### PR DESCRIPTION
Unit **F0.4** of the ThemeKitTravel plan (ADR-F3 model layer + ADR-F2 provider). Adds the edition's model spine and provider env, plus two additive neutral conformances.

### Edition models (`Sources/ThemeKitTravel/Models/`)
- **FlightSearchModels** — `Airport`, `CabinClass`, `TripType`, `PassengerCount` (clamps in init/`didSet`/decode), `TripSearchDraft` (`swapRoute` + return≥departure date clamp).
- **PassengerModels** — `PassengerGender`, `PassengerDraft`. *(DialCode deferred to F1.1, neutral.)*
- **PaymentModels** — `PaymentMethodOption` (+`Kind`), `SavedCard` (`isExpired`, `Codable`).
- **FlightStatusModels** — `FlightStatusInfo` wrapping neutral `FlightLeg`+`FlightStatus`.

### Provider env
- `FlightDefaults` (`Equatable, Sendable`) + `\.flightDefaults` key (plain Sendable `defaultValue`, no `nonisolated(unsafe)`) + `.flightDefaults(...)` non-nil-merge modifier, modeled on `ComponentDefaults`.

### Neutral additive conformances (api-gate safe)
- **`SemanticColor: +Sendable`** — required so a `Sendable` `FlightDefaults` can hold a `SemanticColor?` (Swift 6 gives no cross-module Sendable inference for a public non-`@frozen` enum; matches sibling token enums already declaring it).
- **`CardBrand: +Sendable, CaseIterable, Codable`** — so `SavedCard`'s `Codable` synthesizes.

### Verification
- `swift build` clean; **`ThemeKitTravelModelTests` 15/15 pass** (count/date clamps, swapRoute, isExpired boundaries, 2-digit year, Codable round-trip — all fixed dates, no `Date.now`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)