### PR TITLE
feat(travel): PassengerForm + PaymentMethodSelector edition organisms (F1.2, F1.3)

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1A1111111111111111111112 /* ThemeKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1A1111111111111111111111 /* ThemeKit */; };
 		1A1111111111111111111122 /* ThemeKitCalendar in Frameworks */ = {isa = PBXBuildFile; productRef = 1A1111111111111111111121 /* ThemeKitCalendar */; };
+		1A1111111111111111111132 /* ThemeKitTravel in Frameworks */ = {isa = PBXBuildFile; productRef = 1A1111111111111111111131 /* ThemeKitTravel */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 			files = (
 				1A1111111111111111111112 /* ThemeKit in Frameworks */,
 				1A1111111111111111111122 /* ThemeKitCalendar in Frameworks */,
+				1A1111111111111111111132 /* ThemeKitTravel in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -70,6 +72,7 @@
 			packageProductDependencies = (
 				1A1111111111111111111111 /* ThemeKit */,
 				1A1111111111111111111121 /* ThemeKitCalendar */,
+				1A1111111111111111111131 /* ThemeKitTravel */,
 			);
 			productName = Demo;
 			productReference = 1A1111111111111111111105 /* Demo.app */;
@@ -344,6 +347,10 @@
 		1A1111111111111111111121 /* ThemeKitCalendar */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ThemeKitCalendar;
+		};
+		1A1111111111111111111131 /* ThemeKitTravel */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ThemeKitTravel;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Demo/Demo/Gallery/ComponentRegistry.swift
+++ b/Demo/Demo/Gallery/ComponentRegistry.swift
@@ -337,6 +337,8 @@ enum ComponentRegistry {
         .knob("MapCallout", .organisms, demo: MapCalloutDemo(), usage: ##"MapCallout(title: "Mirage Park Resort").image(url).score(8.9).price(9_600).onSelect { }   // over any Map, no MapKit dep"##),
         .knob("AgentPriceRow", .organisms, demo: AgentPriceRowDemo(), usage: ##"AgentPriceRow("Trip.com") { open() }.logo(url).rating(4.2).badge("Cheapest").original(4_100).price(3_538).cta("Go to site").recommended()"##),
         .knob("PriceAlertCard", .organisms, demo: PriceAlertCardDemo(), usage: ##"PriceAlertCard("Get price alerts", isOn: $alerts).subtitle("…").price(3_538).trend(.down, "-8%")"##),
+        .knob("PassengerForm", .organisms, demo: PassengerFormDemo(), usage: ##"PassengerForm("Passenger 1 · Adult", draft: $traveler).documentRequired().validator(form)   // ThemeKitTravel"##, isNew: true),
+        .knob("PaymentMethodSelector", .organisms, demo: PaymentMethodSelectorDemo(), usage: ##"PaymentMethodSelector(options, selection: $method).installments([1,3,6], selection: $months, total: fareTotal)   // ThemeKitTravel"##, isNew: true),
         .knob("PaymentCardField", .molecules, demo: PaymentCardFieldDemo(), usage: ##"PaymentCardField(number: $n, expiry: $e, cvv: $c).holder($name)   // brand auto-detect + 4-4-4-4 / MM/YY"##),
         .knob("InstallmentPicker", .molecules, demo: InstallmentPickerDemo(), usage: ##"InstallmentPicker([InstallmentOption(count: 3, total: 9_900, monthly: 3_300), …], selection: $count).currency("TRY")"##),
         .knob("MapPriceMarker", .molecules, demo: MapPriceMarkerDemo(), usage: ##"MapPriceMarker("₺1.250").selected(isActive).icon("heart.fill")   // in any Map annotation"##),

--- a/Demo/Demo/Gallery/Demos/PassengerFormDemo.swift
+++ b/Demo/Demo/Gallery/Demos/PassengerFormDemo.swift
@@ -1,0 +1,106 @@
+// REGISTER: PassengerForm · deep-link "PassengerForm" · organism · isNew
+//
+//  PassengerFormDemo.swift
+//  Demo
+//
+//  Interactive demo page for the ThemeKitTravel PassengerForm organism (F1.2).
+//  Live knobs for the field list, documentRequired, the validator wiring and
+//  the slot/accent modifiers; submission follows the §1.4 rev-4 call site
+//  (`form.validateAll(draft.formValues)` — canonical ISO-8601/rawValue strings).
+//
+
+import SwiftUI
+import ThemeKit
+import ThemeKitTravel
+
+struct PassengerFormDemo: View {
+    @State private var draft = PassengerDraft()
+    @State private var documentSection = true
+    @State private var showNationality = true
+    @State private var documentRequired = true
+    @State private var useValidator = true
+    @State private var accentOn = false
+    @State private var footerSlot = false
+    @State private var accepted = false
+
+    // FormValidator takes a KeyValuePairs literal, so the two field-list shapes
+    // get one validator each and the knob switches between them.
+    @State private var fullForm = FormValidator<PassengerFormField>([
+        .givenName: [.required()],
+        .familyName: [.required()],
+        .gender: [.required()],
+        .dateOfBirth: [.required()],
+        .documentNumber: [.required(), .documentNumber],
+        .documentExpiry: [.required(), .expiryInFuture()],
+    ])
+    @State private var basicForm = FormValidator<PassengerFormField>([
+        .givenName: [.required()],
+        .familyName: [.required()],
+        .dateOfBirth: [.required()],
+    ])
+
+    private var form: FormValidator<PassengerFormField> { documentSection ? fullForm : basicForm }
+
+    private var fieldList: [PassengerFormField] {
+        var fields: [PassengerFormField] = [.givenName, .familyName, .gender, .dateOfBirth]
+        if showNationality { fields.append(.nationality) }
+        if documentSection { fields += [.documentNumber, .documentExpiry] }
+        return fields
+    }
+
+    private var passengerForm: PassengerForm {
+        var pf = PassengerForm("Passenger 1 · Adult", draft: $draft)
+            .fields(fieldList)
+            .documentRequired(documentRequired)
+        if useValidator { pf = pf.validator(form) }
+        if accentOn { pf = pf.accent(.accent) }
+        if footerSlot {
+            pf = pf.footer {
+                Text("Enter the name exactly as printed on the travel document.")
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(Theme.shared.text(.textTertiary))
+            }
+        }
+        return pf
+    }
+
+    var body: some View {
+        ComponentStage("PassengerForm", inspector: [
+            ("fields", "\(fieldList.count)"),
+            ("documentRequired", "\(documentRequired)"),
+            ("validator", useValidator ? "wired" : "off"),
+            ("accepted", "\(accepted)"),
+        ]) {
+            VStack(alignment: .leading, spacing: 16) {
+                passengerForm
+
+                if useValidator {
+                    PrimaryButton("Continue") {
+                        // §1.4 rev 4 — submit via validateAll + canonical formValues:
+                        accepted = form.validateAll(draft.formValues) == nil
+                    }
+                    .fullWidth()
+                }
+
+                if accepted {
+                    Text("Traveler accepted — draft reads back whole.")
+                        .textStyle(.labelSm600)
+                        .foregroundStyle(Theme.shared.foreground(.systemcolorsFgSuccess))
+                }
+            }
+        } knobs: {
+            Toggle("Travel document section", isOn: $documentSection)
+            Toggle("Nationality field", isOn: $showNationality)
+            Toggle("Document required (asterisks + rule pack)", isOn: $documentRequired)
+            Toggle("Validator wired (messages · focus · live re-validate)", isOn: $useValidator)
+            Toggle("Accent tint (pickers, menu checkmarks)", isOn: $accentOn)
+            Toggle("Footer slot", isOn: $footerSlot)
+            Button("Reset draft + validation") {
+                draft = PassengerDraft()
+                fullForm.reset()
+                basicForm.reset()
+                accepted = false
+            }
+        }
+    }
+}

--- a/Demo/Demo/Gallery/Demos/PaymentMethodSelectorDemo.swift
+++ b/Demo/Demo/Gallery/Demos/PaymentMethodSelectorDemo.swift
@@ -1,0 +1,73 @@
+// REGISTER: PaymentMethodSelector · deep-link "PaymentMethodSelector" · organism · isNew
+//
+//  PaymentMethodSelectorDemo.swift
+//  Demo
+//
+//  Interactive demo for the ThemeKitTravel `PaymentMethodSelector` organism
+//  (F1.3) — variant, inline installments, per-option badge, disabled methods,
+//  accent and footer are all live knobs.
+//
+
+import SwiftUI
+import ThemeKit
+import ThemeKitTravel
+
+struct PaymentMethodSelectorDemo: View {
+    @State private var method: String? = "card"
+    @State private var months = 3
+    @State private var variant: PaymentMethodVariant = .list
+    @State private var showInstallments = true
+    @State private var showBadge = true
+    @State private var disableWallet = true
+    @State private var accented = false
+    @State private var showFooter = true
+    @State private var readOnly = false
+
+    private let options: [PaymentMethodOption] = [
+        .init(id: "card", kind: .card, title: "Credit / debit card"),
+        .init(id: "wallet", kind: .wallet, title: "Digital wallet", subtitle: "Pay in one tap"),
+        .init(id: "transfer", kind: .transfer, title: "Bank transfer"),
+    ]
+
+    private var selector: some View {
+        var s = PaymentMethodSelector(options, selection: $method)
+            .variant(variant)
+            .disabledMethods(disableWallet ? ["wallet"] : [])
+            .accent(accented ? .success : nil)
+        if showInstallments {
+            s = s.installments([1, 3, 6, 9], selection: $months, total: 1_240)
+        }
+        if showBadge {
+            s = s.badge("No fee", for: "transfer")
+        }
+        if showFooter {
+            s = s.footer {
+                Text("All payments are encrypted.")
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(Theme.shared.text(.textTertiary))
+            }
+        }
+        return s.readOnly(readOnly)
+    }
+
+    var body: some View {
+        ComponentStage("PaymentMethodSelector", inspector: [
+            ("selection", method ?? "nil"),
+            ("variant", variant == .list ? "list" : "grid"),
+            ("installments", showInstallments ? "\(months)×" : "off"),
+        ]) {
+            selector
+        } knobs: {
+            Picker("Variant", selection: $variant) {
+                Text("List").tag(PaymentMethodVariant.list)
+                Text("Grid").tag(PaymentMethodVariant.grid)
+            }.pickerStyle(.segmented)
+            Toggle("Installments (total 1,240 · under card)", isOn: $showInstallments)
+            Toggle("Badge (\"No fee\" on transfer)", isOn: $showBadge)
+            Toggle("Disable wallet method", isOn: $disableWallet)
+            Toggle("Success accent", isOn: $accented)
+            Toggle("Footer slot", isOn: $showFooter)
+            Toggle("Read-only", isOn: $readOnly)
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/PassengerForm.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PassengerForm.swift
@@ -1,0 +1,418 @@
+//
+//  PassengerForm.swift
+//  ThemeKitTravel
+//
+//  Organism (§9.2, P0). The editable traveler-details form — name / gender /
+//  date of birth / nationality / travel document — bound to a `PassengerDraft`.
+//  Distinct from `PassengerRow` (a display row for review screens).
+//
+//  Composes neutral ThemeKit fields (`Fieldset`, `TextInput`, `SelectBox`,
+//  `DateField`); all of them inherit `FieldDefaults` / `FieldStyle` from the
+//  environment, so the form re-skins with the subtree's field chrome and needs
+//  no style protocol of its own (structure, not skinnable chrome).
+//
+//  Controlled-only (ADR-F4): a traveler form the app can't read is useless.
+//  Multi-passenger checkout is the app's `ForEach` of `PassengerForm`s — the
+//  component stays single-traveler.
+//
+//  Validation (ADR-F6, §1.4 rev 4): `.validator(_:)` wires every rendered
+//  field into one `FormValidator<PassengerFormField>`. Submission stays
+//  app-side against the canonical serialization:
+//
+//      if form.validateAll(traveler.formValues) == nil { proceed(traveler) }
+//
+//  Wiring nuance (documented, fine for Phase 1): the TextInput-backed fields
+//  (names, document number) use `.field(_:in:)` — their display string IS the
+//  canonical string, so messages, focus-first-invalid and live re-validation
+//  are exact. The SelectBox/DateField-backed fields display *localized* text
+//  while the canonical value is ISO-8601 / `rawValue`, so the form re-validates
+//  those from `draft.formValues` on change instead (same "only after the form
+//  has validated the field" gate as `.field`). Their focus analogs are
+//  best-effort: DateField opens its picker, SelectBox renders its focus ring.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - PassengerFormField
+
+/// The form's field keys — `FormValidator` keys, `formValues` keys, and the
+/// `fields(_:)` render list all speak this vocabulary.
+public enum PassengerFormField: Hashable, Sendable, CaseIterable {
+    case givenName, familyName, gender, dateOfBirth, nationality, documentNumber, documentExpiry
+}
+
+// MARK: - PassengerForm
+
+/// The editable traveler form for booking flows. Controlled-only: bind a
+/// `PassengerDraft` and read it back whole.
+///
+///     @State private var traveler = PassengerDraft()
+///     @State private var form = FormValidator<PassengerFormField>([
+///         .givenName: [.required()], .familyName: [.required()],
+///         .documentNumber: [.required(), .documentNumber],
+///         .documentExpiry: [.expiryInFuture(after: tripDate)],
+///     ])
+///
+///     PassengerForm("Passenger 1 · Adult", draft: $traveler)
+///         .documentRequired()
+///         .validator(form)
+///
+///     PrimaryButton("Continue") {
+///         if form.validateAll(traveler.formValues) == nil { proceed(traveler) }
+///     }
+public struct PassengerForm: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.locale) private var locale
+
+    private let title: String
+    @Binding private var draft: PassengerDraft
+
+    // Appearance/config — mutated only through the modifiers below (R2).
+    private var fieldList: [PassengerFormField] = Array(PassengerFormField.allCases)
+    private var explicitNationalities: [String]?
+    private var isDocumentRequired = false
+    private var explicitBirthRange: ClosedRange<Date>?
+    private var form: FormValidator<PassengerFormField>?
+    private var accent: SemanticColor?
+    private var customHeader: AnyView?
+    private var customFooter: AnyView?
+
+    /// R1 — title + controlled draft. Controlled-only (ADR-F4).
+    public init(_ title: String, draft: Binding<PassengerDraft>) {
+        self.title = title
+        self._draft = draft
+    }
+
+    // MARK: Derived state
+
+    private static let personalSection: [PassengerFormField] = [.givenName, .familyName, .gender, .dateOfBirth, .nationality]
+    private static let documentSection: [PassengerFormField] = [.documentNumber, .documentExpiry]
+
+    /// The render list partitioned into the two fieldsets, preserving the
+    /// caller's `fields(_:)` order within each.
+    private var personalFields: [PassengerFormField] { fieldList.filter(Self.personalSection.contains) }
+    private var documentFields: [PassengerFormField] { fieldList.filter(Self.documentSection.contains) }
+
+    /// Default DOB window: 120 years back … today. Clamped either way.
+    private var birthRange: ClosedRange<Date> {
+        if let explicitBirthRange { return explicitBirthRange }
+        let floor = Calendar.current.date(byAdding: .year, value: -120, to: .now) ?? .distantPast
+        return floor...Date.now
+    }
+
+    /// Expiry picker window: today … +50 years (an expiry is future by nature;
+    /// the *policy* check — valid past the trip date — is the validator's job).
+    private var expiryRange: ClosedRange<Date> {
+        let ceiling = Calendar.current.date(byAdding: .year, value: 50, to: .now) ?? .distantFuture
+        return Date.now...ceiling
+    }
+
+    /// ISO 3166-1 region codes for the nationality selector, sorted by their
+    /// localized display name in the environment locale.
+    private var nationalityCodes: [String] {
+        let codes = explicitNationalities
+            ?? Locale.Region.isoRegions
+                .map(\.identifier)
+                .filter { $0.count == 2 }   // countries — continents/macroregions are numeric (e.g. "150")
+        return codes.sorted { regionName($0) < regionName($1) }
+    }
+
+    private func regionName(_ code: String) -> String {
+        locale.localizedString(forRegionCode: code) ?? code
+    }
+
+    /// Non-TextInput fields whose canonical value (ISO-8601 / rawValue) differs
+    /// from the displayed text — live re-validation runs from `formValues`.
+    private static let canonicalRevalidated: [PassengerFormField] = [.gender, .dateOfBirth, .nationality, .documentExpiry]
+
+    // MARK: Body
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+            if let customHeader {
+                customHeader
+            } else {
+                titleHeader
+            }
+
+            if !personalFields.isEmpty {
+                Fieldset(String(themeKitTravel: "Personal details")) {
+                    ForEach(personalFields, id: \.self) { field(for: $0) }
+                }
+            }
+
+            if !documentFields.isEmpty {
+                Fieldset(String(themeKitTravel: "Travel document")) {
+                    ForEach(documentFields, id: \.self) { field(for: $0) }
+                }
+            }
+
+            if let customFooter { customFooter }
+        }
+        .tint(accent?.base)
+        // Live canonical re-validation for the select/date fields (see header
+        // note): same gate as `.field(_:in:)` — only once the form has
+        // validated the field (a failed submit or a prior live pass).
+        .onChange(of: draft) { _, newDraft in
+            guard let form else { return }
+            let values = newDraft.formValues
+            for field in Self.canonicalRevalidated
+            where fieldList.contains(field) && form.messages.index(forKey: field) != nil {
+                form.validate(field, values[field] ?? "")
+            }
+        }
+        // A labeled container: VoiceOver announces the traveler ("Passenger 1,
+        // Adult") before stepping into the fields, which self-label.
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(title)
+    }
+
+    // MARK: Sub-views
+
+    private var titleHeader: some View {
+        Text(title)
+            .textStyle(.headingSm)
+            .foregroundStyle(theme.text(.textPrimary))
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    @ViewBuilder
+    private func field(for field: PassengerFormField) -> some View {
+        switch field {
+        case .givenName: givenNameField
+        case .familyName: familyNameField
+        case .gender: genderField
+        case .dateOfBirth: birthDateField
+        case .nationality: nationalityField
+        case .documentNumber: documentNumberField
+        case .documentExpiry: documentExpiryField
+        }
+    }
+
+    private var givenNameField: some View {
+        var input = TextInput(String(themeKitTravel: "Given name"), text: $draft.givenName)
+            .keyboard(contentType: .givenName, submit: .next, capitalization: .words)
+            .a11yID("passenger-form.given-name")
+        if let form { input = input.field(.givenName, in: form) }
+        return input
+    }
+
+    private var familyNameField: some View {
+        var input = TextInput(String(themeKitTravel: "Family name"), text: $draft.familyName)
+            .keyboard(contentType: .familyName, submit: .next, capitalization: .words)
+            .a11yID("passenger-form.family-name")
+        if let form { input = input.field(.familyName, in: form) }
+        return input
+    }
+
+    private var genderField: some View {
+        var box = SelectBox(String(themeKitTravel: "Gender"),
+                            options: PassengerGender.allCases,
+                            selection: $draft.gender) { $0.label }
+            .a11yID("passenger-form.gender")
+        if let form {
+            box = box.infoMessages(form.messages(for: .gender))
+                .externalFocus(form.focusBinding(.gender))
+        }
+        return box
+    }
+
+    private var birthDateField: some View {
+        var field = DateField(String(themeKitTravel: "Date of birth"), date: $draft.dateOfBirth)
+            .range(birthRange)
+            .a11yID("passenger-form.date-of-birth")
+        if let form {
+            field = field.infoMessages(form.messages(for: .dateOfBirth))
+                .externalFocus(form.focusBinding(.dateOfBirth))
+        }
+        return field
+    }
+
+    private var nationalityField: some View {
+        var box = SelectBox(String(themeKitTravel: "Nationality"),
+                            options: nationalityCodes,
+                            selection: $draft.nationality) { regionName($0) }
+            .a11yID("passenger-form.nationality")
+        if let form {
+            box = box.infoMessages(form.messages(for: .nationality))
+                .externalFocus(form.focusBinding(.nationality))
+        }
+        return box
+    }
+
+    private var documentNumberField: some View {
+        var input = TextInput(String(themeKitTravel: "Document number"), text: $draft.documentNumber)
+            .keyboard(submit: .next, capitalization: .characters)
+            .required(isDocumentRequired)
+            .a11yID("passenger-form.document-number")
+        if let form {
+            input = input.field(.documentNumber, in: form)
+        } else if isDocumentRequired {
+            // No form brain wired — the rule pack runs field-locally instead.
+            input = input.validate([.required(), .documentNumber])
+        }
+        return input
+    }
+
+    private var documentExpiryField: some View {
+        var field = DateField(String(themeKitTravel: "Document expiry"), date: $draft.documentExpiry)
+            .range(expiryRange)   // picker prevents past dates; trip-date policy is the validator's
+            .required(isDocumentRequired)
+            .a11yID("passenger-form.document-expiry")
+        if let form {
+            field = field.infoMessages(form.messages(for: .documentExpiry))
+                .externalFocus(form.focusBinding(.documentExpiry))
+        } else if isDocumentRequired {
+            field = field.validate([.required()])
+        }
+        return field
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension PassengerForm {
+    /// Which fields render, in order (default: all). Absent fields aren't
+    /// rendered — and a wired validator only receives live re-validation for
+    /// rendered fields (declare rules only for what you render).
+    func fields(_ list: [PassengerFormField]) -> Self { copy { $0.fieldList = list } }
+
+    /// Nationality options as ISO 3166-1 region codes (default: all ISO
+    /// regions). Display names resolve via the environment `Locale`; the list
+    /// is sorted by localized name either way.
+    func nationalities(_ regions: [String]) -> Self { copy { $0.explicitNationalities = regions } }
+
+    /// Renders document number + expiry as required — asterisks on both, and
+    /// (only when no `validator(_:)` is wired) the rule pack runs field-locally:
+    /// `.required() + .documentNumber` on the number, `.required()` plus a
+    /// future-only picker window on the expiry. With a validator wired, declare
+    /// the rules there instead (see the type-level example) — the form never
+    /// double-validates.
+    func documentRequired(_ on: Bool = true) -> Self { copy { $0.isDocumentRequired = on } }
+
+    /// Selectable date-of-birth window (default: 120 years back … today).
+    /// The picker clamps to it.
+    func birthDateRange(_ range: ClosedRange<Date>) -> Self { copy { $0.explicitBirthRange = range } }
+
+    /// Wires every rendered field into the given validator (ADR-F6): messages,
+    /// focus and live re-validation flow through it, keyed by
+    /// `PassengerFormField`. Submission stays app-side:
+    /// `if form.validateAll(draft.formValues) == nil { … }`.
+    func validator(_ form: FormValidator<PassengerFormField>) -> Self { copy { $0.form = form } }
+
+    /// Accent tint for the interactive chrome (date pickers, menu checkmarks).
+    /// `nil` inherits the surrounding tint.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+
+    /// Replaces the built-in title row.
+    func header<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.customHeader = AnyView(content()) } }
+
+    /// Bottom-aligned accessory area under the fieldsets.
+    func footer<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.customFooter = AnyView(content()) } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+// MARK: - Previews
+
+#Preview("PassengerForm — validator wired") {
+    struct Demo: View {
+        @Environment(\.theme) private var theme
+        @State private var traveler = PassengerDraft()
+        @State private var accepted = false
+        @State private var form = FormValidator<PassengerFormField>([
+            .givenName: [.required()],
+            .familyName: [.required()],
+            .gender: [.required()],
+            .dateOfBirth: [.required()],
+            .documentNumber: [.required(), .documentNumber],
+            .documentExpiry: [.required(), .expiryInFuture()],
+        ])
+
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+                    PassengerForm("Passenger 1 · Adult", draft: $traveler)
+                        .documentRequired()
+                        .validator(form)
+                        .footer {
+                            Text("Enter the name exactly as printed on the travel document.")
+                                .textStyle(.bodySm400)
+                                .foregroundStyle(theme.text(.textTertiary))
+                        }
+
+                    PrimaryButton("Continue") {
+                        // §1.4 rev 4 — submission via validateAll + canonical formValues:
+                        accepted = form.validateAll(traveler.formValues) == nil
+                    }
+                    .fullWidth()
+
+                    if accepted {
+                        Text("Traveler accepted.")
+                            .textStyle(.labelSm600)
+                            .foregroundStyle(theme.foreground(.systemcolorsFgSuccess))
+                    }
+                }
+                .padding()
+            }
+            .background(theme.background(.bgBase))
+        }
+    }
+    return Demo()
+}
+
+#Preview("Variants — fields · accent · header · standalone rules") {
+    struct Demo: View {
+        @Environment(\.theme) private var theme
+        @State private var minimal = PassengerDraft()
+        @State private var domestic = PassengerDraft()
+
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                    // Domestic subset — no travel document, custom header, accent:
+                    PassengerForm("Traveler", draft: $domestic)
+                        .fields([.givenName, .familyName, .dateOfBirth])
+                        .accent(.accent)
+                        .header {
+                            HStack(spacing: Theme.SpacingKey.sm.value) {
+                                Icon(systemName: "person.text.rectangle")
+                                Text("Lead traveler").textStyle(.headingSm)
+                            }
+                        }
+
+                    // No validator — documentRequired runs the rule pack field-locally:
+                    PassengerForm("Passenger 2 · Adult", draft: $minimal)
+                        .documentRequired()
+                        .nationalities(["DE", "FR", "JP", "BR", "NO"])
+                        .birthDateRange(Date.distantPast...Date.now)
+                }
+                .padding()
+            }
+            .background(theme.background(.bgBase))
+        }
+    }
+    return Demo()
+}
+
+#Preview("Dark") {
+    struct Demo: View {
+        @State private var traveler = PassengerDraft()
+        var body: some View {
+            ScrollView {
+                PassengerForm("Passenger 1 · Adult", draft: $traveler)
+                    .documentRequired()
+                    .padding()
+            }
+            .background(Theme.shared.background(.bgBase))
+            .onAppear { Theme.shared.loadTheme(named: Theme.defaultThemeName, dark: true) }
+            .onDisappear { Theme.shared.loadTheme(named: Theme.defaultThemeName, dark: false) }
+        }
+    }
+    return Demo()
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelector.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelector.swift
@@ -1,0 +1,341 @@
+//
+//  PaymentMethodSelector.swift
+//  ThemeKitTravel
+//
+//  Edition organism (F1.3 · ADR §9.3). Choose how to pay — card / wallet /
+//  transfer rows (`.list`, the default) or tiles (`.grid`), with an optional
+//  inline `InstallmentPicker` under the selected `.card` option. Composes
+//  ThemeKit's neutral `ListRow` anatomy, `RadioButton`, `Badge` and
+//  `InstallmentPicker` — nothing is re-implemented here.
+//
+//  State follows ADR-F4: controlled-first (`selection: Binding<String?>`) plus
+//  an uncontrolled preview convenience (`initiallySelected:`), both funneled
+//  through `ControllableState`. Currency for the installment amounts is NOT a
+//  parameter — it resolves inside `InstallmentPicker` via the §10 chain
+//  (`\.formatDefaults` > locale currency > "USD").
+//
+//  ```swift
+//  PaymentMethodSelector(options, selection: $method)
+//      .installments([1, 3, 6, 9], selection: $months, total: fareTotal)
+//      .badge("No fee", for: "transfer")
+//  ```
+//
+
+import SwiftUI
+import ThemeKit
+
+/// Layout archetype of a ``PaymentMethodSelector``: radio rows or tiles.
+public enum PaymentMethodVariant: Sendable { case list, grid }
+
+/// A payment-method chooser — radio-semantic rows (or tiles) over
+/// ``PaymentMethodOption`` values, with an optional inline instalment picker
+/// under the selected card option.
+public struct PaymentMethodSelector: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.isReadOnly) private var isReadOnly
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let options: [PaymentMethodOption]
+    /// Selected option id — controlled or uncontrolled per init (ADR-F4).
+    @ControllableState private var selection: String?
+
+    // Config — mutated only through the modifiers below (R2).
+    private var variantValue: PaymentMethodVariant = .list
+    private var installmentMonths: [Int]?
+    private var installmentSelection: Binding<Int>?
+    private var installmentTotal: Decimal?
+    private var badges: [String: String] = [:]
+    private var disabledIDs: Set<String> = []
+    private var accent: SemanticColor?
+    private var footerSlot: AnyView?
+
+    /// R1 — options + controlled selection (option id). The binding is the
+    /// change channel; observe with `.onChange(of:)` at the call site.
+    public init(_ options: [PaymentMethodOption], selection: Binding<String?>) {
+        self.options = options
+        self._selection = ControllableState(wrappedValue: nil, external: selection)
+    }
+
+    /// Uncontrolled convenience (browse/preview contexts); the component owns
+    /// the selection and it reads back only visually.
+    public init(_ options: [PaymentMethodOption], initiallySelected: String? = nil) {
+        self.options = options
+        self._selection = ControllableState(wrappedValue: initiallySelected)
+    }
+
+    private var motion: Animation? {
+        MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion)
+    }
+    private var accentBase: Color { (accent ?? .primary).base }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+            switch variantValue {
+            case .list: listBody
+            case .grid: gridBody
+            }
+            if let footerSlot { footerSlot }
+        }
+        .animation(motion, value: selection)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(String(themeKitTravel: "Payment method, \(options.count) options"))
+    }
+
+    // MARK: List variant — ListRow anatomy with radio semantics
+
+    @MainActor
+    private var listBody: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(options.enumerated()), id: \.element.id) { index, option in
+                row(option)
+                if showsInstallments(under: option) {
+                    inlineInstallments
+                        .padding(.bottom, Theme.SpacingKey.sm.value)
+                }
+                if index < options.count - 1 {
+                    DividerView().size(.small)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func row(_ option: PaymentMethodOption) -> some View {
+        let isOn = selection == option.id
+        return ListRow(option.title) { select(option.id) }
+            .subtitle(option.subtitle)
+            .leading {
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    RadioButton(isSelected: isSelectedBinding(option.id)).accent(accent)
+                    Icon(systemName: option.systemImage)
+                        .size(.sm)
+                        .color(isOn ? accentBase : theme.text(.textSecondary))
+                }
+            }
+            .badge(badges[option.id])
+            .selected(isOn)
+            .trailing(ListRowTrailing.none)
+            .disabled(disabledIDs.contains(option.id))
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+
+    // MARK: Grid variant — selection tiles (vertical fallback at a11y sizes)
+
+    @MainActor
+    @ViewBuilder
+    private var gridBody: some View {
+        let gap = Theme.SpacingKey.sm.value
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(spacing: gap) { ForEach(options) { tile($0) } }
+        } else {
+            LazyVGrid(
+                columns: [GridItem(.flexible(), spacing: gap), GridItem(.flexible(), spacing: gap)],
+                spacing: gap
+            ) {
+                ForEach(options) { tile($0) }
+            }
+        }
+        if options.contains(where: { showsInstallments(under: $0) }) {
+            inlineInstallments
+        }
+    }
+
+    @MainActor
+    private func tile(_ option: PaymentMethodOption) -> some View {
+        let isOn = selection == option.id
+        let isDisabled = disabledIDs.contains(option.id)
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
+        return Button { select(option.id) } label: {
+            VStack(spacing: Theme.SpacingKey.xs.value) {
+                Icon(systemName: option.systemImage)
+                    .size(.md)
+                    .color(isDisabled ? theme.text(.textDisabled) : (isOn ? accentBase : theme.text(.textSecondary)))
+                Text(option.title)
+                    .textStyle(.labelSm600)
+                    .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
+                    .multilineTextAlignment(.center)
+                if let subtitle = option.subtitle {
+                    Text(subtitle)
+                        .textStyle(.bodySm400)
+                        .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textSecondary))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 88)
+            .padding(Theme.SpacingKey.md.value)
+            .background(isOn ? (accent ?? .primary).bg : theme.background(.bgBase), in: shape)
+            .overlay(shape.stroke(isOn ? accentBase : theme.border(.borderPrimary), lineWidth: isOn ? 1.5 : 1))
+            .overlay(alignment: .topTrailing) {
+                if let badgeText = badges[option.id] {
+                    Badge(badgeText).badgeStyle(.info).variant(.soft).size(.small)
+                        .padding(Theme.SpacingKey.xs.value)
+                }
+            }
+            .contentShape(shape)
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .allowsHitTesting(!isReadOnly)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+
+    // MARK: Installments (composes the existing InstallmentPicker)
+
+    /// Whether the inline instalment picker belongs under this option: the
+    /// modifier is configured, the option is the current selection, and it is
+    /// a `.card` method.
+    @MainActor
+    private func showsInstallments(under option: PaymentMethodOption) -> Bool {
+        installmentMonths?.isEmpty == false
+            && installmentSelection != nil
+            && installmentTotal != nil
+            && option.kind == .card
+            && option.id == selection
+    }
+
+    @MainActor
+    @ViewBuilder
+    private var inlineInstallments: some View {
+        if let months = installmentMonths, let picked = installmentSelection, let total = installmentTotal {
+            // Currency deliberately not set: InstallmentPicker resolves it via
+            // the §10 chain (`\.formatDefaults` > locale currency > "USD").
+            InstallmentPicker(months.map { count in
+                InstallmentOption(
+                    count: count,
+                    total: total,
+                    monthly: count > 1 ? total / Decimal(count) : nil
+                )
+            }, selection: picked)
+            .accent(accent)
+            .padding(.leading, Theme.SpacingKey.lg.value)
+            .transition(.opacity)
+        }
+    }
+
+    // MARK: Selection plumbing
+
+    @MainActor
+    private func select(_ id: String) {
+        guard !isReadOnly else { return }   // E1 — read-only blocks mutation, not focus
+        selection = id
+    }
+
+    /// Radio-style binding for one option: setting `true` selects it; a
+    /// payment method can't be deselected by tapping its own radio.
+    @MainActor
+    private func isSelectedBinding(_ id: String) -> Binding<Bool> {
+        Binding(
+            get: { selection == id },
+            set: { if $0 { select(id) } }
+        )
+    }
+}
+
+// MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
+
+public extension PaymentMethodSelector {
+    /// Layout archetype: `.list` radio rows (default) or `.grid` tiles.
+    func variant(_ v: PaymentMethodVariant) -> Self { copy { $0.variantValue = v } }
+
+    /// Instalment plans shown inline under the selected `.card` option.
+    /// `total` is required (§1.4 rev. 5) — per-month amounts derive from it
+    /// (`total / months`); `selection` is the chosen instalment count, a
+    /// separate outcome owned by the caller. Currency resolves via the
+    /// environment chain (`\.formatDefaults` > locale > "USD").
+    func installments(_ months: [Int], selection: Binding<Int>, total: Decimal) -> Self {
+        copy {
+            $0.installmentMonths = months
+            $0.installmentSelection = selection
+            $0.installmentTotal = total
+        }
+    }
+
+    /// Per-option badge, e.g. "No fee" on a transfer method. Pass `nil` to clear.
+    func badge(_ text: String?, for optionID: String) -> Self {
+        copy { $0.badges[optionID] = text }
+    }
+
+    /// Options rendered disabled and excluded from selection.
+    func disabledMethods(_ ids: Set<String>) -> Self { copy { $0.disabledIDs = ids } }
+
+    /// Semantic tint for the radio / selected chrome / instalment rows;
+    /// `nil` (default) uses the primary triad.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+
+    /// Bottom-aligned accessory area (canonical `.footer { }` slot), e.g. a
+    /// security note or fee disclaimer.
+    func footer<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.footerSlot = AnyView(content()) }
+    }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+// MARK: - Previews
+
+#Preview("List · installments · badge · disabled") {
+    struct Demo: View {
+        @State private var method: String? = "card"
+        @State private var months = 3
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                    PaymentMethodSelector([
+                        .init(id: "card", kind: .card, title: "Credit / debit card"),
+                        .init(id: "wallet", kind: .wallet, title: "Digital wallet", subtitle: "Pay in one tap"),
+                        .init(id: "transfer", kind: .transfer, title: "Bank transfer"),
+                    ], selection: $method)
+                        .installments([1, 3, 6, 9], selection: $months, total: 1_240)
+                        .badge("No fee", for: "transfer")
+                        .disabledMethods(["wallet"])
+                        .footer {
+                            Text("All payments are encrypted.")
+                                .textStyle(.bodySm400)
+                        }
+
+                    ListSectionHeader("Uncontrolled · accent · read-only")
+                    PaymentMethodSelector([
+                        .init(id: "card", kind: .card, title: "Credit / debit card"),
+                        .init(id: "transfer", kind: .transfer, title: "Bank transfer"),
+                    ], initiallySelected: "transfer")
+                        .accent(.success)
+                        .readOnly()
+                }
+                .padding()
+            }
+        }
+    }
+    return Demo()
+}
+
+#Preview("Grid · dark") {
+    struct Demo: View {
+        @State private var method: String? = "wallet"
+        var body: some View {
+            let dark = Theme()
+            dark.loadTheme(named: Theme.defaultThemeName, dark: true)
+            return VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                PaymentMethodSelector([
+                    .init(id: "card", kind: .card, title: "Card"),
+                    .init(id: "wallet", kind: .wallet, title: "Wallet", subtitle: "One tap"),
+                    .init(id: "transfer", kind: .transfer, title: "Transfer"),
+                    .init(id: "card2", kind: .card, title: "Corporate card"),
+                ], selection: $method)
+                    .variant(.grid)
+                    .badge("New", for: "wallet")
+            }
+            .padding()
+            .background(dark.background(.bgBase))
+            .theme(dark)
+        }
+    }
+    return Demo()
+}

--- a/Sources/ThemeKitTravel/Models/PassengerModels.swift
+++ b/Sources/ThemeKitTravel/Models/PassengerModels.swift
@@ -47,3 +47,25 @@ public struct PassengerDraft: Sendable, Equatable, Codable {
 
     public init() {}
 }
+
+public extension PassengerDraft {
+    /// The canonical-strings serialization (ADR-F6) `FormValidator` consumes:
+    ///
+    ///     if form.validateAll(traveler.formValues) == nil { proceed(traveler) }
+    ///
+    /// Pinned conventions (§1.4 rev 4): dates serialize as ISO-8601 calendar
+    /// dates (`"2027-04-19"`, locale-independent — the rule pack's date
+    /// factories parse the same shape), enums as their `rawValue`, and absent
+    /// optionals as `""` (so `.required()` applies naturally).
+    var formValues: [PassengerFormField: String] {
+        [
+            .givenName: givenName,
+            .familyName: familyName,
+            .gender: gender?.rawValue ?? "",
+            .dateOfBirth: dateOfBirth.map(ISO8601Day.string(from:)) ?? "",
+            .nationality: nationality ?? "",
+            .documentNumber: documentNumber,
+            .documentExpiry: documentExpiry.map(ISO8601Day.string(from:)) ?? "",
+        ]
+    }
+}

--- a/Sources/ThemeKitTravel/Validation/PassengerRules.swift
+++ b/Sources/ThemeKitTravel/Validation/PassengerRules.swift
@@ -1,0 +1,60 @@
+//
+//  PassengerRules.swift
+//  ThemeKitTravel
+//
+//  The traveler-document VALIDATION RULE PACK (§9.2 / ADR-F6): domain factories
+//  on the neutral `ValidationRule` so an app declares document policy in one
+//  `FormValidator` literal:
+//
+//      FormValidator<PassengerFormField>([
+//          .documentNumber: [.required(), .documentNumber],
+//          .documentExpiry: [.expiryInFuture(after: tripDate)],
+//      ])
+//
+//  Canonical strings (ADR-F6, §1.4 rev 4): rules validate the SERIALIZED form
+//  value from `PassengerDraft.formValues` — dates are pinned to ISO-8601
+//  calendar dates (`yyyy-MM-dd`), enums to their `rawValue`. Date factories
+//  parse ISO-8601 only; a non-ISO string fails the rule (never crashes).
+//
+
+import Foundation
+import ThemeKit
+
+// MARK: - ISO-8601 calendar-date serialization (ADR-F6)
+
+/// The edition's single date⇄string convention: ISO-8601 calendar date
+/// ("2027-04-19"), locale-independent in both directions. Shared by
+/// `PassengerDraft.formValues` (serialize) and the rule pack (parse).
+enum ISO8601Day {
+    static func string(from date: Date) -> String {
+        date.formatted(.iso8601.year().month().day().dateSeparator(.dash))
+    }
+
+    static func date(from string: String) -> Date? {
+        try? Date(string, strategy: .iso8601.year().month().day().dateSeparator(.dash))
+    }
+}
+
+// MARK: - Traveler-document rules
+
+public extension ValidationRule {
+    /// A generic machine-readable travel-document number (passport / national
+    /// ID): 5–20 letters and digits, no spaces or punctuation. Deliberately
+    /// permissive — per-country policy belongs to the app's own rule.
+    static var documentNumber: ValidationRule {
+        .regex("^[A-Za-z0-9]{5,20}$",
+               String(themeKitTravel: "Enter a valid document number"))
+    }
+
+    /// The document's expiry date (an ISO-8601 calendar-date string, per
+    /// `PassengerDraft.formValues`) must fall strictly after `reference` —
+    /// pass the trip date so documents expiring mid-trip fail. Skipped while
+    /// the value is empty (pair with `.required()` to also demand a date).
+    static func expiryInFuture(after reference: Date = .now,
+                               _ message: String? = nil) -> ValidationRule {
+        ValidationRule(message ?? String(themeKitTravel: "Document must be valid on the travel date")) { value in
+            guard let date = ISO8601Day.date(from: value) else { return false }
+            return date > reference
+        }
+    }
+}

--- a/Tests/ThemeKitTests/Snapshot/PaymentSnapshotTests.swift
+++ b/Tests/ThemeKitTests/Snapshot/PaymentSnapshotTests.swift
@@ -1,0 +1,62 @@
+//
+//  PaymentSnapshotTests.swift
+//  ThemeKitTests
+//
+//  Visual-regression coverage for the ThemeKitTravel payment components
+//  (F1.3 `PaymentMethodSelector`): list rows with inline installments, a
+//  per-option badge and a disabled method, plus the grid tile variant.
+//  iOS-only + opt-in (see SnapshotSupport.swift).
+//
+
+#if canImport(UIKit)
+import SnapshotTesting
+import SwiftUI
+import XCTest
+@testable import ThemeKit
+import ThemeKitTravel
+
+@MainActor
+final class PaymentSnapshotTests: SnapshotTestCase {
+
+    private var options: [PaymentMethodOption] {
+        [
+            .init(id: "card", kind: .card, title: "Credit / debit card"),
+            .init(id: "wallet", kind: .wallet, title: "Digital wallet", subtitle: "Pay in one tap"),
+            .init(id: "transfer", kind: .transfer, title: "Bank transfer"),
+        ]
+    }
+
+    // MARK: PaymentMethodSelector (F1.3)
+
+    func testPaymentMethodSelector_states() {
+        assertComponentSnapshot(
+            PaymentMethodSelector(options, selection: .constant("card"))
+                .installments([1, 3, 6], selection: .constant(3), total: 1_240)
+                .badge("No fee", for: "transfer")
+                .disabledMethods(["wallet"])
+                .footer { Text("All payments are encrypted.").textStyle(.bodySm400) }
+                .environment(\.locale, Locale(identifier: "en_US"))   // deterministic currency (§10 chain)
+                .padding()
+        )
+    }
+
+    func testPaymentMethodSelector_grid() {
+        assertComponentSnapshot(
+            PaymentMethodSelector(options, selection: .constant("wallet"))
+                .variant(.grid)
+                .badge("New", for: "wallet")
+                .accent(.success)
+                .padding()
+        )
+    }
+
+    func testPaymentMethodSelector_grid_rtl() {
+        assertComponentSnapshot(
+            PaymentMethodSelector(options, selection: .constant("card"))
+                .variant(.grid)
+                .padding(),
+            layoutDirection: .rightToLeft
+        )
+    }
+}
+#endif

--- a/Tests/ThemeKitTests/Snapshot/TravelEditionSnapshotTests.swift
+++ b/Tests/ThemeKitTests/Snapshot/TravelEditionSnapshotTests.swift
@@ -1,0 +1,83 @@
+//
+//  TravelEditionSnapshotTests.swift
+//  ThemeKitTests
+//
+//  Visual-regression coverage for the ThemeKitTravel EDITION organisms (F1.x).
+//  Opt-in + iOS-only (see SnapshotSupport.swift); records references on the
+//  pinned Simulator, skips in CI. Bindings use `.constant` and dates are fixed
+//  so references are reproducible.
+//
+
+#if canImport(UIKit)
+import SnapshotTesting
+import SwiftUI
+import XCTest
+@testable import ThemeKit
+import ThemeKitTravel
+
+@MainActor
+final class TravelEditionSnapshotTests: SnapshotTestCase {
+
+    // MARK: - F1.2 PassengerForm (begin)
+
+    /// Fixed-date traveler so DateField text is reproducible.
+    private var filledDraft: PassengerDraft {
+        var draft = PassengerDraft()
+        draft.givenName = "Alex"
+        draft.familyName = "Morgan"
+        draft.gender = .female
+        draft.dateOfBirth = Date(timeIntervalSinceReferenceDate: -347_000_000)   // ~1990
+        draft.nationality = "NO"
+        draft.documentNumber = "U1234567"
+        draft.documentExpiry = Date(timeIntervalSinceReferenceDate: 900_000_000) // ~2029
+        return draft
+    }
+
+    func testPassengerForm_states() {
+        // Empty + filled, documentRequired asterisks, footer slot.
+        assertComponentSnapshot(
+            VStack(alignment: .leading, spacing: 16) {
+                PassengerForm("Passenger 1 · Adult", draft: .constant(PassengerDraft()))
+                    .fields([.givenName, .familyName, .gender, .dateOfBirth])
+
+                PassengerForm("Passenger 2 · Adult", draft: .constant(filledDraft))
+                    .documentRequired()
+                    .footer {
+                        Text("Enter the name exactly as printed on the travel document.")
+                            .textStyle(.bodySm400)
+                    }
+            }
+            .padding()
+        )
+
+        // Error state — a failed submit populates the validator's messages,
+        // which every wired field renders (§1.4 rev 4: validateAll + canonical
+        // formValues; no form.submit until HEROUI 13b).
+        let form = FormValidator<PassengerFormField>([
+            .givenName: [.required()],
+            .familyName: [.required()],
+            .documentNumber: [.required(), .documentNumber],
+            .documentExpiry: [.required(), .expiryInFuture()],
+        ])
+        form.validateAll(PassengerDraft().formValues)
+        assertComponentSnapshot(
+            PassengerForm("Passenger 1 · Adult", draft: .constant(PassengerDraft()))
+                .documentRequired()
+                .validator(form)
+                .padding(),
+            named: "errors"
+        )
+
+        // Dark — token re-skin of both fieldsets.
+        assertComponentSnapshot(
+            PassengerForm("Passenger 1 · Adult", draft: .constant(filledDraft))
+                .documentRequired()
+                .padding(),
+            colorScheme: .dark,
+            named: "dark"
+        )
+    }
+
+    // MARK: - F1.2 PassengerForm (end)
+}
+#endif


### PR DESCRIPTION
The P0 booking-completion pair — the **first ThemeKitTravel edition components** — plus the Demo integration that lets the edition ship demos.

### F1.2 PassengerForm (ADR-F3 / §9.2)
Controlled-only traveler form (name / gender / DOB / nationality / document) composing `Fieldset` + `TextInput` + `SelectBox` + `DateField`. Modifiers: `fields`/`nationalities`/`documentRequired`/`birthDateRange`/`validator(FormValidator<PassengerFormField>)`/`accent`/`header`/`footer`. Adds `PassengerDraft.formValues` (ISO-8601 canonical strings) + a domain `ValidationRule` pack (`documentNumber`, `expiryInFuture`). Messages/focus flow through the validator; canonical-vs-display re-validation split documented.

### F1.3 PaymentMethodSelector (§9.3)
Card/wallet/transfer rows (`.list`) or tiles (`.grid`); controlled + uncontrolled (`ControllableState`) inits; inline `InstallmentPicker` under the card option (`total:` required); `.badge`/`.disabledMethods`/`.accent`/`.footer`. **Currency resolves via the F0.3 env chain** (no explicit code).

### Edition Demo integration
- **`Demo.xcodeproj`: links the `ThemeKitTravel` product into the Demo app target** (the deferred-from-F0.1 wiring, now that real edition demos exist).
- `PassengerFormDemo` + `PaymentMethodSelectorDemo` (`import ThemeKitTravel`) + `ComponentRegistry` entries (`isNew`); `-openDemo "PassengerForm"` / `"PaymentMethodSelector"`.
- Opt-in snapshot suites `TravelEditionSnapshotTests` + `PaymentSnapshotTests`.

### Verification
- `swift build` clean; **284 tests pass**; **Demo BUILD SUCCEEDED** (iPhone 17 sim, edition product linked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)