### PR TITLE
feat(travel): softer TripTypeToggle track (.bgBase) + token-fed .surface(_:)

### DIFF
--- a/Sources/ThemeKitTravel/Components/Molecules/TripTypeToggle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/TripTypeToggle.swift
@@ -25,6 +25,7 @@ public struct TripTypeToggle: View {
     private var icons: [String] = []
     private var accent: SemanticColor?
     private var fullWidth = true
+    private var surface: Theme.BackgroundColorKey = .bgBase
 
     public init(_ options: [String], selection: Binding<Int>) {   // R1
         self.options = options
@@ -38,7 +39,7 @@ public struct TripTypeToggle: View {
             ForEach(Array(options.enumerated()), id: \.offset) { i, option in pill(i, option) }
         }
         .padding(4)
-        .background(theme.background(.bgSecondary), in: Capsule())
+        .background(theme.background(surface), in: Capsule())
         .frame(maxWidth: fullWidth ? .infinity : nil)
     }
 
@@ -73,6 +74,10 @@ public extension TripTypeToggle {
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     /// Stretch pills to fill the width (default on); off = intrinsic width.
     func fullWidth(_ on: Bool = true) -> Self { copy { $0.fullWidth = on } }
+    /// Token-fed track fill behind the pills (default `.bgBase` — a soft,
+    /// low-contrast track that reads well on a white card). Pass `.bgWhite` for a
+    /// flush track or `.bgSecondary` for the stronger grey.
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surface = key } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self


### PR DESCRIPTION
The TripTypeToggle pill track was hardcoded to `.bgSecondary` (**#BCC5D2** in the light theme — a fairly strong grey that stood out on a white card).

- **Default is now `.bgBase`** (#F6F7F9) — a soft, low-contrast track that reads well on a card.
- **New token-fed `.surface(_ key: Theme.BackgroundColorKey)` modifier** so callers can re-tint the track (`.bgWhite`, `.bgSecondary`, …) — token keys only, never raw `Color` (house rule).

Verified on iPad — the search card's trip toggle now shows a subtle track with the blue selected pill standing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)