### PR TITLE
feat(travel): environment currency resolution + FormatDefaults env (F0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ breaking changes bump the **major**.
 ## [Unreleased]
 
 ### Added
+- **`FormatDefaults` environment + `.formatDefaults(currencyCode:)` modifier** (neutral `ThemeKit`) — sets a subtree-wide default ISO-4217 currency for every price-bearing component, so the currency is provided once at the root instead of per call site.
 - **`SemanticColor` now conforms to `Sendable`**, and **`CardBrand` now conforms to `Sendable, CaseIterable, Codable`** — additive conformances (no signature change) so `Sendable` value types (e.g. edition environment defaults) can carry a `SemanticColor`, and `CardBrand`-bearing models can be `Codable`.
+
+### Changed
+- **Price components now resolve their currency from the environment** instead of a hardcoded `"TRY"`/`"USD"` default. The resolution chain is: explicit `currencyCode:` argument › `.formatDefaults(currencyCode:)` › the environment `\.locale`'s currency › `"USD"` terminal fallback. **Source-compatible** (existing signatures unchanged; added omitted-argument overloads), but **render-visible**: a call site that omitted `currencyCode:` and relied on silently getting `TRY`/`USD` will now show the environment-resolved currency. Pin it explicitly with `.formatDefaults(currencyCode: "TRY")` at your root, or pass an explicit code per call. Affects ~23 components (PriceTag, FareSummary, FlightCard, RoomCard, DestinationCard, InstallmentPicker, …).
 - **`ThemeKitTravel`** library product — the opt-in flight/booking **domain edition** (composition over forking: it wraps the neutral `ThemeKit` catalog rather than re-implementing it). This first drop is the packaging foundation — the SPM target/product plus the edition's own String Catalog (`String(themeKitTravel:)`); the booking-flow components land in follow-ups. **No package trait and no re-export** (mirroring `ThemeKitCalendar`): add `ThemeKitTravel` to a target and write `import ThemeKitTravel` alongside `import ThemeKit` to opt in — a consumer who doesn't compiles nothing from it and downloads the same package. Part of the [#229](https://github.com/isamercan/ThemeKit/issues/229) modular direction (ADR: `THEMEKITTRAVEL_ARCHITECTURE.md`).
 
 ## [1.1.0] - 2026-07-10

--- a/Sources/ThemeKit/Components/Atoms/PriceTag.swift
+++ b/Sources/ThemeKit/Components/Atoms/PriceTag.swift
@@ -73,9 +73,11 @@ public struct PriceTag: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let amount: Decimal
-    private let currencyCode: String
+    private let currencyCode: String?
     // Appearance/state — mutated only through the modifiers below (R2).
     private var original: Decimal?
     private var originalBelow = false
@@ -92,6 +94,17 @@ public struct PriceTag: View {
     public init(_ amount: Decimal, currencyCode: String = "TRY") {   // R1 — content
         self.amount = amount
         self.currencyCode = currencyCode
+    }
+
+    /// Omitted-currency form — resolves the code from the environment:
+    /// `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
+    public init(_ amount: Decimal) {   // R1 — content
+        self.amount = amount
+        self.currencyCode = nil
+    }
+
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
     public var body: some View {
@@ -151,7 +164,7 @@ public struct PriceTag: View {
     }
 
     private func formatted(_ value: Decimal) -> String {
-        value.formatted(.currency(code: currencyCode).precision(.fractionLength(fractionDigits)))
+        value.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(fractionDigits)))
     }
 
     private var discountPercent: Int? { Self.discountPercent(original: original, amount: amount) }

--- a/Sources/ThemeKit/Components/Atoms/SeatCell.swift
+++ b/Sources/ThemeKit/Components/Atoms/SeatCell.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 public struct SeatCell: View {
     @Environment(\.theme) private var theme
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     // Content (R1) + state.
     private let seat: Seat
@@ -22,7 +24,7 @@ public struct SeatCell: View {
     private let display: SeatDisplay
     private let palette: SeatPalette
     private let customContent: ((SeatContext) -> AnyView)?
-    private let currencyCode: String
+    private let currencyCode: String?
     private let action: () -> Void
 
     public init(_ seat: Seat,
@@ -47,6 +49,35 @@ public struct SeatCell: View {
         self.customContent = customContent
         self.currencyCode = currencyCode
         self.action = action
+    }
+
+    /// Omitted-currency form — resolves the code from the environment:
+    /// `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
+    public init(_ seat: Seat,
+                size: CGFloat = 44,
+                isSelected: Bool = false,
+                isSelectable: Bool = true,
+                isRecommended: Bool = false,
+                assignedInitials: String? = nil,
+                display: SeatDisplay = .icon,
+                palette: SeatPalette = .default,
+                customContent: ((SeatContext) -> AnyView)? = nil,
+                action: @escaping () -> Void = {}) {
+        self.seat = seat
+        self.size = size
+        self.isSelected = isSelected
+        self.isSelectable = isSelectable
+        self.isRecommended = isRecommended
+        self.assignedInitials = assignedInitials
+        self.display = display
+        self.palette = palette
+        self.customContent = customContent
+        self.currencyCode = nil
+        self.action = action
+    }
+
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
     public var body: some View {
@@ -151,7 +182,7 @@ public struct SeatCell: View {
         if seat.isOccupied { return "Occupied" }
         if !isSelectable { return "Unavailable" }
         if isSelected { return "Selected" }
-        if let price = seat.price { return "Available, \(price.formatted(.currency(code: currencyCode).precision(.fractionLength(0))))" }
+        if let price = seat.price { return "Available, \(price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0))))" }
         return "Available"
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/DatePriceStrip.swift
+++ b/Sources/ThemeKit/Components/Molecules/DatePriceStrip.swift
@@ -28,12 +28,14 @@ public struct DatePriceCard: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let item: DatePriceItem
     private let isSelected: Bool
     private let action: () -> Void
     // Appearance — mutated only through the modifiers below (R2).
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var isCheapest = false
     private var pill = false
 
@@ -41,6 +43,11 @@ public struct DatePriceCard: View {
         self.item = item
         self.isSelected = isSelected
         self.action = action
+    }
+
+    /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
     private var priceColor: Color {
@@ -52,7 +59,7 @@ public struct DatePriceCard: View {
             if pill { pillShell } else { cardedShell }
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(item.date), \(item.price.formatted(.currency(code: currencyCode).precision(.fractionLength(0))))\(isCheapest ? ", lowest fare" : "")")
+        .accessibilityLabel("\(item.date), \(item.price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0))))\(isCheapest ? ", lowest fare" : "")")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
@@ -77,7 +84,7 @@ public struct DatePriceCard: View {
             Text(item.date)
                 .textStyle(isSelected ? .labelSm600 : .bodySm400)
                 .foregroundStyle(theme.text(.textPrimary))
-            Text(item.price.formatted(.currency(code: currencyCode).precision(.fractionLength(0))))
+            Text(item.price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0))))
                 .textStyle(.overline400)
                 .foregroundStyle(isCheapest ? theme.foreground(.systemcolorsFgSuccess) : theme.text(.textTertiary))
         }
@@ -94,7 +101,7 @@ public struct DatePriceCard: View {
         VStack(spacing: 2) {
             Text(item.date).textStyle(.labelSm600)
                 .foregroundStyle(isSelected ? theme.foreground(.fgHero) : theme.text(.textSecondary))
-            Text(item.price.formatted(.currency(code: currencyCode).precision(.fractionLength(2))))
+            Text(item.price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(2))))
                 .textStyle(.labelBase700).foregroundStyle(priceColor)
         }
         .frame(maxWidth: .infinity)
@@ -105,7 +112,8 @@ public struct DatePriceCard: View {
 }
 
 public extension DatePriceCard {
-    /// Currency code for the price (default "TRY").
+    /// Currency code for the price. Unset, it resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
     /// Highlights this as the lowest fare (price shown in success green).
     func cheapest(_ on: Bool = true) -> Self { copy { $0.isCheapest = on } }
@@ -126,7 +134,9 @@ public struct DatePriceStrip: View {
     @Binding private var selection: Int
     // Appearance/state — mutated only through the modifiers below (R2).
     @Environment(\.theme) private var theme
-    private var currencyCode = "TRY"
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
+    private var currencyCode: String?
     private var columns = 3
     private var highlightsCheapest = true
     private var stripLayout = false
@@ -141,6 +151,12 @@ public struct DatePriceStrip: View {
     private var cheapestIndex: Int? {
         guard highlightsCheapest, !items.isEmpty else { return nil }
         return items.indices.min(by: { items[$0].price < items[$1].price })
+    }
+
+    /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    /// Passed down explicitly so every card renders the strip's one resolved code.
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
     public var body: some View {
@@ -166,7 +182,7 @@ public struct DatePriceStrip: View {
                 HStack(spacing: Theme.SpacingKey.xs.value) {
                     ForEach(Array(items.enumerated()), id: \.offset) { i, item in
                         DatePriceCard(item, isSelected: i == selection) { selection = i }
-                            .currency(currencyCode)
+                            .currency(resolvedCurrency)
                             .cheapest(i == cheapest)
                             .pill()
                             .id(i)
@@ -186,7 +202,7 @@ public struct DatePriceStrip: View {
         return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: max(1, columns)), spacing: 8) {
             ForEach(Array(items.enumerated()), id: \.offset) { i, item in
                 DatePriceCard(item, isSelected: i == selection) { selection = i }
-                    .currency(currencyCode)
+                    .currency(resolvedCurrency)
                     .cheapest(i == cheapest)
             }
         }
@@ -209,7 +225,8 @@ public struct DatePriceStrip: View {
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension DatePriceStrip {
-    /// Currency code for the prices (default "TRY").
+    /// Currency code for the prices. Unset, it resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
     /// Number of columns for the grid layout (default 3).
     func columns(_ count: Int) -> Self { copy { $0.columns = max(1, count) } }

--- a/Sources/ThemeKit/Components/Molecules/FlightRoute.swift
+++ b/Sources/ThemeKit/Components/Molecules/FlightRoute.swift
@@ -59,8 +59,8 @@ public struct FlightRoute: View {
     }
 
     private var accessibilitySummary: String {
-        let departs = departure.formatted(date: .omitted, time: .shortened)
-        let arrives = arrival.formatted(date: .omitted, time: .shortened)
+        let departs = departure.formatted(Date.FormatStyle(date: .omitted, time: .shortened).locale(locale))
+        let arrives = arrival.formatted(Date.FormatStyle(date: .omitted, time: .shortened).locale(locale))
         return "\(origin) \(departs) to \(destination) \(arrives), \(durationText), \(stopsAccessibility)"
     }
 

--- a/Sources/ThemeKit/Components/Molecules/InstallmentPicker.swift
+++ b/Sources/ThemeKit/Components/Molecules/InstallmentPicker.swift
@@ -33,11 +33,13 @@ public struct InstallmentOption: Identifiable, Sendable {
 public struct InstallmentPicker: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let options: [InstallmentOption]
     @Binding private var selection: Int
     // Config — mutated only through the modifiers below (R2).
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var accent: SemanticColor?
 
     public init(_ options: [InstallmentOption], selection: Binding<Int>) {   // R1
@@ -45,8 +47,12 @@ public struct InstallmentPicker: View {
         self._selection = selection
     }
 
+    /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
     private var accentBase: Color { (accent ?? .primary).base }
-    private func money(_ d: Decimal) -> String { d.formatted(.currency(code: currencyCode).precision(.fractionLength(0))) }
+    private func money(_ d: Decimal) -> String { d.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0))) }
     private func title(_ o: InstallmentOption) -> String { o.label ?? (o.count <= 1 ? "Single payment" : "\(o.count) instalments") }
 
     public var body: some View {
@@ -86,6 +92,8 @@ public struct InstallmentPicker: View {
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension InstallmentPicker {
+    /// Currency code for the amounts. Unset, it resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
 

--- a/Sources/ThemeKit/Components/Molecules/InstallmentSelector.swift
+++ b/Sources/ThemeKit/Components/Molecules/InstallmentSelector.swift
@@ -19,11 +19,13 @@ public struct InstallmentSelector: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let total: Decimal
     private let options: [Int]
     @Binding private var selection: Int
-    private let currencyCode: String
+    private let currencyCode: String?
     // Appearance/state — mutated only through the modifiers below (R2).
     private var interestFreeUpTo: Int = 0
     private var recommendedCount: Int?
@@ -34,6 +36,20 @@ public struct InstallmentSelector: View {
         self.options = options
         self._selection = selection
         self.currencyCode = currencyCode
+    }
+
+    /// Omitted-currency overload — the currency resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD" (§10).
+    public init(total: Decimal, options: [Int], selection: Binding<Int>) {
+        self.total = total
+        self.options = options
+        self._selection = selection
+        self.currencyCode = nil
+    }
+
+    /// Explicit `currencyCode:` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
     public var body: some View {
@@ -101,7 +117,7 @@ public struct InstallmentSelector: View {
     }
 
     private func formatted(_ value: Decimal) -> String {
-        value.formatted(.currency(code: currencyCode).precision(.fractionLength(0)))
+        value.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0)))
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/PriceBreakdown.swift
+++ b/Sources/ThemeKit/Components/Molecules/PriceBreakdown.swift
@@ -18,9 +18,11 @@ import SwiftUI
 
 public struct PriceBreakdown: View {
     @Environment(\.theme) private var theme
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let amount: Decimal
-    private let currencyCode: String
+    private let currencyCode: String?
     // Appearance/content — mutated only through the modifiers below (R2).
     private var originalPrice: Decimal?
     private var discountText: String?
@@ -37,9 +39,20 @@ public struct PriceBreakdown: View {
         self.currencyCode = currencyCode
     }
 
-    private func money(_ d: Decimal) -> String { d.formatted(.currency(code: currencyCode).precision(.fractionLength(0))) }
+    /// Omitted-currency overload — the currency resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD" (§10).
+    public init(_ amount: Decimal) {   // R1
+        self.amount = amount
+        self.currencyCode = nil
+    }
+
+    /// Explicit `currencyCode:` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
+    private func money(_ d: Decimal) -> String { d.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0))) }
     private var priceTag: PriceTag {
-        var t = PriceTag(amount, currencyCode: currencyCode).size(size).emphasis(emphasis).fractionDigits(0)
+        var t = PriceTag(amount, currencyCode: resolvedCurrency).size(size).emphasis(emphasis).fractionDigits(0)
         if let unit { t = t.unit(unit) }
         return t
     }

--- a/Sources/ThemeKit/Components/Molecules/PriceHistogram.swift
+++ b/Sources/ThemeKit/Components/Molecules/PriceHistogram.swift
@@ -21,6 +21,8 @@ public struct PriceHistogram: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let bins: [Int]
     @Binding private var lowerValue: Double
@@ -29,7 +31,7 @@ public struct PriceHistogram: View {
     // Appearance/state — mutated only through the modifiers below (R2).
     private var barHeight: CGFloat = 56
     private var accent: Color?
-    private var currencyCode: String = "TRY"
+    private var currencyCode: String?
     private var resultCount: Int?
     private var showsBounds: Bool = false
 
@@ -78,8 +80,13 @@ public struct PriceHistogram: View {
 
     private var selectedColor: Color { accent ?? theme.foreground(.fgHero) }
 
+    /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
+
     private func formatted(_ value: Double) -> String {
-        Decimal(Int(value.rounded())).formatted(.currency(code: currencyCode).precision(.fractionLength(0)))
+        Decimal(Int(value.rounded())).formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0)))
     }
 
     private func heightRatio(_ count: Int) -> CGFloat {
@@ -106,7 +113,8 @@ public extension PriceHistogram {
     func accent(_ color: Color?) -> Self { copy { $0.accent = color } }
     /// Token-bound overload — selected bars use the semantic colour's base.
     func accent(_ color: SemanticColor) -> Self { copy { $0.accent = color.base } }
-    /// Currency for the range / bound labels (default TRY).
+    /// Currency for the range / bound labels. Unset, it resolves from
+    /// `\.formatDefaults`, then the locale's currency, then "USD".
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
     /// Shows a live selected-range readout and how many results it matches.
     func resultCount(_ count: Int?) -> Self { copy { $0.resultCount = count } }

--- a/Sources/ThemeKit/Components/Molecules/PriceTrendChart.swift
+++ b/Sources/ThemeKit/Components/Molecules/PriceTrendChart.swift
@@ -26,12 +26,14 @@ public struct PriceTrendPoint: Identifiable, Sendable {
 public struct PriceTrendChart: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let points: [PriceTrendPoint]
     @Binding private var selection: Int
     // Appearance/state — mutated only through the modifiers below (R2).
     private var title: String?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var accentColor: SemanticColor?
     private var selectionColorToken: SemanticColor?
     private var barHeight: CGFloat = 120
@@ -67,7 +69,11 @@ public struct PriceTrendChart: View {
     }
     private var selectionBg: Color { selectionColorToken?.base ?? theme.text(.textPrimary) }
     private var selectionFg: Color { selectionColorToken?.onSolid ?? theme.text(.textSecondaryInverse) }
-    private func priceText(_ p: Decimal) -> String { p.formatted(.currency(code: currencyCode).precision(.fractionLength(0))) }
+    /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
+    private func priceText(_ p: Decimal) -> String { p.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0))) }
 
     // MARK: Body
 
@@ -186,7 +192,8 @@ public struct PriceTrendChart: View {
 public extension PriceTrendChart {
     /// A centered title (e.g. the month).
     func title(_ text: String?) -> Self { copy { $0.title = text } }
-    /// Currency code for the prices (default "TRY").
+    /// Currency code for the prices. Unset, it resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
     /// Bar accent colour (token); `nil` (default) uses the hero foreground.
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accentColor = color } }

--- a/Sources/ThemeKit/Components/Organisms/AgentPriceRow.swift
+++ b/Sources/ThemeKit/Components/Organisms/AgentPriceRow.swift
@@ -18,6 +18,8 @@ import SwiftUI
 public struct AgentPriceRow: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let provider: String
     private let action: () -> Void
@@ -30,7 +32,7 @@ public struct AgentPriceRow: View {
     private var badgeStyle: BadgeStyle = .success
     private var warningText: String?
     private var price: Decimal?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var originalPrice: Decimal?
     private var ctaTitle = "Select"
     private var recommended = false
@@ -46,6 +48,11 @@ public struct AgentPriceRow: View {
     @Environment(\.componentDefaults) private var defaults
     private var accentSemantic: SemanticColor { accent ?? defaults.accent ?? .primary }
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: radiusRole.value, style: .continuous) }
+
+    /// Explicit `price(_:currencyCode:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
 
     public var body: some View {
         VStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
@@ -91,7 +98,7 @@ public struct AgentPriceRow: View {
     }
     private var priceBreakdown: PriceBreakdown? {
         guard let price else { return nil }
-        var b = PriceBreakdown(price, currencyCode: currencyCode).size(.medium).emphasis(.hero).align(.trailing)
+        var b = PriceBreakdown(price, currencyCode: resolvedCurrency).size(.medium).emphasis(.hero).align(.trailing)
         if let originalPrice { b = b.original(originalPrice) }
         return b
     }
@@ -117,6 +124,9 @@ public extension AgentPriceRow {
     func badge(_ text: String?, style: BadgeStyle = .success) -> Self { copy { $0.badgeText = text; $0.badgeStyle = style } }
     func warning(_ text: String?) -> Self { copy { $0.warningText = text } }
     func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// Omitted-currency overload — the currency resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
+    func price(_ amount: Decimal?) -> Self { copy { $0.price = amount } }
     func original(_ amount: Decimal?) -> Self { copy { $0.originalPrice = amount } }
     func cta(_ title: String) -> Self { copy { $0.ctaTitle = title } }
     func recommended(_ on: Bool = true) -> Self { copy { $0.recommended = on } }

--- a/Sources/ThemeKit/Components/Organisms/AncillaryCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/AncillaryCard.swift
@@ -23,6 +23,8 @@ public struct AncillaryCard: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let title: String
     // Content/appearance — mutated only through the modifiers below (R2).
@@ -30,7 +32,7 @@ public struct AncillaryCard: View {
     private var imageURL: URL?
     private var subtitle: String?
     private var price: Decimal?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var priceSuffix: String?
     private var badgeText: String?
     private var quantity: Binding<Int>?
@@ -46,6 +48,9 @@ public struct AncillaryCard: View {
 
     @Environment(\.componentDefaults) private var defaults
     private var accentSemantic: SemanticColor { accent ?? defaults.accent ?? .primary }
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: radiusRole.value, style: .continuous) }
     private var isActive: Bool { (added?.wrappedValue ?? false) || ((quantity?.wrappedValue ?? 0) > 0) }
 
@@ -94,7 +99,7 @@ public struct AncillaryCard: View {
 
     private func priceLine(_ amount: Decimal) -> some View {
         HStack(spacing: 2) {
-            Text(amount.formatted(.currency(code: currencyCode).precision(.fractionLength(0))))
+            Text(amount.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0))))
                 .textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
             if let priceSuffix { Text(priceSuffix).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary)) }
         }
@@ -161,6 +166,13 @@ public extension AncillaryCard {
     func subtitle(_ text: String?) -> Self { copy { $0.subtitle = text } }
     func price(_ amount: Decimal?, currencyCode: String = "TRY", suffix: String? = nil) -> Self {
         copy { $0.price = amount; $0.currencyCode = currencyCode; $0.priceSuffix = suffix }
+    }
+    /// Omitted-currency form — resolves the code from the environment:
+    /// `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
+    /// Replicates every parameter except `currencyCode` so
+    /// `price(450, suffix: "/ bag")` binds here, not the hardcoded default.
+    func price(_ amount: Decimal?, suffix: String? = nil) -> Self {
+        copy { $0.price = amount; $0.priceSuffix = suffix }
     }
     func badge(_ text: String?) -> Self { copy { $0.badgeText = text } }
     /// A quantity stepper bound to `binding` (mutually exclusive with ``added(_:)``).

--- a/Sources/ThemeKit/Components/Organisms/DestinationCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/DestinationCard.swift
@@ -27,6 +27,8 @@ public struct DestinationCard: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     // Required content (R1).
     private let title: String
@@ -35,7 +37,7 @@ public struct DestinationCard: View {
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
     private var subtitle: String?
     private var price: Decimal?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var rating: Double?
     private var ribbon: String?
     private var ribbonColor: SemanticColor = .primary
@@ -53,6 +55,11 @@ public struct DestinationCard: View {
     public init(_ title: String, image url: URL? = nil) {   // R1 — content
         self.title = title
         self.imageURL = url
+    }
+
+    /// Explicit `price(_:currencyCode:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
     public var body: some View {
@@ -165,7 +172,7 @@ public struct DestinationCard: View {
             }
             if price != nil || rating != nil || footerSlot != nil {
                 HStack(alignment: .center) {
-                    if let price { PriceTag(price, currencyCode: currencyCode).emphasis(.hero) }
+                    if let price { PriceTag(price, currencyCode: resolvedCurrency).emphasis(.hero) }
                     Spacer(minLength: Theme.SpacingKey.sm.value)
                     if let rating { ScoreBadge(rating) }
                 }
@@ -185,6 +192,9 @@ public extension DestinationCard {
     func subtitle(_ text: String?) -> Self { copy { $0.subtitle = text } }
     /// The price, rendered as a hero `PriceTag` in the footer row.
     func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// Omitted-currency overload — the currency resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
+    func price(_ amount: Decimal?) -> Self { copy { $0.price = amount } }
     /// A 0–5 review score, rendered as a `ScoreBadge`.
     func rating(_ value: Double?) -> Self { copy { $0.rating = value } }
     /// A corner ribbon, e.g. "Top #1".

--- a/Sources/ThemeKit/Components/Organisms/FareFamilyCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/FareFamilyCard.swift
@@ -29,13 +29,15 @@ import SwiftUI
 public struct FareFamilyCard: View {
     @Environment(\.componentDensity) private var density
     @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     // Required content (R1).
     private let name: String
     private let price: Decimal
     // Appearance/state — mutated only through the modifiers below (R2).
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var accent: SemanticColor = .success
     private var features: [FareFeature] = []
     private var isSelected = false
@@ -49,6 +51,11 @@ public struct FareFamilyCard: View {
     }
 
     private var active: Bool { selection?.wrappedValue ?? isSelected }
+
+    /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
 
     public var body: some View {
         // The shell (fill, hairline, selected hero frame) is drawn by the active
@@ -96,7 +103,7 @@ public struct FareFamilyCard: View {
     @ViewBuilder private var footer: some View {
         if let selection {
             HStack {
-                PriceTag(price, currencyCode: currencyCode).emphasis(.hero)
+                PriceTag(price, currencyCode: resolvedCurrency).emphasis(.hero)
                 Spacer()
                 RadioButton(isSelected: selection)
             }
@@ -109,7 +116,7 @@ public struct FareFamilyCard: View {
     }
 
     private var priceText: String {
-        price.formatted(.currency(code: currencyCode).precision(.fractionLength(2)))
+        price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(2)))
     }
     private func select() { selection?.wrappedValue = true; onSelect?() }
 }
@@ -119,7 +126,8 @@ public struct FareFamilyCard: View {
 public extension FareFamilyCard {
     /// Surface fill (background token key, default `.bgBase`).
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
-    /// Currency code for the price (default "TRY").
+    /// Currency code for the price. Unset, it resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
     /// The tier accent colour — brands the name badge and CTA (green / orange / purple…).
     func accent(_ color: SemanticColor) -> Self { copy { $0.accent = color } }

--- a/Sources/ThemeKit/Components/Organisms/FareSummary.swift
+++ b/Sources/ThemeKit/Components/Organisms/FareSummary.swift
@@ -24,9 +24,11 @@ import SwiftUI
 public struct FareSummary: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let lines: [FareLine]
-    private let currencyCode: String
+    private let currencyCode: String?
     // Appearance/state — mutated only through the modifiers below (R2).
     private var onInfoHandler: ((FareLine) -> Void)?
     private var footerSlot: AnyView?
@@ -34,6 +36,17 @@ public struct FareSummary: View {
     public init(_ lines: [FareLine], currencyCode: String = "TRY") {   // R1 — content
         self.lines = lines
         self.currencyCode = currencyCode
+    }
+
+    /// Omitted-currency form — resolves the code from the environment:
+    /// `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
+    public init(_ lines: [FareLine]) {   // R1 — content
+        self.lines = lines
+        self.currencyCode = nil
+    }
+
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
     public var body: some View {
@@ -74,13 +87,13 @@ public struct FareSummary: View {
             HStack {
                 Text(line.label).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
                 Spacer()
-                PriceTag(line.amount, currencyCode: currencyCode).size(.large).emphasis(.hero).animatesValue()
+                PriceTag(line.amount, currencyCode: resolvedCurrency).size(.large).emphasis(.hero).animatesValue()
             }
         }
     }
 
     private func formatted(_ value: Decimal) -> String {
-        value.formatted(.currency(code: currencyCode).precision(.fractionLength(0)))
+        value.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0)))
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/FlightCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightCard.swift
@@ -28,6 +28,8 @@ public struct FlightCard: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     // Required content (R1).
     private let airline: String
@@ -40,7 +42,7 @@ public struct FlightCard: View {
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
     private var stops: Int = 0
     private var price: Decimal?
-    private var currencyCode: String = "TRY"
+    private var currencyCode: String?
     private var airlineSystemImage: String = "airplane.circle.fill"
     private var badge: String?
     private var onSelect: (() -> Void)?
@@ -202,9 +204,14 @@ public struct FlightCard: View {
         .accessibilityElement(children: .combine)
     }
 
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
+
     private func timeColumn(_ date: Date, code: String, alignment: HorizontalAlignment) -> some View {
         VStack(alignment: alignment, spacing: 2) {
-            Text(date.formatted(date: .omitted, time: .shortened))
+            // Captured-locale fix (§10): schedule times honour the injected \.locale.
+            Text(date.formatted(Date.FormatStyle(date: .omitted, time: .shortened).locale(locale)))
                 .textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
             Text(code)
                 .textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary))
@@ -237,7 +244,7 @@ public struct FlightCard: View {
             footerSlot
         } else {
             HStack {
-                if let price { PriceTag(price, currencyCode: currencyCode).size(.large).emphasis(.hero) }
+                if let price { PriceTag(price, currencyCode: resolvedCurrency).size(.large).emphasis(.hero) }
                 Spacer()
                 if let onSelect { PrimaryButton("Select") { onSelect() }.size(.small) }
             }
@@ -269,6 +276,9 @@ public extension FlightCard {
     func stops(_ count: Int) -> Self { copy { $0.stops = max(0, count) } }
     /// The fare, rendered as a hero `PriceTag` in the footer.
     func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// Omitted-currency form — resolves the code from the environment:
+    /// `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
+    func price(_ amount: Decimal?) -> Self { copy { $0.price = amount } }
     /// A leading airline SF Symbol (default `airplane.circle.fill`).
     func airlineIcon(_ systemName: String) -> Self { copy { $0.airlineSystemImage = systemName } }
     /// A success badge in the header, e.g. `"Cheapest"`.

--- a/Sources/ThemeKit/Components/Organisms/FlightListItem.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightListItem.swift
@@ -26,6 +26,7 @@ public struct FlightListItem: View {
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.locale) private var locale
+    @Environment(\.formatDefaults) private var formatDefaults
     @Environment(\.flightListItemStyle) private var style
 
     // Required content (R1).
@@ -39,7 +40,7 @@ public struct FlightListItem: View {
     private var logo: AnyView?
     private var priceAmount: Decimal?
     private var originalAmount: Decimal?
-    private var currencyCode = "USD"
+    private var currencyCode: String?
     private var priceCaption: String?
     private var fares: [FlightFare] = []
     private var departures: [Date] = []
@@ -71,13 +72,17 @@ public struct FlightListItem: View {
                                departure: departure, arrival: arrival)]
     }
 
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
+
     public var body: some View {
         let expanded = expandedBinding?.wrappedValue ?? internalExpanded
         let configuration = FlightListItemConfiguration(
             legs: legs, sliceLabels: sliceLabels, flightNo: flightNo, cabin: cabin,
             airlineSystemImage: airlineSystemImage, logo: logo,
             priceAmount: priceAmount, originalAmount: originalAmount,
-            currencyCode: currencyCode, priceCaption: priceCaption,
+            currencyCode: resolvedCurrency, priceCaption: priceCaption,
             fares: fares, departures: departures, scheduleNote: scheduleNote,
             dealText: dealText, dealTone: dealTone, trend: trend,
             badge: badge, amenities: amenities,
@@ -116,6 +121,13 @@ public extension FlightListItem {
     /// The headline price. `caption` qualifies it ("from", "total · round trip").
     func price(_ amount: Decimal?, currencyCode: String = "USD", caption: String? = nil) -> Self {
         copy { $0.priceAmount = amount; $0.currencyCode = currencyCode; $0.priceCaption = caption }
+    }
+    /// Omitted-currency form — resolves the code from the environment:
+    /// `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
+    /// Replicates every parameter except `currencyCode` so
+    /// `price(214, caption: "from")` binds here, not the hardcoded default.
+    func price(_ amount: Decimal?, caption: String? = nil) -> Self {
+        copy { $0.priceAmount = amount; $0.priceCaption = caption }
     }
     /// A compare-at price (typical/undiscounted) — deal-aware styles strike it through.
     func original(_ amount: Decimal?) -> Self { copy { $0.originalAmount = amount } }

--- a/Sources/ThemeKit/Components/Organisms/FlightResultRow.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightResultRow.swift
@@ -22,6 +22,8 @@ public struct FlightResultRow: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     // Required content (R1).
     private let airline: String
@@ -38,7 +40,7 @@ public struct FlightResultRow: View {
     private var stops = 0
     private var extraLegs: [FlightLeg] = []
     private var price: Decimal?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var baggage: String?
     private var badge: String?
     private var favorite: Binding<Bool>?
@@ -107,6 +109,10 @@ public struct FlightResultRow: View {
         }
     }
 
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
+
     private var priceBlock: some View {
         VStack(alignment: .trailing, spacing: 4) {
             if favorite != nil || bookmark != nil {
@@ -127,9 +133,9 @@ public struct FlightResultRow: View {
                     }
                 }
             }
-            if let price { PriceTag(price, currencyCode: currencyCode).emphasis(.hero).fractionDigits(2) }
+            if let price { PriceTag(price, currencyCode: resolvedCurrency).emphasis(.hero).fractionDigits(2) }
             if let totalLabel, let totalAmount {
-                Text("\(totalLabel): \(totalAmount.formatted(.currency(code: currencyCode).precision(.fractionLength(0))))")
+                Text("\(totalLabel): \(totalAmount.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0))))")
                     .textStyle(.overline400).foregroundStyle(theme.text(.textTertiary)).fixedSize()
             }
             if let onSelect { ThemeButton(selectTitle) { onSelect() }.size(.small) }
@@ -178,6 +184,9 @@ public extension FlightResultRow {
     func addLeg(_ leg: FlightLeg) -> Self { copy { $0.extraLegs.append(leg) } }
     /// The fare.
     func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// Omitted-currency form — resolves the code from the environment:
+    /// `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
+    func price(_ amount: Decimal?) -> Self { copy { $0.price = amount } }
     /// A leading airline SF Symbol (default `airplane.circle.fill`).
     func airlineIcon(_ systemName: String) -> Self { copy { $0.airlineSystemImage = systemName } }
     /// A remote airline logo (overrides the SF Symbol).

--- a/Sources/ThemeKit/Components/Organisms/FlightTicketCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/FlightTicketCard.swift
@@ -28,6 +28,8 @@ import SwiftUI
 public struct FlightTicketCard: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let from: String
     private let to: String
@@ -42,7 +44,7 @@ public struct FlightTicketCard: View {
     private var airlineIcon = "airplane"
     private var airlineLogo: URL?
     private var price: Decimal?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var favorite: Binding<Bool>?
     private var accent: SemanticColor?
     private var elevation: CardElevation = .soft
@@ -54,6 +56,10 @@ public struct FlightTicketCard: View {
     }
 
     private var accentBase: Color { (accent ?? .primary).base }
+
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
 
     public var body: some View {
         // Decorative-shell exception: the perforated `TicketStub` surface (fill +
@@ -119,7 +125,7 @@ public struct FlightTicketCard: View {
             }
             if let airline { Text(airline).textStyle(.bodyBase500).foregroundStyle(theme.text(.textPrimary)).lineLimit(1) }
             Spacer(minLength: 6)
-            if let price { PriceTag(price, currencyCode: currencyCode).size(.medium).emphasis(.standard).fractionDigits(0) }
+            if let price { PriceTag(price, currencyCode: resolvedCurrency).size(.medium).emphasis(.standard).fractionDigits(0) }
             if let favorite {
                 Button { favorite.wrappedValue.toggle() } label: {
                     Image(systemName: favorite.wrappedValue ? "heart.fill" : "heart")
@@ -154,6 +160,9 @@ public extension FlightTicketCard {
     func airline(_ name: String?, icon: String = "airplane") -> Self { copy { $0.airline = name; $0.airlineIcon = icon } }
     func airlineLogo(_ url: URL?) -> Self { copy { $0.airlineLogo = url } }
     func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// Omitted-currency form — resolves the code from the environment:
+    /// `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
+    func price(_ amount: Decimal?) -> Self { copy { $0.price = amount } }
     func favorite(_ binding: Binding<Bool>) -> Self { copy { $0.favorite = binding } }
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     func elevation(_ e: CardElevation) -> Self { copy { $0.elevation = e } }

--- a/Sources/ThemeKit/Components/Organisms/HotelResultCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/HotelResultCard.swift
@@ -22,6 +22,8 @@ public struct HotelResultCard: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let name: String
     // Content — mutated only through the modifiers below (R2).
@@ -35,7 +37,7 @@ public struct HotelResultCard: View {
     private var features: [String] = []
     private var promos: [String] = []
     private var price: Decimal?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var originalPrice: Decimal?
     private var discountText: String?
     private var stayText: String?
@@ -61,6 +63,11 @@ public struct HotelResultCard: View {
 
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: radiusRole.value, style: .continuous) }
     private var accentColor: Color { accent.map { $0.base } ?? theme.foreground(.fgHero) }
+
+    /// Explicit `price(_:currencyCode:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
 
     public var body: some View {
         // The shell (fill, corner clipping, border, shadow) is drawn by the active
@@ -200,7 +207,7 @@ public struct HotelResultCard: View {
     /// The reusable ``PriceBreakdown`` molecule, configured from this card's fields.
     private var priceBreakdown: PriceBreakdown? {
         guard let price else { return nil }
-        var b = PriceBreakdown(price, currencyCode: currencyCode).size(.large).emphasis(.standard)
+        var b = PriceBreakdown(price, currencyCode: resolvedCurrency).size(.large).emphasis(.standard)
         if let stayText { b = b.note(stayText) }
         if let originalPrice { b = b.original(originalPrice) }
         if let discountText { b = b.discountBadge(discountText) }
@@ -239,6 +246,9 @@ public extension HotelResultCard {
     func features(_ items: [String]) -> Self { copy { $0.features = items } }
     func promos(_ items: [String]) -> Self { copy { $0.promos = items } }
     func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// Omitted-currency overload — the currency resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
+    func price(_ amount: Decimal?) -> Self { copy { $0.price = amount } }
     func original(_ amount: Decimal?) -> Self { copy { $0.originalPrice = amount } }
     func discountBadge(_ text: String?) -> Self { copy { $0.discountText = text } }
     func stay(_ text: String?) -> Self { copy { $0.stayText = text } }

--- a/Sources/ThemeKit/Components/Organisms/MapCallout.swift
+++ b/Sources/ThemeKit/Components/Organisms/MapCallout.swift
@@ -27,6 +27,8 @@ public struct MapCallout: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let title: String
     // Content — mutated only through the modifiers below (R2).
@@ -34,7 +36,7 @@ public struct MapCallout: View {
     private var subtitle: String?
     private var score: Double?
     private var price: Decimal?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var onSelect: (() -> Void)?
     private var accent: SemanticColor?
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
@@ -43,6 +45,11 @@ public struct MapCallout: View {
     public init(title: String) { self.title = title }   // R1
 
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous) }
+
+    /// Explicit `price(_:currencyCode:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
 
     public var body: some View {
         VStack(spacing: 0) {
@@ -89,7 +96,7 @@ public struct MapCallout: View {
                 if let subtitle { Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(1) }
                 HStack(spacing: 6) {
                     if let score { ScoreBadge(score) }
-                    if let price { PriceTag(price, currencyCode: currencyCode).size(.small).emphasis(.hero).fractionDigits(0) }
+                    if let price { PriceTag(price, currencyCode: resolvedCurrency).size(.small).emphasis(.hero).fractionDigits(0) }
                 }
             }
             Spacer(minLength: 4)
@@ -120,6 +127,9 @@ public extension MapCallout {
     func subtitle(_ text: String?) -> Self { copy { $0.subtitle = text } }
     func score(_ value: Double?) -> Self { copy { $0.score = value } }
     func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// Omitted-currency overload — the currency resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
+    func price(_ amount: Decimal?) -> Self { copy { $0.price = amount } }
     func onSelect(_ action: @escaping () -> Void) -> Self { copy { $0.onSelect = action } }
     /// Tints the border and CTA chevron (default: neutral border, tertiary chevron).
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }

--- a/Sources/ThemeKit/Components/Organisms/PriceAlertCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/PriceAlertCard.swift
@@ -26,6 +26,8 @@ public struct PriceAlertCard: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let title: String
     @Binding private var isOn: Bool
@@ -33,7 +35,7 @@ public struct PriceAlertCard: View {
     private var subtitle: String?
     private var systemImage = "bell.fill"
     private var price: Decimal?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var trend: PriceTrend?
     private var trendText: String?
     private var accent: SemanticColor?
@@ -48,6 +50,11 @@ public struct PriceAlertCard: View {
 
     @Environment(\.componentDefaults) private var defaults
     private var accentSemantic: SemanticColor { accent ?? defaults.accent ?? .primary }
+
+    /// Explicit `price(_:currencyCode:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
     private var trendColor: Color {
         switch trend { case .down: theme.foreground(.systemcolorsFgSuccess); case .up: theme.foreground(.systemcolorsFgError); default: theme.text(.textSecondary) }
     }
@@ -91,7 +98,7 @@ public struct PriceAlertCard: View {
 
     private var priceTrend: some View {
         HStack(spacing: 6) {
-            if let price { PriceTag(price, currencyCode: currencyCode).size(.small).fractionDigits(0) }
+            if let price { PriceTag(price, currencyCode: resolvedCurrency).size(.small).fractionDigits(0) }
             if trend != nil {
                 HStack(spacing: 2) {
                     Image(systemName: trendIcon).font(.system(size: 10, weight: .bold))
@@ -109,6 +116,9 @@ public extension PriceAlertCard {
     func subtitle(_ text: String?) -> Self { copy { $0.subtitle = text } }
     func icon(_ systemName: String) -> Self { copy { $0.systemImage = systemName } }
     func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// Omitted-currency overload — the currency resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
+    func price(_ amount: Decimal?) -> Self { copy { $0.price = amount } }
     func trend(_ direction: PriceTrend?, _ text: String? = nil) -> Self { copy { $0.trend = direction; $0.trendText = text } }
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }

--- a/Sources/ThemeKit/Components/Organisms/RoomCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/RoomCard.swift
@@ -26,6 +26,8 @@ public struct RoomCard: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let name: String
     // Content — mutated only through the modifiers below (R2).
@@ -35,7 +37,7 @@ public struct RoomCard: View {
     private var occupancyIcon = "person.2.fill"
     private var features: [FareFeature] = []
     private var price: Decimal?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var originalPrice: Decimal?
     private var unit: String?
     private var discountText: String?
@@ -55,6 +57,11 @@ public struct RoomCard: View {
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: radiusRole.value, style: .continuous) }
     @Environment(\.componentDefaults) private var defaults
     private var accentSemantic: SemanticColor { accent ?? defaults.accent ?? .primary }
+
+    /// Explicit `price(_:currencyCode:)` > `\.formatDefaults` > locale currency > "USD" (§10).
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
 
     public var body: some View {
         // The shell (fill, corner clipping, border, shadow) is drawn by the active
@@ -97,7 +104,7 @@ public struct RoomCard: View {
 
     private var priceBreakdown: PriceBreakdown? {
         guard let price else { return nil }
-        var b = PriceBreakdown(price, currencyCode: currencyCode).size(.medium)
+        var b = PriceBreakdown(price, currencyCode: resolvedCurrency).size(.medium)
         if let unit { b = b.unit(unit) }
         if let originalPrice { b = b.original(originalPrice) }
         if let discountText { b = b.discountBadge(discountText) }
@@ -146,6 +153,9 @@ public extension RoomCard {
     func occupancy(_ text: String?, icon: String = "person.2.fill") -> Self { copy { $0.occupancy = text; $0.occupancyIcon = icon } }
     func features(_ items: [FareFeature]) -> Self { copy { $0.features = items } }
     func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// Omitted-currency overload — the currency resolves from `\.formatDefaults`,
+    /// then the locale's currency, then "USD".
+    func price(_ amount: Decimal?) -> Self { copy { $0.price = amount } }
     func original(_ amount: Decimal?) -> Self { copy { $0.originalPrice = amount } }
     func unit(_ text: String?) -> Self { copy { $0.unit = text } }
     func discountBadge(_ text: String?) -> Self { copy { $0.discountText = text } }

--- a/Sources/ThemeKit/Components/Organisms/SeatMap.swift
+++ b/Sources/ThemeKit/Components/Organisms/SeatMap.swift
@@ -30,6 +30,8 @@ public struct SeatMap: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let sections: [SeatSection]
     private let index: SeatIndex
@@ -46,7 +48,7 @@ public struct SeatMap: View {
     private var showsFuselage = false
     private var showsInfo = false
     private var recommended: Set<String> = []
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var seatEnabled: ((Seat) -> Bool)?
     private var passengers: [Passenger] = []
     private var assignment: Binding<[String: String]>?
@@ -60,6 +62,9 @@ public struct SeatMap: View {
     private var passengerMode: Bool { !passengers.isEmpty && assignment != nil }
     private var gapWidth: CGFloat { aisleWidthOverride ?? seatSize }
     private var palette: SeatPalette { SeatPalette(tierOverrides) }
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
 
     // MARK: Init (all delegate to `sections:` so the index is built once)
 
@@ -97,7 +102,7 @@ public struct SeatMap: View {
                 SeatSummaryBar(seat: focusedSeat.flatMap { index.byId[$0] },
                                position: focusedSeat.flatMap { index.positions[$0] },
                                palette: palette, selectedCount: selection.count,
-                               totalPrice: totalPrice, hasPrices: index.hasPrices, currencyCode: currencyCode)
+                               totalPrice: totalPrice, hasPrices: index.hasPrices, currencyCode: resolvedCurrency)
             }
         }
     }
@@ -171,7 +176,7 @@ public struct SeatMap: View {
         return SeatCell(seat, size: seatSize, isSelected: selected, isSelectable: isSelectable(seat),
                         isRecommended: recommended.contains(seat.id), assignedInitials: assigned,
                         display: seatDisplay, palette: palette, customContent: customContent,
-                        currencyCode: currencyCode, action: {
+                        currencyCode: resolvedCurrency, action: {
             focusedSeat = seat.id
             withAnimation(Animation.snappy.ifMotionAllowed(reduceMotion)) {
                 if passengerMode { assignSeat(seat) } else { toggle(seat) }
@@ -257,7 +262,8 @@ public extension SeatMap {
     func showsSeatInfo(_ on: Bool = true) -> Self { copy { $0.showsInfo = on } }
     /// Highlights recommended seats with a star.
     func recommended(_ ids: Set<String>) -> Self { copy { $0.recommended = ids } }
-    /// Currency code for per-seat and total pricing (default "TRY").
+    /// Currency code for per-seat and total pricing. When unset it resolves from
+    /// the environment: `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
     /// A custom availability predicate — return false to block a seat (e.g. exit rows
     /// for a passenger with an infant). Blocked seats render dimmed and untappable.

--- a/Sources/ThemeKit/Components/Organisms/StickyBookingBar.swift
+++ b/Sources/ThemeKit/Components/Organisms/StickyBookingBar.swift
@@ -27,12 +27,14 @@ public struct StickyBookingBar: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.barStyle) private var barStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
 
     private let ctaTitle: String
     private let action: () -> Void
     // Content/appearance — mutated only through the modifiers below (R2).
     private var price: Decimal?
-    private var currencyCode = "TRY"
+    private var currencyCode: String?
     private var originalPrice: Decimal?
     private var note: String?
     private var discountText: String?
@@ -54,6 +56,10 @@ public struct StickyBookingBar: View {
 
     @Environment(\.componentDefaults) private var defaults
     private var accentSemantic: SemanticColor { accent ?? defaults.accent ?? .primary }
+
+    private var resolvedCurrency: String {
+        currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
+    }
 
     public var body: some View {
         if barStyle.isDefault {
@@ -97,7 +103,7 @@ public struct StickyBookingBar: View {
     }
     private var priceBreakdown: PriceBreakdown? {
         guard let price else { return nil }
-        var b = PriceBreakdown(price, currencyCode: currencyCode).size(.large).emphasis(.hero)
+        var b = PriceBreakdown(price, currencyCode: resolvedCurrency).size(.large).emphasis(.hero)
         if let note { b = b.note(note) }
         if let originalPrice { b = b.original(originalPrice) }
         if let discountText { b = b.discountBadge(discountText) }
@@ -125,6 +131,9 @@ private struct BarShadow: ViewModifier {
 
 public extension StickyBookingBar {
     func price(_ amount: Decimal?, currencyCode: String = "TRY") -> Self { copy { $0.price = amount; $0.currencyCode = currencyCode } }
+    /// Omitted-currency form — resolves the code from the environment:
+    /// `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
+    func price(_ amount: Decimal?) -> Self { copy { $0.price = amount } }
     func original(_ amount: Decimal?) -> Self { copy { $0.originalPrice = amount } }
     func note(_ text: String?) -> Self { copy { $0.note = text } }
     func discountBadge(_ text: String?) -> Self { copy { $0.discountText = text } }

--- a/Sources/ThemeKit/FormatDefaults.swift
+++ b/Sources/ThemeKit/FormatDefaults.swift
@@ -1,0 +1,45 @@
+//
+//  FormatDefaults.swift
+//  ThemeKit
+//
+//  A subtree-level "house style" for formatting — the app-wide currency code that
+//  price-bearing components use when a call site doesn't pass one. Set it once with
+//  `.formatDefaults(...)` and components read it as their default. Additive and
+//  Open/Closed: a per-call argument still wins; this only fills the default.
+//
+//  Resolution chain (per §10): explicit argument > formatDefaults.currencyCode
+//  > locale.currency?.identifier > "USD".
+//
+//  ```swift
+//  BookingScreen()
+//      .formatDefaults(currencyCode: "EUR")
+//  ```
+//
+
+import SwiftUI
+
+public struct FormatDefaults: Equatable, Sendable {
+    /// ISO-4217 code price components use when a call site doesn't pass one.
+    public var currencyCode: String?
+    public init(currencyCode: String? = nil) { self.currencyCode = currencyCode }
+}
+
+private struct FormatDefaultsKey: EnvironmentKey {
+    static let defaultValue = FormatDefaults()
+}
+
+public extension EnvironmentValues {
+    var formatDefaults: FormatDefaults {
+        get { self[FormatDefaultsKey.self] }
+        set { self[FormatDefaultsKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// House formatting defaults for this subtree. Per-call arguments still win.
+    func formatDefaults(currencyCode: String? = nil) -> some View {
+        transformEnvironment(\.formatDefaults) { d in
+            if let currencyCode { d.currencyCode = currencyCode }
+        }
+    }
+}


### PR DESCRIPTION
Unit **F0.3** of the ThemeKitTravel plan (ADR-F2 / §10). Replaces the hardcoded per-component currency default with a subtree-scoped, environment-resolved chain — the one consumer-visible behavior change in the F0 foundations, landed early per the ADR.

### New neutral env (`Sources/ThemeKit/FormatDefaults.swift`)
`FormatDefaults(currencyCode:)` (`Equatable, Sendable`) + `\.formatDefaults` env key + `.formatDefaults(currencyCode:)` non-nil-merge modifier, modeled on `ComponentDefaults`.

### Resolution chain (read-side only)
```
explicit currencyCode arg  >  \.formatDefaults.currencyCode
  >  \.locale.currency?.identifier  >  "USD" (terminal fallback)
```
Applied uniformly across **23 price components** (PriceTag, SeatCell, FareSummary, FlightCard/ResultRow/TicketCard, FlightListItem, StickyBookingBar, AncillaryCard, SeatMap, DatePriceStrip, Installment{Picker,Selector}, PriceBreakdown, PriceHistogram, PriceTrendChart, DestinationCard, RoomCard, MapCallout, AgentPriceRow, PriceAlertCard, FareFamilyCard, HotelResultCard): private currency storage → optional; a `resolvedCurrency` helper reads `\.formatDefaults` + `\.locale`.

### Source-compatible (api-gate green)
Via the proven **omitted-argument overload pair** (Q3 mechanic): each modifier/init that defaulted `currencyCode` gains an overload *without* the param (replicating all other params, e.g. `caption`/`suffix`) that leaves storage nil → resolution kicks in; the existing signature is untouched, so explicit callers still win. Verified by an executable overload-preference probe (omitting calls bind the new overload; `price(214, caption:)` too).

Also threads the captured `\.locale` through the last device-locale stragglers (FlightCard.timeColumn; FlightRoute accessibility summary).

### ⚠️ Behavior change (intended, render-visible, source-compatible)
A call site that omitted `currencyCode:` and relied on silent `TRY`/`USD` now resolves from `formatDefaults` → locale currency. Pin with `.formatDefaults(currencyCode: "TRY")` at the root or pass explicit codes. CHANGELOG documents it.

### Verification
- `swift build` clean; **full suite 284 tests, 0 failures** (4 opt-in snapshots skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)