### PR TITLE
feat(travel): close the P1 token-fed modifier gaps (audit)

### DIFF
--- a/Sources/ThemeKitTravel/Components/Atoms/SeatCell.swift
+++ b/Sources/ThemeKitTravel/Components/Atoms/SeatCell.swift
@@ -157,18 +157,18 @@ public struct SeatCell: View {
     // MARK: Colours
 
     private var fillColor: Color {
-        if isSelected { return theme.foreground(.fgHero) }
-        if seat.isOccupied { return theme.background(.bgSecondary) }
+        if isSelected { return palette.selectedColors(theme: theme).fill }
+        if seat.isOccupied { return palette.occupiedColors(theme: theme).fill }
         return palette.colors(for: seat.tier, theme: theme).fill
     }
     private var strokeColor: Color {
-        if isSelected { return theme.foreground(.fgHero) }
-        if seat.isOccupied { return theme.border(.borderPrimary) }
+        if isSelected { return palette.selectedColors(theme: theme).stroke }
+        if seat.isOccupied { return palette.occupiedColors(theme: theme).stroke }
         return palette.colors(for: seat.tier, theme: theme).stroke
     }
     private var contentColor: Color {
-        if isSelected { return theme.text(.textSecondaryInverse) }
-        if seat.isOccupied { return theme.text(.textTertiary) }
+        if isSelected { return palette.selectedColors(theme: theme).content }
+        if seat.isOccupied { return palette.occupiedColors(theme: theme).content }
         return theme.text(.textSecondary)
     }
 
@@ -198,5 +198,7 @@ public struct SeatCell: View {
         PreviewCase("Occupied") { SeatCell(Seat("1E", occupied: true)) }
         PreviewCase("Recommended") { SeatCell(Seat("1F"), isRecommended: true) }
         PreviewCase("Number display") { SeatCell(Seat("1G"), display: .number) }
+        PreviewCase("Accent selected") { SeatCell(Seat("2A"), isSelected: true, palette: SeatPalette().selected(.accent)) }
+        PreviewCase("Accent occupied") { SeatCell(Seat("2B", occupied: true), palette: SeatPalette().occupied(.warning)) }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Molecules/DatePriceStrip.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/DatePriceStrip.swift
@@ -39,6 +39,7 @@ public struct DatePriceCard: View {
     private var currencyCode: String?
     private var isCheapest = false
     private var pill = false
+    private var surface: Theme.BackgroundColorKey = .bgElevatorPrimary
 
     public init(_ item: DatePriceItem, isSelected: Bool, action: @escaping () -> Void) {   // R1
         self.item = item
@@ -76,7 +77,7 @@ public struct DatePriceCard: View {
             elevation: .none,
             isSelected: isSelected,
             isPressed: false,
-            surfaceKey: .bgElevatorPrimary,
+            surfaceKey: surface,
             radius: .selector))
     }
 
@@ -124,6 +125,8 @@ public extension DatePriceCard {
     func cheapest(_ on: Bool = true) -> Self { copy { $0.isCheapest = on } }
     /// Render as a horizontal-strip pill (rounded capsule) instead of a card.
     func pill(_ on: Bool = true) -> Self { copy { $0.pill = on } }
+    /// Surface token for the carded shell (default `.bgElevatorPrimary`).
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surface = key } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {
         var c = self
@@ -145,6 +148,7 @@ public struct DatePriceStrip: View {
     private var columns = 3
     private var highlightsCheapest = true
     private var stripLayout = false
+    private var surface: Theme.BackgroundColorKey = .bgElevatorPrimary
     private var onPrev: (() -> Void)?
     private var onNext: (() -> Void)?
 
@@ -189,13 +193,14 @@ public struct DatePriceStrip: View {
                         DatePriceCard(item, isSelected: i == selection) { selection = i }
                             .currency(resolvedCurrency)
                             .cheapest(i == cheapest)
+                            .surface(surface)
                             .pill()
                             .id(i)
                     }
                 }
                 .padding(density.scale(Theme.SpacingKey.sm.value))
             }
-            .background(theme.background(.bgElevatorPrimary))
+            .background(theme.background(surface))
             .onChange(of: selection) { _, new in
                 withAnimation { proxy.scrollTo(new, anchor: .center) }
             }
@@ -209,6 +214,7 @@ public struct DatePriceStrip: View {
                 DatePriceCard(item, isSelected: i == selection) { selection = i }
                     .currency(resolvedCurrency)
                     .cheapest(i == cheapest)
+                    .surface(surface)
             }
         }
     }
@@ -241,6 +247,8 @@ public extension DatePriceStrip {
     func strip(_ on: Bool = true) -> Self { copy { $0.stripLayout = on } }
     /// Auto-highlight the lowest fare in success green (default on).
     func highlightCheapest(_ on: Bool = true) -> Self { copy { $0.highlightsCheapest = on } }
+    /// Surface token for the strip track and the cards it builds (default `.bgElevatorPrimary`).
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surface = key } }
     /// Adds prev/next paging chevrons flanking the strip.
     func onPage(prev: @escaping () -> Void, next: @escaping () -> Void) -> Self { copy { $0.onPrev = prev; $0.onNext = next } }
 
@@ -262,6 +270,7 @@ public extension DatePriceStrip {
         PreviewCase("Timeline strip (pills)") { DatePriceStrip(items, selection: $sel).strip() }
         PreviewCase("Grid") { DatePriceStrip(items, selection: $sel) }
         PreviewCase("Paged grid") { DatePriceStrip(items, selection: $sel).onPage(prev: {}, next: {}) }
+        PreviewCase("Custom surface") { DatePriceStrip(items, selection: $sel).surface(.bgSecondaryLight) }
     }
 }
 

--- a/Sources/ThemeKitTravel/Components/Molecules/SeatLegend.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/SeatLegend.swift
@@ -3,8 +3,8 @@
 //  ThemeKit
 //
 //  Molecule. A key for a ``SeatMap`` — the fare tiers present, plus Selected and
-//  Occupied — wrapping to rows. Tier colours come from a ``SeatPalette`` so it
-//  matches whatever the map (or a brand override) uses.
+//  Occupied — wrapping to rows. Tier *and* selected/occupied colours come from a
+//  ``SeatPalette`` so it matches whatever the map (or a brand override) uses.
 //
 
 import SwiftUI
@@ -31,8 +31,10 @@ public struct SeatLegend: View {
             let c = palette.colors(for: tier, theme: theme)
             return Entry(fill: c.fill, border: c.stroke, label: tier.label)
         }
-        e.append(Entry(fill: theme.foreground(.fgHero), border: theme.foreground(.fgHero), label: String(themeKit: "Selected")))
-        e.append(Entry(fill: theme.background(.bgSecondary), border: theme.border(.borderPrimary), label: String(themeKit: "Occupied")))
+        let selected = palette.selectedColors(theme: theme)
+        e.append(Entry(fill: selected.fill, border: selected.stroke, label: String(themeKit: "Selected")))
+        let occupied = palette.occupiedColors(theme: theme)
+        e.append(Entry(fill: occupied.fill, border: occupied.stroke, label: String(themeKit: "Occupied")))
         return e
     }
 
@@ -72,5 +74,9 @@ public struct SeatLegend: View {
         PreviewCase("Economy tiers") { SeatLegend(tiers: [.standard, .extraLegroom, .exit]) }
         PreviewCase("All cabins") { SeatLegend(tiers: [.standard, .premium, .business, .first]) }
         PreviewCase("Default + premium") { SeatLegend().showsPremium() }
+        PreviewCase("Accent selected/occupied") {
+            SeatLegend(tiers: [.standard, .exit],
+                       palette: SeatPalette().selected(.accent).occupied(.warning))
+        }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Organisms/AncillaryCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/AncillaryCard.swift
@@ -43,6 +43,7 @@ public struct AncillaryCard: View {
     private var addedTitle = "Added"
     private var accent: SemanticColor?
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    private var controlSurfaceKey: Theme.BackgroundColorKey = .bgSecondary
     private var radiusRole: Theme.RadiusRole = .box
 
     public init(_ title: String) { self.title = title }   // R1
@@ -126,7 +127,7 @@ public struct AncillaryCard: View {
             }
         }
         .padding(.horizontal, 4)
-        .background(theme.background(.bgSecondary), in: Capsule())
+        .background(theme.background(controlSurfaceKey), in: Capsule())
     }
 
     private func stepButton(_ icon: String, label: String, value: Int, enabled: Bool, _ action: @escaping () -> Void) -> some View {
@@ -182,6 +183,9 @@ public extension AncillaryCard {
     func added(_ binding: Binding<Bool>, title: String = "Add", addedTitle: String = "Added") -> Self { copy { $0.added = binding; $0.addTitle = title; $0.addedTitle = addedTitle } }
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
+    /// Surface token for the quantity stepper's capsule track (default
+    /// `.bgSecondary`) — distinct from ``surface(_:)``, which fills the card shell.
+    func controlSurface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.controlSurfaceKey = key } }
     func cornerRadius(_ role: Theme.RadiusRole) -> Self { copy { $0.radiusRole = role } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
@@ -199,6 +203,9 @@ public extension AncillaryCard {
             VStack(spacing: 10) {
                 AncillaryCard("Checked baggage").icon("suitcase.fill").subtitle("20 kg").price(450, suffix: "/ bag").quantity($bags, range: 0...4)
                 AncillaryCard("Travel insurance").icon("cross.case.fill").subtitle("Full coverage").price(120).badge("Popular").added($insurance)
+                AncillaryCard("Extra legroom").icon("figure.seated.side").subtitle("Row 12").price(75).quantity($bags, range: 0...4)
+                    .surface(.bgSecondaryLight)
+                    .controlSurface(.bgWhite)
             }
             .padding()
         }

--- a/Sources/ThemeKitTravel/Components/Organisms/FilterBar.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FilterBar.swift
@@ -56,6 +56,7 @@ public struct FilterBar: View {
     private var spacing: CGFloat = 8
     private var chipStyleVariant: FilterChipStyle = .solid
     private var leadingShapeVariant: FilterLeadingShape = .adaptive
+    private var chipSurfaceKey: Theme.BackgroundColorKey = .bgWhite
 
     @State private var collapsed = false
     @State private var scrolledID: String?
@@ -162,11 +163,11 @@ public struct FilterBar: View {
         return isOn ? accentFg : chipOffText
     }
     private func chipFill(isOn: Bool, outlined: Bool) -> Color {
-        if outlined { return isOn ? SemanticColor.primary.soft : theme.background(.bgWhite) }
-        return isOn ? accentBg : theme.background(.bgWhite)
+        if outlined { return isOn ? (accentColor?.soft ?? SemanticColor.primary.soft) : theme.background(chipSurfaceKey) }
+        return isOn ? accentBg : theme.background(chipSurfaceKey)
     }
     private func chipBorderColor(isOn: Bool, outlined: Bool) -> Color {
-        if outlined { return isOn ? theme.border(.borderHero) : theme.background(.bgElevatorTertiary) }
+        if outlined { return isOn ? (accentColor?.border ?? theme.border(.borderHero)) : theme.background(.bgElevatorTertiary) }
         return isOn ? Color.clear : theme.border(.borderPrimary)
     }
 }
@@ -194,6 +195,8 @@ public extension FilterBar {
     func leadingShape(_ shape: FilterLeadingShape) -> Self { copy { $0.leadingShapeVariant = shape } }
     /// Token-fed accent for the leading buttons and selected chips (default hero).
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accentColor = color } }
+    /// Surface token for the unselected chip fill (default `.bgWhite`).
+    func chipSurface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.chipSurfaceKey = key } }
     /// Gap between controls (default 8).
     func spacing(_ value: CGFloat) -> Self { copy { $0.spacing = max(0, value) } }
     /// Gap between controls from a theme spacing token.
@@ -223,6 +226,14 @@ public extension FilterBar {
                            QuickFilter("Fast & Cheap"), QuickFilter("Direct")], selection: $sel)
                     .chipStyle(.outlined).leadingShape(.circle).size(.small)
                     .onFilter { }.onSort { }
+                // Outlined honors the accent — turquoise soft fill + turquoise border.
+                FilterBar([QuickFilter("Beachfront", id: "8"), QuickFilter("Pool"),
+                           QuickFilter("Spa")], selection: $sel)
+                    .accent(.turquoise).chipStyle(.outlined).size(.small)
+                // Unselected chips on a tinted surface.
+                FilterBar([QuickFilter("Breakfast", id: "8"), QuickFilter("Pet friendly"),
+                           QuickFilter("Parking")], selection: $sel)
+                    .chipSurface(.bgSecondaryLight).size(.small)
             }
             .padding(.vertical)
         }

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightCard.swift
@@ -44,6 +44,7 @@ public struct FlightCard: View {
     private let legs: [FlightLeg]?
     // Appearance/state — mutated only through the modifiers below (R2).
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    private var accent: SemanticColor?
     private var stops: Int = 0
     private var price: Decimal?
     private var currencyCode: String?
@@ -80,6 +81,10 @@ public struct FlightCard: View {
         self.legs = legs
     }
 
+    /// The brand-chrome tint: explicit `.accent(_:)` when set, else the theme's
+    /// hero foreground — `nil` reproduces today's rendering exactly.
+    private var accentBase: Color { accent?.base ?? theme.foreground(.fgHero) }
+
     public var body: some View {
         // The shell (fill, corner clipping, border) is drawn by the active
         // `CardStyle` — built-ins and custom styles go through the same gate.
@@ -110,7 +115,7 @@ public struct FlightCard: View {
         HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
             Image(systemName: airlineSystemImage)
                 .font(.title3)
-                .foregroundStyle(theme.foreground(.fgHero))
+                .foregroundStyle(accentBase)
             Text(airline).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
             if let fareBrand {
                 Text(fareBrand).textStyle(.overline500).foregroundStyle(theme.text(.textSecondary))
@@ -181,7 +186,7 @@ public struct FlightCard: View {
             HStack(spacing: 4) {
                 Circle().fill(theme.text(.textTertiary)).frame(width: 5, height: 5)
                 line
-                Image(systemName: "airplane").font(.system(size: 12)).foregroundStyle(theme.foreground(.fgHero))
+                Image(systemName: "airplane").font(.system(size: 12)).foregroundStyle(accentBase)
                 line
                 Circle().fill(theme.text(.textTertiary)).frame(width: 5, height: 5)
             }
@@ -236,7 +241,7 @@ public struct FlightCard: View {
             HStack(spacing: 4) {
                 Circle().fill(theme.text(.textTertiary)).frame(width: 5, height: 5)
                 line
-                Image(systemName: "airplane").font(.system(size: 12)).foregroundStyle(theme.foreground(.fgHero))
+                Image(systemName: "airplane").font(.system(size: 12)).foregroundStyle(accentBase)
                 line
                 Circle().fill(theme.text(.textTertiary)).frame(width: 5, height: 5)
             }
@@ -258,7 +263,15 @@ public struct FlightCard: View {
             HStack {
                 if let price { PriceTag(price, currencyCode: resolvedCurrency).size(.large).emphasis(.hero) }
                 Spacer()
-                if let onSelect { PrimaryButton(String(themeKit: "Select")) { onSelect() }.size(.small) }
+                if let onSelect {
+                    // Accent set → semantic-colored ThemeButton; nil → the stock
+                    // hero PrimaryButton, byte-for-byte today's rendering.
+                    if let accent {
+                        ThemeButton(String(themeKit: "Select")) { onSelect() }.color(accent).size(.small)
+                    } else {
+                        PrimaryButton(String(themeKit: "Select")) { onSelect() }.size(.small)
+                    }
+                }
             }
         }
     }
@@ -284,6 +297,11 @@ public extension FlightCard {
     /// Surface fill (background token key, default `.bgBase`) — feeds the
     /// active `CardStyle`'s configuration.
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
+    /// A semantic accent for the brand chrome — the airline icon, the route-path
+    /// planes and the Select button. `nil` (default) keeps the theme's hero
+    /// styling. Semantic colours (favourite red, scarcity, nonstop green) are
+    /// fixed and unaffected.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     /// Number of stops (0 = nonstop, shown in green).
     func stops(_ count: Int) -> Self { copy { $0.stops = max(0, count) } }
     /// The fare, rendered as a hero `PriceTag` in the footer.
@@ -331,6 +349,9 @@ public extension FlightCard {
             .price(1_299).badge("Cheapest").favorite().onSelect { }
         FlightCard(airline: "Blue Wings", from: "IST", to: "AMS", departure: dep, arrival: dep.addingTimeInterval(4 * 3_600))
             .stops(1).price(3_499).favorite(.constant(true))
+        // Accented brand chrome — icon, route planes and Select follow the accent.
+        FlightCard(airline: "Sunrise Air", from: "IST", to: "LHR", departure: dep, arrival: dep.addingTimeInterval(3 * 3_600))
+            .accent(.success).price(2_199).onSelect { }
     }
     .padding()
 }

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightResultRow.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightResultRow.swift
@@ -37,6 +37,7 @@ public struct FlightResultRow: View {
     private let arrival: Date
     // Appearance/state — mutated only through the modifiers below (R2).
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    private var accent: SemanticColor?
     private var flightNo: String?
     private var cabinClass: String?
     private var airlineSystemImage = "airplane.circle.fill"
@@ -68,6 +69,10 @@ public struct FlightResultRow: View {
         self.departure = departure
         self.arrival = arrival
     }
+
+    /// The brand-chrome tint: explicit `.accent(_:)` when set, else the theme's
+    /// hero foreground — `nil` reproduces today's rendering exactly.
+    private var accentBase: Color { accent?.base ?? theme.foreground(.fgHero) }
 
     public var body: some View {
         // The shell (fill, corner clipping, border) is drawn by the active
@@ -109,7 +114,7 @@ public struct FlightResultRow: View {
             if let url = airlineLogoURL {
                 RemoteImage(url).ratio(1).frame(width: 22, height: 22)
             } else {
-                Image(systemName: airlineSystemImage).font(.title3).foregroundStyle(theme.foreground(.fgHero))
+                Image(systemName: airlineSystemImage).font(.title3).foregroundStyle(accentBase)
             }
             VStack(alignment: .leading, spacing: 1) {
                 Text(airline).textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
@@ -131,7 +136,7 @@ public struct FlightResultRow: View {
                     if showsBookmark {
                         Button { bookmarkState.toggle() } label: {
                             Image(systemName: bookmarkState ? "bookmark.fill" : "bookmark")
-                                .font(.system(size: 14)).foregroundStyle(bookmarkState ? theme.foreground(.fgHero) : theme.text(.textTertiary))
+                                .font(.system(size: 14)).foregroundStyle(bookmarkState ? accentBase : theme.text(.textTertiary))
                                 .frame(width: 40, height: 40).contentShape(Rectangle())
                         }.buttonStyle(.plain).disabled(isReadOnly)
                             .accessibilityLabel(bookmarkState ? String(themeKit: "Remove saved flight") : String(themeKit: "Save"))
@@ -152,7 +157,15 @@ public struct FlightResultRow: View {
                 Text("\(totalLabel): \(totalAmount.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0)).locale(locale)))")
                     .textStyle(.overline400).foregroundStyle(theme.text(.textTertiary)).fixedSize()
             }
-            if let onSelect { ThemeButton(selectTitle) { onSelect() }.size(.small) }
+            if let onSelect {
+                // Accent set → semantic-colored Select; nil → the button's stock
+                // resolution (componentDefaults.accent → .primary), unchanged.
+                if let accent {
+                    ThemeButton(selectTitle) { onSelect() }.color(accent).size(.small)
+                } else {
+                    ThemeButton(selectTitle) { onSelect() }.size(.small)
+                }
+            }
         }
     }
 
@@ -185,6 +198,11 @@ public extension FlightResultRow {
     /// Surface fill (background token key, default `.bgBase`) — feeds the
     /// active `CardStyle`'s configuration.
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
+    /// A semantic accent for the brand chrome — the airline fallback glyph, the
+    /// active bookmark and the Select button. `nil` (default) keeps the theme's
+    /// hero styling. Semantic colours (favourite red, urgency red, nonstop
+    /// green) are fixed and unaffected.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     /// Flight number, e.g. "TK 2434".
     func flightNo(_ text: String?) -> Self { copy { $0.flightNo = text } }
     /// Cabin class caption, e.g. "Economy".
@@ -259,6 +277,10 @@ public extension FlightResultRow {
             .flightNo("BW 810").price(2_899).favorite().bookmark()
         FlightResultRow(airline: "Blue Wings", from: "IST", to: "ADB", departure: dep, arrival: dep.addingTimeInterval(70 * 60))
             .flightNo("BW 812").price(2_499).favorite(.constant(true))
+        // Accented brand chrome — glyph, active bookmark and Select follow the accent.
+        FlightResultRow(airline: "Sunrise Air", from: "IST", to: "LHR", departure: dep, arrival: dep.addingTimeInterval(3 * 3_600))
+            .accent(.success).flightNo("SA 101").price(4_120).bookmark(.constant(true))
+            .onSelect("Select") { }
     }
     .padding()
 }

--- a/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelector.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelector.swift
@@ -50,6 +50,7 @@ public struct PaymentMethodSelector: View {
     private var disabledIDs: Set<String> = []
     private var accent: SemanticColor?
     private var footerSlot: AnyView?
+    private var surfaceKey: Theme.BackgroundColorKey = .bgBase
 
     /// R1 — options + controlled selection (option id). The binding is the
     /// change channel; observe with `.onChange(of:)` at the call site.
@@ -166,7 +167,7 @@ public struct PaymentMethodSelector: View {
             }
             .frame(maxWidth: .infinity, minHeight: 88)
             .padding(Theme.SpacingKey.md.value)
-            .background(isOn ? (accent ?? .primary).bg : theme.background(.bgBase), in: shape)
+            .background(isOn ? (accent ?? .primary).bg : theme.background(surfaceKey), in: shape)
             .overlay(shape.stroke(isOn ? accentBase : theme.border(.borderPrimary), lineWidth: isOn ? 1.5 : 1))
             .overlay(alignment: .topTrailing) {
                 if let badgeText = badges[option.id] {
@@ -266,6 +267,10 @@ public extension PaymentMethodSelector {
     /// `nil` (default) uses the primary triad.
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
 
+    /// Surface token for the *unselected* `.grid` tile fill (default `.bgBase`);
+    /// the selected tile keeps the accent tint and stroke.
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
+
     /// Bottom-aligned accessory area (canonical `.footer { }` slot), e.g. a
     /// security note or fee disclaimer.
     func footer<V: View>(@ViewBuilder _ content: () -> V) -> Self {
@@ -331,6 +336,14 @@ public extension PaymentMethodSelector {
                 ], selection: $method)
                     .variant(.grid)
                     .badge("New", for: "wallet")
+
+                ListSectionHeader("Grid · surface(.bgWhite)")
+                PaymentMethodSelector([
+                    .init(id: "card", kind: .card, title: "Card"),
+                    .init(id: "wallet", kind: .wallet, title: "Wallet"),
+                ], initiallySelected: "card")
+                    .variant(.grid)
+                    .surface(.bgWhite)
             }
             .padding()
             .background(dark.background(.bgBase))

--- a/Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift
@@ -58,6 +58,7 @@ public struct SeatMap: View {
     private var customContent: ((SeatContext) -> AnyView)?
     private var aisleWidthOverride: CGFloat?
     private var tierOverrides: [SeatTier: Color] = [:]
+    private var accentOverride: SemanticColor?
 
     private let gutter: CGFloat = 22
     private var passengerMode: Bool { !passengers.isEmpty && assignment != nil }
@@ -92,10 +93,10 @@ public struct SeatMap: View {
     public var body: some View {
         VStack(spacing: density.scale(Theme.SpacingKey.md.value)) {
             if passengerMode {
-                PassengerRail(passengers: passengers, assignment: assignment ?? .constant([:]), active: $activePassenger)
+                PassengerRail(passengers: passengers, assignment: assignment ?? .constant([:]), active: $activePassenger, accent: accentOverride)
             }
             if index.floors.count > 1 {
-                DeckSelector(floors: index.floors, active: $activeFloor)
+                DeckSelector(floors: index.floors, active: $activeFloor, accent: accentOverride)
             }
             cabin.modifier(PinchZoom(enabled: zoomable, zoom: $zoom))
             if showsLegend { SeatLegend(tiers: index.tiers, palette: palette) }
@@ -292,6 +293,10 @@ public extension SeatMap {
     func tierColors(_ overrides: [SeatTier: SemanticColor]) -> Self {
         copy { $0.tierOverrides = overrides.mapValues(\.base) }
     }
+    /// Accent for the passenger rail's and deck selector's **active** pill — the
+    /// token's `.solid` shade fills the pill and `.onSolid` colours its text.
+    /// Pass `nil` to restore the theme's hero default.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accentOverride = color } }
     /// Raw-color tier overrides (back-compat); prefer the token-bound overload.
     /// Disfavored so member-shorthand literals like `[.extraLegroom: .purple]` —
     /// valid as both `Color` and `SemanticColor` values — resolve to the token
@@ -360,6 +365,10 @@ private struct PassengerRail: View {
     let passengers: [Passenger]
     let assignment: Binding<[String: String]>
     @Binding var active: String?
+    let accent: SemanticColor?
+
+    private var activeFill: Color { accent?.solid ?? theme.foreground(.fgHero) }
+    private var activeContent: Color { accent?.onSolid ?? theme.text(.textSecondaryInverse) }
 
     var body: some View {
         HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
@@ -370,9 +379,9 @@ private struct PassengerRail: View {
                         Text(p.initials).textStyle(.labelSm600)
                         Text(assignment.wrappedValue[p.id] ?? "—").textStyle(.overline400)
                     }
-                    .foregroundStyle(isActive ? theme.text(.textSecondaryInverse) : theme.text(.textPrimary))
+                    .foregroundStyle(isActive ? activeContent : theme.text(.textPrimary))
                     .padding(.horizontal, 12).padding(.vertical, 6)
-                    .background(isActive ? theme.foreground(.fgHero) : theme.background(.bgSecondaryLight), in: Capsule())
+                    .background(isActive ? activeFill : theme.background(.bgSecondaryLight), in: Capsule())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(String(themeKit: "Passenger \(p.initials), seat \(assignment.wrappedValue[p.id] ?? String(themeKit: "unassigned"))"))
@@ -386,6 +395,10 @@ private struct DeckSelector: View {
     @Environment(\.componentDensity) private var density
     let floors: [Int]
     @Binding var active: Int?
+    let accent: SemanticColor?
+
+    private var activeFill: Color { accent?.solid ?? theme.foreground(.fgHero) }
+    private var activeContent: Color { accent?.onSolid ?? theme.text(.textSecondaryInverse) }
 
     var body: some View {
         HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
@@ -393,9 +406,9 @@ private struct DeckSelector: View {
                 let isActive = (active ?? floors.first) == floor
                 Button { active = floor } label: {
                     Text(String(themeKit: "Deck \(floor)")).textStyle(.labelSm600)
-                        .foregroundStyle(isActive ? theme.text(.textSecondaryInverse) : theme.text(.textPrimary))
+                        .foregroundStyle(isActive ? activeContent : theme.text(.textPrimary))
                         .padding(.horizontal, 14).padding(.vertical, 6)
-                        .background(isActive ? theme.foreground(.fgHero) : theme.background(.bgSecondaryLight), in: Capsule())
+                        .background(isActive ? activeFill : theme.background(.bgSecondaryLight), in: Capsule())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(String(themeKit: "Deck \(floor)"))
@@ -537,6 +550,8 @@ private struct PinchZoom: ViewModifier {
 #Preview {
     struct Demo: View {
         @State private var picked: Set<String> = ["12C"]
+        @State private var accentPicked: Set<String> = []
+        @State private var assignment: [String: String] = [:]
         private let sold: Set<String> = ["12B", "13E", "16A"]
         var body: some View {
             ScrollView {
@@ -548,6 +563,15 @@ private struct PinchZoom: ViewModifier {
                 .showsLabels().legend().showsSeatInfo()
                 .recommended(["11C"]).maxSelection(3).currency("USD")
                 .tierColors([.extraLegroom: .purple]).padding()
+
+                // Accent override — passenger rail + deck selector pick up the token.
+                SeatMap(columns: "AB CD", rows: Array(1...3), selection: $accentPicked) { _, row, _ in
+                    SeatInfo(floor: row <= 2 ? 1 : 2)
+                }
+                .passengers([Passenger(id: "p1", initials: "AB"), Passenger(id: "p2", initials: "CD")],
+                            assignment: $assignment)
+                .accent(.accent)
+                .padding()
             }
         }
     }

--- a/Sources/ThemeKitTravel/Components/Organisms/SeatMapModels.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SeatMapModels.swift
@@ -98,9 +98,16 @@ public enum SeatTier: String, Sendable, Hashable, Codable, CaseIterable {
 }
 
 /// Maps a ``SeatTier`` to its fill + stroke colours — token-derived by default,
-/// fully overridable per tier so a brand can map its own palette.
+/// fully overridable per tier so a brand can map its own palette. The **selected**
+/// and **occupied** states are palette entries too (``selected(_:)`` /
+/// ``occupied(_:)``), so ``SeatCell`` and ``SeatLegend`` always agree.
 public struct SeatPalette: Sendable {
-    private let overrides: [SeatTier: Color]
+    private var overrides: [SeatTier: Color]
+    private var selectedAccent: SemanticColor?
+    private var selectedRaw: Color?
+    private var occupiedAccent: SemanticColor?
+    private var occupiedRaw: Color?
+
     public init(_ overrides: [SeatTier: Color] = [:]) { self.overrides = overrides }
     public static let `default` = SeatPalette()
 
@@ -115,6 +122,55 @@ public struct SeatPalette: Sendable {
         case .business: return (SemanticColor.purple.bg, SemanticColor.purple.base)
         case .first: return (SemanticColor.pink.bg, SemanticColor.pink.base)
         }
+    }
+
+    /// Fill + stroke + content colour of a **selected** seat. Defaults to the
+    /// theme's hero foreground; an accent override uses its `.solid` / `.onSolid` pair.
+    public func selectedColors(theme: Theme) -> (fill: Color, stroke: Color, content: Color) {
+        if let accent = selectedAccent { return (accent.solid, accent.solid, accent.onSolid) }
+        if let raw = selectedRaw { return (raw, raw, theme.text(.textSecondaryInverse)) }
+        return (theme.foreground(.fgHero), theme.foreground(.fgHero), theme.text(.textSecondaryInverse))
+    }
+
+    /// Fill + stroke + content colour of an **occupied** seat. Defaults to the
+    /// theme's muted secondary surface; an accent override uses its `.soft` /
+    /// `.border` / `.base` shades.
+    public func occupiedColors(theme: Theme) -> (fill: Color, stroke: Color, content: Color) {
+        if let accent = occupiedAccent { return (accent.soft, accent.border, accent.base) }
+        if let raw = occupiedRaw { return (raw.opacity(0.14), raw, theme.text(.textTertiary)) }
+        return (theme.background(.bgSecondary), theme.border(.borderPrimary), theme.text(.textTertiary))
+    }
+}
+
+public extension SeatPalette {
+    /// Accent for the **selected** state — fill/stroke use the token's `.solid`
+    /// shade and content its `.onSolid`. Pass `nil` to restore the hero default.
+    func selected(_ color: SemanticColor?) -> Self {
+        copy { $0.selectedAccent = color; $0.selectedRaw = nil }
+    }
+    /// Accent for the **occupied** state — surface uses the token's `.soft` /
+    /// `.border` shades. Pass `nil` to restore the muted default.
+    func occupied(_ color: SemanticColor?) -> Self {
+        copy { $0.occupiedAccent = color; $0.occupiedRaw = nil }
+    }
+
+    /// Raw-color selected override (back-compat); prefer the token-bound overload.
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Use selected(_: SemanticColor?) — the token-bound overload.")
+    func selected(_ color: Color?) -> Self {
+        copy { $0.selectedRaw = color; $0.selectedAccent = nil }
+    }
+    /// Raw-color occupied override (back-compat); prefer the token-bound overload.
+    @_disfavoredOverload
+    @available(*, deprecated, message: "Use occupied(_: SemanticColor?) — the token-bound overload.")
+    func occupied(_ color: Color?) -> Self {
+        copy { $0.occupiedRaw = color; $0.occupiedAccent = nil }
+    }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {
+        var c = self
+        mutate(&c)
+        return c
     }
 }
 

--- a/Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCard.swift
@@ -97,6 +97,7 @@ public struct TransportCrossSellCard: View {
     private var variantValue: TransportCrossSellVariant = .ribbon
     private var accentOverride: SemanticColor?
     private var logoSlot: AnyView?
+    private var surfaceKey: Theme.BackgroundColorKey = .bgBase
 
     /// Bespoke coupon geometry (TicketStub-class chrome) — fixed constants,
     /// not knobs: the notch cut radius and the dash inset past the notch.
@@ -215,7 +216,7 @@ public struct TransportCrossSellCard: View {
         let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
         return ZStack {
             shape
-                .fill(theme.background(.bgBase))
+                .fill(theme.background(surfaceKey))
                 .overlay { if let tearX { notches(tearX: tearX, height: size.height) } }
                 .compositingGroup()                       // scope the destinationOut cut
                 .themeShadow(.soft)
@@ -362,6 +363,10 @@ public extension TransportCrossSellCard {
     func logo<L: View>(@ViewBuilder _ content: () -> L) -> Self {
         copy { $0.logoSlot = AnyView(content()) }
     }
+    /// Surface token for the ribbon's coupon fill (default `.bgBase`); the
+    /// notch cut and dashed perforation are unaffected. `.inline` draws no
+    /// surface of its own, so the key applies to the `.ribbon` variant.
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -402,6 +407,11 @@ private struct TearXAnchorKey: PreferenceKey {
                 .duration("5h drive")
                 .accent(.success)
                 .onSelect("Rent a car") {}
+            TransportCrossSellCard(.train, from: "Harbor City", to: "Riverton")
+                .price(28)
+                .duration("3h 40m")
+                .surface(.bgWhite)
+                .onSelect {}
         }
         .padding()
     }


### PR DESCRIPTION
Implements the **P1** findings from the [ThemeKitTravel modifier-gap audit](https://claude.ai/code/artifact/61be32fa-4825-4ff1-b82d-cdcf507f9f64) — the appearance values hardcoded in travel components that a consumer couldn't override (same class as `TripTypeToggle`'s track). All **additive** (defaults reproduce today's rendering → api-breakage gate green), **token-fed** (`SemanticColor` / `Theme.BackgroundColorKey`), never a raw `Color`.

### Surfaces
| Component | New modifier | Was |
|---|---|---|
| TransportCrossSellCard | `.surface(_:)` | ribbon `.bgBase` |
| PaymentMethodSelector | `.surface(_:)` | grid tile `.bgBase` |
| AncillaryCard | `.controlSurface(_:)` | stepper track `.bgSecondary` |
| DatePriceCard + DatePriceStrip | `.surface(_:)` (strip forwards to cards) | `.bgElevatorPrimary` |
| FilterBar | `.chipSurface(_:)` | chip fill `.bgWhite` |

### Accent axes (the only card organisms that lacked one)
`FlightCard.accent(_:)`, `FlightResultRow.accent(_:)` (airline glyph · route plane · bookmark-active · Select CTA), `SeatMap.accent(_:)` (passenger/deck pills). `nil` = today's `.fgHero`; semantic-fixed reds/greens left untouched.

### Seat palette — single source of truth
`SeatPalette.selected(_:)` / `.occupied(_:)` (+ a deprecated raw-`Color` escape hatch mirroring `.tierColors`); **SeatCell and SeatLegend now both read `palette.selectedColors/occupiedColors`**, so the cell and its legend can't drift.

### Bug fix
`FilterBar`'s `.outlined` chip style now honours `.accent(_:)` (was hardcoded blue) — **no-op when no accent is set**.

Built by 4 parallel sr-ios-dev agents on disjoint files. `swift build` clean · **284 tests pass** · **Demo BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)