### PR TITLE
feat(travel): full-flexibility sweep — ~150 additive knobs across the ThemeKitTravel edition

### DIFF
--- a/Sources/ThemeKitTravel/Components/Atoms/FlightStatusBadge.swift
+++ b/Sources/ThemeKitTravel/Components/Atoms/FlightStatusBadge.swift
@@ -14,31 +14,137 @@
 import SwiftUI
 import ThemeKit
 
+/// Fill emphasis of a ``FlightStatusBadge`` — the hue is always the status's
+/// own semantic colour; emphasis only changes how loudly it's applied.
+public enum FlightStatusEmphasis: Sendable {
+    /// Soft tint fill (default).
+    case soft
+    /// Solid semantic fill.
+    case solid
+    /// Hairline outline, no fill.
+    case outline
+    /// A small status dot before plain text — no fill, no border.
+    case dot
+}
+
+/// Size ramp of a ``FlightStatusBadge`` (internal heights 20/24/28 pt with
+/// stepped text styles).
+public enum FlightStatusBadgeSize: Sendable {
+    case small, medium, large
+
+    var height: CGFloat {
+        switch self {
+        case .small: 20
+        case .medium: 24
+        case .large: 28
+        }
+    }
+    var labelStyle: TextStyle {
+        switch self {
+        case .small: .overline500
+        case .medium: .labelSm700
+        case .large: .labelBase700
+        }
+    }
+    var timeStyle: TextStyle {
+        switch self {
+        case .small: .overline400
+        case .medium: .labelSm600
+        case .large: .labelBase600
+        }
+    }
+    var iconStyle: TextStyle {
+        switch self {
+        case .small: .overline500
+        case .medium: .labelSm600
+        case .large: .labelBase600
+        }
+    }
+}
+
+/// Corner treatment of a ``FlightStatusBadge``: a full `.capsule` (default) or
+/// a `.rounded` rectangle at the selector radius role.
+public enum FlightStatusBadgeShape: Sendable { case capsule, rounded }
+
 public struct FlightStatusBadge: View {
     @Environment(\.theme) private var theme
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulsePhase = false
 
     private let status: FlightStatus
     // Appearance — mutated only through the modifiers below (R2).
     private var time: String?
     private var customLabel: String?
     private var showsIcon = true
-    private var solid = false
+    private var emphasis: FlightStatusEmphasis = .soft
+    private var size: FlightStatusBadgeSize = .medium
+    private var shape: FlightStatusBadgeShape = .capsule
+    private var pulses = false
+    private var iconSetting: IconSetting = .automatic
+
+    /// Tri-state icon override: the status glyph, a custom symbol, or hidden.
+    private enum IconSetting { case automatic, custom(String), hidden }
 
     public init(_ status: FlightStatus) { self.status = status }   // R1
 
     private var color: SemanticColor { status.semantic }
 
+    private var resolvedIcon: String? {
+        guard showsIcon else { return nil }
+        switch iconSetting {
+        case .automatic: return status.icon
+        case .custom(let name): return name
+        case .hidden: return nil
+        }
+    }
+
+    private var foreground: Color {
+        switch emphasis {
+        case .solid: color.onSolid
+        case .dot: theme.text(.textPrimary)
+        case .soft, .outline: color.base
+        }
+    }
+
+    private var badgeShape: AnyShape {
+        shape == .capsule
+            ? AnyShape(Capsule(style: .continuous))
+            : AnyShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
+    }
+
+    /// Whether the opt-in urgency pulse actually plays — the `microAnimations`
+    /// switch and the system Reduce Motion setting both gate it.
+    private var pulseActive: Bool { pulses && micro && !reduceMotion }
+
     public var body: some View {
         HStack(spacing: 4) {
-            if showsIcon { Image(systemName: status.icon).font(.system(size: 11, weight: .semibold)) }
-            Text(customLabel ?? status.label).textStyle(.labelSm700)
-            if let time { Text(time).textStyle(.labelSm600).opacity(0.9) }
+            if emphasis == .dot {
+                Circle().fill(color.base).frame(width: 6, height: 6)
+            } else if let resolvedIcon {
+                Image(systemName: resolvedIcon).textStyle(size.iconStyle)
+            }
+            Text(customLabel ?? status.label).textStyle(size.labelStyle)
+            if let time { Text(time).textStyle(size.timeStyle).opacity(0.9) }
         }
-        .foregroundStyle(solid ? color.onSolid : color.base)
-        .padding(.horizontal, Theme.SpacingKey.sm.value)
-        .frame(height: 24)
-        .background(solid ? color.solid : color.bg, in: Capsule())
+        .foregroundStyle(foreground)
+        .padding(.horizontal, emphasis == .dot ? 0 : Theme.SpacingKey.sm.value)
+        .frame(height: size.height)
+        .background(backgroundFill, in: badgeShape)
+        .overlay { if emphasis == .outline { badgeShape.stroke(color.border, lineWidth: 1) } }
+        .opacity(pulseActive && pulsePhase ? 0.55 : 1)
+        .animation(pulseActive ? Motion.slower.animation.repeatForever(autoreverses: true) : nil, value: pulsePhase)
+        .onAppear { pulsePhase = pulseActive }
+        .onChange(of: pulseActive) { _, active in pulsePhase = active }
         .accessibilityLabel([customLabel ?? status.label, time].compactMap { $0 }.joined(separator: " "))
+    }
+
+    private var backgroundFill: Color {
+        switch emphasis {
+        case .soft: color.bg
+        case .solid: color.solid
+        case .outline, .dot: .clear
+        }
     }
 }
 
@@ -51,8 +157,25 @@ public extension FlightStatusBadge {
     func label(_ text: String?) -> Self { copy { $0.customLabel = text } }
     /// Show the leading icon (default on).
     func showsIcon(_ on: Bool) -> Self { copy { $0.showsIcon = on } }
-    /// Solid fill (vs the default soft tint).
-    func solid(_ on: Bool = true) -> Self { copy { $0.solid = on } }
+    /// Solid fill (vs the default soft tint). Sugar for `.emphasis(.solid)`.
+    func solid(_ on: Bool = true) -> Self { copy { $0.emphasis = on ? .solid : .soft } }
+    /// Fill emphasis — `.soft` tint (default), `.solid`, hairline `.outline`,
+    /// or a chrome-free `.dot` indicator. The hue stays the status's own
+    /// semantic colour.
+    func emphasis(_ e: FlightStatusEmphasis) -> Self { copy { $0.emphasis = e } }
+    /// Size ramp (default `.medium`, 24 pt).
+    func size(_ s: FlightStatusBadgeSize) -> Self { copy { $0.size = s } }
+    /// Corner treatment — `.capsule` (default) or `.rounded` at the selector
+    /// radius role.
+    func shape(_ s: FlightStatusBadgeShape) -> Self { copy { $0.shape = s } }
+    /// Opt-in gentle opacity pulse for urgent statuses (boarding, gate closing).
+    /// Gated by `microAnimations` and the system Reduce Motion setting; never on
+    /// by default.
+    func pulses(_ on: Bool = true) -> Self { copy { $0.pulses = on } }
+    /// Per-instance glyph override; `nil` hides the icon (≡ `showsIcon(false)`).
+    func icon(_ systemName: String?) -> Self {
+        copy { $0.iconSetting = systemName.map { .custom($0) } ?? .hidden }
+    }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -71,6 +194,27 @@ public extension FlightStatusBadge {
         }
         PreviewCase("No icon, custom label") {
             FlightStatusBadge(.boarding).showsIcon(false).label("Now boarding")
+        }
+        PreviewCase("Emphasis ramp") {
+            HStack(spacing: 8) {
+                FlightStatusBadge(.onTime).emphasis(.soft)
+                FlightStatusBadge(.onTime).emphasis(.solid)
+                FlightStatusBadge(.onTime).emphasis(.outline)
+                FlightStatusBadge(.onTime).emphasis(.dot)
+            }
+        }
+        PreviewCase("Sizes") {
+            HStack(spacing: 8) {
+                FlightStatusBadge(.delayed).size(.small)
+                FlightStatusBadge(.delayed).size(.medium)
+                FlightStatusBadge(.delayed).size(.large)
+            }
+        }
+        PreviewCase("Rounded + icon override") {
+            FlightStatusBadge(.cancelled).shape(.rounded).icon("xmark.octagon.fill")
+        }
+        PreviewCase("Pulsing (urgency, Reduce-Motion gated)") {
+            FlightStatusBadge(.boarding).emphasis(.solid).pulses()
         }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Atoms/SeatCell.swift
+++ b/Sources/ThemeKitTravel/Components/Atoms/SeatCell.swift
@@ -3,12 +3,26 @@
 //  ThemeKit
 //
 //  Atom. A single seat button — token-bound fill/border by tier + state, a
-//  configurable inner label (icon / number / initials / custom) and a recommended
-//  star. Composed by ``SeatMap`` but reusable on its own for bespoke seat grids.
+//  configurable inner label (icon / number / initials / custom), a swappable
+//  silhouette (rounded / circle / seatback) and a recommended star. Composed by
+//  ``SeatMap`` but reusable on its own for bespoke seat grids.
+//
+//  NOTE: this atom predates the copy-on-write modifier convention — its knobs
+//  are DEFAULTED init params by design. COW migration deferred to next major.
 //
 
 import SwiftUI
 import ThemeKit
+
+/// How a selected ``SeatCell`` is emphasized. Both looks resolve their colours
+/// from ``SeatPalette/selectedColors(theme:)``, so a palette override drives
+/// either treatment.
+public enum SeatSelectionEmphasis: Sendable {
+    /// The selected fill plus an emphasized 2 pt ring — the shipped default.
+    case border
+    /// The selected fill alone; the ring is dropped for a flat look.
+    case fill
+}
 
 public struct SeatCell: View {
     @Environment(\.theme) private var theme
@@ -26,6 +40,9 @@ public struct SeatCell: View {
     private let palette: SeatPalette
     private let customContent: ((SeatContext) -> AnyView)?
     private let currencyCode: String?
+    private let shape: SeatShape
+    private let recommendedSymbol: String
+    private let selectionEmphasis: SeatSelectionEmphasis
     private let action: () -> Void
 
     public init(_ seat: Seat,
@@ -38,6 +55,9 @@ public struct SeatCell: View {
                 palette: SeatPalette = .default,
                 customContent: ((SeatContext) -> AnyView)? = nil,
                 currencyCode: String = "USD",
+                shape: SeatShape = .rounded,
+                recommendedSymbol: String = "star.fill",
+                selectionEmphasis: SeatSelectionEmphasis = .border,
                 action: @escaping () -> Void = {}) {
         self.seat = seat
         self.size = size
@@ -49,6 +69,9 @@ public struct SeatCell: View {
         self.palette = palette
         self.customContent = customContent
         self.currencyCode = currencyCode
+        self.shape = shape
+        self.recommendedSymbol = recommendedSymbol
+        self.selectionEmphasis = selectionEmphasis
         self.action = action
     }
 
@@ -63,6 +86,9 @@ public struct SeatCell: View {
                 display: SeatDisplay = .icon,
                 palette: SeatPalette = .default,
                 customContent: ((SeatContext) -> AnyView)? = nil,
+                shape: SeatShape = .rounded,
+                recommendedSymbol: String = "star.fill",
+                selectionEmphasis: SeatSelectionEmphasis = .border,
                 action: @escaping () -> Void = {}) {
         self.seat = seat
         self.size = size
@@ -74,7 +100,42 @@ public struct SeatCell: View {
         self.palette = palette
         self.customContent = customContent
         self.currencyCode = nil
+        self.shape = shape
+        self.recommendedSymbol = recommendedSymbol
+        self.selectionEmphasis = selectionEmphasis
         self.action = action
+    }
+
+    /// Token-stepped size overload — `size:` takes a ``SeatSizeRamp`` instead of
+    /// raw points (compact 36 · regular 44 · large 52 · xl 60). A `nil`
+    /// `currencyCode` resolves from the environment like the omitted-currency init.
+    public init(_ seat: Seat,
+                size ramp: SeatSizeRamp,
+                isSelected: Bool = false,
+                isSelectable: Bool = true,
+                isRecommended: Bool = false,
+                assignedInitials: String? = nil,
+                display: SeatDisplay = .icon,
+                palette: SeatPalette = .default,
+                customContent: ((SeatContext) -> AnyView)? = nil,
+                currencyCode: String? = nil,
+                shape: SeatShape = .rounded,
+                recommendedSymbol: String = "star.fill",
+                selectionEmphasis: SeatSelectionEmphasis = .border,
+                action: @escaping () -> Void = {}) {
+        if let currencyCode {
+            self.init(seat, size: ramp.points, isSelected: isSelected, isSelectable: isSelectable,
+                      isRecommended: isRecommended, assignedInitials: assignedInitials,
+                      display: display, palette: palette, customContent: customContent,
+                      currencyCode: currencyCode, shape: shape, recommendedSymbol: recommendedSymbol,
+                      selectionEmphasis: selectionEmphasis, action: action)
+        } else {
+            self.init(seat, size: ramp.points, isSelected: isSelected, isSelectable: isSelectable,
+                      isRecommended: isRecommended, assignedInitials: assignedInitials,
+                      display: display, palette: palette, customContent: customContent,
+                      shape: shape, recommendedSymbol: recommendedSymbol,
+                      selectionEmphasis: selectionEmphasis, action: action)
+        }
     }
 
     private var resolvedCurrency: String {
@@ -82,13 +143,11 @@ public struct SeatCell: View {
     }
 
     public var body: some View {
+        let cellShape = shape.anyShape(cornerRadius: Theme.RadiusRole.selector.value)
         Button(action: action) {
-            RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
+            cellShape
                 .fill(fillColor)
-                .overlay(
-                    RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
-                        .stroke(strokeColor, lineWidth: isSelected ? 2 : 1)
-                )
+                .overlay(cellShape.stroke(strokeColor, lineWidth: strokeWidth))
                 .overlay(glyph)
                 .overlay(alignment: .topTrailing) { if showsStar { recommendedStar } }
                 .frame(width: size, height: size)
@@ -133,20 +192,22 @@ public struct SeatCell: View {
         }
     }
 
+    // Glyphs step through the type ramp (Dynamic Type for free) instead of
+    // hardcoded point sizes.
     @ViewBuilder private var iconGlyph: some View {
         if let assignedInitials {
             Text(assignedInitials).textStyle(.labelSm600).foregroundStyle(contentColor)
         } else if isSelected {
-            Image(systemName: "checkmark").font(.system(size: 13, weight: .bold)).foregroundStyle(contentColor)
+            Image(systemName: "checkmark").textStyle(.labelSm700).foregroundStyle(contentColor)
         } else if seat.isOccupied {
-            Image(systemName: "xmark").font(.system(size: 12, weight: .semibold)).foregroundStyle(contentColor)
+            Image(systemName: "xmark").textStyle(.labelSm600).foregroundStyle(contentColor)
         } else {
-            Image(systemName: seat.tier.glyph).font(.system(size: 13, weight: .semibold)).foregroundStyle(contentColor)
+            Image(systemName: seat.tier.glyph).textStyle(.labelSm600).foregroundStyle(contentColor)
         }
     }
 
     private var recommendedStar: some View {
-        Image(systemName: "star.fill")
+        Image(systemName: recommendedSymbol)
             .font(.system(size: 8, weight: .bold))
             .foregroundStyle(theme.foreground(.systemcolorsFgWarning))
             .padding(2)
@@ -162,9 +223,15 @@ public struct SeatCell: View {
         return palette.colors(for: seat.tier, theme: theme).fill
     }
     private var strokeColor: Color {
-        if isSelected { return palette.selectedColors(theme: theme).stroke }
+        if isSelected {
+            return selectionEmphasis == .border ? palette.selectedColors(theme: theme).stroke : .clear
+        }
         if seat.isOccupied { return palette.occupiedColors(theme: theme).stroke }
         return palette.colors(for: seat.tier, theme: theme).stroke
+    }
+    private var strokeWidth: CGFloat {
+        guard isSelected else { return 1 }
+        return selectionEmphasis == .border ? 2 : 0
     }
     private var contentColor: Color {
         if isSelected { return palette.selectedColors(theme: theme).content }
@@ -200,5 +267,18 @@ public struct SeatCell: View {
         PreviewCase("Number display") { SeatCell(Seat("1G"), display: .number) }
         PreviewCase("Accent selected") { SeatCell(Seat("2A"), isSelected: true, palette: SeatPalette().selected(.accent)) }
         PreviewCase("Accent occupied") { SeatCell(Seat("2B", occupied: true), palette: SeatPalette().occupied(.warning)) }
+        PreviewCase("Circle shape") { SeatCell(Seat("3A"), shape: .circle) }
+        PreviewCase("Seatback shape") { SeatCell(Seat("3B"), shape: .seatback) }
+        PreviewCase("Seatback selected") { SeatCell(Seat("3C"), isSelected: true, shape: .seatback) }
+        PreviewCase("Ramp sizes") {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                SeatCell(Seat("4A"), size: .compact)
+                SeatCell(Seat("4B"), size: .regular)
+                SeatCell(Seat("4C"), size: .large)
+                SeatCell(Seat("4D"), size: .xl)
+            }
+        }
+        PreviewCase("Fill emphasis") { SeatCell(Seat("5A"), isSelected: true, selectionEmphasis: .fill) }
+        PreviewCase("Custom star") { SeatCell(Seat("5B"), isRecommended: true, recommendedSymbol: "sparkles") }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Molecules/CabinClassSelector.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/CabinClassSelector.swift
@@ -15,9 +15,40 @@ import ThemeKit
 // MARK: - Variant
 
 /// How ``CabinClassSelector`` renders its options: an inline `SegmentedControl`
-/// (default), a horizontally-scrolling `Chip` row, or `RadioGroup`-style rows
-/// for sheet contexts.
-public enum CabinClassVariant: Sendable { case segmented, chips, list }
+/// (default), a horizontally-scrolling `Chip` row, `RadioGroup`-style rows
+/// for sheet contexts, or a 2×2 grid of selectable `.cards` (glyph + label +
+/// optional description).
+public enum CabinClassVariant: Sendable { case segmented, chips, list, cards }
+
+/// Control-size ramp forwarded to the wrapped kit controls (`SegmentedControl`
+/// / `Chip`); `.cards` steps its padding on the same ramp. `.list` keeps the
+/// stock `RadioGroup` anatomy.
+public enum CabinClassSelectorSize: Sendable {
+    case small, medium, large
+
+    var segmented: SegmentedSize {
+        switch self {
+        case .small: .small
+        case .medium: .medium
+        case .large: .large
+        }
+    }
+    var chip: ChipSize {
+        switch self {
+        case .small: .small
+        case .medium: .medium
+        case .large: .large
+        }
+    }
+    /// Vertical padding step for the `.cards` grid.
+    var cardPadding: CGFloat {
+        switch self {
+        case .small: Theme.SpacingKey.sm.value
+        case .medium: Theme.SpacingKey.md.value
+        case .large: Theme.SpacingKey.base.value
+        }
+    }
+}
 
 // MARK: - CabinClassSelector
 
@@ -33,6 +64,8 @@ public enum CabinClassVariant: Sendable { case segmented, chips, list }
 public struct CabinClassSelector: View {
     @Environment(\.isEnabled) private var isEnabled     // R3 — set natively by `.disabled(_:)`
     @Environment(\.isReadOnly) private var isReadOnly   // E1 — normal chrome, selection blocked
+    @Environment(\.theme) private var theme
+    @Environment(\.layoutDirection) private var layoutDirection
 
     @ControllableState private var selection: CabinClass
 
@@ -41,6 +74,11 @@ public struct CabinClassSelector: View {
     private var variant: CabinClassVariant = .segmented
     private var showsGlyphs = false
     private var accent: SemanticColor? = nil
+    private var sizeOverride: CabinClassSelectorSize?
+    private var chipsWrap = false
+    private var labelOverride: ((CabinClass) -> String)?
+    private var glyphOverride: ((CabinClass) -> String)?
+    private var descriptionProvider: ((CabinClass) -> String?)?
 
     /// Controlled — reads and writes flow through the caller's binding.
     public init(selection: Binding<CabinClass>) {   // R1
@@ -55,12 +93,18 @@ public struct CabinClassSelector: View {
     /// Never render an empty control: an empty `classes` list falls back to all four.
     private var displayedClasses: [CabinClass] { classes.isEmpty ? CabinClass.allCases : classes }
 
+    // Per-cabin content resolution — overrides win, the canonical model is the fallback.
+    private func label(for cabin: CabinClass) -> String { labelOverride?(cabin) ?? cabin.label }
+    private func glyph(for cabin: CabinClass) -> String { glyphOverride?(cabin) ?? cabin.glyph }
+    private func description(for cabin: CabinClass) -> String? { descriptionProvider?(cabin) }
+
     public var body: some View {
         Group {
             switch variant {
             case .segmented: segmented
             case .chips: chipRow
             case .list: radioList
+            case .cards: cardGrid
             }
         }
         .allowsHitTesting(!isReadOnly)   // E1 — read-only keeps chrome + VoiceOver value
@@ -83,10 +127,11 @@ public struct CabinClassSelector: View {
     }
 
     @ViewBuilder private var segmented: some View {
-        let control = SegmentedControl(
-            displayedClasses.map { SegmentItem($0.label, systemImage: showsGlyphs ? $0.glyph : nil) },
+        let base = SegmentedControl(
+            displayedClasses.map { SegmentItem(label(for: $0), systemImage: showsGlyphs ? glyph(for: $0) : nil) },
             selection: indexBinding
         )
+        let control = sizeOverride.map { base.size($0.segmented) } ?? base
         // Spec mapping: accent → the thumbless `.tinted` selection style; the
         // stock raised thumb keeps its neutral chroma when no accent is set.
         if let accent { control.tinted(accent) } else { control }
@@ -94,22 +139,35 @@ public struct CabinClassSelector: View {
 
     // MARK: .chips — Chip row (radio semantics: tapping the selected chip keeps it)
 
-    private var chipRow: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: Theme.SpacingKey.sm.value) {
-                ForEach(displayedClasses, id: \.self) { cabin in
-                    Chip(cabin.label, isSelected: Binding(
-                        get: { selection == cabin },
-                        set: { isOn in if isOn { selection = cabin } }
-                    ))
-                    .icon(showsGlyphs ? cabin.glyph : nil)
-                }
-            }
-        }
+    @ViewBuilder private var chipRow: some View {
         // Accent flows down the standard ComponentDefaults cascade so
         // accent-aware `ChipStyle`s resolve it; the built-in tonal/solid
         // chip chroma stays hero-tinted by design.
-        .componentDefaults(accent: accent)
+        if chipsWrap {
+            // Wrapping FlowLayout — RTL-aware via the injected layout direction.
+            FlowLayout(spacing: Theme.SpacingKey.sm.value,
+                       lineSpacing: Theme.SpacingKey.sm.value,
+                       layoutDirection: layoutDirection) {
+                chipItems
+            }
+            .componentDefaults(accent: accent)
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Theme.SpacingKey.sm.value) { chipItems }
+            }
+            .componentDefaults(accent: accent)
+        }
+    }
+
+    private var chipItems: some View {
+        ForEach(displayedClasses, id: \.self) { cabin in
+            let chip = Chip(label(for: cabin), isSelected: Binding(
+                get: { selection == cabin },
+                set: { isOn in if isOn { selection = cabin } }
+            ))
+            .icon(showsGlyphs ? glyph(for: cabin) : nil)
+            if let sizeOverride { chip.size(sizeOverride.chip) } else { chip }
+        }
     }
 
     // MARK: .list — RadioGroup rows for sheet contexts
@@ -121,9 +179,51 @@ public struct CabinClassSelector: View {
                 get: { selection },
                 set: { newValue in if let newValue { selection = newValue } }
             ),
-            label: { $0.label }
+            label: { label(for: $0) }
         )
         .accent(accent)
+    }
+
+    // MARK: .cards — 2×2 grid of selectable cards (glyph + label + optional description)
+
+    private var cardGrid: some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: Theme.SpacingKey.sm.value), count: 2),
+            spacing: Theme.SpacingKey.sm.value
+        ) {
+            ForEach(displayedClasses, id: \.self) { cabin in card(cabin) }
+        }
+    }
+
+    private func card(_ cabin: CabinClass) -> some View {
+        let isOn = selection == cabin
+        let tint = accent ?? .primary
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
+        return Button { selection = cabin } label: {
+            VStack(spacing: Theme.SpacingKey.xs.value) {
+                Image(systemName: glyph(for: cabin))
+                    .textStyle(.headingXs)
+                    .foregroundStyle(isOn ? tint.base : theme.text(.textSecondary))
+                Text(label(for: cabin))
+                    .textStyle(.labelBase600)
+                    .foregroundStyle(theme.text(.textPrimary))
+                if let description = description(for: cabin) {
+                    Text(description)
+                        .textStyle(.bodySm400)
+                        .foregroundStyle(theme.text(.textSecondary))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, (sizeOverride ?? .medium).cardPadding)
+            .padding(.horizontal, Theme.SpacingKey.sm.value)
+            .background(isOn ? tint.soft : theme.background(.bgElevatorPrimary), in: shape)
+            .overlay { shape.strokeBorder(isOn ? tint.base : theme.border(.borderPrimary), lineWidth: isOn ? 1.5 : 1) }
+            .contentShape(shape)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel([label(for: cabin), description(for: cabin)].compactMap { $0 }.joined(separator: ", "))
+        .accessibilityAddTraits(isOn ? .isSelected : [])
     }
 }
 
@@ -141,9 +241,23 @@ public extension CabinClassSelector {
     /// the `.list` rows stay text-only, matching `RadioGroup` anatomy).
     func showsGlyphs(_ on: Bool = true) -> Self { copy { $0.showsGlyphs = on } }
     /// Semantic tint: `.segmented` switches to the tinted selection style,
-    /// `.list` tints the radios, `.chips` feeds the subtree accent cascade.
-    /// `nil` (default) keeps the stock hero chroma.
+    /// `.list` tints the radios, `.chips` feeds the subtree accent cascade,
+    /// `.cards` tints the selected card. `nil` (default) keeps the stock hero chroma.
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+    /// Control-size ramp forwarded to the wrapped `SegmentedControl` / `Chip`
+    /// (and the `.cards` padding step). Unset keeps each control's stock size.
+    func size(_ s: CabinClassSelectorSize) -> Self { copy { $0.sizeOverride = s } }
+    /// Lay `.chips` out as a wrapping ``FlowLayout`` (RTL-aware) instead of a
+    /// horizontal `ScrollView` — every option visible at once.
+    func chipsWrap(_ on: Bool = true) -> Self { copy { $0.chipsWrap = on } }
+    /// Override the display label per cabin (default: the canonical
+    /// ``CabinClass/label``), e.g. shortened labels for tight segmented rows.
+    func label(_ f: @escaping (CabinClass) -> String) -> Self { copy { $0.labelOverride = f } }
+    /// Override the SF Symbol per cabin (default: the canonical ``CabinClass/glyph``).
+    func glyph(_ f: @escaping (CabinClass) -> String) -> Self { copy { $0.glyphOverride = f } }
+    /// Per-cabin description line, rendered by the `.cards` variant beneath the
+    /// label (`nil` for no description on that card). Other variants ignore it.
+    func description(_ f: @escaping (CabinClass) -> String?) -> Self { copy { $0.descriptionProvider = f } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -167,8 +281,23 @@ public extension CabinClassSelector {
                     CabinClassSelector(selection: $cabin).classes([.economy, .business]).accent(.success)
                     Text(verbatim: "Chips")
                     CabinClassSelector(selection: $cabin).variant(.chips).showsGlyphs()
+                    Text(verbatim: "Chips · wrapping + small")
+                    CabinClassSelector(selection: $cabin).variant(.chips).chipsWrap().size(.small)
                     Text(verbatim: "List (sheet contexts)")
                     CabinClassSelector(selection: $cabin).variant(.list).accent(.info)
+                    Text(verbatim: "Cards (glyph + label + description)")
+                    CabinClassSelector(selection: $cabin)
+                        .variant(.cards)
+                        .description { cabin in
+                            cabin == .economy ? String(themeKitTravel: "Best value") : nil
+                        }
+                        .accent(.success)
+                    Text(verbatim: "Label + glyph overrides · large")
+                    CabinClassSelector(selection: $cabin)
+                        .showsGlyphs()
+                        .size(.large)
+                        .label { $0 == .premiumEconomy ? String(themeKitTravel: "Premium") : $0.label }
+                        .glyph { $0 == .first ? "star" : $0.glyph }
                     Text(verbatim: "Uncontrolled · read-only · disabled")
                     CabinClassSelector(initiallySelected: .business)
                     CabinClassSelector(selection: $cabin).variant(.chips).readOnly()
@@ -189,6 +318,7 @@ public extension CabinClassSelector {
                 CabinClassSelector(selection: $cabin).showsGlyphs()
                 CabinClassSelector(selection: $cabin).variant(.chips)
                 CabinClassSelector(selection: $cabin).variant(.list).accent(.success)
+                CabinClassSelector(selection: $cabin).variant(.cards)
             }
             .padding()
         }

--- a/Sources/ThemeKitTravel/Components/Molecules/DatePriceStrip.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/DatePriceStrip.swift
@@ -16,9 +16,38 @@ public struct DatePriceItem: Identifiable, Sendable {
     public var id: String { date }
     public let date: String    // e.g. "18 Jul"
     public let price: Decimal
-    public init(_ date: String, price: Decimal) {
+    /// Optional weekday overline, e.g. "Fri" (rendered above the date on cards).
+    public let weekday: String?
+    /// Marks the date as sold out / not bookable — the card renders disabled and
+    /// the strip skips it for selection and the cheapest-fare highlight.
+    public let unavailable: Bool
+
+    public init(_ date: String, price: Decimal, weekday: String? = nil, unavailable: Bool = false) {
         self.date = date
         self.price = price
+        self.weekday = weekday
+        self.unavailable = unavailable
+    }
+}
+
+/// Layout of a ``DatePriceStrip``: a multi-column ``grid(columns:)`` (the stock
+/// three-column presentation) or the horizontal ``strip`` of scrollable pills.
+/// `.strip()` / `.columns(_:)` remain as forwarding sugar.
+public enum DatePriceLayout: Sendable {
+    case grid(columns: Int)
+    case strip
+}
+
+/// Height ramp for the strip-layout pills (internal 32 / 40 / 48 pt).
+public enum DatePricePillSize: Sendable {
+    case compact, regular, large
+
+    var height: CGFloat {
+        switch self {
+        case .compact: 32
+        case .regular: 40
+        case .large: 48
+        }
     }
 }
 
@@ -40,6 +69,9 @@ public struct DatePriceCard: View {
     private var isCheapest = false
     private var pill = false
     private var surface: Theme.BackgroundColorKey = .bgElevatorPrimary
+    private var accent: SemanticColor?
+    private var cheapestToneOverride: SemanticColor?
+    private var pillSize: DatePricePillSize = .regular
 
     public init(_ item: DatePriceItem, isSelected: Bool, action: @escaping () -> Void) {   // R1
         self.item = item
@@ -52,8 +84,25 @@ public struct DatePriceCard: View {
         currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
+    /// Selected-state foreground — the accent's base shade, or the stock hero.
+    private var selectedColor: Color { accent?.base ?? theme.foreground(.fgHero) }
+    /// Lowest-fare foreground — the tone's base shade, or the stock success token.
+    private var cheapestColor: Color { cheapestToneOverride?.base ?? theme.foreground(.systemcolorsFgSuccess) }
+
     private var priceColor: Color {
-        isSelected ? theme.foreground(.fgHero) : (isCheapest ? theme.foreground(.systemcolorsFgSuccess) : theme.text(.textPrimary))
+        if item.unavailable { return theme.text(.textDisabled) }
+        return isSelected ? selectedColor : (isCheapest ? cheapestColor : theme.text(.textPrimary))
+    }
+
+    /// VoiceOver label — built in explicit steps to keep the SwiftUI body type-checkable.
+    private var accessibilityText: String {
+        let dayDate = [item.weekday, item.date].compactMap { $0 }.joined(separator: " ")
+        let priceText = item.price.formatted(
+            .currency(code: resolvedCurrency).precision(.fractionLength(0)).locale(locale))
+        var parts = [dayDate, priceText]
+        if isCheapest { parts.append(String(themeKit: "lowest fare")) }
+        if item.unavailable { parts.append(String(themeKit: "unavailable")) }
+        return parts.joined(separator: ", ")
     }
 
     public var body: some View {
@@ -61,11 +110,8 @@ public struct DatePriceCard: View {
             if pill { pillShell } else { cardedShell }
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(
-            "\(item.date), "
-                + item.price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0)).locale(locale))
-                + (isCheapest ? ", " + String(themeKit: "lowest fare") : "")
-        )
+        .disabled(item.unavailable)
+        .accessibilityLabel(accessibilityText)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
@@ -82,38 +128,48 @@ public struct DatePriceCard: View {
     }
 
     /// The pill shell — the horizontal "Timeline" strip presentation: a rounded
-    /// capsule that turns hero-soft with a 2pt hero border + semibold date when
-    /// selected. Brand color resolves from the theme.
+    /// capsule that turns accent-soft with a 2pt accent border + semibold date
+    /// when selected. Brand color resolves from the theme (or ``accent(_:)``).
     private var pillShell: some View {
         let shape = Capsule(style: .continuous)
         return VStack(spacing: 2) {
             Text(item.date)
                 .textStyle(isSelected ? .labelSm600 : .bodySm400)
-                .foregroundStyle(theme.text(.textPrimary))
+                .foregroundStyle(item.unavailable ? theme.text(.textDisabled) : theme.text(.textPrimary))
             Text(item.price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0)).locale(locale)))
                 .textStyle(.overline400)
-                .foregroundStyle(isCheapest ? theme.foreground(.systemcolorsFgSuccess) : theme.text(.textTertiary))
+                .foregroundStyle(item.unavailable
+                                 ? theme.text(.textDisabled)
+                                 : (isCheapest ? cheapestColor : theme.text(.textTertiary)))
         }
         .padding(.horizontal, Theme.SpacingKey.base.value)
-        .frame(height: 40)
-        .background(isSelected ? SemanticColor.primary.soft : theme.background(.bgWhite), in: shape)
-        .overlay { if isSelected { shape.strokeBorder(theme.border(.borderHero), lineWidth: 2) } }
+        .frame(height: pillSize.height)
+        .background(isSelected ? (accent ?? .primary).soft : theme.background(.bgWhite), in: shape)
+        .overlay {
+            if isSelected { shape.strokeBorder(accent?.base ?? theme.border(.borderHero), lineWidth: 2) }
+        }
     }
 
-    /// The card's inner layout — everything inside the shell. The 6% hero wash on
-    /// selection is not expressible as a `surfaceKey` token, so it stays in-content,
-    /// layered over the style's surface fill (a custom style cannot recolour it).
+    /// The card's inner layout — everything inside the shell. The selected wash is
+    /// the accent's `bg` shade (token-fed; not expressible as a `surfaceKey`, so it
+    /// stays in-content, layered over the style's surface fill).
     private var cardContent: some View {
         VStack(spacing: 2) {
+            if let weekday = item.weekday {
+                Text(weekday).textStyle(.overline400)
+                    .foregroundStyle(item.unavailable ? theme.text(.textDisabled) : theme.text(.textTertiary))
+            }
             Text(item.date).textStyle(.labelSm600)
-                .foregroundStyle(isSelected ? theme.foreground(.fgHero) : theme.text(.textSecondary))
+                .foregroundStyle(item.unavailable
+                                 ? theme.text(.textDisabled)
+                                 : (isSelected ? selectedColor : theme.text(.textSecondary)))
             Text(item.price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(2)).locale(locale)))
                 .textStyle(.labelBase700).foregroundStyle(priceColor)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
         .padding(.horizontal, Theme.SpacingKey.xs.value)
-        .background(isSelected ? theme.background(.bgHero).opacity(0.06) : Color.clear)
+        .background(isSelected ? (accent ?? .primary).bg : Color.clear)
     }
 }
 
@@ -127,6 +183,13 @@ public extension DatePriceCard {
     func pill(_ on: Bool = true) -> Self { copy { $0.pill = on } }
     /// Surface token for the carded shell (default `.bgElevatorPrimary`).
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surface = key } }
+    /// Semantic accent for the selected state — pill fill `soft` + border `base`,
+    /// card date/price `base`, wash `bg`. `nil` (default) keeps the stock hero chroma.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+    /// Semantic tone for the lowest-fare highlight (default `.success`).
+    func cheapestTone(_ color: SemanticColor) -> Self { copy { $0.cheapestToneOverride = color } }
+    /// Height ramp for the pill presentation (default `.regular`, 40 pt).
+    func pillSize(_ s: DatePricePillSize) -> Self { copy { $0.pillSize = s } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {
         var c = self
@@ -149,6 +212,10 @@ public struct DatePriceStrip: View {
     private var highlightsCheapest = true
     private var stripLayout = false
     private var surface: Theme.BackgroundColorKey = .bgElevatorPrimary
+    private var accent: SemanticColor?
+    private var cheapestToneOverride: SemanticColor?
+    private var pillSize: DatePricePillSize = .regular
+    private var customCell: ((DatePriceItem, Bool) -> AnyView)?
     private var onPrev: (() -> Void)?
     private var onNext: (() -> Void)?
 
@@ -158,8 +225,9 @@ public struct DatePriceStrip: View {
     }
 
     private var cheapestIndex: Int? {
-        guard highlightsCheapest, !items.isEmpty else { return nil }
-        return items.indices.min(by: { items[$0].price < items[$1].price })
+        guard highlightsCheapest else { return nil }
+        let bookable = items.indices.filter { !items[$0].unavailable }
+        return bookable.min(by: { items[$0].price < items[$1].price })
     }
 
     /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
@@ -183,18 +251,15 @@ public struct DatePriceStrip: View {
     }
 
     /// The horizontal "Timeline" strip — scrollable pills on a surface, with the
-    /// selected pill auto-centered.
+    /// selected pill auto-centered. The scroll/selection machinery also hosts a
+    /// custom ``cell(_:)`` when one is set.
     private var stripView: some View {
         let cheapest = cheapestIndex
         return ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: Theme.SpacingKey.xs.value) {
                     ForEach(Array(items.enumerated()), id: \.offset) { i, item in
-                        DatePriceCard(item, isSelected: i == selection) { selection = i }
-                            .currency(resolvedCurrency)
-                            .cheapest(i == cheapest)
-                            .surface(surface)
-                            .pill()
+                        cell(i, item, cheapest: cheapest, pill: true)
                             .id(i)
                     }
                 }
@@ -211,17 +276,38 @@ public struct DatePriceStrip: View {
         let cheapest = cheapestIndex
         return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: max(1, columns)), spacing: 8) {
             ForEach(Array(items.enumerated()), id: \.offset) { i, item in
-                DatePriceCard(item, isSelected: i == selection) { selection = i }
-                    .currency(resolvedCurrency)
-                    .cheapest(i == cheapest)
-                    .surface(surface)
+                cell(i, item, cheapest: cheapest, pill: false)
             }
         }
     }
 
+    /// One cell — a fully custom ``cell(_:)`` slot (selection machinery retained)
+    /// or the built-in ``DatePriceCard``, configured with the strip's settings.
+    @ViewBuilder private func cell(_ i: Int, _ item: DatePriceItem, cheapest: Int?, pill: Bool) -> some View {
+        if let customCell {
+            Button { selection = i } label: { customCell(item, i == selection) }
+                .buttonStyle(.plain)
+                .disabled(item.unavailable)
+                .accessibilityAddTraits(i == selection ? .isSelected : [])
+        } else {
+            configuredCard(i, item, cheapest: cheapest, pill: pill)
+        }
+    }
+
+    private func configuredCard(_ i: Int, _ item: DatePriceItem, cheapest: Int?, pill: Bool) -> DatePriceCard {
+        var card = DatePriceCard(item, isSelected: i == selection) { selection = i }
+            .currency(resolvedCurrency)
+            .cheapest(i == cheapest)
+            .surface(surface)
+            .accent(accent)
+        if let cheapestToneOverride { card = card.cheapestTone(cheapestToneOverride) }
+        if pill { card = card.pill().pillSize(pillSize) }
+        return card
+    }
+
     private func pageButton(_ name: String, label: String, _ action: (() -> Void)?) -> some View {
         Button { action?() } label: {
-            Image(systemName: name).font(.system(size: 13, weight: .semibold))
+            Image(systemName: name).textStyle(.labelBase600)
                 .foregroundStyle(theme.foreground(.fgHero))
                 .mirrorsInRTL()
                 .frame(width: 30, height: 30)
@@ -240,15 +326,43 @@ public extension DatePriceStrip {
     /// Currency code for the prices. Unset, it resolves from `\.formatDefaults`,
     /// then the locale's currency, then "USD".
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
-    /// Number of columns for the grid layout (default 3).
+    /// Number of columns for the grid layout (default 3). Sugar for
+    /// `.layout(.grid(columns:))`.
     func columns(_ count: Int) -> Self { copy { $0.columns = max(1, count) } }
     /// Lay the dates out as a horizontal **strip** of scrollable pills (the
-    /// "Timeline" presentation) instead of the multi-column grid.
+    /// "Timeline" presentation) instead of the multi-column grid. Sugar for
+    /// `.layout(.strip)`.
     func strip(_ on: Bool = true) -> Self { copy { $0.stripLayout = on } }
+    /// Layout of the strip: `.grid(columns:)` (default, 3 columns) or the
+    /// horizontal `.strip` of scrollable pills. Consolidates `.strip()` / `.columns(_:)`.
+    func layout(_ l: DatePriceLayout) -> Self {
+        copy {
+            switch l {
+            case .grid(let columns):
+                $0.stripLayout = false
+                $0.columns = max(1, columns)
+            case .strip:
+                $0.stripLayout = true
+            }
+        }
+    }
     /// Auto-highlight the lowest fare in success green (default on).
     func highlightCheapest(_ on: Bool = true) -> Self { copy { $0.highlightsCheapest = on } }
     /// Surface token for the strip track and the cards it builds (default `.bgElevatorPrimary`).
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surface = key } }
+    /// Semantic accent for the selected state, forwarded to every card — pill
+    /// fill `soft` + border `base`, card date/price `base`, wash `bg`.
+    /// `nil` (default) keeps the stock hero chroma.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+    /// Semantic tone for the lowest-fare highlight (default `.success`).
+    func cheapestTone(_ color: SemanticColor) -> Self { copy { $0.cheapestToneOverride = color } }
+    /// Height ramp for the strip-layout pills (default `.regular`, 40 pt).
+    func pillSize(_ s: DatePricePillSize) -> Self { copy { $0.pillSize = s } }
+    /// Fully custom cell — render your own view per date; the strip keeps its
+    /// selection, disabled-date and scroll-centering machinery.
+    func cell<V: View>(@ViewBuilder _ content: @escaping (DatePriceItem, Bool) -> V) -> Self {
+        copy { $0.customCell = { item, isSelected in AnyView(content(item, isSelected)) } }
+    }
     /// Adds prev/next paging chevrons flanking the strip.
     func onPage(prev: @escaping () -> Void, next: @escaping () -> Void) -> Self { copy { $0.onPrev = prev; $0.onNext = next } }
 
@@ -271,6 +385,36 @@ public extension DatePriceStrip {
         PreviewCase("Grid") { DatePriceStrip(items, selection: $sel) }
         PreviewCase("Paged grid") { DatePriceStrip(items, selection: $sel).onPage(prev: {}, next: {}) }
         PreviewCase("Custom surface") { DatePriceStrip(items, selection: $sel).surface(.bgSecondaryLight) }
+        PreviewCase("Accent + cheapest tone") {
+            DatePriceStrip(items, selection: $sel).accent(.info).cheapestTone(.warning)
+        }
+        PreviewCase("Strip · large pills · accent") {
+            DatePriceStrip(items, selection: $sel).layout(.strip).pillSize(.large).accent(.success)
+        }
+        PreviewCase("Weekdays + unavailable · 2 columns") {
+            DatePriceStrip(
+                [
+                    DatePriceItem("17 Jul", price: 1_697.99, weekday: "Fri"),
+                    DatePriceItem("18 Jul", price: 1_767.99, weekday: "Sat", unavailable: true),
+                    DatePriceItem("19 Jul", price: 1_474.99, weekday: "Sun"),
+                    DatePriceItem("20 Jul", price: 1_914.99, weekday: "Mon"),
+                ],
+                selection: $sel
+            )
+            .layout(.grid(columns: 2))
+        }
+        PreviewCase("Custom cell slot") {
+            DatePriceStrip(items, selection: $sel).strip().cell { item, isSelected in
+                VStack(spacing: 2) {
+                    Text(item.date).textStyle(isSelected ? .labelSm700 : .bodySm400)
+                    Text(item.price.formatted(.currency(code: "USD").precision(.fractionLength(0))))
+                        .textStyle(.overline500)
+                }
+                .padding(Theme.SpacingKey.sm.value)
+                .background(isSelected ? SemanticColor.accent.soft : .clear,
+                            in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value))
+            }
+        }
     }
 }
 

--- a/Sources/ThemeKitTravel/Components/Molecules/FlightRoute.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/FlightRoute.swift
@@ -22,7 +22,15 @@ public enum FlightRouteTrack {
     /// Design-system spec: full-width hairlines flanking the duration, the
     /// stops label centered beneath in tertiary — no capsule, no accent.
     case inline
+    /// A dashed arc with a plane glyph at its apex (mirrors under RTL).
+    case arc
+    /// Endpoint dots on a hairline, with hollow mid-line dots per stop.
+    case dots
 }
+
+/// Type ramp for ``FlightRoute`` — steps the time / code / duration text styles
+/// together (default `.regular`, the stock mapping).
+public enum FlightRouteSize: Sendable { case compact, regular, large }
 
 public struct FlightRoute: View {
     @Environment(\.theme) private var theme
@@ -38,6 +46,11 @@ public struct FlightRoute: View {
     private var nextDay = false
     private var accentKey: Theme.ForegroundColorKey = .systemcolorsFgSuccess
     private var track: FlightRouteTrack = .path
+    private var size: FlightRouteSize = .regular
+    private var originCity: String?
+    private var destinationCity: String?
+    private var durationOverride: String?
+    private var stopsTone: SemanticColor?
 
     public init(from origin: String, to destination: String, departure: Date, arrival: Date) {   // R1
         self.origin = origin
@@ -48,15 +61,58 @@ public struct FlightRoute: View {
 
     public var body: some View {
         HStack(spacing: density.scale(track == .inline ? Theme.SpacingKey.lg.value : Theme.SpacingKey.sm.value)) {
-            timeColumn(departure, code: origin, alignment: track == .inline ? .trailing : .leading, marker: nil)
+            timeColumn(departure, code: origin, city: originCity,
+                       alignment: track == .inline ? .trailing : .leading, marker: nil)
             switch track {
             case .path: path
             case .inline: inlineTrack
+            case .arc: arcTrack
+            case .dots: dotsTrack
             }
-            timeColumn(arrival, code: destination, alignment: track == .inline ? .leading : .trailing, marker: nextDay ? "+1" : nil)
+            timeColumn(arrival, code: destination, city: destinationCity,
+                       alignment: track == .inline ? .leading : .trailing, marker: nextDay ? "+1" : nil)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilitySummary)
+    }
+
+    // MARK: Size ramp — steps the three text roles together, per track family.
+
+    private var timeStyle: TextStyle {
+        switch (track, size) {
+        case (.inline, .compact): .labelBase600
+        case (.inline, .regular): .labelMd600
+        case (.inline, .large): .labelLg600
+        case (_, .compact): .labelSm700
+        case (_, .regular): .labelBase700
+        case (_, .large): .labelMd700
+        }
+    }
+    private var codeStyle: TextStyle {
+        switch (track, size) {
+        case (.inline, .compact): .overline500
+        case (.inline, .regular): .bodySm400
+        case (.inline, .large): .bodyBase400
+        case (_, .compact): .overline400
+        case (_, .regular): .overline500
+        case (_, .large): .labelSm600
+        }
+    }
+    private var durationStyle: TextStyle {
+        switch (track, size) {
+        case (.inline, .compact): .overline400
+        case (.inline, .regular): .bodySm400
+        case (.inline, .large): .bodyBase400
+        case (_, .compact): .overline400
+        case (_, .regular): .overline400
+        case (_, .large): .bodySm400
+        }
+    }
+
+    /// Stops label colour: direct keeps the path accent, 1+ stops uses the
+    /// ``stopsTone(_:)`` (default tertiary).
+    private var stopsLabelColor: Color {
+        stops == 0 ? theme.foreground(accentKey) : (stopsTone?.base ?? theme.text(.textTertiary))
     }
 
     private var accessibilitySummary: String {
@@ -65,18 +121,21 @@ public struct FlightRoute: View {
         return String(themeKit: "\(origin) \(departs) to \(destination) \(arrives), \(durationText), \(stopsAccessibility)")
     }
 
-    private func timeColumn(_ date: Date, code: String, alignment: HorizontalAlignment, marker: String?) -> some View {
+    private func timeColumn(_ date: Date, code: String, city: String?, alignment: HorizontalAlignment, marker: String?) -> some View {
         let time = date.formatted(Date.FormatStyle(date: .omitted, time: .shortened).locale(locale))
         return VStack(alignment: alignment, spacing: track == .inline ? 0 : 2) {
             HStack(alignment: .top, spacing: 2) {
                 Text(time)
-                    .textStyle(track == .inline ? .labelMd600 : .labelBase700)
+                    .textStyle(timeStyle)
                     .foregroundStyle(theme.text(.textPrimary))
                 if let marker { Text(marker).textStyle(.overline500).foregroundStyle(theme.text(.textTertiary)) }
             }
             Text(code)
-                .textStyle(track == .inline ? .bodySm400 : .overline500)
+                .textStyle(codeStyle)
                 .foregroundStyle(theme.text(.textSecondary))
+            if let city {
+                Text(city).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary)).lineLimit(1)
+            }
         }
         .fixedSize()
     }
@@ -86,10 +145,11 @@ public struct FlightRoute: View {
         VStack(spacing: 0) {
             HStack(spacing: Theme.SpacingKey.xs.value) {
                 Rectangle().fill(theme.border(.borderPrimary)).frame(height: 1)
-                Text(durationText).textStyle(.bodySm400).foregroundStyle(theme.text(.textPrimary)).fixedSize()
+                Text(durationText).textStyle(durationStyle).foregroundStyle(theme.text(.textPrimary)).fixedSize()
                 Rectangle().fill(theme.border(.borderPrimary)).frame(height: 1)
             }
-            Text(stopsText).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
+            Text(stopsText).textStyle(durationStyle)
+                .foregroundStyle(stops > 0 ? (stopsTone?.base ?? theme.text(.textTertiary)) : theme.text(.textTertiary))
         }
         .frame(maxWidth: .infinity)
     }
@@ -98,26 +158,90 @@ public struct FlightRoute: View {
 
     private var path: some View {
         VStack(spacing: 3) {
-            Text(durationText).textStyle(.overline400).foregroundStyle(theme.text(.textSecondary))
+            Text(durationText).textStyle(durationStyle).foregroundStyle(theme.text(.textSecondary))
             ZStack {
                 Capsule().fill(lineColor).frame(height: 2)
                 if stops > 0 {
                     HStack(spacing: 10) {
-                        ForEach(0..<min(stops, 3), id: \.self) { _ in
-                            Circle().fill(theme.background(.bgBase)).frame(width: 6, height: 6)
-                                .overlay(Circle().stroke(theme.text(.textTertiary), lineWidth: 1.5))
-                        }
+                        ForEach(0..<min(stops, 3), id: \.self) { _ in stopDot }
                     }
                 }
             }
             .frame(width: 46)
-            Text(stopsText).textStyle(.overline400)
-                .foregroundStyle(stops == 0 ? theme.foreground(accentKey) : theme.text(.textTertiary))
+            Text(stopsText).textStyle(durationStyle)
+                .foregroundStyle(stopsLabelColor)
         }
         .frame(maxWidth: .infinity)
     }
 
+    /// Dashed arc with a plane glyph at the apex. The `Path` is absolute
+    /// geometry, so it's flipped explicitly for RTL and the plane glyph mirrors.
+    private var arcTrack: some View {
+        VStack(spacing: 3) {
+            Text(durationText).textStyle(durationStyle).foregroundStyle(theme.text(.textSecondary))
+            ZStack(alignment: .top) {
+                ArcLine()
+                    .stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+                    .flipsForRightToLeftLayoutDirection(true)
+                Image(systemName: "airplane")
+                    .textStyle(codeStyle)
+                    .foregroundStyle(theme.foreground(accentKey))
+                    .mirrorsInRTL()
+                    .offset(y: -2)
+            }
+            .frame(width: 56, height: 14)
+            Text(stopsText).textStyle(durationStyle)
+                .foregroundStyle(stopsLabelColor)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// Endpoint dots on a hairline, hollow mid-line dots per stop.
+    private var dotsTrack: some View {
+        VStack(spacing: 3) {
+            Text(durationText).textStyle(durationStyle).foregroundStyle(theme.text(.textSecondary))
+            ZStack {
+                Capsule().fill(theme.border(.borderPrimary)).frame(height: 2)
+                HStack(spacing: 0) {
+                    endpointDot
+                    Spacer(minLength: 0)
+                    if stops > 0 {
+                        HStack(spacing: 8) {
+                            ForEach(0..<min(stops, 3), id: \.self) { _ in stopDot }
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    endpointDot
+                }
+            }
+            .frame(width: 56)
+            Text(stopsText).textStyle(durationStyle)
+                .foregroundStyle(stopsLabelColor)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var endpointDot: some View {
+        Circle().fill(theme.foreground(accentKey)).frame(width: 6, height: 6)
+    }
+    private var stopDot: some View {
+        Circle().fill(theme.background(.bgBase)).frame(width: 6, height: 6)
+            .overlay(Circle().stroke(theme.text(.textTertiary), lineWidth: 1.5))
+    }
+
+    /// A shallow quad-curve arc from the leading to the trailing edge, apex at the top.
+    private struct ArcLine: Shape {
+        func path(in rect: CGRect) -> Path {
+            Path { p in
+                p.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+                p.addQuadCurve(to: CGPoint(x: rect.maxX, y: rect.maxY),
+                               control: CGPoint(x: rect.midX, y: rect.minY - rect.height))
+            }
+        }
+    }
+
     private var durationText: String {
+        if let durationOverride { return durationOverride }
         let minutes = max(0, Int(arrival.timeIntervalSince(departure) / 60))
         let h = minutes / 60, m = minutes % 60
         return h > 0 ? String(themeKit: "\(h)h \(m)m") : String(themeKit: "\(m)m")
@@ -149,9 +273,23 @@ public extension FlightRoute {
     func nextDay(_ on: Bool = true) -> Self { copy { $0.nextDay = on } }
     /// Path/direct-label colour (foreground token key, default success green).
     func pathColor(_ key: Theme.ForegroundColorKey) -> Self { copy { $0.accentKey = key } }
-    /// Track presentation — the stock `.path` capsule or the design-system
-    /// `.inline` hairline layout (see ``FlightRouteTrack``).
+    /// Track presentation — the stock `.path` capsule, the design-system
+    /// `.inline` hairline layout, a dashed `.arc` with a plane glyph, or
+    /// endpoint-`.dots` on a hairline (see ``FlightRouteTrack``).
     func track(_ t: FlightRouteTrack) -> Self { copy { $0.track = t } }
+    /// Type ramp — steps the time / code / duration styles together
+    /// (default `.regular`, the stock mapping).
+    func size(_ s: FlightRouteSize) -> Self { copy { $0.size = s } }
+    /// Optional city names rendered as a second line under each airport code.
+    func cityNames(_ origin: String, _ destination: String) -> Self {
+        copy { $0.originCity = origin; $0.destinationCity = destination }
+    }
+    /// Override the computed duration label ("2h 30m"); `nil` restores the
+    /// computed text.
+    func durationText(_ text: String?) -> Self { copy { $0.durationOverride = text } }
+    /// Semantic tone for the 1+-stop label (default tertiary text). Direct
+    /// flights keep the ``pathColor(_:)`` accent.
+    func stopsTone(_ color: SemanticColor?) -> Self { copy { $0.stopsTone = color } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -171,6 +309,33 @@ public extension FlightRoute {
         }
         PreviewCase("Inline track") {
             FlightRoute(from: "IST", to: "JFK", departure: dep, arrival: dep.addingTimeInterval(690 * 60)).stops(1).track(.inline)
+        }
+        PreviewCase("Arc track + city names") {
+            FlightRoute(from: "IST", to: "JFK", departure: dep, arrival: dep.addingTimeInterval(690 * 60))
+                .track(.arc)
+                .cityNames("Istanbul", "New York")
+        }
+        PreviewCase("Dots track · 2 stops · warning tone") {
+            FlightRoute(from: "IST", to: "SYD", departure: dep, arrival: dep.addingTimeInterval(1_300 * 60))
+                .track(.dots)
+                .stops(2)
+                .stopsTone(.warning)
+        }
+        PreviewCase("Compact / regular / large") {
+            VStack(spacing: 16) {
+                FlightRoute(from: "IST", to: "AYT", departure: dep, arrival: dep.addingTimeInterval(90 * 60)).size(.compact)
+                FlightRoute(from: "IST", to: "AYT", departure: dep, arrival: dep.addingTimeInterval(90 * 60))
+                FlightRoute(from: "IST", to: "AYT", departure: dep, arrival: dep.addingTimeInterval(90 * 60)).size(.large)
+            }
+        }
+        PreviewCase("Duration override") {
+            FlightRoute(from: "IST", to: "FRA", departure: dep, arrival: dep.addingTimeInterval(200 * 60))
+                .durationText("3h+")
+        }
+        PreviewCase("Arc · RTL") {
+            FlightRoute(from: "IST", to: "JFK", departure: dep, arrival: dep.addingTimeInterval(690 * 60))
+                .track(.arc)
+                .environment(\.layoutDirection, .rightToLeft)
         }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Molecules/LayoverRow.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/LayoverRow.swift
@@ -14,6 +14,14 @@
 import SwiftUI
 import ThemeKit
 
+/// Presentation of a ``LayoverRow``: the stock centered `.line` label, a soft
+/// `.pill` capsule sitting on the lines, or a full-width tinted `.banner` band.
+public enum LayoverVariant: Sendable { case line, pill, banner }
+
+/// Style of the flanking connector lines: `.dashed` (default), `.solid`, or
+/// `.hidden` (lines removed; the label stays centered).
+public enum LayoverLineStyle: Sendable { case dashed, solid, hidden }
+
 public struct LayoverRow: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
@@ -22,40 +30,78 @@ public struct LayoverRow: View {
     private let airport: String
     // Appearance — mutated only through the modifiers below (R2).
     private var warningText: String?
+    private var warningTone: SemanticColor?
     private var layoverLabel = "layover"
     private var systemImage = "clock.arrow.2.circlepath"
     private var accent: SemanticColor?
+    private var variant: LayoverVariant = .line
+    private var lineStyleValue: LayoverLineStyle = .dashed
 
     public init(duration: String, airport: String) {   // R1
         self.duration = duration
         self.airport = airport
     }
 
-    private var accentBase: Color { warningText != nil ? theme.foreground(.systemcolorsFgWarning) : ((accent ?? .neutral).base) }
+    private var warningColor: Color { warningTone?.base ?? theme.foreground(.systemcolorsFgWarning) }
+    private var accentBase: Color { warningText != nil ? warningColor : ((accent ?? .neutral).base) }
+    /// Semantic tone that tints the pill / banner chrome.
+    private var chromeTone: SemanticColor { warningText != nil ? (warningTone ?? .warning) : (accent ?? .neutral) }
 
     public var body: some View {
         VStack(spacing: 4) {
-            HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-                dashes
-                HStack(spacing: 5) {
-                    Image(systemName: systemImage).font(.system(size: 11)).foregroundStyle(accentBase)
-                    Text("\(duration) \(layoverLabel) · \(airport)")
-                        .textStyle(.overline500).foregroundStyle(theme.text(.textSecondary)).fixedSize()
+            switch variant {
+            case .line:
+                HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
+                    lines
+                    labelContent
+                    lines
                 }
-                dashes
+            case .pill:
+                HStack(spacing: 0) {
+                    lines
+                    labelContent
+                        .padding(.horizontal, density.scale(Theme.SpacingKey.sm.value))
+                        .padding(.vertical, Theme.SpacingKey.xs.value)
+                        .background(chromeTone.soft, in: Capsule(style: .continuous))
+                    lines
+                }
+            case .banner:
+                labelContent
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
+                    .padding(.horizontal, Theme.SpacingKey.sm.value)
+                    .background(chromeTone.bg,
+                                in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
             }
             if let warningText {
                 HStack(spacing: 4) {
-                    Image(systemName: "exclamationmark.triangle.fill").font(.system(size: 10))
+                    Image(systemName: "exclamationmark.triangle.fill").textStyle(.overline500)
                     Text(warningText).textStyle(.overline400)
                 }
-                .foregroundStyle(theme.foreground(.systemcolorsFgWarning))
+                .foregroundStyle(warningColor)
             }
         }
     }
 
-    private var dashes: some View {
-        Line().stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: 1, dash: [3, 3])).frame(height: 1).frame(maxWidth: .infinity)
+    private var labelContent: some View {
+        HStack(spacing: 5) {
+            Image(systemName: systemImage).textStyle(.labelSm600).foregroundStyle(accentBase)
+            Text("\(duration) \(layoverLabel) · \(airport)")
+                .textStyle(.overline500).foregroundStyle(theme.text(.textSecondary)).fixedSize()
+        }
+    }
+
+    @ViewBuilder private var lines: some View {
+        switch lineStyleValue {
+        case .dashed:
+            Line().stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+                .frame(height: 1).frame(maxWidth: .infinity)
+        case .solid:
+            Line().stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: 1))
+                .frame(height: 1).frame(maxWidth: .infinity)
+        case .hidden:
+            Color.clear.frame(height: 1).frame(maxWidth: .infinity)
+        }
     }
 
     private struct Line: Shape {
@@ -70,6 +116,17 @@ public struct LayoverRow: View {
 public extension LayoverRow {
     /// A short/long-connection warning shown below (in warning colour).
     func warning(_ text: String?) -> Self { copy { $0.warningText = text } }
+    /// A short/long-connection warning shown below, in a custom semantic tone
+    /// (default `.warning`) — the tone also tints the icon and pill/banner chrome.
+    func warning(_ text: String?, tone: SemanticColor = .warning) -> Self {
+        copy { $0.warningText = text; $0.warningTone = tone }
+    }
+    /// Presentation: the stock centered `.line` label (default), a soft `.pill`
+    /// capsule on the lines, or a full-width tinted `.banner` band.
+    func variant(_ v: LayoverVariant) -> Self { copy { $0.variant = v } }
+    /// Style of the flanking connector lines — `.dashed` (default), `.solid`,
+    /// or `.hidden`.
+    func lineStyle(_ s: LayoverLineStyle) -> Self { copy { $0.lineStyleValue = s } }
     /// Localise the "layover" word (English default).
     func layoverLabel(_ text: String) -> Self { copy { $0.layoverLabel = text } }
     func icon(_ systemName: String) -> Self { copy { $0.systemImage = systemName } }
@@ -87,5 +144,18 @@ public extension LayoverRow {
         PreviewCase("Default") { LayoverRow(duration: "2h 15m", airport: "Istanbul (IST)") }
         PreviewCase("Warning") { LayoverRow(duration: "0h 45m", airport: "Ankara (ESB)").warning("Short connection — 45 min") }
         PreviewCase("Accent + icon") { LayoverRow(duration: "5h 30m", airport: "Frankfurt (FRA)").accent(.info).icon("airplane.arrival") }
+        PreviewCase("Pill") { LayoverRow(duration: "2h 15m", airport: "Istanbul (IST)").variant(.pill).accent(.info) }
+        PreviewCase("Banner") { LayoverRow(duration: "5h 30m", airport: "Frankfurt (FRA)").variant(.banner).accent(.info) }
+        PreviewCase("Solid + hidden lines") {
+            VStack(spacing: 12) {
+                LayoverRow(duration: "1h 05m", airport: "Vienna (VIE)").lineStyle(.solid)
+                LayoverRow(duration: "1h 05m", airport: "Vienna (VIE)").lineStyle(.hidden)
+            }
+        }
+        PreviewCase("Warning tone (error)") {
+            LayoverRow(duration: "0h 35m", airport: "Ankara (ESB)")
+                .variant(.pill)
+                .warning("Very short connection — 35 min", tone: .error)
+        }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Molecules/PassengerRow.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/PassengerRow.swift
@@ -25,6 +25,7 @@ public struct PassengerRow: View {
     private let action: () -> Void
     // Content/appearance — mutated only through the modifiers below (R2).
     private var typeText: String?
+    private var typeStyle: BadgeStyle = .neutral
     private var subtitle: String?
     private var seat: String?
     private var statusText: String?
@@ -32,8 +33,13 @@ public struct PassengerRow: View {
     private var avatarContent: AvatarContent?
     private var systemImage = "person.crop.circle.fill"
     private var onEdit: (() -> Void)?
+    private var onRemove: (() -> Void)?
     private var accessory: PassengerAccessory = .none
     private var accent: SemanticColor?
+    private var bordered = false
+    private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    private var selectionBinding: Binding<Bool>?
+    private var customTrailing: AnyView?
 
     public init(_ name: String, action: @escaping () -> Void = {}) {   // R1
         self.name = name
@@ -41,15 +47,28 @@ public struct PassengerRow: View {
     }
 
     private var accentBase: Color { (accent ?? .primary).base }
+    private var isSelected: Bool { selectionBinding?.wrappedValue ?? false }
+    private var rowShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
+    }
 
     public var body: some View {
-        Button(action: action) {
+        Button {
+            selectionBinding?.wrappedValue.toggle()
+            action()
+        } label: {
             HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
+                if let selectionBinding {
+                    // Visual-only — the whole row is the toggle target.
+                    Checkbox(isChecked: selectionBinding)
+                        .accent(accent)
+                        .allowsHitTesting(false)
+                }
                 leading
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 6) {
                         Text(name).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
-                        if let typeText { Badge(typeText).badgeStyle(.neutral).variant(.soft).size(.small).fixedSize() }
+                        if let typeText { Badge(typeText).badgeStyle(typeStyle).variant(.soft).size(.small).fixedSize() }
                     }
                     if let subtitle { Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(1) }
                 }
@@ -57,12 +76,16 @@ public struct PassengerRow: View {
                 trailing
             }
             .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
+            .padding(.horizontal, bordered ? density.scale(Theme.SpacingKey.sm.value) : 0)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .background(bordered ? theme.background(surfaceKey) : .clear, in: rowShape)
+            .overlay { if bordered { rowShape.stroke(theme.border(.borderPrimary), lineWidth: 1) } }
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
         .accessibilityLabel([name, typeText, seat.map { String(themeKit: "seat \($0)") }, statusText].compactMap { $0 }.joined(separator: ", "))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     @ViewBuilder private var leading: some View {
@@ -81,10 +104,18 @@ public struct PassengerRow: View {
                     .background(theme.background(.bgElevatorTertiary), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
             }
             if let statusText { Badge(statusText).badgeStyle(statusStyle).variant(.soft).size(.small) }
-            if let onEdit {
+            if let customTrailing {
+                customTrailing
+            } else if let onEdit {
                 Button { onEdit() } label: {
-                    Image(systemName: "pencil").font(.system(size: 14, weight: .semibold)).foregroundStyle(accentBase).frame(width: 44, height: 44).contentShape(Rectangle())
+                    Image(systemName: "pencil").textStyle(.labelBase600).foregroundStyle(accentBase)
+                        .frame(width: 44, height: 44).contentShape(Rectangle())
                 }.buttonStyle(.plain).accessibilityLabel(String(themeKit: "Edit"))
+            } else if let onRemove {
+                Button { onRemove() } label: {
+                    Image(systemName: "xmark").textStyle(.labelSm600).foregroundStyle(theme.text(.textTertiary))
+                        .frame(width: 44, height: 44).contentShape(Rectangle())
+                }.buttonStyle(.plain).accessibilityLabel(String(themeKit: "Remove"))
             } else if accessory == .chevron {
                 Image(systemName: "chevron.right").font(.system(size: 12, weight: .semibold)).foregroundStyle(theme.text(.textTertiary)).mirrorsInRTL()
                     .accessibilityHidden(true)   // decorative disclosure indicator
@@ -98,6 +129,10 @@ public struct PassengerRow: View {
 public extension PassengerRow {
     /// Passenger type badge, e.g. "Adult" / "Child" / "Infant".
     func type(_ text: String?) -> Self { copy { $0.typeText = text } }
+    /// Passenger type badge in a custom badge style (default `.neutral`).
+    func type(_ text: String, style: BadgeStyle = .neutral) -> Self {
+        copy { $0.typeText = text; $0.typeStyle = style }
+    }
     func subtitle(_ text: String?) -> Self { copy { $0.subtitle = text } }
     /// A trailing seat chip, e.g. "14C".
     func seat(_ text: String?) -> Self { copy { $0.seat = text } }
@@ -108,8 +143,23 @@ public extension PassengerRow {
     func icon(_ systemName: String) -> Self { copy { $0.systemImage = systemName } }
     /// Adds a trailing edit (pencil) button.
     func onEdit(_ action: @escaping () -> Void) -> Self { copy { $0.onEdit = action } }
+    /// Adds a trailing remove (✕) button (``onEdit(_:)`` takes precedence).
+    func onRemove(_ action: @escaping () -> Void) -> Self { copy { $0.onRemove = action } }
     func accessory(_ a: PassengerAccessory) -> Self { copy { $0.accessory = a } }
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+    /// Wrap in a bordered card surface (default off — flush list row).
+    func bordered(_ on: Bool = true) -> Self { copy { $0.bordered = on } }
+    /// Surface fill of the bordered card (background token key, default `.bgBase`).
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
+    /// Selectable mode — a leading checkbox mirrors the binding and tapping the
+    /// row toggles it (the row `action` still fires). Pair with an
+    /// `@State`/`ControllableState` bool at the call site.
+    func selectable(_ isSelected: Binding<Bool>) -> Self { copy { $0.selectionBinding = isSelected } }
+    /// Replaces the built-in trailing accessory (edit / remove / chevron) with
+    /// custom content; the seat chip and status badge stay.
+    func trailing<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.customTrailing = AnyView(content()) }
+    }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -119,8 +169,26 @@ public extension PassengerRow {
 }
 
 #Preview {
+    @Previewable @State var selected = true
     PreviewMatrix("PassengerRow") {
         PreviewCase("Editable + seat") { PassengerRow("İsa Mercan").type("Adult").subtitle("Passport · TR12345678").seat("14C").onEdit { } }
         PreviewCase("Avatar + status + chevron") { PassengerRow("Ada Mercan").type("Child").avatar(.initials("AM")).status("Checked in").accessory(.chevron) }
+        PreviewCase("Bordered card + typed badge") {
+            PassengerRow("Mia Doe").type("Infant", style: .info).subtitle("No seat required")
+                .bordered().surface(.bgWhite)
+        }
+        PreviewCase("Selectable (row toggles)") {
+            PassengerRow("John Doe").type("Adult").subtitle("Frequent flyer")
+                .selectable($selected)
+                .bordered()
+        }
+        PreviewCase("Removable") {
+            PassengerRow("Sam Doe").type("Adult").onRemove { }
+        }
+        PreviewCase("Custom trailing slot") {
+            PassengerRow("Alex Doe").type("Adult").trailing {
+                Badge(String(themeKitTravel: "Visa required")).badgeStyle(.warning).variant(.soft).size(.small)
+            }
+        }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Molecules/RecentSearchRow.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/RecentSearchRow.swift
@@ -15,6 +15,32 @@
 import SwiftUI
 import ThemeKit
 
+/// Chrome of a ``RecentSearchRow``: a flush `.plain` list row (default), a
+/// `.bordered` card, or a fully-rounded `.pill` capsule (the mini search bar).
+/// Consolidates the `.bordered()` / `.pill()` boolean pair — the previously
+/// silently-resolved `.bordered().pill()` conflict is unrepresentable.
+public enum RecentSearchVariant: Sendable { case plain, bordered, pill }
+
+/// Size ramp of the leading icon tile (internal 32/12 · 40/16 · 48/20 pt).
+public enum RecentSearchTileSize: Sendable {
+    case sm, md, lg
+
+    var tile: CGFloat {
+        switch self {
+        case .sm: 32
+        case .md: 40
+        case .lg: 48
+        }
+    }
+    var icon: CGFloat {
+        switch self {
+        case .sm: 12
+        case .md: 16
+        case .lg: 20
+        }
+    }
+}
+
 public struct RecentSearchRow: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
@@ -31,9 +57,12 @@ public struct RecentSearchRow: View {
     private var onSearch: (() -> Void)?
     private var searchAccent: SemanticColor = .neutral
     private var accent: SemanticColor?
-    private var bordered = false
-    private var pill = false
+    private var variant: RecentSearchVariant = .plain
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    private var radiusRole: Theme.RadiusRole = .field
+    private var tileSize: RecentSearchTileSize = .md
+    private var viaCodes: [String] = []
+    private var customLeading: AnyView?
 
     public init(from: String, to: String, action: @escaping () -> Void = {}) {   // R1
         self.from = from
@@ -41,25 +70,30 @@ public struct RecentSearchRow: View {
         self.action = action
     }
 
+    private var bordered: Bool { variant == .bordered }
+    private var pill: Bool { variant == .pill }
+
     private var shape: AnyShape {
         pill
             ? AnyShape(Capsule(style: .continuous))
-            : AnyShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+            : AnyShape(RoundedRectangle(cornerRadius: radiusRole.value, style: .continuous))
     }
     private var caption: String? {
         [dates, passengers].compactMap { $0 }.joined(separator: " · ").nilIfEmpty
     }
+    /// The full route — origin, any `via` codes, destination.
+    private var routeStops: [String] { [from] + viaCodes + [to] }
 
     public var body: some View {
         Button(action: action) {
             HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-                if let systemImage { IconTile(systemImage).size(40).iconSize(16).accent(accent) }
+                if let customLeading {
+                    customLeading
+                } else if let systemImage {
+                    IconTile(systemImage).size(tileSize.tile).iconSize(tileSize.icon).accent(accent)
+                }
                 VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
-                        Text(from).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
-                        Image(systemName: roundTrip ? "arrow.left.arrow.right" : "arrow.right").font(.system(size: 12, weight: .semibold)).foregroundStyle(theme.text(.textTertiary)).mirrorsInRTL()
-                        Text(to).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
-                    }
+                    routeLine
                     if let caption { Text(caption).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(1) }
                 }
                 Spacer(minLength: 6)
@@ -69,16 +103,38 @@ public struct RecentSearchRow: View {
             // tile) insets its content from the left (Figma pl-24 · pr-8 · py-8).
             .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
             .padding(.trailing, density.scale(Theme.SpacingKey.sm.value))
-            .padding(.leading, density.scale(pill && systemImage == nil
+            .padding(.leading, density.scale(pill && systemImage == nil && customLeading == nil
                                              ? Theme.SpacingKey.base.value
                                              : Theme.SpacingKey.sm.value))
             .frame(maxWidth: .infinity, alignment: .leading)
             .background((bordered || pill) ? theme.background(surfaceKey) : .clear, in: shape)
-            .overlay { if bordered && !pill { shape.stroke(theme.border(.borderPrimary), lineWidth: 1) } }
+            .overlay { if bordered { shape.stroke(theme.border(.borderPrimary), lineWidth: 1) } }
             .contentShape(shape)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(String(themeKit: "\(from) to \(to)") + (caption.map { ", " + $0 } ?? ""))
+        .accessibilityLabel(
+            String(themeKit: "\(from) to \(to)")
+                + (viaCodes.isEmpty ? "" : ", " + String(themeKit: "via \(viaCodes.joined(separator: ", "))"))
+                + (caption.map { ", " + $0 } ?? "")
+        )
+    }
+
+    /// The route — a from → to pair, or a multi-city chain when ``via(_:)`` is set
+    /// (IST → FRA → JFK). Multi-city always renders one-way arrows.
+    private var routeLine: some View {
+        HStack(spacing: 6) {
+            ForEach(Array(routeStops.enumerated()), id: \.offset) { i, code in
+                if i > 0 { routeArrow }
+                Text(code).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
+            }
+        }
+    }
+
+    private var routeArrow: some View {
+        Image(systemName: roundTrip && viaCodes.isEmpty ? "arrow.left.arrow.right" : "arrow.right")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(theme.text(.textTertiary))
+            .mirrorsInRTL()
     }
 
     @ViewBuilder private var trailing: some View {
@@ -123,13 +179,29 @@ public extension RecentSearchRow {
     func searchAccent(_ color: SemanticColor) -> Self { copy { $0.searchAccent = color } }
     /// Brand-tints the leading icon tile (default: neutral tile).
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
-    /// Wrap in a bordered surface (default off — flush list row).
-    func bordered(_ on: Bool = true) -> Self { copy { $0.bordered = on } }
+    /// Chrome: a flush `.plain` list row (default), a `.bordered` card, or the
+    /// fully-rounded `.pill` capsule. Consolidates `.bordered()` / `.pill()`.
+    func variant(_ v: RecentSearchVariant) -> Self { copy { $0.variant = v } }
+    /// Wrap in a bordered surface (default off — flush list row). Sugar for
+    /// `.variant(.bordered)`.
+    func bordered(_ on: Bool = true) -> Self { copy { $0.variant = on ? .bordered : .plain } }
     /// Fully-rounded **capsule** surface — a pill that sits on a colored band (the
     /// search-result mini bar). Fills with ``surface(_:)`` and drops the hairline.
-    func pill(_ on: Bool = true) -> Self { copy { $0.pill = on } }
+    /// Sugar for `.variant(.pill)`.
+    func pill(_ on: Bool = true) -> Self { copy { $0.variant = on ? .pill : .plain } }
     /// Surface fill of the bordered / pill variant (background token key, default `.bgBase`).
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
+    /// Corner radius role of the `.bordered` variant (default `.field`).
+    func radius(_ role: Theme.RadiusRole) -> Self { copy { $0.radiusRole = role } }
+    /// Intermediate stops for a multi-city route — renders IST → FRA → JFK
+    /// instead of the fixed from → to pair.
+    func via(_ codes: [String]) -> Self { copy { $0.viaCodes = codes } }
+    /// Size ramp of the leading icon tile (default `.md`).
+    func tileSize(_ s: RecentSearchTileSize) -> Self { copy { $0.tileSize = s } }
+    /// Replaces the leading icon tile with custom content (an avatar, a flag…).
+    func leading<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.customLeading = AnyView(content()) }
+    }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -143,6 +215,22 @@ public extension RecentSearchRow {
         PreviewCase("Round trip") { RecentSearchRow(from: "IST", to: "AYT") { }.roundTrip().dates("18 – 27 Jul").passengers("2 adults · Economy") }
         PreviewCase("Removable") { RecentSearchRow(from: "SAW", to: "ESB") { }.dates("2 Aug").passengers("1 adult").onRemove { } }
         PreviewCase("Bordered") { RecentSearchRow(from: "IST", to: "LHR") { }.dates("5 Sep").passengers("1 adult").bordered() }
+        PreviewCase("Bordered · box radius · large tile") {
+            RecentSearchRow(from: "IST", to: "CDG") { }
+                .dates("12 Oct").passengers("2 adults")
+                .variant(.bordered).radius(.box).tileSize(.lg)
+        }
+        PreviewCase("Multi-city via") {
+            RecentSearchRow(from: "IST", to: "JFK") { }
+                .via(["FRA"])
+                .dates("3 Nov").passengers("1 adult · Business")
+                .tileSize(.sm)
+        }
+        PreviewCase("Custom leading slot") {
+            RecentSearchRow(from: "SAW", to: "AMS") { }
+                .dates("9 Dec")
+                .leading { Avatar(.initials("KL")).size(.sm) }
+        }
     }
 }
 

--- a/Sources/ThemeKitTravel/Components/Molecules/SeatLegend.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/SeatLegend.swift
@@ -5,18 +5,38 @@
 //  Molecule. A key for a ``SeatMap`` — the fare tiers present, plus Selected and
 //  Occupied — wrapping to rows. Tier *and* selected/occupied colours come from a
 //  ``SeatPalette`` so it matches whatever the map (or a brand override) uses.
+//  Configuration flows through chainable copy-on-write modifiers (R2); the
+//  original init parameters remain for source compatibility.
 //
 
 import SwiftUI
 import ThemeKit
 
+/// How a ``SeatLegend`` lays out its entries.
+public enum SeatLegendOrientation: Sendable {
+    /// Wraps into rows of `perRow(_:)` entries — the default.
+    case rows
+    /// One entry per line.
+    case vertical
+    /// A single unwrapped row.
+    case inline
+}
+
 public struct SeatLegend: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
 
+    // Appearance/state — mutated only through the modifiers below (R2). The
+    // init params are kept as a convenience/back-compat surface.
     private var tiers: [SeatTier]
-    private let palette: SeatPalette
-    private let perRow: Int
+    private var palette: SeatPalette
+    private var perRow: Int
+    private var showsSelected = true
+    private var showsOccupied = true
+    private var extraEntries: [(label: String, color: SemanticColor)] = []
+    private var swatchShape: SeatShape = .rounded
+    private var swatchRamp: SeatSizeRamp?
+    private var orientation: SeatLegendOrientation = .rows
 
     public init(tiers: [SeatTier] = [.standard], palette: SeatPalette = .default, perRow: Int = 3) {
         self.tiers = tiers
@@ -31,30 +51,59 @@ public struct SeatLegend: View {
             let c = palette.colors(for: tier, theme: theme)
             return Entry(fill: c.fill, border: c.stroke, label: tier.label)
         }
-        let selected = palette.selectedColors(theme: theme)
-        e.append(Entry(fill: selected.fill, border: selected.stroke, label: String(themeKit: "Selected")))
-        let occupied = palette.occupiedColors(theme: theme)
-        e.append(Entry(fill: occupied.fill, border: occupied.stroke, label: String(themeKit: "Occupied")))
+        e += extraEntries.map { Entry(fill: $0.color.bg, border: $0.color.base, label: $0.label) }
+        if showsSelected {
+            let selected = palette.selectedColors(theme: theme)
+            e.append(Entry(fill: selected.fill, border: selected.stroke, label: String(themeKit: "Selected")))
+        }
+        if showsOccupied {
+            let occupied = palette.occupiedColors(theme: theme)
+            e.append(Entry(fill: occupied.fill, border: occupied.stroke, label: String(themeKit: "Occupied")))
+        }
         return e
     }
 
     public var body: some View {
         let items = entries
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
-            ForEach(Array(stride(from: 0, to: items.count, by: perRow)), id: \.self) { start in
-                HStack(spacing: density.scale(Theme.SpacingKey.md.value)) {
-                    ForEach(items[start..<min(start + perRow, items.count)]) { swatch($0) }
-                    Spacer(minLength: 0)
+        switch orientation {
+        case .rows:
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                ForEach(Array(stride(from: 0, to: items.count, by: perRow)), id: \.self) { start in
+                    HStack(spacing: density.scale(Theme.SpacingKey.md.value)) {
+                        ForEach(items[start..<min(start + perRow, items.count)]) { swatch($0) }
+                        Spacer(minLength: 0)
+                    }
                 }
+            }
+        case .vertical:
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                ForEach(items) { swatch($0) }
+            }
+        case .inline:
+            HStack(spacing: density.scale(Theme.SpacingKey.md.value)) {
+                ForEach(items) { swatch($0) }
             }
         }
     }
 
+    // Legend swatches are keys, not touch targets — the ramp maps to a scaled-
+    // down side so `.swatchSize(.large)` tracks a larger map without dwarfing
+    // the labels.
+    private var swatchSide: CGFloat {
+        switch swatchRamp {
+        case nil, .regular: return 14
+        case .compact: return 12
+        case .large: return 17
+        case .xl: return 20
+        }
+    }
+
     private func swatch(_ entry: Entry) -> some View {
-        HStack(spacing: Theme.SpacingKey.xs.value) {
-            RoundedRectangle(cornerRadius: 4, style: .continuous).fill(entry.fill)
-                .overlay(RoundedRectangle(cornerRadius: 4, style: .continuous).stroke(entry.border, lineWidth: 1))
-                .frame(width: 14, height: 14)
+        let shape = swatchShape.anyShape(cornerRadius: 4)
+        return HStack(spacing: Theme.SpacingKey.xs.value) {
+            shape.fill(entry.fill)
+                .overlay(shape.stroke(entry.border, lineWidth: 1))
+                .frame(width: swatchSide, height: swatchSide)
             Text(entry.label).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
                 .fixedSize(horizontal: true, vertical: false)
         }
@@ -69,6 +118,41 @@ public struct SeatLegend: View {
     }
 }
 
+// MARK: - Modifiers (R2 — copy-on-write)
+
+public extension SeatLegend {
+    /// The fare tiers to key (replaces the current set).
+    func tiers(_ tiers: [SeatTier]) -> Self { copy { $0.tiers = tiers } }
+    /// The palette the swatches resolve their colours from — pass the same one
+    /// the map uses so the key always matches.
+    func palette(_ palette: SeatPalette) -> Self { copy { $0.palette = palette } }
+    /// Entries per row in the default `.rows` orientation.
+    func perRow(_ count: Int) -> Self { copy { $0.perRow = max(1, count) } }
+    /// Whether the synthetic "Selected" entry is appended (default `true`).
+    func showsSelected(_ on: Bool = true) -> Self { copy { $0.showsSelected = on } }
+    /// Whether the synthetic "Occupied" entry is appended (default `true`).
+    func showsOccupied(_ on: Bool = true) -> Self { copy { $0.showsOccupied = on } }
+    /// Appends a custom key (e.g. "Bassinet") — the swatch fills with the
+    /// token's soft background and strokes with its base shade, matching how
+    /// tier overrides resolve.
+    func entry(_ label: String, color: SemanticColor) -> Self {
+        copy { $0.extraEntries.append((label: label, color: color)) }
+    }
+    /// The swatch silhouette — pass the map's ``SeatShape`` so the key matches
+    /// the seats (``SeatMap`` forwards its own automatically).
+    func swatchShape(_ shape: SeatShape) -> Self { copy { $0.swatchShape = shape } }
+    /// Steps the swatch size alongside a map using the same ``SeatSizeRamp``.
+    func swatchSize(_ ramp: SeatSizeRamp) -> Self { copy { $0.swatchRamp = ramp } }
+    /// Layout direction of the entries: `.rows` (wrap, default) · `.vertical` · `.inline`.
+    func orientation(_ orientation: SeatLegendOrientation) -> Self { copy { $0.orientation = orientation } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
 #Preview {
     PreviewMatrix("SeatLegend") {
         PreviewCase("Economy tiers") { SeatLegend(tiers: [.standard, .extraLegroom, .exit]) }
@@ -77,6 +161,22 @@ public struct SeatLegend: View {
         PreviewCase("Accent selected/occupied") {
             SeatLegend(tiers: [.standard, .exit],
                        palette: SeatPalette().selected(.accent).occupied(.warning))
+        }
+        PreviewCase("Chained config (R2)") {
+            SeatLegend().tiers([.standard, .business]).perRow(2)
+                .palette(SeatPalette().selected(.purple))
+        }
+        PreviewCase("Custom entry, tiers only") {
+            SeatLegend(tiers: [.standard, .extraLegroom])
+                .entry(String(themeKit: "Bassinet"), color: .info)
+                .showsSelected(false).showsOccupied(false)
+        }
+        PreviewCase("Seatback swatches, large") {
+            SeatLegend(tiers: [.standard, .exit]).swatchShape(.seatback).swatchSize(.large)
+        }
+        PreviewCase("Vertical") { SeatLegend(tiers: [.standard, .exit]).orientation(.vertical) }
+        PreviewCase("Inline, circle") {
+            SeatLegend(tiers: [.standard]).orientation(.inline).swatchShape(.circle)
         }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Molecules/TripTypeToggle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/TripTypeToggle.swift
@@ -15,53 +15,149 @@
 import SwiftUI
 import ThemeKit
 
+/// Size ramp of a ``TripTypeToggle`` — steps the minimum option height
+/// (internal 28/36/44 pt) together with the icon + label text styles.
+public enum TripTypeToggleSize: Sendable {
+    case compact, regular, large
+
+    var minHeight: CGFloat {
+        switch self {
+        case .compact: 28
+        case .regular: 36
+        case .large: 44
+        }
+    }
+    var textStyle: TextStyle {
+        switch self {
+        case .compact: .labelSm600
+        case .regular: .labelSm700
+        case .large: .labelBase700
+        }
+    }
+    var iconStyle: TextStyle {
+        switch self {
+        case .compact: .overline500
+        case .regular: .labelSm600
+        case .large: .labelBase600
+        }
+    }
+}
+
+/// Look of a ``TripTypeToggle``: the stock accent-filled `.pill` inside a soft
+/// track, or a borderless `.underline` tab row with an indicator bar.
+public enum TripTypeToggleVariant: Sendable { case pill, underline }
+
+/// Corner treatment of the pill variant's track and thumb: a full `.capsule`
+/// (default) or a `.rounded(_:)` rectangle at a radius role.
+public enum TripTypeToggleShape {
+    case capsule
+    case rounded(Theme.RadiusRole)
+}
+
 public struct TripTypeToggle: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let options: [String]
-    @Binding private var selection: Int
+    @ControllableState private var selection: Int
     // Appearance — mutated only through the modifiers below (R2).
     private var icons: [String] = []
     private var accent: SemanticColor?
     private var fullWidth = true
     private var surface: Theme.BackgroundColorKey = .bgBase
+    private var size: TripTypeToggleSize = .regular
+    private var variant: TripTypeToggleVariant = .pill
+    private var shape: TripTypeToggleShape = .capsule
 
+    /// Controlled — reads and writes flow through the caller's binding (ADR-4).
     public init(_ options: [String], selection: Binding<Int>) {   // R1
         self.options = options
-        self._selection = selection
+        self._selection = ControllableState(wrappedValue: selection.wrappedValue, external: selection)
+    }
+
+    /// Uncontrolled — the component owns its selection state.
+    public init(_ options: [String], initiallySelected: Int = 0) {   // R1
+        self.options = options
+        self._selection = ControllableState(wrappedValue: initiallySelected)
     }
 
     private var accentSemantic: SemanticColor { accent ?? .primary }
+    /// Selection slide, gated by `microAnimations` + Reduce Motion.
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
+
+    private var trackShape: AnyShape {
+        switch shape {
+        case .capsule: AnyShape(Capsule(style: .continuous))
+        case .rounded(let role): AnyShape(RoundedRectangle(cornerRadius: role.value, style: .continuous))
+        }
+    }
 
     public var body: some View {
-        HStack(spacing: 4) {
-            ForEach(Array(options.enumerated()), id: \.offset) { i, option in pill(i, option) }
+        switch variant {
+        case .pill:
+            HStack(spacing: 4) {
+                ForEach(Array(options.enumerated()), id: \.offset) { i, option in pill(i, option) }
+            }
+            .padding(4)
+            .background(theme.background(surface), in: trackShape)
+            .frame(maxWidth: fullWidth ? .infinity : nil)
+        case .underline:
+            HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
+                ForEach(Array(options.enumerated()), id: \.offset) { i, option in underlineTab(i, option) }
+            }
+            .frame(maxWidth: fullWidth ? .infinity : nil)
         }
-        .padding(4)
-        .background(theme.background(surface), in: Capsule())
-        .frame(maxWidth: fullWidth ? .infinity : nil)
     }
 
     private func pill(_ i: Int, _ option: String) -> some View {
         let isOn = i == selection
         return Button {
-            withAnimation(.easeOut(duration: 0.18)) { selection = i }
+            withAnimation(motion) { selection = i }
         } label: {
-            HStack(spacing: 5) {
-                if i < icons.count { Image(systemName: icons[i]).font(.system(size: 12, weight: .semibold)) }
-                Text(option).textStyle(.labelSm700).lineLimit(1).minimumScaleFactor(0.8)
-            }
-            .foregroundStyle(isOn ? accentSemantic.onSolid : theme.text(.textSecondary))
-            .padding(.horizontal, density.scale(Theme.SpacingKey.sm.value))
-            .frame(maxWidth: fullWidth ? .infinity : nil)
-            .frame(minHeight: 36)
-            .background(isOn ? accentSemantic.solid : .clear, in: Capsule())
-            .contentShape(Capsule())
+            optionLabel(i, option)
+                .foregroundStyle(isOn ? accentSemantic.onSolid : theme.text(.textSecondary))
+                .padding(.horizontal, density.scale(Theme.SpacingKey.sm.value))
+                .frame(maxWidth: fullWidth ? .infinity : nil)
+                .frame(minHeight: size.minHeight)
+                .background(isOn ? accentSemantic.solid : .clear, in: trackShape)
+                .contentShape(trackShape)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(option)
         .accessibilityAddTraits(isOn ? .isSelected : [])
+    }
+
+    /// Borderless tab look — no track, a 2pt accent indicator bar under the
+    /// selected option.
+    private func underlineTab(_ i: Int, _ option: String) -> some View {
+        let isOn = i == selection
+        return Button {
+            withAnimation(motion) { selection = i }
+        } label: {
+            VStack(spacing: Theme.SpacingKey.xs.value) {
+                optionLabel(i, option)
+                    .foregroundStyle(isOn ? accentSemantic.base : theme.text(.textSecondary))
+                Rectangle()
+                    .fill(isOn ? accentSemantic.base : Color.clear)
+                    .frame(height: 2)
+            }
+            .padding(.horizontal, density.scale(Theme.SpacingKey.xs.value))
+            .frame(maxWidth: fullWidth ? .infinity : nil)
+            .frame(minHeight: size.minHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(option)
+        .accessibilityAddTraits(isOn ? .isSelected : [])
+    }
+
+    private func optionLabel(_ i: Int, _ option: String) -> some View {
+        HStack(spacing: 5) {
+            if i < icons.count { Image(systemName: icons[i]).textStyle(size.iconStyle) }
+            Text(option).textStyle(size.textStyle).lineLimit(1).minimumScaleFactor(0.8)
+        }
     }
 }
 
@@ -78,6 +174,15 @@ public extension TripTypeToggle {
     /// low-contrast track that reads well on a white card). Pass `.bgWhite` for a
     /// flush track or `.bgSecondary` for the stronger grey.
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surface = key } }
+    /// Size ramp — steps the option height and the icon + label styles
+    /// (default `.regular`).
+    func size(_ s: TripTypeToggleSize) -> Self { copy { $0.size = s } }
+    /// Look: the stock accent-filled `.pill` (default) or the borderless
+    /// `.underline` tab row with an indicator bar.
+    func variant(_ v: TripTypeToggleVariant) -> Self { copy { $0.variant = v } }
+    /// Corner treatment of the pill track + thumb: `.capsule` (default) or
+    /// `.rounded(_:)` at a radius role.
+    func shape(_ s: TripTypeToggleShape) -> Self { copy { $0.shape = s } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -100,6 +205,24 @@ public extension TripTypeToggle {
         PreviewCase("Intrinsic width") {
             TripTypeToggle(["One way", "Round trip"], selection: .constant(0))
                 .fullWidth(false)
+        }
+        PreviewCase("Uncontrolled") {
+            TripTypeToggle(["One way", "Round trip", "Multi-city"], initiallySelected: 2)
+        }
+        PreviewCase("Compact / large") {
+            VStack(spacing: 12) {
+                TripTypeToggle(["One way", "Round trip"], selection: $sel).size(.compact)
+                TripTypeToggle(["One way", "Round trip"], selection: $sel).size(.large)
+            }
+        }
+        PreviewCase("Rounded shape") {
+            TripTypeToggle(["One way", "Round trip", "Multi-city"], selection: $sel)
+                .shape(.rounded(.field))
+        }
+        PreviewCase("Underline tabs") {
+            TripTypeToggle(["One way", "Round trip", "Multi-city"], selection: $sel)
+                .variant(.underline)
+                .accent(.info)
         }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Organisms/AirportPicker.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/AirportPicker.swift
@@ -25,9 +25,16 @@
 import SwiftUI
 import ThemeKit
 
-/// Where the picker lives: embedded in the screen (`.inline`) or behind a
-/// field-shaped trigger that opens a bottom sheet (`.sheet`).
-public enum AirportPickerPresentation: Sendable { case inline, sheet }
+/// Where the picker lives: embedded in the screen (`.inline`), or behind a
+/// field-shaped trigger that opens a bottom sheet (`.sheet`), a popover
+/// (`.popover` — anchored, for iPad/Mac), or a full-screen cover
+/// (`.fullScreenCover` — phone-first immersive search; falls back to a sheet
+/// on macOS, where full-screen covers don't exist).
+public enum AirportPickerPresentation: Sendable { case inline, sheet, popover, fullScreenCover }
+
+/// Vertical density of the suggestion rows: `.regular` (default) or
+/// `.compact` (tighter row padding and section gaps for dense pickers).
+public enum AirportPickerDensity: Sendable { case compact, regular }
 
 /// Airport search & select. Controlled selection + caller-owned suggestions;
 /// the debounced `.onQueryChange` callback is where the caller runs its lookup.
@@ -64,6 +71,17 @@ public struct AirportPicker: View {
     private var customEmpty: AnyView?
     private var accentColor: SemanticColor?
     private var accessibilityID: String?
+    /// Per-airport row replacement (`(airport, isSelected)`); nil = built-in row.
+    private var rowContentSlot: ((Airport, Bool) -> AnyView)?
+    /// Replaces the built-in Skeleton loading rows.
+    private var loadingSlot: AnyView?
+    private var nearbyTitle: String?
+    private var recentTitle: String?
+    private var popularTitle: String?
+    private var chipVariantValue: FillVariant = .soft
+    private var sheetDetents: [BottomSheetDetent] = [.large]
+    private var triggerIconName = "airplane"
+    private var densityValue: AirportPickerDensity = .regular
 
     /// Query is internal UI state (§9.4); selection is the controlled outcome.
     @State private var query = ""
@@ -90,7 +108,17 @@ public struct AirportPicker: View {
         switch presentationStyle {
         case .inline: inlineBody
         case .sheet: sheetTrigger
+        case .popover: popoverTrigger
+        case .fullScreenCover: fullScreenTrigger
         }
+    }
+
+    /// Row/section paddings resolved from the density axis (token-fed).
+    private var rowVPad: CGFloat {
+        densityValue == .compact ? Theme.SpacingKey.xs.value : Theme.SpacingKey.sm.value
+    }
+    private var sectionGap: CGFloat {
+        densityValue == .compact ? Theme.SpacingKey.sm.value : Theme.SpacingKey.md.value
     }
 
     private var inlineBody: some View {
@@ -100,22 +128,68 @@ public struct AirportPicker: View {
         }
     }
 
-    // MARK: - Sheet presentation (reuses the shared BottomSheet)
+    // MARK: - Presented forms (sheet / popover / full-screen cover)
 
-    /// `.sheet`: a `FieldButton` trigger (label = current selection or the
-    /// placeholder) opening the same search UI in a `BottomSheet`. FieldButton
+    /// The shared search UI hosted by every presented form.
+    private var presentedSearch: some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+            searchField
+            ScrollView { listContent }
+        }
+    }
+
+    /// The field-shaped trigger shared by the presented forms. FieldButton
     /// natively honors `.disabled(_:)` and `.readOnly(_:)`.
-    private var sheetTrigger: some View {
+    private var trigger: some View {
         FieldButton(selection.map(Self.displayText) ?? placeholderText) { isSheetPresented = true }
-            .icon("airplane")
+            .icon(triggerIconName)
             .placeholder(selection == nil)
             .travelA11y("trigger", in: accessibilityID)
-            .bottomSheet(isPresented: $isSheetPresented, detents: [.large]) {
-                VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
-                    searchField
-                    ScrollView { listContent }
-                }
+    }
+
+    /// `.sheet`: the trigger opens the search UI in a `BottomSheet`; detents
+    /// come from `.detents(_:)` (default `[.large]`).
+    private var sheetTrigger: some View {
+        trigger
+            .bottomSheet(isPresented: $isSheetPresented, detents: sheetDetents) {
+                presentedSearch
             }
+    }
+
+    /// `.popover`: the trigger anchors the search UI in a popover — the
+    /// iPad/Mac counterpart of the bottom sheet.
+    private var popoverTrigger: some View {
+        trigger
+            .popover(isPresented: $isSheetPresented) {
+                presentedSearch
+                    .padding(Theme.SpacingKey.md.value)
+                    .frame(minWidth: 320, minHeight: 360)
+            }
+    }
+
+    /// `.fullScreenCover`: immersive phone-first search. macOS has no
+    /// full-screen cover, so it degrades to a plain sheet there.
+    @ViewBuilder
+    private var fullScreenTrigger: some View {
+        #if os(iOS)
+        trigger
+            .fullScreenCover(isPresented: $isSheetPresented) {
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                    HStack {
+                        Spacer()
+                        CloseButton { isSheetPresented = false }
+                    }
+                    presentedSearch
+                }
+                .padding(Theme.SpacingKey.md.value)
+                .background(theme.background(.bgWhite))
+            }
+        #else
+        trigger
+            .sheet(isPresented: $isSheetPresented) {
+                presentedSearch.padding(Theme.SpacingKey.md.value)
+            }
+        #endif
     }
 
     // MARK: - Search field (debounce delegated to SearchBar → onDebouncedChange)
@@ -145,7 +219,7 @@ public struct AirportPicker: View {
     @ViewBuilder
     private var listContent: some View {
         if isLoading {
-            loadingRows
+            if let loadingSlot { loadingSlot } else { loadingRows }
         } else if query.isEmpty {
             preTypingSections
         } else if suggestions.isEmpty {
@@ -159,15 +233,16 @@ public struct AirportPicker: View {
     /// Shown before/alongside typing — each section only when it has airports.
     @ViewBuilder
     private var preTypingSections: some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+        VStack(alignment: .leading, spacing: sectionGap) {
             if !nearbyAirports.isEmpty {
-                section(String(themeKitTravel: "Nearby"), airports: nearbyAirports)
+                section(nearbyTitle ?? String(themeKitTravel: "Nearby"), airports: nearbyAirports)
             }
             if !recentAirports.isEmpty {
-                section(String(themeKitTravel: "Recent"), airports: recentAirports, onClear: onClearRecent)
+                section(recentTitle ?? String(themeKitTravel: "Recent"),
+                        airports: recentAirports, onClear: onClearRecent)
             }
             if !popularAirports.isEmpty {
-                section(String(themeKitTravel: "Popular"), airports: popularAirports)
+                section(popularTitle ?? String(themeKitTravel: "Popular"), airports: popularAirports)
             }
         }
     }
@@ -213,26 +288,15 @@ public struct AirportPicker: View {
     private func row(_ airport: Airport) -> some View {
         let isSelected = selection?.id == airport.id
         return Button { select(airport) } label: {
-            HStack(spacing: Theme.SpacingKey.sm.value) {
-                codeChip(airport.code)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(airport.city)
-                        .textStyle(.bodyBase400)
-                        .foregroundStyle(theme.text(.textPrimary))
-                    Text(airport.name)
-                        .textStyle(.bodySm400)
-                        .foregroundStyle(theme.text(.textTertiary))
-                }
-                .lineLimit(1)
-                Spacer(minLength: Theme.SpacingKey.xs.value)
-                if isSelected {
-                    Icon(systemName: "checkmark")
-                        .size(.sm)
-                        .color(accentColor?.accent ?? theme.foreground(.fgHero))
+            Group {
+                if let rowContentSlot {
+                    rowContentSlot(airport, isSelected)
+                } else {
+                    builtInRowLabel(airport, isSelected: isSelected)
                 }
             }
             .padding(.horizontal, Theme.SpacingKey.md.value)
-            .padding(.vertical, Theme.SpacingKey.sm.value)
+            .padding(.vertical, rowVPad)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }
@@ -244,17 +308,60 @@ public struct AirportPicker: View {
         .travelA11y("row.\(airport.code)", in: accessibilityID)
     }
 
-    /// Bold IATA code chip — token-fed fill/foreground, accent-tintable.
+    /// The stock row anatomy — IATA chip + city/airport + selection checkmark.
+    private func builtInRowLabel(_ airport: Airport, isSelected: Bool) -> some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            codeChip(airport.code)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(airport.city)
+                    .textStyle(.bodyBase400)
+                    .foregroundStyle(theme.text(.textPrimary))
+                Text(airport.name)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(theme.text(.textTertiary))
+            }
+            .lineLimit(1)
+            Spacer(minLength: Theme.SpacingKey.xs.value)
+            if isSelected {
+                Icon(systemName: "checkmark")
+                    .size(.sm)
+                    .color(accentColor?.accent ?? theme.foreground(.fgHero))
+            }
+        }
+    }
+
+    /// Bold IATA code chip — token-fed fill/foreground, accent-tintable, with
+    /// a `FillVariant` axis (`.soft` default, `.solid`, `.outline`, `.ghost`).
     private func codeChip(_ code: String) -> some View {
-        Text(code)
+        let tone = accentColor ?? .primary
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
+        let fill: Color
+        let text: Color
+        switch chipVariantValue {
+        case .soft:
+            fill = accentColor?.soft ?? theme.background(.bgSecondaryLight)
+            text = accentColor?.accent ?? theme.text(.textPrimary)
+        case .solid:
+            fill = tone.solid
+            text = tone.onSolid
+        case .outline:
+            fill = .clear
+            text = accentColor?.accent ?? theme.text(.textPrimary)
+        case .ghost:
+            fill = .clear
+            text = accentColor?.accent ?? theme.text(.textSecondary)
+        }
+        return Text(code)
             .textStyle(.labelSm700)
-            .foregroundStyle(accentColor?.accent ?? theme.text(.textPrimary))
+            .foregroundStyle(text)
             .padding(.vertical, Theme.SpacingKey.xs.value)
             .frame(minWidth: Metrics.chipMinWidth)
-            .background(
-                accentColor?.soft ?? theme.background(.bgSecondaryLight),
-                in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
-            )
+            .background(fill, in: shape)
+            .overlay {
+                if chipVariantValue == .outline {
+                    shape.strokeBorder(accentColor?.border ?? theme.border(.borderPrimary), lineWidth: 1)
+                }
+            }
     }
 
     // MARK: - Loading (Skeleton rows) & empty states
@@ -350,9 +457,49 @@ public extension AirportPicker {
     /// Placeholder for the search field / sheet trigger (default "City or airport").
     func placeholder(_ text: String) -> Self { copy { $0.placeholderText = text } }
 
-    /// `.inline` (default) embeds the picker; `.sheet` renders a field-shaped
-    /// trigger opening the search UI in a `BottomSheet`.
+    /// `.inline` (default) embeds the picker; `.sheet`, `.popover` and
+    /// `.fullScreenCover` render a field-shaped trigger that opens the search
+    /// UI in the matching container (`.fullScreenCover` degrades to a sheet on
+    /// macOS).
     func presentation(_ p: AirportPickerPresentation) -> Self { copy { $0.presentationStyle = p } }
+
+    /// Replaces the built-in suggestion row with caller content, built per
+    /// `(airport, isSelected)`. Selection tap handling, read-only gating and
+    /// the row's VoiceOver label/traits are preserved around the slot.
+    func rowContent(@ViewBuilder _ content: @escaping (Airport, Bool) -> some View) -> Self {
+        copy { $0.rowContentSlot = { AnyView(content($0, $1)) } }
+    }
+
+    /// Replaces the built-in Skeleton loading rows shown while `.loading(true)`.
+    func loadingContent<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.loadingSlot = AnyView(content()) }
+    }
+
+    /// Overrides the pre-typing section headers; `nil` keeps the stock
+    /// English-generic titles ("Nearby" / "Recent" / "Popular").
+    func sectionTitles(nearby: String? = nil, recent: String? = nil, popular: String? = nil) -> Self {
+        copy {
+            $0.nearbyTitle = nearby
+            $0.recentTitle = recent
+            $0.popularTitle = popular
+        }
+    }
+
+    /// Fill style of the IATA code chip: `.soft` (default), `.solid`,
+    /// `.outline` or `.ghost` — all resolved from the accent's semantic ladder.
+    func chipVariant(_ v: FillVariant) -> Self { copy { $0.chipVariantValue = v } }
+
+    /// Detents for the `.sheet` presentation (default `[.large]`).
+    func detents(_ detents: [BottomSheetDetent]) -> Self {
+        copy { $0.sheetDetents = detents.isEmpty ? [.large] : detents }
+    }
+
+    /// SF Symbol on the field-shaped trigger (default `"airplane"`).
+    func triggerIcon(_ systemName: String) -> Self { copy { $0.triggerIconName = systemName } }
+
+    /// Row density: `.regular` (default) or `.compact` — tighter row padding
+    /// and section gaps, resolved from spacing tokens.
+    func density(_ d: AirportPickerDensity) -> Self { copy { $0.densityValue = d } }
 
     /// Replaces the built-in "No airports found" state (T2 slot). Shown when a
     /// typed query has no suggestions and no lookup is in flight.
@@ -465,6 +612,65 @@ private let previewAirports: [Airport] = [
                 }
                 .popular(previewAirports)
                 .padding()
+        }
+    }
+    return Demo()
+}
+
+#Preview("Flexibility — row slot · chip variants · density · titles") {
+    struct Demo: View {
+        @Environment(\.theme) private var theme
+        @State var popoverSel: Airport?
+        @State var coverSel: Airport?
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    // Custom row content — tap/selection/a11y preserved.
+                    AirportPicker(selection: .constant(previewAirports[0]),
+                                  suggestions: [previewAirports[0], previewAirports[2]])
+                        .seedQuery("i")
+                        .rowContent { airport, isSelected in
+                            HStack(spacing: Theme.SpacingKey.sm.value) {
+                                Icon(systemName: isSelected ? "airplane.circle.fill" : "airplane.circle")
+                                    .size(.md)
+                                Text("\(airport.city) — \(airport.code)").textStyle(.labelBase600)
+                                Spacer()
+                            }
+                        }
+                    // Solid chip variant + custom section titles + compact density.
+                    AirportPicker(selection: .constant(nil), suggestions: [])
+                        .chipVariant(.solid)
+                        .accent(.info)
+                        .density(.compact)
+                        .sectionTitles(recent: "Your searches", popular: "Trending routes")
+                        .recent([previewAirports[2], previewAirports[4]])
+                        .popular([previewAirports[0], previewAirports[5]])
+                    // Outline chips.
+                    AirportPicker(selection: .constant(nil), suggestions: [])
+                        .chipVariant(.outline)
+                        .popular([previewAirports[3], previewAirports[6]])
+                    // Custom loading slot.
+                    AirportPicker(selection: .constant(nil), suggestions: [])
+                        .seedQuery("Lon")
+                        .loading()
+                        .loadingContent {
+                            Text("Searching airports…")
+                                .textStyle(.bodySm400)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, Theme.SpacingKey.lg.value)
+                        }
+                    // Popover + full-screen cover triggers (custom icon, tight detents).
+                    HStack(spacing: Theme.SpacingKey.sm.value) {
+                        AirportPicker(selection: $popoverSel, suggestions: previewAirports)
+                            .presentation(.popover)
+                            .triggerIcon("airplane.departure")
+                        AirportPicker(selection: $coverSel, suggestions: previewAirports)
+                            .presentation(.fullScreenCover)
+                            .detents([.medium])
+                    }
+                }
+                .padding()
+            }
         }
     }
     return Demo()

--- a/Sources/ThemeKitTravel/Components/Organisms/AncillaryCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/AncillaryCard.swift
@@ -36,25 +36,36 @@ public struct AncillaryCard: View {
     private var currencyCode: String?
     private var priceSuffix: String?
     private var badgeText: String?
-    private var quantity: Binding<Int>?
+    private var badgeStyle: BadgeStyle = .info
+    /// Quantity / added state — dual-mode via `ControllableState` (ADR-F4);
+    /// renamed from `quantity`/`added` so the binding-less overloads aren't
+    /// invalid redeclarations. Hidden until the `shows…` flags flip.
+    @ControllableState private var quantityState = 0
+    private var showsQuantity = false
     private var quantityRange: ClosedRange<Int> = 0...9
-    private var added: Binding<Bool>?
+    @ControllableState private var addedState = false
+    private var showsAdded = false
     private var addTitle = "Add"
     private var addedTitle = "Added"
     private var accent: SemanticColor?
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
     private var controlSurfaceKey: Theme.BackgroundColorKey = .bgSecondary
     private var radiusRole: Theme.RadiusRole = .box
+    private var elevation: CardElevation = .none
+    private var leadingSlot: AnyView?
+    private var trailingSlot: AnyView?
 
     public init(_ title: String) { self.title = title }   // R1
 
     @Environment(\.componentDefaults) private var defaults
+    @Environment(\.isReadOnly) private var isReadOnly   // E1 — set by `.readOnly(_:)`
     private var accentSemantic: SemanticColor { accent ?? defaults.accent ?? .primary }
     private var resolvedCurrency: String {
         currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: radiusRole.value, style: .continuous) }
-    private var isActive: Bool { (added?.wrappedValue ?? false) || ((quantity?.wrappedValue ?? 0) > 0) }
+    @MainActor
+    private var isActive: Bool { (showsAdded && addedState) || (showsQuantity && quantityState > 0) }
 
     public var body: some View {
         // The shell (fill, corner clipping, border, shadow) is drawn by the active
@@ -64,7 +75,7 @@ public struct AncillaryCard: View {
         // elevation reproduces today's flat look: a 1pt hairline border, no shadow.
         cardStyle.makeBody(configuration: CardStyleConfiguration(
             content: AnyView(cardContent),
-            elevation: .none,
+            elevation: elevation,
             isSelected: isActive,
             isPressed: false,
             surfaceKey: surfaceKey,
@@ -73,13 +84,14 @@ public struct AncillaryCard: View {
     }
 
     /// The card's inner layout — everything inside the shell.
+    @MainActor
     private var cardContent: some View {
         HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
             leading
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Text(title).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
-                    if let badgeText { Badge(badgeText).badgeStyle(.info).variant(.soft).size(.small).fixedSize() }
+                    if let badgeText { Badge(badgeText).badgeStyle(badgeStyle).variant(.soft).size(.small).fixedSize() }
                 }
                 if let subtitle { Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(1) }
                 if let price { priceLine(price) }
@@ -91,7 +103,9 @@ public struct AncillaryCard: View {
     }
 
     @ViewBuilder private var leading: some View {
-        if let imageURL {
+        if let leadingSlot {
+            leadingSlot
+        } else if let imageURL {
             RemoteImage(imageURL).contentMode(.fill).frame(width: 46, height: 46)
                 .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
         } else {
@@ -107,11 +121,14 @@ public struct AncillaryCard: View {
         }
     }
 
+    @MainActor
     @ViewBuilder private var control: some View {
-        if let quantity {
-            stepper(quantity)
-        } else if let added {
-            addButton(added)
+        if let trailingSlot {
+            trailingSlot
+        } else if showsQuantity {
+            stepper($quantityState)
+        } else if showsAdded {
+            addButton($addedState)
         }
     }
 
@@ -128,6 +145,7 @@ public struct AncillaryCard: View {
         }
         .padding(.horizontal, 4)
         .background(theme.background(controlSurfaceKey), in: Capsule())
+        .disabled(isReadOnly)   // E1 — read-only surfaces render but don't mutate
     }
 
     private func stepButton(_ icon: String, label: String, value: Int, enabled: Bool, _ action: @escaping () -> Void) -> some View {
@@ -155,6 +173,7 @@ public struct AncillaryCard: View {
             .background(on ? accentSemantic.solid : accentSemantic.bg, in: Capsule())
         }
         .buttonStyle(.plain)
+        .disabled(isReadOnly)   // E1 — read-only surfaces render but don't mutate
         .accessibilityLabel(title)
         .accessibilityAddTraits(on ? .isSelected : [])
     }
@@ -177,11 +196,46 @@ public extension AncillaryCard {
         copy { $0.price = amount; $0.priceSuffix = suffix }
     }
     func badge(_ text: String?) -> Self { copy { $0.badgeText = text } }
-    /// A quantity stepper bound to `binding` (mutually exclusive with ``added(_:)``).
-    func quantity(_ binding: Binding<Int>, range: ClosedRange<Int> = 0...9) -> Self { copy { $0.quantity = binding; $0.quantityRange = range } }
-    /// An add/remove toggle bound to `binding` (English defaults, overridable).
-    func added(_ binding: Binding<Bool>, title: String = "Add", addedTitle: String = "Added") -> Self { copy { $0.added = binding; $0.addTitle = title; $0.addedTitle = addedTitle } }
+    /// A title badge with an explicit `BadgeStyle` (the one-argument form keeps
+    /// the classic `.info` styling).
+    func badge(_ text: String?, style: BadgeStyle) -> Self { copy { $0.badgeText = text; $0.badgeStyle = style } }
+    /// A quantity stepper bound to `binding` (controlled — mutually exclusive
+    /// with ``added(_:title:addedTitle:)``).
+    func quantity(_ binding: Binding<Int>, range: ClosedRange<Int> = 0...9) -> Self {
+        copy {
+            $0.showsQuantity = true
+            $0._quantityState = ControllableState(wrappedValue: 0, external: binding)
+            $0.quantityRange = range
+        }
+    }
+    /// A self-managed quantity stepper (uncontrolled). Survives List *scrolling*
+    /// (state-per-identity) but not identity churn — use ``quantity(_:range:)``
+    /// when the count must persist.
+    func quantity(range: ClosedRange<Int> = 0...9) -> Self {
+        copy { $0.showsQuantity = true; $0.quantityRange = range }
+    }
+    /// An add/remove toggle bound to `binding` (controlled; English defaults, overridable).
+    func added(_ binding: Binding<Bool>, title: String = "Add", addedTitle: String = "Added") -> Self {
+        copy {
+            $0.showsAdded = true
+            $0._addedState = ControllableState(wrappedValue: false, external: binding)
+            $0.addTitle = title
+            $0.addedTitle = addedTitle
+        }
+    }
+    /// A self-managed add/remove toggle (uncontrolled) — same identity caveat
+    /// as ``quantity(range:)``.
+    func added(title: String = "Add", addedTitle: String = "Added") -> Self {
+        copy { $0.showsAdded = true; $0.addTitle = title; $0.addedTitle = addedTitle }
+    }
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+    /// Shell elevation, fed to the active `CardStyle` (default `.none` — today's
+    /// flat, hairline-only chrome).
+    func elevation(_ e: CardElevation) -> Self { copy { $0.elevation = e } }
+    /// Replaces the built-in icon tile / thumbnail.
+    func leading<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.leadingSlot = AnyView(content()) } }
+    /// Replaces the built-in stepper / add-button control area.
+    func trailing<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.trailingSlot = AnyView(content()) } }
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
     /// Surface token for the quantity stepper's capsule track (default
     /// `.bgSecondary`) — distinct from ``surface(_:)``, which fills the card shell.
@@ -206,6 +260,18 @@ public extension AncillaryCard {
                 AncillaryCard("Extra legroom").icon("figure.seated.side").subtitle("Row 12").price(75).quantity($bags, range: 0...4)
                     .surface(.bgSecondaryLight)
                     .controlSurface(.bgWhite)
+                // Uncontrolled stepper + toggle, styled badge, soft elevation.
+                AncillaryCard("Sports equipment").icon("figure.skiing.downhill").price(300, suffix: "/ item")
+                    .quantity(range: 0...2).badge("New", style: .warning).elevation(.soft)
+                AncillaryCard("Fast track").icon("hare.fill").price(60)
+                    .added(title: "Add", addedTitle: "In basket")
+                // Leading + trailing slots replace the tile and the control.
+                AncillaryCard("Lounge access").subtitle("3h stay")
+                    .leading { Badge("VIP").badgeStyle(.purple).size(.small) }
+                    .trailing { TextLink("View") { } }
+                // Read-only: the stepper and toggle render but don't mutate.
+                AncillaryCard("Checked baggage").icon("suitcase.fill").price(450).quantity($bags, range: 0...4)
+                    .readOnly()
             }
             .padding()
         }

--- a/Sources/ThemeKitTravel/Components/Organisms/BoardingPass.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/BoardingPass.swift
@@ -26,6 +26,18 @@ import SwiftUI
 import ThemeKit
 
 public struct BoardingPass: View {
+    /// Footprint of the stub's QR / barcode, mapped to the component's internal
+    /// point constants (medium reproduces the classic 72pt QR / 48pt barcode).
+    public enum CodeSize: String, CaseIterable, Sendable { case small, medium, large }
+
+    /// Arrangement of the labelled detail cells.
+    public enum DetailsLayout: String, CaseIterable, Sendable {
+        /// One horizontal row (the classic layout).
+        case row
+        /// A two-column grid — prevents clipping when many cells or large type.
+        case grid
+    }
+
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
 
@@ -50,6 +62,13 @@ public struct BoardingPass: View {
     private var accent: SemanticColor?
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
     private var elevation: CardElevation = .elevated
+    private var radiusRole: Theme.RadiusRole = .box
+    private var showsPerforation = true
+    private var dashKey: Theme.BorderColorKey = .borderPrimary
+    private var codeSize: CodeSize = .medium
+    private var detailsLayout: DetailsLayout = .row
+    private var headerSlot: AnyView?
+    private var customStub: AnyView?
 
     public init(passenger: String, from: String, to: String) {   // R1
         self.passenger = passenger
@@ -57,7 +76,18 @@ public struct BoardingPass: View {
         self.to = to
     }
 
+    // deferred: accent-fallback unification — keeps the `.primary` fallback
+    // (matching AncillaryCard/StickyBookingBar would be visually breaking here).
     private var accentBase: Color { (accent ?? .primary).base }
+
+    /// Internal point constants behind the `CodeSize` ramp (token rule: ramp
+    /// enums map to private CGFloats; no raw sizes in the public signature).
+    private var qrSide: CGFloat {
+        switch codeSize { case .small: return 56; case .medium: return 72; case .large: return 96 }
+    }
+    private var barcodeHeight: CGFloat {
+        switch codeSize { case .small: return 36; case .medium: return 48; case .large: return 64 }
+    }
 
     public var body: some View {
         // Decorative-shell exception: the perforated `TicketStub` surface (fill +
@@ -65,12 +95,15 @@ public struct BoardingPass: View {
         // see the header note. `.surface()`/`.elevation()` feed it directly.
         TicketStub {
             VStack(alignment: .leading, spacing: density.scale(Theme.SpacingKey.md.value)) {
-                header
+                if let headerSlot { headerSlot } else { header }
                 route
-                if !details.isEmpty { detailGrid }
+                if !details.isEmpty { detailArea }
             }
         }
-        .stub { stub }
+        .stub { if let customStub { customStub } else { stub } }
+        .cornerRadius(radiusRole)
+        .perforation(showsPerforation)
+        .dashColor(dashKey)
         .elevation(elevation)
         .surface(surfaceKey)
     }
@@ -113,15 +146,48 @@ public struct BoardingPass: View {
         .fixedSize()
     }
 
-    private var detailGrid: some View {
+    @ViewBuilder private var detailArea: some View {
+        switch detailsLayout {
+        case .row: detailRow
+        case .grid: detailTwoColumnGrid
+        }
+    }
+
+    private var detailRow: some View {
         HStack(alignment: .top, spacing: density.scale(Theme.SpacingKey.md.value)) {
             ForEach(Array(details.enumerated()), id: \.offset) { _, item in
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(item.0).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
-                    Text(item.1).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
-                }
+                detailCell(item)
             }
             Spacer(minLength: 0)
+        }
+    }
+
+    /// Two-column layout — pairs of cells per `GridRow`, so five details wrap
+    /// to three rows instead of clipping off the trailing edge.
+    private var detailTwoColumnGrid: some View {
+        Grid(alignment: .leading,
+             horizontalSpacing: density.scale(Theme.SpacingKey.md.value),
+             verticalSpacing: density.scale(Theme.SpacingKey.sm.value)) {
+            ForEach(Array(stride(from: 0, to: details.count, by: 2)), id: \.self) { index in
+                GridRow {
+                    detailCell(details[index])
+                        .gridColumnAlignment(.leading)
+                    if index + 1 < details.count {
+                        detailCell(details[index + 1])
+                            .gridColumnAlignment(.leading)
+                    } else {
+                        Color.clear.gridCellUnsizedAxes([.horizontal, .vertical])
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func detailCell(_ item: (String, String)) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(item.0).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+            Text(item.1).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
         }
     }
 
@@ -141,9 +207,9 @@ public struct BoardingPass: View {
 
     @ViewBuilder private var code: some View {
         if let qrValue {
-            QRCode(qrValue).size(72)
+            QRCode(qrValue).size(qrSide)
         } else if let barcodeValue {
-            Barcode(barcodeValue).height(48).showsValue()
+            Barcode(barcodeValue).height(barcodeHeight).showsValue()
         }
     }
 }
@@ -180,6 +246,21 @@ public extension BoardingPass {
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
     func elevation(_ e: CardElevation) -> Self { copy { $0.elevation = e } }
+    /// Replaces the built-in passenger / booking-ref / code stub with custom
+    /// content — forwarded to ``TicketStub``'s stub slot below the tear line.
+    func stub<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.customStub = AnyView(content()) } }
+    /// Replaces the built-in airline / flight-number header row.
+    func header<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.headerSlot = AnyView(content()) } }
+    /// Footprint of the stub's QR / barcode (default `.medium` — the classic sizes).
+    func codeSize(_ s: CodeSize) -> Self { copy { $0.codeSize = s } }
+    /// Detail-cell arrangement: one `.row` (default) or a two-column `.grid`.
+    func detailsLayout(_ l: DetailsLayout) -> Self { copy { $0.detailsLayout = l } }
+    /// Outer corner radius (radius role token, default `.box`) — forwarded to ``TicketStub``.
+    func cornerRadius(_ role: Theme.RadiusRole) -> Self { copy { $0.radiusRole = role } }
+    /// Draw the dashed perforation across the tear line (default on) — forwarded to ``TicketStub``.
+    func perforation(_ on: Bool = true) -> Self { copy { $0.showsPerforation = on } }
+    /// Perforation dash colour (border token key, default `.borderPrimary`) — forwarded to ``TicketStub``.
+    func dashColor(_ key: Theme.BorderColorKey) -> Self { copy { $0.dashKey = key } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -189,12 +270,44 @@ public extension BoardingPass {
 }
 
 #Preview {
-    BoardingPass(passenger: "İsa Mercan", from: "SAW", to: "BER")
-        .airline("Pegasus").flightNo("PC 1234").cabin("Economy")
-        .cities(from: "Istanbul", to: "Berlin").times(departure: "13:15", arrival: "16:05").date("13 Sep")
-        .gate("A12", seat: "14C", boarding: "12:45", terminal: "1")
-        .bookingRef("PNR: X7K2QF").barcode("PC1234SAWBER14C")
+    ScrollView {
+        VStack(spacing: 20) {
+            BoardingPass(passenger: "İsa Mercan", from: "SAW", to: "BER")
+                .airline("Pegasus").flightNo("PC 1234").cabin("Economy")
+                .cities(from: "Istanbul", to: "Berlin").times(departure: "13:15", arrival: "16:05").date("13 Sep")
+                .gate("A12", seat: "14C", boarding: "12:45", terminal: "1")
+                .bookingRef("PNR: X7K2QF").barcode("PC1234SAWBER14C")
+            // Two-column detail grid + large QR + tinted dashes + field corner.
+            BoardingPass(passenger: "Alex Morgan", from: "IST", to: "LHR")
+                .airline("Sunrise Air").flightNo("SA 101")
+                .times(departure: "09:20", arrival: "12:15")
+                .details([("Terminal", "2"), ("Gate", "B7"), ("Boarding", "08:40"),
+                          ("Seat", "3A"), ("Zone", "1")])
+                .detailsLayout(.grid)
+                .qr("SA101ISTLHR3A").codeSize(.large)
+                .cornerRadius(.field).dashColor(.borderHero)
+            // Small barcode, no perforation, custom header + stub slots.
+            BoardingPass(passenger: "Sam Carter", from: "AMS", to: "CDG")
+                .times(departure: "18:05", arrival: "19:20")
+                .header {
+                    HStack {
+                        Badge("Priority").badgeStyle(.warning).size(.small)
+                        Spacer()
+                        Text("BW 810").textStyle(.labelSm600)
+                    }
+                }
+                .stub {
+                    HStack {
+                        Text("Group 1").textStyle(.labelBase700)
+                        Spacer()
+                        Barcode("BW810AMSCDG").height(36)
+                    }
+                }
+                .barcode("BW810AMSCDG").codeSize(.small)
+                .perforation(false)
+        }
         .frame(maxWidth: 340).padding()
+    }
 }
 
 // The perforated ticket shell is exempt from `CardStyle` (see header note):

--- a/Sources/ThemeKitTravel/Components/Organisms/CheckInFlow.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/CheckInFlow.swift
@@ -35,6 +35,23 @@
 import SwiftUI
 import ThemeKit
 
+/// Alignment of the built-in Back / Continue dock: trailing-packed (default)
+/// or stretched full-width buttons.
+public enum DockLayout: Sendable { case trailing, stretch }
+
+/// How pages change: a directional slide (default, RTL-mirrored), a
+/// cross-fade, or an instant swap. All of them respect `MicroMotion` /
+/// Reduce Motion — when motion is off every transition applies instantly.
+public enum PageTransition: Sendable { case slide, fade, none }
+
+/// Where the progress chrome sits: above the page (default) or as a vertical
+/// rail on the leading edge (wide/iPad hosts).
+public enum StepperPlacement: Sendable { case top, leading }
+
+/// The progress chrome itself: the `Steps` markers (default) or a thin
+/// determinate `ProgressBar`.
+public enum CheckInProgressStyle: Sendable { case steps, bar }
+
 /// A check-in journey scaffold — `Steps` header + the current page + a
 /// Back / Continue dock. Pages are the app's content; the scaffold owns only
 /// the progression chrome.
@@ -61,6 +78,15 @@ public struct CheckInFlow<Page: View>: View {
     private var onCompleteAction: (() -> Void)?
     private var showsStepperValue = true
     private var accent: SemanticColor?
+    /// Replaces the built-in Back / Continue dock.
+    private var dockSlot: AnyView?
+    private var dockLayoutValue: DockLayout = .trailing
+    private var buttonSizeValue: ButtonSize = .medium
+    private var stepsTappableValue = false
+    private var pageTransitionValue: PageTransition = .slide
+    private var stepperSizeValue: StepsSize = .medium
+    private var stepperPlacementValue: StepperPlacement = .top
+    private var progressStyleValue: CheckInProgressStyle = .steps
 
     /// R1 — the step definitions + controlled index + per-step page builder.
     /// The binding is the change channel; observe with `.onChange(of:)` at the
@@ -115,22 +141,59 @@ public struct CheckInFlow<Page: View>: View {
         if steps.isEmpty {
             EmptyView()
         } else {
-            VStack(spacing: 0) {
-                if showsStepperValue {
-                    header
-                        .padding(.horizontal, Theme.SpacingKey.md.value)
-                        .padding(.vertical, Theme.SpacingKey.sm.value)
+            Group {
+                if showsStepperValue, stepperPlacementValue == .leading, progressStyleValue == .steps {
+                    // Leading rail: vertical Steps beside the page area.
+                    HStack(alignment: .top, spacing: 0) {
+                        header(axis: .vertical)
+                            .padding(.horizontal, Theme.SpacingKey.md.value)
+                            .padding(.vertical, Theme.SpacingKey.sm.value)
+                        pageContainer
+                    }
+                } else {
+                    VStack(spacing: 0) {
+                        if showsStepperValue {
+                            progressChrome
+                                .padding(.horizontal, Theme.SpacingKey.md.value)
+                                .padding(.vertical, Theme.SpacingKey.sm.value)
+                        }
+                        pageContainer
+                    }
                 }
-                pageContainer
             }
-            .buttonDock { dock }
+            .buttonDock {
+                if let dockSlot {
+                    // Custom dock: the caller owns Back/Continue semantics —
+                    // canAdvance gating and onComplete become its job.
+                    dockSlot.allowsHitTesting(!isReadOnly)
+                } else {
+                    dock
+                }
+            }
             .accessibilityElement(children: .contain)
         }
     }
 
+    /// The `.progressStyle(_:)` switch: Steps markers or a determinate bar.
     @MainActor
-    private var header: some View {
-        let base = Steps(derivedSteps)
+    @ViewBuilder
+    private var progressChrome: some View {
+        switch progressStyleValue {
+        case .steps:
+            header(axis: .horizontal)
+        case .bar:
+            // Step titles are internal to the neutral `Steps.Step`, so the
+            // announcement is positional ("Step 2 of 3").
+            ProgressBar(value: Double(currentIndex + 1) / Double(max(steps.count, 1)))
+                .progressLabel(String(themeKitTravel: "Step \(currentIndex + 1) of \(steps.count)"))
+        }
+    }
+
+    @MainActor
+    private func header(axis: Axis) -> some View {
+        let base = Steps(derivedSteps, onSelect: stepsTappableValue ? { jump(to: $0) } : nil)
+            .axis(axis)
+            .size(stepperSizeValue)
         return Group {
             if let accent {
                 base.marker { _, index in accentMarker(index: index, color: accent) }
@@ -180,20 +243,27 @@ public struct CheckInFlow<Page: View>: View {
         }
     }
 
-    /// Directional slide on leading/trailing edges — mirrored under RTL
-    /// automatically; `motion == nil` (MicroMotion off / Reduce Motion)
-    /// applies the change instantly.
+    /// The `.pageTransition(_:)` switch. `.slide` (default) moves on
+    /// leading/trailing edges — mirrored under RTL automatically; `.fade`
+    /// cross-fades; `.none` swaps identity without motion. All are gated the
+    /// same way: `motion == nil` (MicroMotion off / Reduce Motion) applies
+    /// the change instantly.
     private var pageTransition: AnyTransition {
-        if movesForward {
-            .asymmetric(
-                insertion: .move(edge: .trailing).combined(with: .opacity),
-                removal: .move(edge: .leading).combined(with: .opacity)
-            )
-        } else {
-            .asymmetric(
-                insertion: .move(edge: .leading).combined(with: .opacity),
-                removal: .move(edge: .trailing).combined(with: .opacity)
-            )
+        switch pageTransitionValue {
+        case .fade:
+            return .opacity
+        case .none:
+            return .identity
+        case .slide:
+            return movesForward
+                ? .asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                )
+                : .asymmetric(
+                    insertion: .move(edge: .leading).combined(with: .opacity),
+                    removal: .move(edge: .trailing).combined(with: .opacity)
+                )
         }
     }
 
@@ -201,11 +271,15 @@ public struct CheckInFlow<Page: View>: View {
     private var dock: some View {
         ButtonGroup(.horizontal) {
             SecondaryButton(backTitleValue) { goBack() }
+                .size(buttonSizeValue)
+                .fullWidth(dockLayoutValue == .stretch)
                 .disabled(currentIndex == 0)
             PrimaryButton(isLastStep ? doneTitleValue : nextTitleValue) { advance() }
+                .size(buttonSizeValue)
+                .fullWidth(dockLayoutValue == .stretch)
                 .disabled(!advanceAllowed)
         }
-        .frame(maxWidth: .infinity, alignment: .trailing)
+        .frame(maxWidth: .infinity, alignment: dockLayoutValue == .stretch ? .center : .trailing)
         .allowsHitTesting(!isReadOnly)   // E1 — read-only blocks progression
     }
 
@@ -227,6 +301,16 @@ public struct CheckInFlow<Page: View>: View {
         guard !isReadOnly, currentIndex > 0 else { return }
         movesForward = false
         selection = currentIndex - 1
+    }
+
+    /// `.stepsTappable` jump: only *backward*, to an already-done marker — a
+    /// tap can never advance past the `canAdvance` gate because it can never
+    /// advance at all.
+    @MainActor
+    private func jump(to index: Int) {
+        guard !isReadOnly, index < currentIndex, steps.indices.contains(index) else { return }
+        movesForward = false
+        selection = index
     }
 }
 
@@ -263,6 +347,43 @@ public extension CheckInFlow {
     /// Semantic tint for the done/active step markers; `nil` (default) keeps
     /// the stock theme-hero markers.
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+
+    /// Replaces the built-in Back / Continue `ButtonGroup` with caller
+    /// content (canonical `.dock { }` slot). With a custom dock the scaffold
+    /// no longer drives progression: `canAdvance` gating, `onComplete` and
+    /// the index changes become the caller's job (mutate the bound
+    /// `selection`). Hit-testing still respects `.readOnly()`.
+    func dock<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.dockSlot = AnyView(content()) }
+    }
+
+    /// Built-in dock alignment: `.trailing` (default, packed buttons) or
+    /// `.stretch` (full-width buttons).
+    func dockLayout(_ l: DockLayout) -> Self { copy { $0.dockLayoutValue = l } }
+
+    /// Control size of the built-in dock buttons (default `.medium`).
+    func buttonSize(_ s: ButtonSize) -> Self { copy { $0.buttonSizeValue = s } }
+
+    /// Lets a tap on a *done* marker jump back to that step (markers gain the
+    /// button trait). Forward taps are ignored, so a jump can never bypass
+    /// the `canAdvance` gate. Default off.
+    func stepsTappable(_ on: Bool = true) -> Self { copy { $0.stepsTappableValue = on } }
+
+    /// Page-change motion: `.slide` (default, RTL-mirrored), `.fade`, or
+    /// `.none` — all applied through the `MicroMotion` / Reduce-Motion gate.
+    func pageTransition(_ t: PageTransition) -> Self { copy { $0.pageTransitionValue = t } }
+
+    /// Marker/label size of the `Steps` header (default `.medium`).
+    func stepperSize(_ s: StepsSize) -> Self { copy { $0.stepperSizeValue = s } }
+
+    /// Progress-chrome placement: `.top` (default) or `.leading` — a vertical
+    /// `Steps` rail beside the page (steps style only; the `.bar` progress
+    /// style always renders on top).
+    func stepperPlacement(_ p: StepperPlacement) -> Self { copy { $0.stepperPlacementValue = p } }
+
+    /// Progress chrome: `.steps` markers (default) or `.bar` — a thin
+    /// determinate `ProgressBar` announcing "Step N of M".
+    func progressStyle(_ s: CheckInProgressStyle) -> Self { copy { $0.progressStyleValue = s } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -314,6 +435,69 @@ public extension CheckInFlow {
                 if completed {
                     Text("Check-in complete").textStyle(.labelSm600)
                 }
+            }
+        }
+    }
+    return Demo()
+}
+
+#Preview("Flexibility — dock · bar · leading rail · tappable steps") {
+    struct Demo: View {
+        @State private var custom = 1
+        @State private var barStep = 1
+        @State private var railStep = 1
+        @State private var tappable = 2
+
+        var body: some View {
+            ScrollView {
+                VStack(spacing: Theme.SpacingKey.lg.value) {
+                    // Custom dock slot — caller drives progression.
+                    CheckInFlow(steps: [
+                        .init("Bags", state: .active), .init("Seats", state: .todo),
+                    ], selection: $custom) { index in
+                        Text("Page \(index + 1)").textStyle(.bodyBase400).padding()
+                    }
+                    .dock {
+                        PrimaryButton("Skip to seats") { custom = 1 }.fullWidth()
+                    }
+                    .frame(height: 180)
+
+                    // Progress bar chrome + stretched dock + fade transition.
+                    CheckInFlow(steps: [
+                        .init("Passengers", state: .todo), .init("Seats", state: .todo),
+                        .init("Pass", state: .todo),
+                    ], selection: $barStep) { index in
+                        Text("Step \(index + 1)").textStyle(.bodyBase400).padding()
+                    }
+                    .progressStyle(.bar)
+                    .pageTransition(.fade)
+                    .dockLayout(.stretch)
+                    .buttonSize(.large)
+                    .frame(height: 200)
+
+                    // Leading vertical rail + small tappable markers.
+                    CheckInFlow(steps: [
+                        .init("Bags", state: .todo), .init("Seats", state: .todo),
+                        .init("Confirm", state: .todo),
+                    ], selection: $railStep) { index in
+                        Text("Rail page \(index + 1)").textStyle(.bodyBase400).padding()
+                    }
+                    .stepperPlacement(.leading)
+                    .stepperSize(.small)
+                    .stepsTappable()
+                    .frame(height: 220)
+
+                    // Tappable done markers jump back; forward taps are ignored.
+                    CheckInFlow(steps: [
+                        .init("A", state: .todo), .init("B", state: .todo), .init("C", state: .todo),
+                    ], selection: $tappable) { index in
+                        Text("Page \(index + 1)").textStyle(.bodyBase400).padding()
+                    }
+                    .stepsTappable()
+                    .pageTransition(.none)
+                    .frame(height: 160)
+                }
+                .padding()
             }
         }
     }

--- a/Sources/ThemeKitTravel/Components/Organisms/FareFamilyCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FareFamilyCard.swift
@@ -18,6 +18,15 @@
 import SwiftUI
 import ThemeKit
 
+/// Layout archetype for ``FareFamilyCard``.
+public enum FareFamilyLayout: String, CaseIterable, Sendable {
+    /// The classic full-width card — leading chip, feature list, price footer.
+    case stacked
+    /// A narrow comparison-matrix column — centered chip, condensed features,
+    /// price pinned at the bottom. Place several side by side in an `HStack`.
+    case column
+}
+
 /// A token-bound fare-family option card.
 ///
 /// ```swift
@@ -45,6 +54,11 @@ public struct FareFamilyCard: View {
     private var selection: Binding<Bool>?
     private var onSelect: (() -> Void)?
     private var footerSlot: AnyView?
+    private var headerSlot: AnyView?
+    private var ctaTitleOverride: String?
+    private var chipVariant: FillVariant = .solid
+    private var elevation: CardElevation = .none
+    private var layout: FareFamilyLayout = .stacked
 
     public init(_ name: String, price: Decimal) {   // R1
         self.name = name
@@ -65,7 +79,7 @@ public struct FareFamilyCard: View {
         // elevation keeps the classic hairline (no shadow), as in HotelResultCard.
         cardStyle.makeBody(configuration: CardStyleConfiguration(
             content: AnyView(cardContent),
-            elevation: .none,
+            elevation: elevation,
             isSelected: active,
             isPressed: false,
             surfaceKey: surfaceKey,
@@ -77,13 +91,16 @@ public struct FareFamilyCard: View {
     }
 
     /// The card's inner layout — everything inside the shell.
-    private var cardContent: some View {
+    @ViewBuilder private var cardContent: some View {
+        switch layout {
+        case .stacked: stackedContent
+        case .column: columnContent
+        }
+    }
+
+    private var stackedContent: some View {
         VStack(alignment: .leading, spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            Text(name.uppercased())
-                .textStyle(.labelSm700)
-                .foregroundStyle(accent.onSolid)
-                .padding(.horizontal, 10).padding(.vertical, 4)
-                .background(accent.solid, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            if let headerSlot { headerSlot } else { tierChip }
 
             if !features.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
@@ -101,6 +118,63 @@ public struct FareFamilyCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    /// The narrow comparison-matrix column: centered chip, condensed features,
+    /// price at the bottom. Designed to sit side by side in an `HStack`.
+    private var columnContent: some View {
+        VStack(alignment: .leading, spacing: density.scale(Theme.SpacingKey.sm.value)) {
+            Group {
+                if let headerSlot { headerSlot } else { tierChip }
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+
+            if !features.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(features) { FareFeatureRow($0) }
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if let footerSlot {
+                footerSlot
+            } else {
+                columnFooter
+            }
+        }
+        .padding(density.scale(Theme.SpacingKey.sm.value))
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// The tier name chip, rendered per ``FillVariant`` on the accent's ladder.
+    private var tierChip: some View {
+        Text(name.uppercased())
+            .textStyle(.labelSm700)
+            .foregroundStyle(chipForeground)
+            .padding(.horizontal, 10).padding(.vertical, 4)
+            .background(chipBackground,
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
+            .overlay {
+                if chipVariant == .outline {
+                    RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
+                        .strokeBorder(accent.border, lineWidth: 1)
+                }
+            }
+    }
+
+    private var chipForeground: Color {
+        switch chipVariant {
+        case .solid: return accent.onSolid
+        case .soft, .outline, .ghost: return accent.accent
+        }
+    }
+    private var chipBackground: Color {
+        switch chipVariant {
+        case .solid: return accent.solid
+        case .soft: return accent.soft
+        case .outline, .ghost: return .clear
+        }
+    }
+
     @ViewBuilder private var footer: some View {
         if let selection {
             HStack {
@@ -110,12 +184,29 @@ public struct FareFamilyCard: View {
             }
             .padding(.top, 2)
         } else {
-            ThemeButton(priceText) { select() }
+            ThemeButton(ctaText) { select() }
                 .color(accent).shape(.rounded).fullWidth()
                 .padding(.top, 4)
         }
     }
 
+    /// Column-mode footer — price and control stacked, centered, pinned at the bottom.
+    @ViewBuilder private var columnFooter: some View {
+        if let selection {
+            VStack(spacing: Theme.SpacingKey.xs.value) {
+                PriceTag(price, currencyCode: resolvedCurrency).emphasis(.hero)
+                RadioButton(isSelected: selection)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 2)
+        } else {
+            ThemeButton(ctaText) { select() }
+                .color(accent).shape(.rounded).size(.small).fullWidth()
+                .padding(.top, 4)
+        }
+    }
+
+    private var ctaText: String { ctaTitleOverride ?? priceText }
     private var priceText: String {
         price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(2)))
     }
@@ -142,6 +233,18 @@ public extension FareFamilyCard {
     func onSelect(_ action: (() -> Void)?) -> Self { copy { $0.onSelect = action } }
     /// Replace the price/CTA footer with custom content.
     func footer<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.footerSlot = AnyView(content()) } }
+    /// Replace the tier name chip with custom header content.
+    func header<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.headerSlot = AnyView(content()) } }
+    /// A custom CTA title (e.g. "Choose Super Eco"); `nil` (default) keeps the
+    /// formatted price as the button label.
+    func ctaTitle(_ text: String?) -> Self { copy { $0.ctaTitleOverride = text } }
+    /// Fill treatment of the tier name chip (default `.solid`).
+    func badgeVariant(_ v: FillVariant) -> Self { copy { $0.chipVariant = v } }
+    /// Shell elevation, fed to the active `CardStyle` (default `.none` — today's
+    /// flat, hairline-only chrome).
+    func elevation(_ e: CardElevation) -> Self { copy { $0.elevation = e } }
+    /// Layout archetype: `.stacked` (default) or a narrow comparison `.column`.
+    func layout(_ v: FareFamilyLayout) -> Self { copy { $0.layout = v } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -164,8 +267,41 @@ public extension FareFamilyCard {
                 FareFeature("Partial refund", systemImage: "arrow.uturn.backward", status: .included),
                 FareFeature("Snack", systemImage: "takeoutbag.and.cup.and.straw.fill", status: .included),
             ]).onSelect { }
+            // Soft chip variant + custom CTA title + soft elevation.
+            FareFamilyCard("Business", price: 6_420).accent(.info)
+                .badgeVariant(.soft).ctaTitle("Choose Business").elevation(.soft)
+                .features([FareFeature("Lounge access", systemImage: "sofa.fill", status: .included)])
+                .onSelect { }
+            // Outline chip + custom header slot.
+            FareFamilyCard("Promo", price: 999).accent(.orange)
+                .badgeVariant(.outline)
+                .header { HStack { Text("PROMO").textStyle(.labelSm700); Spacer(); Badge("−20%").badgeStyle(.error).size(.small) } }
+                .onSelect { }
         }.padding()
     }
+}
+
+#Preview("Comparison columns") {
+    HStack(alignment: .top, spacing: 10) {
+        FareFamilyCard("Eco", price: 1_871.99).accent(.success).layout(.column)
+            .features([
+                FareFeature("Cabin bag", systemImage: "handbag", status: .included),
+                FareFeature("Checked", systemImage: "suitcase.fill", status: .excluded),
+            ])
+            .selection(.constant(false))
+        FareFamilyCard("Flex", price: 3_116.99).accent(.purple).layout(.column)
+            .features([
+                FareFeature("Cabin bag", systemImage: "handbag", status: .included),
+                FareFeature("Checked", systemImage: "suitcase.fill", status: .included),
+            ])
+            .selection(.constant(true))
+        FareFamilyCard("Biz", price: 6_420).accent(.info).layout(.column)
+            .badgeVariant(.soft).ctaTitle("Choose")
+            .features([FareFeature("Lounge", systemImage: "sofa.fill", status: .included)])
+            .onSelect { }
+    }
+    .frame(height: 260)
+    .padding()
 }
 
 #Preview("Selected + outlined style") {

--- a/Sources/ThemeKitTravel/Components/Organisms/FareSummary.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FareSummary.swift
@@ -27,12 +27,22 @@ public struct FareSummary: View {
     @Environment(\.componentDensity) private var density
     @Environment(\.formatDefaults) private var formatDefaults
     @Environment(\.locale) private var locale
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let lines: [FareLine]
-    private let currencyCode: String?
+    private var currencyCode: String?
     // Appearance/state — mutated only through the modifiers below (R2).
     private var onInfoHandler: ((FareLine) -> Void)?
     private var footerSlot: AnyView?
+    private var headerSlot: AnyView?
+    private var showsDividerFlag = true
+    private var totalSize: PriceSize = .large
+    private var totalEmphasis: PriceEmphasis = .hero
+    /// Expanded/collapsed — dual-mode via `ControllableState` (ADR-F4). Inert
+    /// until `isExpandable`; the uncontrolled form starts collapsed.
+    @ControllableState private var expandedState = true
+    private var isExpandable = false
 
     public init(_ lines: [FareLine], currencyCode: String = "USD") {   // R1 — content
         self.lines = lines
@@ -52,18 +62,33 @@ public struct FareSummary: View {
 
     public var body: some View {
         VStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
+            if let headerSlot { headerSlot }
             // Position-keyed: robust to duplicate labels (two "Fee" lines) which would
             // collide on the content-derived `id`. Fare lists are fixed-order, so index is stable.
-            ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+            ForEach(Array(visibleLines.enumerated()), id: \.offset) { _, line in
                 switch line.kind {
-                case .item:     itemRow(line, value: formatted(line.amount), color: theme.text(.textSecondary), valueColor: theme.text(.textPrimary))
-                case .discount: itemRow(line, value: "-\(formatted(line.amount))", color: theme.foreground(.systemcolorsFgSuccess), valueColor: theme.foreground(.systemcolorsFgSuccess))
-                case .total:    totalRow(line)
+                case .item:
+                    itemRow(line, value: formatted(line.amount),
+                            color: theme.text(.textSecondary), valueColor: theme.text(.textPrimary))
+                case .discount:
+                    itemRow(line, value: "-\(formatted(line.amount))",
+                            color: theme.foreground(.systemcolorsFgSuccess),
+                            valueColor: theme.foreground(.systemcolorsFgSuccess))
+                case .total:
+                    totalRow(line)
                 }
             }
             if let footerSlot { footerSlot }
         }
     }
+
+    /// Collapsed (`.expandable…`, chevron up) shows only the total row(s);
+    /// expanded — and the non-expandable default — shows every line in order.
+    @MainActor private var visibleLines: [FareLine] {
+        (isExpandable && !expandedState) ? lines.filter { $0.kind == .total } : lines
+    }
+
+    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
 
     private func itemRow(_ line: FareLine, value: String, color: Color, valueColor: Color) -> some View {
         HStack(spacing: Theme.SpacingKey.xs.value) {
@@ -82,15 +107,42 @@ public struct FareSummary: View {
         .accessibilityLabel("\(line.label) \(value)")
     }
 
-    private func totalRow(_ line: FareLine) -> some View {
+    @MainActor
+    @ViewBuilder private func totalRow(_ line: FareLine) -> some View {
         VStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            Divider().overlay(theme.border(.borderPrimary))
-            HStack {
-                Text(line.label).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
-                Spacer()
-                PriceTag(line.amount, currencyCode: resolvedCurrency).size(.large).emphasis(.hero).animatesValue()
+            if showsDividerFlag { Divider().overlay(theme.border(.borderPrimary)) }
+            if isExpandable {
+                Button {
+                    withAnimation(motion) { expandedState.toggle() }
+                } label: {
+                    totalContent(line)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(expandedState
+                    ? String(themeKit: "Hide fare breakdown")
+                    : String(themeKit: "Show fare breakdown"))
+            } else {
+                totalContent(line)
             }
         }
+    }
+
+    @MainActor
+    private func totalContent(_ line: FareLine) -> some View {
+        HStack {
+            Text(line.label).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+            if isExpandable {
+                Image(systemName: "chevron.down")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(theme.text(.textTertiary))
+                    .rotationEffect(.degrees(expandedState ? 180 : 0))
+                    .accessibilityHidden(true)   // the row's a11y label announces the state
+            }
+            Spacer()
+            PriceTag(line.amount, currencyCode: resolvedCurrency)
+                .size(totalSize).emphasis(totalEmphasis).animatesValue()
+        }
+        .contentShape(Rectangle())
     }
 
     private func formatted(_ value: Decimal) -> String {
@@ -105,6 +157,34 @@ public extension FareSummary {
     func onInfo(_ handler: @escaping (FareLine) -> Void) -> Self { copy { $0.onInfoHandler = handler } }
     /// A footer slot under the total — a terms link, a CTA, a note.
     func footer<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.footerSlot = AnyView(content()) } }
+    /// A header slot above the breakdown — a title, a route recap, a caption.
+    func header<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.headerSlot = AnyView(content()) } }
+    /// Makes the breakdown collapsible behind the total row, bound to the
+    /// caller's expansion flag (controlled). Collapsed, only the total row and
+    /// a chevron show; tapping the row toggles (Reduce-Motion aware).
+    func expandable(_ isExpanded: Binding<Bool>) -> Self {
+        copy {
+            $0.isExpandable = true
+            $0._expandedState = ControllableState(wrappedValue: true, external: isExpanded)
+        }
+    }
+    /// A self-managed collapsible breakdown (uncontrolled) — starts collapsed
+    /// on the total row. Use ``expandable(_:)`` when the flag must persist.
+    func expandable() -> Self {
+        copy {
+            $0.isExpandable = true
+            $0._expandedState = ControllableState(wrappedValue: false)
+        }
+    }
+    /// Size of the total `PriceTag` (default `.large`).
+    func totalSize(_ s: PriceSize) -> Self { copy { $0.totalSize = s } }
+    /// Emphasis of the total `PriceTag` (default `.hero`).
+    func totalEmphasis(_ e: PriceEmphasis) -> Self { copy { $0.totalEmphasis = e } }
+    /// Draw the divider above the total row (default on).
+    func showsDivider(_ on: Bool) -> Self { copy { $0.showsDividerFlag = on } }
+    /// Currency code for every line. Unset, the init parameter wins, then
+    /// `\.formatDefaults`, the locale's currency, and "USD".
+    func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -114,12 +194,41 @@ public extension FareSummary {
 }
 
 #Preview {
-    FareSummary([
-        .item("Base fare", 1_100),
-        .item("Taxes & fees", 199, info: "Airport tax + carrier surcharge"),
-        .discount("Member discount", 100),
-        .total("Total", 1_199),
-    ])
-    .onInfo { _ in }
-    .padding()
+    @Previewable @State var expanded = true
+    ScrollView {
+        VStack(spacing: 28) {
+            FareSummary([
+                .item("Base fare", 1_100),
+                .item("Taxes & fees", 199, info: "Airport tax + carrier surcharge"),
+                .discount("Member discount", 100),
+                .total("Total", 1_199),
+            ])
+            .onInfo { _ in }
+            // Header slot + EUR override + smaller, standard-emphasis total, no divider.
+            FareSummary([
+                .item("Base fare", 480),
+                .item("Seat selection", 24),
+                .total("Total", 504),
+            ])
+            .header { Text("Price details").textStyle(.labelBase700) }
+            .currency("EUR")
+            .totalSize(.medium).totalEmphasis(.standard)
+            .showsDivider(false)
+            // Uncontrolled expandable — starts collapsed on the total row.
+            FareSummary([
+                .item("Base fare", 1_100),
+                .item("Taxes & fees", 199),
+                .total("Total", 1_299),
+            ])
+            .expandable()
+            // Controlled expandable, initially open.
+            FareSummary([
+                .item("Base fare", 2_050),
+                .discount("Promo", 150),
+                .total("Total", 1_900),
+            ])
+            .expandable($expanded)
+        }
+        .padding()
+    }
 }

--- a/Sources/ThemeKitTravel/Components/Organisms/FilterBar.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FilterBar.swift
@@ -20,9 +20,15 @@ import ThemeKit
 public struct QuickFilter: Identifiable, Hashable, Sendable {
     public let id: String
     public let title: String
-    public init(_ title: String, id: String? = nil) {
+    /// Optional SF Symbol rendered before the title.
+    public let systemImage: String?
+    /// Optional result count rendered as a trailing pill (e.g. "Seafront · 12").
+    public let count: Int?
+    public init(_ title: String, id: String? = nil, systemImage: String? = nil, count: Int? = nil) {
         self.title = title
         self.id = id ?? title
+        self.systemImage = systemImage
+        self.count = count
     }
 }
 
@@ -32,7 +38,12 @@ public enum FilterBarSize: Sendable { case small, medium, large }
 /// Chip selection look. `.solid` fills selected chips with the accent; `.outlined`
 /// is the design-system pill — a light hero-soft fill + a 2pt hero border when
 /// selected, a soft hairline when not (matches the Figma "Filter Section" tabs).
-public enum FilterChipStyle: Sendable { case solid, outlined }
+/// `.ghost` draws no chrome at rest — selected chips gain a soft accent fill.
+public enum FilterChipStyle: Sendable { case solid, outlined, ghost }
+
+/// How chips select. `.multiple` (default) toggles independently; `.single`
+/// keeps at most one chip on — tapping another chip replaces the selection.
+public enum FilterSelectionMode: Sendable { case multiple, single }
 
 /// Leading Filter/Sort button shape. `.adaptive` shows text that collapses to an
 /// icon on scroll; `.circle` is a fixed accent circle (icon-only).
@@ -40,6 +51,8 @@ public enum FilterLeadingShape: Sendable { case adaptive, circle }
 
 public struct FilterBar: View {
     @Environment(\.theme) private var theme
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let chips: [QuickFilter]
     @Binding private var selection: Set<String>
@@ -53,10 +66,15 @@ public struct FilterBar: View {
     private var collapsible = true
     private var size: FilterBarSize = .medium
     private var accentColor: SemanticColor?
-    private var spacing: CGFloat = 8
+    private var spacing: CGFloat = Theme.SpacingKey.sm.value
     private var chipStyleVariant: FilterChipStyle = .solid
     private var leadingShapeVariant: FilterLeadingShape = .adaptive
     private var chipSurfaceKey: Theme.BackgroundColorKey = .bgWhite
+    private var selectionModeValue: FilterSelectionMode = .multiple
+    private var clearAllTitle: String?
+    private var onClearAllAction: (() -> Void)?
+    private var overflowFadeValue = false
+    private var trailingSlot: AnyView?
 
     @State private var collapsed = false
     @State private var scrolledID: String?
@@ -91,11 +109,18 @@ public struct FilterBar: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: spacing) {
                     ForEach(chips) { chipView($0).id($0.id) }
+                    if onClearAllAction != nil, !selection.isEmpty {
+                        clearAllChip
+                    }
                 }
                 .padding(.trailing, 4)
                 .scrollTargetLayout()
             }
             .scrollPosition(id: $scrolledID, anchor: .leading)
+            .mask { overflowMask }
+            if let trailingSlot {
+                trailingSlot.fixedSize()
+            }
         }
         .frame(height: controlHeight)
         .onChange(of: scrolledID) { _, newID in
@@ -105,9 +130,49 @@ public struct FilterBar: View {
             guard collapsible, hasLeading else { return }
             let shouldCollapse = newID != nil && newID != chips.first?.id
             if shouldCollapse != collapsed {
-                withAnimation(.easeOut(duration: 0.22)) { collapsed = shouldCollapse }
+                // Reduce-Motion / microAnimations gate: nil animation snaps.
+                withAnimation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion)) {
+                    collapsed = shouldCollapse
+                }
             }
         }
+    }
+
+    /// Trailing-edge gradient fade hinting at overflowed chips. Built with
+    /// `UnitPoint.leading → .trailing`, which resolve against the layout
+    /// direction — so the fade sits on the correct edge under RTL.
+    @ViewBuilder private var overflowMask: some View {
+        if overflowFadeValue {
+            LinearGradient(
+                stops: [
+                    .init(color: .black, location: 0),
+                    .init(color: .black, location: 0.92),
+                    .init(color: .clear, location: 1),
+                ],
+                startPoint: .leading, endPoint: .trailing
+            )
+        } else {
+            Rectangle()
+        }
+    }
+
+    /// The trailing ghost "Clear" chip — visible only while a selection exists.
+    private var clearAllChip: some View {
+        Button {
+            selection.removeAll()
+            onClearAllAction?()
+        } label: {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                Image(systemName: "xmark").font(.system(size: iconSize, weight: .semibold))
+                Text(clearAllTitle ?? String(themeKit: "Clear")).textStyle(chipTextStyle).fixedSize()
+            }
+            .foregroundStyle(accentColor?.base ?? theme.foreground(.fgHero))
+            .padding(.horizontal, chipHPad)
+            .frame(minHeight: controlHeight)
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(themeKit: "Clear all filters"))
     }
 
     @ViewBuilder private func action(_ icon: String, _ title: String, _ handler: @escaping () -> Void) -> some View {
@@ -135,40 +200,79 @@ public struct FilterBar: View {
 
     private func chipView(_ chip: QuickFilter) -> some View {
         let isOn = selection.contains(chip.id)
-        let outlined = chipStyleVariant == .outlined
         return Button {
-            if isOn { selection.remove(chip.id) } else { selection.insert(chip.id) }
+            toggle(chip.id, isOn: isOn)
         } label: {
-            Text(chip.title)
-                .textStyle(chipTextStyle)
-                .foregroundStyle(chipTextColor(isOn: isOn, outlined: outlined))
-                .padding(.horizontal, chipHPad)
-                .frame(minHeight: controlHeight)
-                .background(chipFill(isOn: isOn, outlined: outlined), in: Capsule())
-                // strokeBorder (not stroke) insets the line fully inside the pill,
-                // so the 2pt selected border isn't clipped at the tight top/bottom
-                // curves — a centered stroke would bleed outside and look distorted.
-                .overlay(Capsule().strokeBorder(chipBorderColor(isOn: isOn, outlined: outlined),
-                                                lineWidth: outlined && isOn ? 2 : 1))
-                .fixedSize()
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                if let symbol = chip.systemImage {
+                    Image(systemName: symbol).font(.system(size: iconSize, weight: .semibold))
+                }
+                Text(chip.title).textStyle(chipTextStyle)
+                if let count = chip.count {
+                    countPill(count, isOn: isOn)
+                }
+            }
+            .foregroundStyle(chipTextColor(isOn: isOn))
+            .padding(.horizontal, chipHPad)
+            .frame(minHeight: controlHeight)
+            .background(chipFill(isOn: isOn), in: Capsule())
+            // strokeBorder (not stroke) insets the line fully inside the pill,
+            // so the 2pt selected border isn't clipped at the tight top/bottom
+            // curves — a centered stroke would bleed outside and look distorted.
+            .overlay(Capsule().strokeBorder(chipBorderColor(isOn: isOn),
+                                            lineWidth: chipStyleVariant == .outlined && isOn ? 2 : 1))
+            .fixedSize()
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(chip.title)
+        .accessibilityLabel(chip.count.map { "\(chip.title), \($0)" } ?? chip.title)
         .accessibilityAddTraits(isOn ? .isSelected : [])
     }
 
+    /// Selection semantics per ``FilterSelectionMode``.
+    private func toggle(_ id: String, isOn: Bool) {
+        switch selectionModeValue {
+        case .multiple:
+            if isOn { selection.remove(id) } else { selection.insert(id) }
+        case .single:
+            selection = isOn ? [] : [id]
+        }
+    }
+
+    /// Trailing count pill — SemanticColor ladder steps, no raw colors.
+    private func countPill(_ count: Int, isOn: Bool) -> some View {
+        let tone = accentColor ?? .primary
+        let solidSelected = chipStyleVariant == .solid && isOn
+        return Text("\(count)")
+            .textStyle(.labelSm600)
+            .foregroundStyle(solidSelected ? tone.onSolid : tone.strong)
+            .padding(.horizontal, Theme.SpacingKey.xs.value)
+            .background(solidSelected ? tone.active : tone.soft, in: Capsule())
+    }
+
     // Chip colors per style (token-fed).
-    private func chipTextColor(isOn: Bool, outlined: Bool) -> Color {
-        if outlined { return theme.text(.textPrimary) }
-        return isOn ? accentFg : chipOffText
+    private func chipTextColor(isOn: Bool) -> Color {
+        switch chipStyleVariant {
+        case .outlined: return theme.text(.textPrimary)
+        case .ghost: return isOn ? (accentColor?.strong ?? theme.foreground(.fgHero)) : theme.text(.textSecondary)
+        case .solid: return isOn ? accentFg : chipOffText
+        }
     }
-    private func chipFill(isOn: Bool, outlined: Bool) -> Color {
-        if outlined { return isOn ? (accentColor?.soft ?? SemanticColor.primary.soft) : theme.background(chipSurfaceKey) }
-        return isOn ? accentBg : theme.background(chipSurfaceKey)
+    private func chipFill(isOn: Bool) -> Color {
+        switch chipStyleVariant {
+        case .outlined: return isOn ? (accentColor?.soft ?? SemanticColor.primary.soft) : theme.background(chipSurfaceKey)
+        case .ghost: return isOn ? (accentColor ?? .primary).soft : .clear
+        case .solid: return isOn ? accentBg : theme.background(chipSurfaceKey)
+        }
     }
-    private func chipBorderColor(isOn: Bool, outlined: Bool) -> Color {
-        if outlined { return isOn ? (accentColor?.border ?? theme.border(.borderHero)) : theme.background(.bgElevatorTertiary) }
-        return isOn ? Color.clear : theme.border(.borderPrimary)
+    private func chipBorderColor(isOn: Bool) -> Color {
+        switch chipStyleVariant {
+        case .outlined:
+            return isOn ? (accentColor?.border ?? theme.border(.borderHero)) : theme.background(.bgElevatorTertiary)
+        case .ghost:
+            return .clear
+        case .solid:
+            return isOn ? Color.clear : theme.border(.borderPrimary)
+        }
     }
 }
 
@@ -176,7 +280,9 @@ public struct FilterBar: View {
 
 public extension FilterBar {
     /// Adds the pinned leading Filter button (collapses to icon-only on scroll).
-    func onFilter(_ title: String = String(themeKit: "Filter"), icon: String = "line.3.horizontal.decrease", action: @escaping () -> Void) -> Self {
+    func onFilter(_ title: String = String(themeKit: "Filter"),
+                  icon: String = "line.3.horizontal.decrease",
+                  action: @escaping () -> Void) -> Self {
         copy { $0.filterTitle = title; $0.filterIcon = icon; $0.onFilter = action }
     }
     /// Adds the pinned leading Sort button (collapses to icon-only on scroll).
@@ -198,9 +304,29 @@ public extension FilterBar {
     /// Surface token for the unselected chip fill (default `.bgWhite`).
     func chipSurface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.chipSurfaceKey = key } }
     /// Gap between controls (default 8).
+    @available(*, deprecated, message: "Use spacing(_: Theme.SpacingKey) — the token-bound overload.")
     func spacing(_ value: CGFloat) -> Self { copy { $0.spacing = max(0, value) } }
-    /// Gap between controls from a theme spacing token.
-    func spacing(_ key: Theme.SpacingKey) -> Self { spacing(key.value) }
+    /// Gap between controls from a theme spacing token (default `.sm`).
+    func spacing(_ key: Theme.SpacingKey) -> Self { copy { $0.spacing = max(0, key.value) } }
+    /// `.multiple` (default) toggles chips independently; `.single` keeps at
+    /// most one chip on — tapping another chip replaces the selection.
+    func selectionMode(_ m: FilterSelectionMode) -> Self { copy { $0.selectionModeValue = m } }
+    /// Appends a trailing ghost "Clear" chip to the scroller, shown only while
+    /// the selection is non-empty. Tapping it empties the bound selection and
+    /// then calls `perform` (analytics, refetch…).
+    func onClearAll(_ title: String = String(themeKit: "Clear"),
+                    perform action: @escaping () -> Void) -> Self {
+        copy { $0.clearAllTitle = title; $0.onClearAllAction = action }
+    }
+    /// Fades the scroller's trailing edge with a gradient mask as an overflow
+    /// hint (RTL-safe — `UnitPoint.leading/.trailing` mirror with the layout).
+    func overflowFade(_ on: Bool = true) -> Self { copy { $0.overflowFadeValue = on } }
+    /// Accessory pinned after the chip scroller (canonical `.trailing { }`
+    /// slot) — e.g. a results counter or a "View map" link. Evaluated
+    /// immediately at the call site.
+    func trailing<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.trailingSlot = AnyView(content()) }
+    }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -234,6 +360,28 @@ public extension FilterBar {
                 FilterBar([QuickFilter("Breakfast", id: "8"), QuickFilter("Pet friendly"),
                            QuickFilter("Parking")], selection: $sel)
                     .chipSurface(.bgSecondaryLight).size(.small)
+                // Icons + counts, single-select, clear-all ghost chip, overflow fade.
+                FilterBar([
+                    QuickFilter("Beach", id: "8", systemImage: "beach.umbrella", count: 24),
+                    QuickFilter("Pool", systemImage: "figure.pool.swim", count: 9),
+                    QuickFilter("Spa", systemImage: "sparkles", count: 3),
+                    QuickFilter("Gym", systemImage: "dumbbell", count: 12),
+                ], selection: $sel)
+                    .selectionMode(.single)
+                    .onClearAll { }
+                    .overflowFade()
+                    .size(.small)
+                // Ghost chips + a trailing pinned slot.
+                FilterBar([QuickFilter("Cheapest", id: "8"), QuickFilter("Fastest"),
+                           QuickFilter("Direct")], selection: $sel)
+                    .chipStyle(.ghost).size(.small)
+                    .trailing {
+                        Text("128 stays").textStyle(.labelSm600)
+                            .padding(.horizontal, Theme.SpacingKey.sm.value)
+                    }
+                // Token-fed spacing overload.
+                FilterBar([QuickFilter("Nonstop", id: "8"), QuickFilter("Refundable")], selection: $sel)
+                    .spacing(Theme.SpacingKey.md).size(.small).onFilter { }
             }
             .padding(.vertical)
         }

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightCard.swift
@@ -49,8 +49,14 @@ public struct FlightCard: View {
     private var price: Decimal?
     private var currencyCode: String?
     private var airlineSystemImage: String = "airplane.circle.fill"
+    private var airlineLogoURL: URL?
     private var badge: String?
+    private var badgeStyle: BadgeStyle = .success
+    private var selectTitle = String(themeKit: "Select")
     private var onSelect: (() -> Void)?
+    private var elevation: CardElevation = .none
+    private var isSelected = false
+    private var headerSlot: AnyView?
     /// Favourite state — dual-mode via `ControllableState` (ADR-F4); renamed
     /// from `favorite` so the nullary `func favorite()` overload isn't an
     /// invalid redeclaration. Hidden until `showsFavorite`.
@@ -91,8 +97,8 @@ public struct FlightCard: View {
         // `.none` matches today's chrome: no shadow, hairline border.
         cardStyle.makeBody(configuration: CardStyleConfiguration(
             content: AnyView(cardContent),
-            elevation: .none,
-            isSelected: false,
+            elevation: elevation,
+            isSelected: isSelected,
             isPressed: false,
             surfaceKey: surfaceKey,
             radius: .box))
@@ -102,7 +108,7 @@ public struct FlightCard: View {
     @MainActor
     private var cardContent: some View {
         VStack(spacing: density.scale(Theme.SpacingKey.md.value)) {
-            header
+            if let headerSlot { headerSlot } else { header }
             routeContent
             if let scarcity { scarcityRow(scarcity) }
             if footerSlot != nil || price != nil || onSelect != nil { footer }
@@ -113,9 +119,13 @@ public struct FlightCard: View {
     @MainActor
     private var header: some View {
         HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            Image(systemName: airlineSystemImage)
-                .font(.title3)
-                .foregroundStyle(accentBase)
+            if let url = airlineLogoURL {
+                RemoteImage(url).ratio(1).frame(width: 22, height: 22)
+            } else {
+                Image(systemName: airlineSystemImage)
+                    .font(.title3)
+                    .foregroundStyle(accentBase)
+            }
             Text(airline).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
             if let fareBrand {
                 Text(fareBrand).textStyle(.overline500).foregroundStyle(theme.text(.textSecondary))
@@ -123,7 +133,7 @@ public struct FlightCard: View {
                     .background(theme.background(.bgSecondaryLight), in: Capsule())
             }
             Spacer()
-            if let badge { Badge(badge).badgeStyle(.success).size(.small) }
+            if let badge { Badge(badge).badgeStyle(badgeStyle).size(.small) }
             if showsFavorite { favoriteButton }
         }
     }
@@ -267,9 +277,9 @@ public struct FlightCard: View {
                     // Accent set → semantic-colored ThemeButton; nil → the stock
                     // hero PrimaryButton, byte-for-byte today's rendering.
                     if let accent {
-                        ThemeButton(String(themeKit: "Select")) { onSelect() }.color(accent).size(.small)
+                        ThemeButton(selectTitle) { onSelect() }.color(accent).size(.small)
                     } else {
-                        PrimaryButton(String(themeKit: "Select")) { onSelect() }.size(.small)
+                        PrimaryButton(selectTitle) { onSelect() }.size(.small)
                     }
                 }
             }
@@ -313,8 +323,26 @@ public extension FlightCard {
     func airlineIcon(_ systemName: String) -> Self { copy { $0.airlineSystemImage = systemName } }
     /// A success badge in the header, e.g. `"Cheapest"`.
     func badge(_ text: String?) -> Self { copy { $0.badge = text } }
+    /// A header badge with an explicit `BadgeStyle` (the one-argument form keeps
+    /// the classic `.success` styling).
+    func badge(_ text: String?, style: BadgeStyle) -> Self { copy { $0.badge = text; $0.badgeStyle = style } }
+    /// A remote airline logo in the header (overrides the SF Symbol) — parity
+    /// with ``FlightResultRow/airlineLogo(_:)``.
+    func airlineLogo(_ url: URL?) -> Self { copy { $0.airlineLogoURL = url } }
+    /// Shell elevation, fed to the active `CardStyle` (default `.none` — today's
+    /// flat, hairline-only chrome).
+    func elevation(_ e: CardElevation) -> Self { copy { $0.elevation = e } }
+    /// Selected state, fed to the active `CardStyle` (the default style draws a
+    /// hero border).
+    func selected(_ on: Bool = true) -> Self { copy { $0.isSelected = on } }
     /// Adds a "Select" button to the footer.
     func onSelect(_ action: (() -> Void)?) -> Self { copy { $0.onSelect = action } }
+    /// Adds a footer button with a custom title (default "Select").
+    func onSelect(_ title: String = "Select", action: @escaping () -> Void) -> Self {
+        copy { $0.selectTitle = title; $0.onSelect = action }
+    }
+    /// Replaces the built-in airline / fare-brand / badge / heart header row.
+    func header<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.headerSlot = AnyView(content()) } }
     /// A heart toggle in the header bound to a favourite flag (controlled —
     /// the caller owns persistence).
     func favorite(_ isFavorite: Binding<Bool>) -> Self {
@@ -352,6 +380,21 @@ public extension FlightCard {
         // Accented brand chrome — icon, route planes and Select follow the accent.
         FlightCard(airline: "Sunrise Air", from: "IST", to: "LHR", departure: dep, arrival: dep.addingTimeInterval(3 * 3_600))
             .accent(.success).price(2_199).onSelect { }
+        // Styled badge + custom Select title + selected/elevated shell.
+        FlightCard(airline: "Anadolu Air", from: "IST", to: "ESB", departure: dep, arrival: arr)
+            .badge("Fastest", style: .info).price(1_499)
+            .onSelect("Book now") { }
+            .selected().elevation(.soft)
+        // Custom header slot replaces the built-in airline row.
+        FlightCard(airline: "Blue Wings", from: "IST", to: "AMS", departure: dep, arrival: dep.addingTimeInterval(4 * 3_600))
+            .header {
+                HStack {
+                    Badge("Round trip").badgeStyle(.info).size(.small)
+                    Spacer()
+                    Badge("Refundable").badgeStyle(.success).size(.small)
+                }
+            }
+            .price(3_499)
     }
     .padding()
 }

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightListItem.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightListItem.swift
@@ -5,7 +5,7 @@
 //  Organism. A flight search-result LIST ITEM whose entire layout is a
 //  swappable ``FlightListItemStyle`` — the component owns the *data* (legs,
 //  fares, price, deal signals, schedule) and the style owns the *presentation*.
-//  Eight built-in styles cover the industry's list-item archetypes (see
+//  Twelve built-in styles cover the industry's list-item archetypes (see
 //  FlightListItemStyle.swift); custom styles get the same typed configuration.
 //
 //      FlightListItem(airline: "Skyline Air", from: "IST", to: "LHR",
@@ -31,6 +31,7 @@ public struct FlightListItem: View {
     @Environment(\.flightListItemStyle) private var style
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.componentDensity) private var density
 
     // Required content (R1).
     private let legs: [FlightLeg]
@@ -70,6 +71,17 @@ public struct FlightListItem: View {
     /// redeclaration).
     @ControllableState private var favoriteState = false
     private var showsFavorite = false
+    private var accent: SemanticColor?
+    private var radiusRole: Theme.RadiusRole?
+    private var metaItems: [(icon: String, text: String)] = []
+    private var accessory: AnyView?
+    private var footer: AnyView?
+    /// Fare-chip selection for `.fareBoard`-class styles — uncontrolled by
+    /// default; `.selectedFare(_:)` swaps in the caller's binding.
+    @ControllableState private var fareState: String?
+    /// Departure-chip selection for `.timetable` — same controlled/uncontrolled
+    /// split via `.selectedDeparture(_:)`.
+    @ControllableState private var departureState: Date?
 
     /// A multi-leg itinerary (round trip / multi-city). One entry per slice.
     public init(legs: [FlightLeg]) {   // R1 — content
@@ -89,6 +101,10 @@ public struct FlightListItem: View {
 
     public var body: some View {
         let heartMotion = MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion)
+        // Expansion springs the MicroMotion-gated way: `.base` duration as a
+        // spring, `nil` (instant, no motion) when micro-animations are off or
+        // Reduce Motion is on.
+        let expandMotion: Animation? = (micro && !reduceMotion) ? Motion.base.spring : nil
         let configuration = FlightListItemConfiguration(
             legs: legs, sliceLabels: sliceLabels, flightNo: flightNo, cabin: cabin,
             airlineSystemImage: airlineSystemImage, logo: logo,
@@ -104,12 +120,18 @@ public struct FlightListItem: View {
             surfaceKey: surfaceKey,
             locale: locale,
             toggleExpand: {
-                withAnimation(.spring(duration: 0.35)) { expandedState.toggle() }
+                withAnimation(expandMotion) { expandedState.toggle() }
             },
             isFavorite: showsFavorite ? favoriteState : nil,
             toggleFavorite: showsFavorite
                 ? { withAnimation(heartMotion) { favoriteState.toggle() } }
-                : nil
+                : nil,
+            accent: accent, radiusRole: radiusRole, density: density,
+            metaItems: metaItems, accessory: accessory, footer: footer,
+            selectedFareID: fareState,
+            onFareSelect: { fareState = $0 },
+            selectedDeparture: departureState,
+            onDepartureSelect: { departureState = $0 }
         )
         style.makeBody(configuration: configuration)
             .opacity(isEnabled ? 1 : 0.5)
@@ -195,6 +217,35 @@ public extension FlightListItem {
             $0._favoriteState = ControllableState(wrappedValue: false, external: isFavorite)
         }
     }
+    /// Selection accent — tints the selected border, fare/time chips and other
+    /// emphasis colours the styles otherwise take from the theme's hero tokens.
+    /// Pass `nil` to restore the hero default.
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
+    /// Corner-radius role of the card shell (default `.box`).
+    func radius(_ role: Theme.RadiusRole) -> Self { copy { $0.radiusRole = role } }
+    /// Generic icon + text meta pairs, e.g. `[("wifi", "Wi-Fi"), ("suitcase", "8kg")]` —
+    /// styles with a meta row render them in order.
+    func meta(_ items: [(icon: String, text: String)]) -> Self { copy { $0.metaItems = items } }
+    /// Trailing accessory in the identity row (a co-brand badge, an emissions
+    /// chip…). Styles that place identity honour it; others ignore it.
+    func accessory<A: View>(@ViewBuilder _ content: () -> A) -> Self {
+        copy { $0.accessory = AnyView(content()) }
+    }
+    /// Footer slot below the style's content — fine print, a promo line, links.
+    func footer<F: View>(@ViewBuilder _ content: () -> F) -> Self {
+        copy { $0.footer = AnyView(content()) }
+    }
+    /// Drives fare-chip selection (`.fareBoard`) from outside — e.g. persisting
+    /// the chosen fare family. Without it the item self-manages (ADR-F4 via
+    /// `ControllableState`, like ``expanded(_:)``).
+    func selectedFare(_ binding: Binding<String?>) -> Self {
+        copy { $0._fareState = ControllableState(wrappedValue: nil, external: binding) }
+    }
+    /// Drives departure-chip selection (`.timetable`) from outside — mirrors
+    /// ``selectedFare(_:)``.
+    func selectedDeparture(_ binding: Binding<Date?>) -> Self {
+        copy { $0._departureState = ControllableState(wrappedValue: nil, external: binding) }
+    }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var next = self
@@ -223,8 +274,85 @@ public extension FlightListItem {
                 .deal("23% below typical", tone: .success)
                 .trend([0.8, 0.75, 0.9, 0.6, 0.5, 0.42])
                 .flightListItemStyle(.deal)
+
+            // NEW archetypes + full-flex axes -----------------------------
+
+            // Hero: deal strip, amenities, xl price — with a purple accent,
+            // selector radius, meta row, accessory + footer slots.
+            FlightListItem(airline: "Skyline Air", from: "IST", to: "LHR", departure: dep, arrival: arr)
+                .flightNo("SK 1123").cabin("Economy")
+                .price(164, currencyCode: "USD", caption: "from").original(214)
+                .deal("Today's best deal", tone: .warning)
+                .badge("Featured")
+                .amenities(["wifi", "powerplug", "cup.and.saucer"])
+                .meta([(icon: "suitcase.rolling", text: "8kg"), (icon: "leaf", text: "-12% CO₂")])
+                .accent(.purple)
+                .radius(.field)
+                .selected()
+                .accessory { Badge("Partner").badgeStyle(.neutral).size(.small) }
+                .footer {
+                    Text("Free cancellation within 24h")
+                        .textStyle(.overline400)
+                        .foregroundStyle(Theme.shared.text(.textTertiary))
+                }
+                .onSelect { }
+                .flightListItemStyle(.hero)
+
+            // Tile: vertical carousel cards.
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(0..<3, id: \.self) { i in
+                        FlightListItem(airline: "Skyline Air", from: "IST", to: "LHR",
+                                       departure: dep.addingTimeInterval(Double(i) * 86_400), arrival: arr)
+                            .price(Decimal(189 + i * 12), currencyCode: "USD", caption: "from")
+                            .badge(i == 0 ? "Best" : nil)
+                            .onSelect { }
+                            .flightListItemStyle(.tile)
+                            .frame(width: 190)
+                    }
+                }
+            }
+
+            // Receipt: checkout read-back — labeled fields, no tap affordance.
+            FlightListItem(legs: [
+                FlightLeg(airline: "Skyline Air", from: "IST", to: "LHR", departure: dep, arrival: arr),
+                FlightLeg(airline: "Skyline Air", from: "LHR", to: "IST",
+                          departure: dep.addingTimeInterval(7 * 86_400),
+                          arrival: arr.addingTimeInterval(7 * 86_400))
+            ])
+                .sliceLabels(["Outbound", "Return"])
+                .flightNo("SK 1123").cabin("Economy Flex")
+                .baggage("8kg", checked: "23kg")
+                .price(438, currencyCode: "USD", caption: "Total · 2 travellers")
+                .flightListItemStyle(.receipt)
+
+            // Controlled fare selection through the caller's binding.
+            FlightListItem(airline: "Skyline Air", from: "IST", to: "LHR", departure: dep, arrival: arr)
+                .fares([FlightFare("Light", price: 164), FlightFare("Standard", price: 214),
+                        FlightFare("Flex", price: 289)])
+                .selectedFare(.constant("Standard"))
+                .accent(.accent)
+                .flightListItemStyle(.fareBoard)
         }
         .padding()
     }
     .background(Theme.shared.background(.bgElevatorPrimary))
+}
+
+#Preview("FlightListItem dark + density", traits: .sizeThatFitsLayout) {
+    let dep = Date(timeIntervalSince1970: 1_781_000_000)
+    let arr = dep.addingTimeInterval(3.5 * 3600)
+    VStack(spacing: 16) {
+        FlightListItem(airline: "Skyline Air", from: "IST", to: "LHR", departure: dep, arrival: arr)
+            .price(214, currencyCode: "USD").badge("Best")
+            .meta([(icon: "suitcase.rolling", text: "8kg")])
+            .accent(.success).selected()
+            .componentDensity(.compact)
+        FlightListItem(airline: "Skyline Air", from: "IST", to: "LHR", departure: dep, arrival: arr)
+            .price(214, currencyCode: "USD")
+            .flightListItemStyle(TimelineFlightListItemStyle(showsRouteTrack: false))
+    }
+    .padding()
+    .background(Theme.shared.background(.bgElevatorPrimary))
+    .environment(\.colorScheme, .dark)
 }

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightListItemStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightListItemStyle.swift
@@ -5,7 +5,7 @@
 //  The styling hook for ``FlightListItem`` — and the most data-rich style
 //  protocol in the library: the configuration hands styles the *typed flight
 //  data* (legs, fares, deal signals, schedule), not pre-laid content, so a
-//  style owns the entire layout. Eight built-ins cover the industry's
+//  style owns the entire layout. Twelve built-ins cover the industry's
 //  search-result archetypes (researched across Skyscanner, Google Flights,
 //  Kayak, Hopper, Delta/THY fare boards, Kiwi itineraries, Expedia bundles):
 //
@@ -17,6 +17,10 @@
 //    .journey    expandable per-leg vertical timeline (Kayak/Kiwi details)
 //    .slices     one card per itinerary, stacked slice rows (Expedia round trip)
 //    .timetable  carrier-grouped departure-time chips (Skyscanner widget)
+//    .tray       nested white card on a soft tray with a CTA rail (design-system spec)
+//    .tile       vertical card for horizontal carousels (destination-deal shelves)
+//    .hero       featured tall card: deal strip + big price + amenities
+//    .receipt    checkout summary — labeled fields, no tap affordance
 //
 //      FlightListItem(legs: [out, back]).price(438, caption: "total")
 //          .flightListItemStyle(.slices)
@@ -80,6 +84,35 @@ public struct FlightListItemConfiguration {
     /// Flips `isFavorite` (animated, `MicroMotion`-gated). Styles with a heart
     /// call this — mirrors `toggleExpand`.
     public let toggleFavorite: (() -> Void)?
+    /// Selection accent (`FlightListItem.accent(_:)`), or `nil` for the theme's
+    /// hero tokens — resolve via ``accentBorder(_:)`` and friends.
+    public let accent: SemanticColor?
+    /// Corner-radius role override (`FlightListItem.radius(_:)`); `nil` = the
+    /// style's standard `.box`. Resolve via ``cornerRadius``.
+    public let radiusRole: Theme.RadiusRole?
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// Generic icon + text meta pairs (`FlightListItem.meta(_:)`) — styles with
+    /// a meta row render them in order.
+    public let metaItems: [(icon: String, text: String)]
+    /// Optional trailing accessory for the identity row (`.accessory { }`).
+    /// Styles that predate this field simply ignore it.
+    public let accessory: AnyView?
+    /// Optional footer below the style's content (`.footer { }`).
+    public let footer: AnyView?
+    /// The chosen fare id — fed by `FlightListItem.selectedFare(_:)` or the
+    /// item's own uncontrolled state. Fare-aware styles read this instead of
+    /// keeping a private selection.
+    public let selectedFareID: String?
+    /// Reports a fare-chip tap. Fare-aware styles call this; when `nil`
+    /// (a hand-built configuration) styles fall back to local state.
+    public let onFareSelect: ((String) -> Void)?
+    /// The chosen departure time (`.timetable`) — controlled/uncontrolled like
+    /// ``selectedFareID``, via `FlightListItem.selectedDeparture(_:)`.
+    public let selectedDeparture: Date?
+    /// Reports a departure-chip tap — mirrors ``onFareSelect``.
+    public let onDepartureSelect: ((Date) -> Void)?
 
     /// The itinerary's first leg — every style's primary subject.
     public var leg: FlightLeg { legs[0] }
@@ -88,6 +121,24 @@ public struct FlightListItemConfiguration {
     public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
         surfaceKey ?? fallback
     }
+
+    /// The `radius(_:)` override's value, or the standard card `.box` radius.
+    public var cornerRadius: CGFloat { (radiusRole ?? .box).value }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so `.componentDensity`
+    /// compacts or airs out the item.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    // Accent resolution — the `accent(_:)` override, else the theme's hero tokens
+    // (the values the built-ins hardcoded before the accent axis existed).
+    /// Selected-state border tint.
+    public func accentBorder(_ theme: Theme) -> Color { accent?.base ?? theme.border(.borderHero) }
+    /// Emphasized foreground tint (selected text/icons).
+    public func accentForeground(_ theme: Theme) -> Color { accent?.base ?? theme.foreground(.fgHero) }
+    /// Selected-chip fill.
+    public func accentFill(_ theme: Theme) -> Color { accent?.solid ?? theme.background(.bgHero) }
+    /// Content colour on top of ``accentFill(_:)``.
+    public func accentOnFill(_ theme: Theme) -> Color { accent?.onSolid ?? theme.foreground(.fgSecondary) }
 
     // Shared formatting, so all styles speak one language.
     public func time(_ date: Date) -> String {
@@ -267,16 +318,38 @@ private struct Sparkline: View {
     }
 }
 
+/// A row of icon + text meta pairs (`FlightListItem.meta(_:)`). Renders nothing
+/// when the configuration carries no meta items.
+private struct MetaRow: View {
+    @Environment(\.theme) private var theme
+    let items: [(icon: String, text: String)]
+
+    var body: some View {
+        if !items.isEmpty {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    HStack(spacing: 2) {
+                        Icon(systemName: item.icon).size(.xs).accent(.neutral)
+                        Text(item.text).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+}
+
 /// The card shell every carded built-in shares: surface fill, continuous
-/// corners, hairline border (accented when selected).
+/// corners (radius-role override honored), hairline border (accent-tinted
+/// when selected).
 private extension View {
     func itemShell(_ configuration: FlightListItemConfiguration, theme: Theme) -> some View {
         self
             .background(theme.background(configuration.surface(default: .bgBase)),
-                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+                        in: RoundedRectangle(cornerRadius: configuration.cornerRadius, style: .continuous))
             .overlay(
-                RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
-                    .strokeBorder(configuration.isSelected ? theme.border(.borderHero) : theme.border(.borderPrimary),
+                RoundedRectangle(cornerRadius: configuration.cornerRadius, style: .continuous)
+                    .strokeBorder(configuration.isSelected ? configuration.accentBorder(theme) : theme.border(.borderPrimary),
                                   lineWidth: configuration.isSelected ? 1.5 : 1)
             )
     }
@@ -305,7 +378,7 @@ private struct CompactChrome: View {
                 FavoriteHeart(configuration: configuration)
                 PriceBlock(configuration: configuration, size: .small)
             }
-            .padding(.vertical, Theme.SpacingKey.sm.value)
+            .padding(.vertical, configuration.spacing(.sm))
             .contentShape(Rectangle())
             .onTapGesture { configuration.onSelect?() }
             Rectangle().fill(theme.border(.borderPrimary)).frame(height: 0.5)
@@ -318,28 +391,49 @@ private struct CompactChrome: View {
 /// Kayak/Skyscanner archetype: 3-column route block over a footer with the
 /// airline identity and price. The library default.
 public struct TimelineFlightListItemStyle: FlightListItemStyle {
-    public init() {}
+    private let showsRouteTrack: Bool
+    /// - Parameter showsRouteTrack: draw the dotted route track between the
+    ///   endpoints (default). `false` swaps in a plain duration/stops column
+    ///   for quieter lists.
+    public init(showsRouteTrack: Bool = true) {
+        self.showsRouteTrack = showsRouteTrack
+    }
     public func makeBody(configuration: FlightListItemConfiguration) -> some View {
-        TimelineChrome(configuration: configuration)
+        TimelineChrome(configuration: configuration, showsRouteTrack: showsRouteTrack)
     }
 }
 
 private struct TimelineChrome: View {
     @Environment(\.theme) private var theme
     let configuration: FlightListItemConfiguration
+    var showsRouteTrack = true
 
     var body: some View {
         let leg = configuration.leg
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+        VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
             if let badge = configuration.badge {
                 Badge(badge).badgeStyle(.info).size(.small)
             }
             HStack(alignment: .center, spacing: Theme.SpacingKey.sm.value) {
                 TimeColumn(time: configuration.time(leg.departure), code: leg.origin, alignment: .leading)
-                RouteTrack(leg: leg, duration: configuration.duration(of: leg), stops: configuration.stopsText(leg))
+                if showsRouteTrack {
+                    RouteTrack(leg: leg, duration: configuration.duration(of: leg), stops: configuration.stopsText(leg))
+                        .frame(maxWidth: .infinity)
+                } else {
+                    VStack(spacing: 2) {
+                        Text(configuration.duration(of: leg))
+                            .textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+                        Text(configuration.stopsText(leg))
+                            .textStyle(.overline400)
+                            .foregroundStyle(leg.stops == 0
+                                ? theme.foreground(.systemcolorsFgSuccess)
+                                : theme.text(.textTertiary))
+                    }
                     .frame(maxWidth: .infinity)
+                }
                 TimeColumn(time: configuration.time(leg.arrival), code: leg.destination, alignment: .trailing)
             }
+            MetaRow(items: configuration.metaItems)
             Rectangle().fill(theme.border(.borderPrimary)).frame(height: 0.5)
             HStack(spacing: Theme.SpacingKey.sm.value) {
                 (configuration.logo ?? AnyView(Icon(systemName: configuration.airlineSystemImage).size(.md).accent(.primary)))
@@ -351,11 +445,13 @@ private struct TimelineChrome: View {
                     }
                 }
                 Spacer()
+                if let accessory = configuration.accessory { accessory }
                 FavoriteHeart(configuration: configuration)
                 PriceBlock(configuration: configuration)
             }
+            if let footer = configuration.footer { footer }
         }
-        .padding(Theme.SpacingKey.md.value)
+        .padding(configuration.spacing(.md))
         .itemShell(configuration, theme: theme)
         .contentShape(Rectangle())
         .onTapGesture { configuration.onSelect?() }
@@ -376,14 +472,22 @@ public struct FareBoardFlightListItemStyle: FlightListItemStyle {
 private struct FareBoardChrome: View {
     @Environment(\.theme) private var theme
     let configuration: FlightListItemConfiguration
+    /// Uncontrolled fallback for hand-built configurations without
+    /// `onFareSelect` — `FlightListItem` always feeds the configuration fields
+    /// (ADR-F4 `ControllableState`), so this stays dormant for the built-ins.
     @State private var chosen: String?
 
+    private var selectedFareID: String? {
+        configuration.onFareSelect != nil ? configuration.selectedFareID : chosen
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+        VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
             HStack(alignment: .center, spacing: Theme.SpacingKey.sm.value) {
                 SliceLine(configuration: configuration, leg: configuration.leg)
-                if configuration.isFavorite != nil {
+                if configuration.accessory != nil || configuration.isFavorite != nil {
                     Spacer(minLength: Theme.SpacingKey.xs.value)
+                    if let accessory = configuration.accessory { accessory }
                     FavoriteHeart(configuration: configuration)
                 }
             }
@@ -396,15 +500,16 @@ private struct FareBoardChrome: View {
                     }
                 }
             }
+            if let footer = configuration.footer { footer }
         }
-        .padding(Theme.SpacingKey.md.value)
+        .padding(configuration.spacing(.md))
         .itemShell(configuration, theme: theme)
     }
 
     private func fareChip(_ fare: FlightFare) -> some View {
-        let selected = chosen == fare.id
+        let selected = selectedFareID == fare.id
         return Button {
-            chosen = fare.id
+            if let onFareSelect = configuration.onFareSelect { onFareSelect(fare.id) } else { chosen = fare.id }
             configuration.onSelect?()
         } label: {
             VStack(alignment: .leading, spacing: 4) {
@@ -424,10 +529,11 @@ private struct FareBoardChrome: View {
                         in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
-                    .strokeBorder(selected ? theme.border(.borderHero) : .clear, lineWidth: 1.5)
+                    .strokeBorder(selected ? configuration.accentBorder(theme) : .clear, lineWidth: 1.5)
             )
         }
         .buttonStyle(.plain)
+        .accessibilityAddTraits(selected ? .isSelected : [])
     }
 }
 
@@ -470,7 +576,7 @@ private struct DealChrome: View {
                 FavoriteHeart(configuration: configuration)
                 PriceBlock(configuration: configuration)
             }
-            .padding(Theme.SpacingKey.md.value)
+            .padding(configuration.spacing(.md))
         }
         .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
         .itemShell(configuration, theme: theme)
@@ -518,7 +624,7 @@ private struct TicketChrome: View {
                     field("Stops", configuration.stopsText(leg))
                 }
             }
-            .padding(Theme.SpacingKey.md.value)
+            .padding(configuration.spacing(.md))
             perforation
             HStack(spacing: Theme.SpacingKey.sm.value) {
                 (configuration.logo ?? AnyView(Icon(systemName: configuration.airlineSystemImage).size(.md).accent(.primary)))
@@ -529,13 +635,13 @@ private struct TicketChrome: View {
                 FavoriteHeart(configuration: configuration)
                 PriceBlock(configuration: configuration, size: .small)
             }
-            .padding(Theme.SpacingKey.md.value)
+            .padding(configuration.spacing(.md))
         }
         .background(theme.background(configuration.surface(default: .bgBase)))
         .clipShape(TicketNotchShape(stubHeight: 58, radius: 7))
         .overlay(
             TicketNotchShape(stubHeight: 58, radius: 7)
-                .stroke(configuration.isSelected ? theme.border(.borderHero) : theme.border(.borderPrimary),
+                .stroke(configuration.isSelected ? configuration.accentBorder(theme) : theme.border(.borderPrimary),
                         lineWidth: configuration.isSelected ? 1.5 : 1)
         )
         .contentShape(Rectangle())
@@ -551,7 +657,7 @@ private struct TicketChrome: View {
     private func bigCode(_ code: String, time: String, alignment: HorizontalAlignment) -> some View {
         VStack(alignment: alignment, spacing: 2) {
             Text(code).textStyle(.headingLg).foregroundStyle(theme.text(.textPrimary))
-            Text(time).textStyle(.labelSm600).foregroundStyle(theme.foreground(.fgHero))
+            Text(time).textStyle(.labelSm600).foregroundStyle(configuration.accentForeground(theme))
         }
     }
 
@@ -618,7 +724,7 @@ private struct JourneyChrome: View {
                         Icon(systemName: "chevron.down").size(.xs).accent(.neutral)
                             .rotationEffect(.degrees(configuration.isExpanded ? 180 : 0))
                     }
-                    .padding(Theme.SpacingKey.md.value)
+                    .padding(configuration.spacing(.md))
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -653,7 +759,7 @@ private struct JourneyChrome: View {
                         }
                     }
                 }
-                .padding([.horizontal, .bottom], Theme.SpacingKey.md.value)
+                .padding([.horizontal, .bottom], configuration.spacing(.md))
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
@@ -663,9 +769,9 @@ private struct JourneyChrome: View {
     private func legTimeline(_ leg: FlightLeg) -> some View {
         HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
             VStack(spacing: 0) {
-                Circle().stroke(theme.border(.borderHero), lineWidth: 1.5).frame(width: 7, height: 7)
+                Circle().stroke(configuration.accentBorder(theme), lineWidth: 1.5).frame(width: 7, height: 7)
                 Rectangle().fill(theme.border(.borderPrimary)).frame(width: 1.5).frame(maxHeight: .infinity)
-                Circle().fill(theme.border(.borderHero)).frame(width: 7, height: 7)
+                Circle().fill(configuration.accentBorder(theme)).frame(width: 7, height: 7)
             }
             .padding(.vertical, 5)
             VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
@@ -734,7 +840,7 @@ private struct SlicesChrome: View {
                 }
             }
         }
-        .padding(Theme.SpacingKey.md.value)
+        .padding(configuration.spacing(.md))
         .itemShell(configuration, theme: theme)
         .contentShape(Rectangle())
         .onTapGesture { configuration.onSelect?() }
@@ -765,15 +871,21 @@ private struct TimetableChrome: View {
     // the container reads the direction and hands it to the layout.
     @Environment(\.layoutDirection) private var layoutDirection
     let configuration: FlightListItemConfiguration
+    /// Uncontrolled fallback — see ``FareBoardChrome/chosen``.
     @State private var chosen: Date?
 
+    private var selectedDeparture: Date? {
+        configuration.onDepartureSelect != nil ? configuration.selectedDeparture : chosen
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
+        VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
             HStack(spacing: Theme.SpacingKey.sm.value) {
                 (configuration.logo ?? AnyView(Icon(systemName: configuration.airlineSystemImage).size(.md).accent(.primary)))
                     .frame(width: 24, height: 24)
                 Text(configuration.leg.airline).textStyle(.labelMd700).foregroundStyle(theme.text(.textPrimary))
                 Spacer()
+                if let accessory = configuration.accessory { accessory }
                 FavoriteHeart(configuration: configuration)
                 PriceBlock(configuration: configuration, size: .small)
             }
@@ -785,26 +897,28 @@ private struct TimetableChrome: View {
                     timeChip(date)
                 }
             }
+            if let footer = configuration.footer { footer }
         }
-        .padding(Theme.SpacingKey.md.value)
+        .padding(configuration.spacing(.md))
         .itemShell(configuration, theme: theme)
     }
 
     private func timeChip(_ date: Date) -> some View {
-        let selected = chosen == date
+        let selected = selectedDeparture == date
         return Button {
-            chosen = date
+            if let onDepartureSelect = configuration.onDepartureSelect { onDepartureSelect(date) } else { chosen = date }
             configuration.onSelect?()
         } label: {
             Text(configuration.time(date))
                 .textStyle(.labelSm700)
-                .foregroundStyle(selected ? theme.foreground(.fgSecondary) : theme.text(.textPrimary))
+                .foregroundStyle(selected ? configuration.accentOnFill(theme) : theme.text(.textPrimary))
                 .padding(.horizontal, Theme.SpacingKey.sm.value)
                 .padding(.vertical, Theme.SpacingKey.xs.value)
-                .background(selected ? theme.background(.bgHero) : theme.background(.bgSecondaryLight),
+                .background(selected ? configuration.accentFill(theme) : theme.background(.bgSecondaryLight),
                             in: Capsule(style: .continuous))
         }
         .buttonStyle(.plain)
+        .accessibilityAddTraits(selected ? .isSelected : [])
     }
 }
 
@@ -884,7 +998,7 @@ private struct TrayChrome: View {
                     }
                 }
             }
-            .padding(Theme.SpacingKey.md.value)
+            .padding(configuration.spacing(.md))
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(theme.background(.bgWhite),
                         in: RoundedRectangle(cornerRadius: cardRadius, style: .continuous))
@@ -927,8 +1041,220 @@ private struct TrayChrome: View {
         .overlay {
             if configuration.isSelected {
                 RoundedRectangle(cornerRadius: trayRadius, style: .continuous)
-                    .strokeBorder(theme.border(.borderHero), lineWidth: 1.5)
+                    .strokeBorder(configuration.accentBorder(theme), lineWidth: 1.5)
             }
+        }
+    }
+}
+
+// MARK: - 10. Tile — vertical carousel card
+
+/// A vertical card for horizontal carousels (destination-deal shelves, "more
+/// dates" rails): identity on top, the route in the middle, price pinned at the
+/// bottom. Width comes from the carousel (`.frame(width:)`); the tile fills
+/// whatever it's given.
+public struct TileFlightListItemStyle: FlightListItemStyle {
+    public init() {}
+    public func makeBody(configuration: FlightListItemConfiguration) -> some View {
+        TileChrome(configuration: configuration)
+    }
+}
+
+private struct TileChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: FlightListItemConfiguration
+
+    var body: some View {
+        let leg = configuration.leg
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                (configuration.logo ?? AnyView(Icon(systemName: configuration.airlineSystemImage).size(.md).accent(.primary)))
+                    .frame(width: 24, height: 24)
+                if let badge = configuration.badge {
+                    Badge(badge).badgeStyle(.info).size(.small)
+                }
+                Spacer(minLength: 0)
+                if let accessory = configuration.accessory { accessory }
+                FavoriteHeart(configuration: configuration)
+            }
+            Text(leg.airline).textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary))
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                Text(leg.origin).textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
+                // `arrow.forward` mirrors under RTL (unlike `arrow.right`).
+                Icon(systemName: "arrow.forward").size(.xs).accent(.neutral)
+                Text(leg.destination).textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
+            }
+            Text("\(configuration.time(leg.departure)) – \(configuration.time(leg.arrival)) · \(configuration.duration(of: leg))")
+                .textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+            Text(configuration.stopsText(leg))
+                .textStyle(.labelSm600)
+                .foregroundStyle(leg.stops == 0 ? theme.foreground(.systemcolorsFgSuccess) : theme.foreground(.systemcolorsFgWarning))
+            MetaRow(items: configuration.metaItems)
+            Spacer(minLength: Theme.SpacingKey.xs.value)
+            PriceBlock(configuration: configuration)
+            if let footer = configuration.footer { footer }
+        }
+        .padding(configuration.spacing(.md))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .itemShell(configuration, theme: theme)
+        .contentShape(Rectangle())
+        .onTapGesture { configuration.onSelect?() }
+    }
+}
+
+// MARK: - 11. Hero — featured tall card
+
+/// The featured/promoted archetype: a deal strip on top, prominent route block,
+/// amenities, an extra-large price and a pinned CTA — the card a "today's best
+/// deal" section leads with.
+public struct HeroFlightListItemStyle: FlightListItemStyle {
+    public init() {}
+    public func makeBody(configuration: FlightListItemConfiguration) -> some View {
+        HeroChrome(configuration: configuration)
+    }
+}
+
+private struct HeroChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: FlightListItemConfiguration
+
+    var body: some View {
+        let leg = configuration.leg
+        VStack(alignment: .leading, spacing: 0) {
+            if let deal = configuration.dealText {
+                HStack(spacing: Theme.SpacingKey.xs.value) {
+                    Icon(systemName: "flame.fill").size(.xs).accent(configuration.dealTone)
+                    Text(deal).textStyle(.labelSm700).foregroundStyle(configuration.dealTone.base)
+                    Spacer()
+                }
+                .padding(.horizontal, configuration.spacing(.md))
+                .padding(.vertical, Theme.SpacingKey.xs.value)
+                .background(configuration.dealTone.soft)
+            }
+            VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    (configuration.logo ?? AnyView(Icon(systemName: configuration.airlineSystemImage).size(.md).accent(.primary)))
+                        .frame(width: 24, height: 24)
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(leg.airline).textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary))
+                        if let no = configuration.flightNo {
+                            Text(no).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+                        }
+                    }
+                    Spacer()
+                    if let badge = configuration.badge {
+                        Badge(badge).badgeStyle(.info).size(.small)
+                    }
+                    if let accessory = configuration.accessory { accessory }
+                    FavoriteHeart(configuration: configuration)
+                }
+                HStack(alignment: .center, spacing: Theme.SpacingKey.sm.value) {
+                    TimeColumn(time: configuration.time(leg.departure), code: leg.origin, alignment: .leading)
+                    RouteTrack(leg: leg, duration: configuration.duration(of: leg), stops: configuration.stopsText(leg))
+                        .frame(maxWidth: .infinity)
+                    TimeColumn(time: configuration.time(leg.arrival), code: leg.destination, alignment: .trailing)
+                }
+                if !configuration.amenities.isEmpty {
+                    HStack(spacing: Theme.SpacingKey.sm.value) {
+                        ForEach(configuration.amenities, id: \.self) { symbol in
+                            Icon(systemName: symbol).size(.sm).accent(.neutral)
+                        }
+                    }
+                }
+                MetaRow(items: configuration.metaItems)
+                Rectangle().fill(theme.border(.borderPrimary)).frame(height: 0.5)
+                HStack(alignment: .bottom) {
+                    PriceBlock(configuration: configuration, size: .xlarge)
+                    Spacer()
+                    if let action = configuration.onSelect {
+                        ThemeButton(configuration.selectTitle, action: action).size(.small)
+                    }
+                }
+                if let footer = configuration.footer { footer }
+            }
+            .padding(configuration.spacing(.md))
+        }
+        .clipShape(RoundedRectangle(cornerRadius: configuration.cornerRadius, style: .continuous))
+        .itemShell(configuration, theme: theme)
+        .contentShape(Rectangle())
+        .onTapGesture { configuration.onSelect?() }
+    }
+}
+
+// MARK: - 12. Receipt — checkout summary, labeled fields
+
+/// The checkout-summary archetype: every slice as a labeled row, then fare,
+/// baggage and meta as labeled fields, closed by the itinerary total. **No tap
+/// affordance** — it's a read-back of what the user already chose, not a
+/// selectable result (so `onSelect` is deliberately not wired).
+public struct ReceiptFlightListItemStyle: FlightListItemStyle {
+    public init() {}
+    public func makeBody(configuration: FlightListItemConfiguration) -> some View {
+        ReceiptChrome(configuration: configuration)
+    }
+}
+
+private struct ReceiptChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: FlightListItemConfiguration
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            ForEach(Array(configuration.legs.enumerated()), id: \.element.id) { index, leg in
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
+                    if index < configuration.sliceLabels.count {
+                        Text(configuration.sliceLabels[index])
+                            .textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+                    }
+                    SliceLine(configuration: configuration, leg: leg)
+                }
+            }
+            Rectangle().fill(theme.border(.borderPrimary)).frame(height: 0.5)
+            if let no = configuration.flightNo { fieldRow(String(themeKit: "Flight"), no) }
+            if let cabin = configuration.cabin { fieldRow(String(themeKit: "Fare"), cabin) }
+            if let carryOn = configuration.baggage {
+                fieldRow(String(themeKit: "Carry-on"), carryOn)
+                fieldRow(String(themeKit: "Checked bag"),
+                         configuration.checkedBaggage ?? String(themeKit: "Not included"))
+            }
+            ForEach(Array(configuration.metaItems.enumerated()), id: \.offset) { _, item in
+                fieldRow(item.text, icon: item.icon)
+            }
+            if let amount = configuration.priceAmount {
+                Rectangle().fill(theme.border(.borderPrimary)).frame(height: 0.5)
+                // The caption doubles as the total row's label, so the price
+                // itself renders bare (no PriceBlock — that would repeat it).
+                HStack(alignment: .firstTextBaseline) {
+                    Text(configuration.priceCaption ?? String(themeKit: "Total"))
+                        .textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary))
+                    Spacer()
+                    PriceTag(amount, currencyCode: configuration.currencyCode)
+                        .original(configuration.originalAmount)
+                }
+            }
+            if let footer = configuration.footer { footer }
+        }
+        .padding(configuration.spacing(.md))
+        .itemShell(configuration, theme: theme)
+        // No contentShape/onTapGesture: a receipt is not a tappable result row.
+    }
+
+    private func fieldRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
+            Spacer(minLength: Theme.SpacingKey.sm.value)
+            Text(value).textStyle(.labelSm700).foregroundStyle(theme.text(.textPrimary))
+                .multilineTextAlignment(.trailing)
+        }
+    }
+
+    /// A meta item rendered receipt-style: icon leading, text as the value.
+    private func fieldRow(_ text: String, icon: String) -> some View {
+        HStack(alignment: .center) {
+            Icon(systemName: icon).size(.xs).accent(.neutral)
+            Spacer(minLength: Theme.SpacingKey.sm.value)
+            Text(text).textStyle(.labelSm700).foregroundStyle(theme.text(.textPrimary))
+                .multilineTextAlignment(.trailing)
         }
     }
 }
@@ -971,6 +1297,18 @@ public extension FlightListItemStyle where Self == TrayFlightListItemStyle {
     /// Nested white card on a soft tray with a details/price/go CTA rail
     /// (design-system spec) — built from FlightRoute, PriceTag, TextLink & co.
     static var tray: TrayFlightListItemStyle { TrayFlightListItemStyle() }
+}
+public extension FlightListItemStyle where Self == TileFlightListItemStyle {
+    /// Vertical card for horizontal carousels: logo top, route mid, price bottom.
+    static var tile: TileFlightListItemStyle { TileFlightListItemStyle() }
+}
+public extension FlightListItemStyle where Self == HeroFlightListItemStyle {
+    /// Featured tall card: deal strip + big price + badge + amenities.
+    static var hero: HeroFlightListItemStyle { HeroFlightListItemStyle() }
+}
+public extension FlightListItemStyle where Self == ReceiptFlightListItemStyle {
+    /// Checkout summary — slices, fare and baggage as labeled fields, no tap affordance.
+    static var receipt: ReceiptFlightListItemStyle { ReceiptFlightListItemStyle() }
 }
 
 // MARK: - Type erasure + environment plumbing

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightResultRow.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightResultRow.swift
@@ -48,6 +48,13 @@ public struct FlightResultRow: View {
     private var currencyCode: String?
     private var baggage: String?
     private var badge: String?
+    private var badgeStyle: BadgeStyle = .success
+    private var isSelected = false
+    private var elevation: CardElevation = .none
+    private var priceFractionDigits = 2
+    private var footerSlot: AnyView?
+    private var trailingSlot: AnyView?
+    private var detailsTitle = String(themeKit: "Details")
     /// Favourite/bookmark state — dual-mode via `ControllableState` (ADR-F4);
     /// renamed from `favorite`/`bookmark` so the nullary overloads aren't
     /// invalid redeclarations. Hidden until the `shows…` flags flip.
@@ -80,8 +87,8 @@ public struct FlightResultRow: View {
         // `.none` matches today's chrome: no shadow, hairline border.
         cardStyle.makeBody(configuration: CardStyleConfiguration(
             content: AnyView(rowContent),
-            elevation: .none,
-            isSelected: false,
+            elevation: elevation,
+            isSelected: isSelected,
             isPressed: false,
             surfaceKey: surfaceKey,
             radius: .box))
@@ -102,9 +109,16 @@ public struct FlightResultRow: View {
                     }
                 }
                 .frame(maxWidth: .infinity)
-                priceBlock.frame(minWidth: 84, alignment: .trailing)
+                Group {
+                    if let trailingSlot { trailingSlot } else { priceBlock }
+                }
+                .frame(minWidth: 84, alignment: .trailing)
             }
-            if badge != nil || baggage != nil || urgencyText != nil || onDetails != nil { metaRow }
+            if let footerSlot {
+                footerSlot
+            } else if badge != nil || baggage != nil || urgencyText != nil || onDetails != nil {
+                metaRow
+            }
         }
         .padding(density.scale(Theme.SpacingKey.md.value))
     }
@@ -152,7 +166,7 @@ public struct FlightResultRow: View {
                     }
                 }
             }
-            if let price { PriceTag(price, currencyCode: resolvedCurrency).emphasis(.hero).fractionDigits(2) }
+            if let price { PriceTag(price, currencyCode: resolvedCurrency).emphasis(.hero).fractionDigits(priceFractionDigits) }
             if let totalLabel, let totalAmount {
                 Text("\(totalLabel): \(totalAmount.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0)).locale(locale)))")
                     .textStyle(.overline400).foregroundStyle(theme.text(.textTertiary)).fixedSize()
@@ -171,7 +185,7 @@ public struct FlightResultRow: View {
 
     @ViewBuilder private var metaRow: some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
-            if let badge { Badge(badge).badgeStyle(.success).variant(.soft).size(.small) }
+            if let badge { Badge(badge).badgeStyle(badgeStyle).variant(.soft).size(.small) }
             if let baggage {
                 HStack(spacing: 3) {
                     Image(systemName: "suitcase.fill").font(.system(size: 11))
@@ -183,7 +197,7 @@ public struct FlightResultRow: View {
                 Text(urgencyText).textStyle(.overline500).foregroundStyle(theme.foreground(.systemcolorsFgError))
             }
             Spacer()
-            if let onDetails { TextLink(String(themeKit: "Details")) { onDetails() } }
+            if let onDetails { TextLink(detailsTitle) { onDetails() } }
         }
     }
 
@@ -228,6 +242,21 @@ public extension FlightResultRow {
     func baggage(_ text: String?) -> Self { copy { $0.baggage = text } }
     /// A success badge, e.g. "Best".
     func badge(_ text: String?) -> Self { copy { $0.badge = text } }
+    /// A meta-row badge with an explicit `BadgeStyle` (the one-argument form
+    /// keeps the classic `.success` styling).
+    func badge(_ text: String?, style: BadgeStyle) -> Self { copy { $0.badge = text; $0.badgeStyle = style } }
+    /// Selected state, fed to the active `CardStyle` (the default style draws a
+    /// hero border).
+    func selected(_ on: Bool = true) -> Self { copy { $0.isSelected = on } }
+    /// Shell elevation, fed to the active `CardStyle` (default `.none` — today's
+    /// flat, hairline-only chrome).
+    func elevation(_ e: CardElevation) -> Self { copy { $0.elevation = e } }
+    /// Fraction digits for the fare `PriceTag` (default 2).
+    func priceFractionDigits(_ n: Int) -> Self { copy { $0.priceFractionDigits = max(0, n) } }
+    /// Replaces the built-in meta row (badge / baggage / urgency / Details).
+    func footer<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.footerSlot = AnyView(content()) } }
+    /// Replaces the built-in trailing price / favourite / Select area.
+    func trailing<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.trailingSlot = AnyView(content()) } }
     /// A heart toggle bound to a favourite flag (controlled — the caller owns
     /// persistence).
     func favorite(_ isFavorite: Binding<Bool>) -> Self {
@@ -258,6 +287,10 @@ public extension FlightResultRow {
     func onSelect(_ title: String = "Select", action: @escaping () -> Void) -> Self { copy { $0.selectTitle = title; $0.onSelect = action } }
     /// Adds a "Details" link in the meta row.
     func onDetails(_ action: @escaping () -> Void) -> Self { copy { $0.onDetails = action } }
+    /// Adds a meta-row link with a custom title (default "Details").
+    func onDetails(_ title: String = "Details", action: @escaping () -> Void) -> Self {
+        copy { $0.detailsTitle = title; $0.onDetails = action }
+    }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -281,6 +314,27 @@ public extension FlightResultRow {
         FlightResultRow(airline: "Sunrise Air", from: "IST", to: "LHR", departure: dep, arrival: dep.addingTimeInterval(3 * 3_600))
             .accent(.success).flightNo("SA 101").price(4_120).bookmark(.constant(true))
             .onSelect("Select") { }
+        // Styled badge · whole-number fare · selected/elevated shell · custom Details title.
+        FlightResultRow(airline: "Anadolu Air", from: "IST", to: "AYT", departure: dep, arrival: dep.addingTimeInterval(95 * 60))
+            .flightNo("TK 2436").price(3_950).priceFractionDigits(0)
+            .badge("Fastest", style: .info)
+            .onDetails("Fare rules") { }
+            .selected().elevation(.soft)
+        // Footer + trailing slots replace the meta row and the price area.
+        FlightResultRow(airline: "Blue Wings", from: "IST", to: "ADB", departure: dep, arrival: dep.addingTimeInterval(70 * 60))
+            .footer {
+                HStack {
+                    Badge("Charter").badgeStyle(.warning).variant(.soft).size(.small)
+                    Spacer()
+                    Text("Operated by partner").textStyle(.overline400)
+                }
+            }
+            .trailing {
+                VStack(alignment: .trailing, spacing: 4) {
+                    Badge("Sold out").badgeStyle(.error).size(.small)
+                    Text("Join waitlist").textStyle(.labelSm600)
+                }
+            }
     }
     .padding()
 }

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightTicketCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightTicketCard.swift
@@ -57,12 +57,20 @@ public struct FlightTicketCard: View {
     private var accent: SemanticColor?
     private var elevation: CardElevation = .soft
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    private var radiusRole: Theme.RadiusRole = .box
+    private var showsPerforation = true
+    private var dashKey: Theme.BorderColorKey = .borderPrimary
+    private var priceEmphasis: PriceEmphasis = .standard
+    private var headerSlot: AnyView?
+    private var customStub: AnyView?
 
     public init(from: String, to: String) {   // R1
         self.from = from
         self.to = to
     }
 
+    // deferred: accent-fallback unification — keeps the `.primary` fallback
+    // (matching AncillaryCard/StickyBookingBar would be visually breaking here).
     private var accentBase: Color { (accent ?? .primary).base }
 
     private var resolvedCurrency: String {
@@ -74,9 +82,12 @@ public struct FlightTicketCard: View {
         // notches + tear line + shadow) is the chrome here and is kept as-is —
         // see the header note. `.surface()`/`.elevation()` feed it directly.
         TicketStub {
-            routeHeader
+            if let headerSlot { headerSlot } else { routeHeader }
         }
-        .stub { stub }
+        .stub { if let customStub { customStub } else { stub } }
+        .cornerRadius(radiusRole)
+        .perforation(showsPerforation)
+        .dashColor(dashKey)
         .elevation(elevation)
         .surface(surfaceKey)
     }
@@ -134,7 +145,7 @@ public struct FlightTicketCard: View {
             }
             if let airline { Text(airline).textStyle(.bodyBase500).foregroundStyle(theme.text(.textPrimary)).lineLimit(1) }
             Spacer(minLength: 6)
-            if let price { PriceTag(price, currencyCode: resolvedCurrency).size(.medium).emphasis(.standard).fractionDigits(0) }
+            if let price { PriceTag(price, currencyCode: resolvedCurrency).size(.medium).emphasis(priceEmphasis).fractionDigits(0) }
             if showsFavorite {
                 Button { favoriteState.toggle() } label: {
                     Image(systemName: favoriteState ? "heart.fill" : "heart")
@@ -189,6 +200,19 @@ public extension FlightTicketCard {
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     func elevation(_ e: CardElevation) -> Self { copy { $0.elevation = e } }
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
+    /// Replaces the built-in airline / price / favourite stub with custom
+    /// content — forwarded to ``TicketStub``'s stub slot below the tear line.
+    func stub<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.customStub = AnyView(content()) } }
+    /// Replaces the built-in route header (codes / cities / timeline) above the tear.
+    func header<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.headerSlot = AnyView(content()) } }
+    /// Outer corner radius (radius role token, default `.box`) — forwarded to ``TicketStub``.
+    func cornerRadius(_ role: Theme.RadiusRole) -> Self { copy { $0.radiusRole = role } }
+    /// Draw the dashed perforation across the tear line (default on) — forwarded to ``TicketStub``.
+    func perforation(_ on: Bool = true) -> Self { copy { $0.showsPerforation = on } }
+    /// Perforation dash colour (border token key, default `.borderPrimary`) — forwarded to ``TicketStub``.
+    func dashColor(_ key: Theme.BorderColorKey) -> Self { copy { $0.dashKey = key } }
+    /// Emphasis of the stub's `PriceTag` (default `.standard`).
+    func priceEmphasis(_ e: PriceEmphasis) -> Self { copy { $0.priceEmphasis = e } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -201,11 +225,35 @@ public extension FlightTicketCard {
     struct Demo: View {
         @State private var fav = true
         var body: some View {
-            FlightTicketCard(from: "NYC", to: "SFO")
-                .cities(from: "New York City", to: "San Francisco").duration("1h 45m")
-                .times(departure: "10:00 AM", arrival: "11:30 AM")
-                .airline("Garuda Indonesia").price(140, currencyCode: "USD").favorite($fav).accent(.info)
+            ScrollView {
+                VStack(spacing: 16) {
+                    FlightTicketCard(from: "NYC", to: "SFO")
+                        .cities(from: "New York City", to: "San Francisco").duration("1h 45m")
+                        .times(departure: "10:00 AM", arrival: "11:30 AM")
+                        .airline("Garuda Indonesia").price(140, currencyCode: "USD").favorite($fav).accent(.info)
+                    // Hero price emphasis + tighter corner + tinted dashes, no perforation variant.
+                    FlightTicketCard(from: "IST", to: "LHR")
+                        .cities(from: "Istanbul", to: "London").duration("3h 55m")
+                        .times(departure: "09:20", arrival: "12:15")
+                        .airline("Sunrise Air").price(220, currencyCode: "USD")
+                        .priceEmphasis(.hero).cornerRadius(.field).dashColor(.borderHero)
+                    FlightTicketCard(from: "IST", to: "AMS")
+                        .duration("3h 30m").times(departure: "07:10", arrival: "09:40")
+                        .airline("Blue Wings").price(180, currencyCode: "USD")
+                        .perforation(false)
+                    // Custom stub slot — forwarded to TicketStub's tear-off area.
+                    FlightTicketCard(from: "SAW", to: "ESB")
+                        .duration("1h 10m").times(departure: "18:00", arrival: "19:10")
+                        .stub {
+                            HStack {
+                                Text("Booking").textStyle(.bodySm400)
+                                Spacer()
+                                Text("X7K2QF").textStyle(.labelSm700)
+                            }
+                        }
+                }
                 .frame(maxWidth: 320).padding()
+            }
         }
     }
     return Demo()

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightTracker.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightTracker.swift
@@ -36,6 +36,10 @@
 import SwiftUI
 import ThemeKit
 
+/// Layout archetype of a ``FlightTracker``: the full status board (`.board`,
+/// default) or a one-row status strip (`.compact`) for lists and widgets.
+public enum FlightTrackerVariant: Sendable { case board, compact }
+
 /// The live flight status board — badge, route + progress, schedule vs
 /// estimate, gate/terminal/belt facts and a phase timeline, on a `Card` shell.
 public struct FlightTracker: View {
@@ -56,6 +60,19 @@ public struct FlightTracker: View {
     private var surfaceKey: Theme.BackgroundColorKey = .bgWhite
     private var elevationValue: CardElevation = .soft
     private var footerSlot: AnyView?
+    private var variantValue: FlightTrackerVariant = .board
+    private var showsFactsValue = true
+    private var showsEstimatesValue = true
+    /// Replaces the built-in airline/route/badge header (`.board` only).
+    private var headerSlot: AnyView?
+    private var checkInTitleOverride: String?
+    private var boardingTitleOverride: String?
+    private var departedTitleOverride: String?
+    private var arrivedTitleOverride: String?
+    private var contentPaddingKey: Theme.SpacingKey = .md
+    /// Replaces the built-in route progress track, built per clamped fraction.
+    private var progressSlot: ((Double) -> AnyView)?
+    private var timelineSizeValue: StepsSize = .small
 
     /// R1 — the canonical live-status model (ADR-F3). Everything else is a modifier.
     public init(_ info: FlightStatusInfo) {
@@ -101,8 +118,13 @@ public struct FlightTracker: View {
     // MARK: Body
 
     public var body: some View {
-        let card = Card { content }
-            .contentPadding(.md)
+        let card = Card {
+            switch variantValue {
+            case .board: content
+            case .compact: compactStrip
+            }
+        }
+            .contentPadding(contentPaddingKey)
             .surface(surfaceKey)
             .elevation(elevationValue)
         Group {
@@ -128,21 +150,52 @@ public struct FlightTracker: View {
 
     private var content: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
-            header
+            if let headerSlot { headerSlot } else { header }
             route
-            if departureEstimate != nil || arrivalEstimate != nil {
+            if showsEstimatesValue, departureEstimate != nil || arrivalEstimate != nil {
                 estimateRows
             }
-            if !factRows.isEmpty {
+            if showsFactsValue, !factRows.isEmpty {
                 KeyValueTable(rows: factRows)
             }
             if timelineVisible {
-                Steps(phases).size(.small)
+                Steps(phases).size(timelineSizeValue)
             }
             if let updatedDate {
                 updatedCaption(updatedDate)
             }
         }
+    }
+
+    // MARK: Compact variant — one-row status strip
+
+    /// One combined VoiceOver element, like the board header; the status
+    /// announcement `onChange` on the card shell covers this variant too.
+    private var compactStrip: some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            FlightStatusBadge(info.status).time(delayText)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(info.leg.origin) – \(info.leg.destination)")
+                    .textStyle(.labelBase600)
+                    .foregroundStyle(theme.text(.textPrimary))
+                Text(info.leg.airline)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+            .lineLimit(1)
+            Spacer(minLength: Theme.SpacingKey.sm.value)
+            if showsEstimatesValue, let estimate = departureEstimate ?? arrivalEstimate {
+                Text(estimate.formatted(timeFormat))
+                    .textStyle(.labelBase600)
+                    .foregroundStyle(tone.base)
+            } else {
+                Text(info.leg.departure.formatted(timeFormat))
+                    .textStyle(.labelBase600)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(headerSummary)
     }
 
     // MARK: Header — one combined VoiceOver element
@@ -195,7 +248,11 @@ public struct FlightTracker: View {
             )
             .stops(info.leg.stops)
             if let fraction = clampedProgress {
-                RouteProgressTrack(fraction: fraction, tone: tone)
+                if let progressSlot {
+                    progressSlot(fraction)
+                } else {
+                    RouteProgressTrack(fraction: fraction, tone: tone)
+                }
             }
         }
     }
@@ -256,10 +313,10 @@ public struct FlightTracker: View {
 
     private var phases: [Steps.Step] {
         let titles = (
-            checkIn: String(themeKitTravel: "Check-in"),
-            boarding: String(themeKitTravel: "Boarding"),
-            departed: String(themeKitTravel: "Departed"),
-            arrived: String(themeKitTravel: "Arrived")
+            checkIn: checkInTitleOverride ?? String(themeKitTravel: "Check-in"),
+            boarding: boardingTitleOverride ?? String(themeKitTravel: "Boarding"),
+            departed: departedTitleOverride ?? String(themeKitTravel: "Departed"),
+            arrived: arrivedTitleOverride ?? String(themeKitTravel: "Arrived")
         )
         let states: [StepState]
         switch info.status {
@@ -359,6 +416,51 @@ public extension FlightTracker {
         copy { $0.footerSlot = AnyView(content()) }
     }
 
+    /// Layout archetype: `.board` (default, the full status card) or
+    /// `.compact` — a one-row badge + route + time strip for lists/widgets.
+    func variant(_ v: FlightTrackerVariant) -> Self { copy { $0.variantValue = v } }
+
+    /// Show the gate/terminal/desk/belt facts grid (default on; `.board` only).
+    func showsFacts(_ on: Bool = true) -> Self { copy { $0.showsFactsValue = on } }
+
+    /// Show the schedule-vs-estimate rows (and the `.compact` estimate time)
+    /// when estimates differ meaningfully from the schedule (default on).
+    func showsEstimates(_ on: Bool = true) -> Self { copy { $0.showsEstimatesValue = on } }
+
+    /// Replaces the built-in airline/route/badge header (canonical
+    /// `.header { }` slot; `.board` variant). The status-change VoiceOver
+    /// announcement lives on the card shell, not the header — it keeps firing
+    /// with a custom header.
+    func header<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.headerSlot = AnyView(content()) }
+    }
+
+    /// Overrides the phase-timeline titles; `nil` keeps the stock
+    /// English-generic titles ("Check-in" / "Boarding" / "Departed" / "Arrived").
+    func phaseTitles(checkIn: String? = nil, boarding: String? = nil,
+                     departed: String? = nil, arrived: String? = nil) -> Self {
+        copy {
+            $0.checkInTitleOverride = checkIn
+            $0.boardingTitleOverride = boarding
+            $0.departedTitleOverride = departed
+            $0.arrivedTitleOverride = arrived
+        }
+    }
+
+    /// Inner padding of the card shell as a spacing token (default `.md`) —
+    /// forwarded to the composed `Card`.
+    func contentPadding(_ key: Theme.SpacingKey) -> Self { copy { $0.contentPaddingKey = key } }
+
+    /// Replaces the built-in route progress track, built per clamped 0…1
+    /// fraction. The replacement must carry its own accessibility value —
+    /// the stock track's "NN percent" read-out is part of what it replaces.
+    func progressContent(@ViewBuilder _ content: @escaping (Double) -> some View) -> Self {
+        copy { $0.progressSlot = { AnyView(content($0)) } }
+    }
+
+    /// Marker/label size of the phase timeline (default `.small`).
+    func timelineSize(_ s: StepsSize) -> Self { copy { $0.timelineSizeValue = s } }
+
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
         mutate(&c)
@@ -415,6 +517,47 @@ public extension FlightTracker {
                         .textStyle(.bodySm400)
                 }
                 .readOnly()
+        }
+        .padding()
+    }
+    .background(Theme.shared.background(.bgBase))
+}
+
+#Preview("Compact · header slot · custom progress · phase titles") {
+    let dep = Date().addingTimeInterval(-2 * 3600)
+    let leg = FlightLeg(airline: "Skyline Air", from: "IST", to: "LHR",
+                        departure: dep, arrival: dep.addingTimeInterval(4 * 3600))
+    return ScrollView {
+        VStack(spacing: Theme.SpacingKey.lg.value) {
+            // Compact strips — delayed shows the estimate in the status tone.
+            FlightTracker(.init(leg: leg, status: .departed))
+                .variant(.compact)
+            FlightTracker(.init(leg: leg, status: .delayed,
+                                estimatedDeparture: dep.addingTimeInterval(45 * 60)))
+                .variant(.compact)
+
+            // Header slot + custom progress content + renamed phases.
+            FlightTracker(.init(leg: leg, status: .departed, gate: "B12", terminal: "1"))
+                .progress(0.4)
+                .header {
+                    HStack(spacing: Theme.SpacingKey.sm.value) {
+                        Icon(systemName: "airplane.circle.fill").size(.md)
+                        Text("SK 1893 · Live").textStyle(.headingSm)
+                        Spacer()
+                    }
+                }
+                .progressContent { fraction in
+                    ProgressBar(value: fraction)
+                }
+                .phaseTitles(checkIn: "Bag drop", arrived: "Landed")
+                .timelineSize(.medium)
+                .contentPadding(.lg)
+
+            // Facts/estimates toggled off.
+            FlightTracker(.init(leg: leg, status: .boarding, gate: "B12", terminal: "1",
+                                estimatedDeparture: dep.addingTimeInterval(20 * 60)))
+                .showsFacts(false)
+                .showsEstimates(false)
         }
         .padding()
     }

--- a/Sources/ThemeKitTravel/Components/Organisms/PassengerForm.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PassengerForm.swift
@@ -42,6 +42,13 @@ public enum PassengerFormField: Hashable, Sendable, CaseIterable {
     case givenName, familyName, gender, dateOfBirth, nationality, documentNumber, documentExpiry
 }
 
+// MARK: - PassengerFormLayout
+
+/// Section chrome of a ``PassengerForm``: two `Fieldset`s (`.stacked`, the
+/// default), bare fields with plain section titles (`.flat`), or every field
+/// inside one `Fieldset` (`.grouped`).
+public enum PassengerFormLayout: Sendable { case stacked, flat, grouped }
+
 // MARK: - PassengerForm
 
 /// The editable traveler form for booking flows. Controlled-only: bind a
@@ -64,6 +71,7 @@ public enum PassengerFormField: Hashable, Sendable, CaseIterable {
 public struct PassengerForm: View {
     @Environment(\.theme) private var theme
     @Environment(\.locale) private var locale
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     private let title: String
     @Binding private var draft: PassengerDraft
@@ -77,6 +85,16 @@ public struct PassengerForm: View {
     private var accent: SemanticColor?
     private var customHeader: AnyView?
     private var customFooter: AnyView?
+    /// Per-field title overrides (`label(_:for:)`); absent = built-in title.
+    private var labelOverrides: [PassengerFormField: String] = [:]
+    /// Section titles: `nil` = built-in, `""` = section renders without a title.
+    private var personalTitleOverride: String?
+    private var documentTitleOverride: String?
+    private var layoutValue: PassengerFormLayout = .stacked
+    /// Extra caller fields appended after the document section.
+    private var additionalFieldsSlot: AnyView?
+    private var genderOptions: [PassengerGender] = Array(PassengerGender.allCases)
+    private var columnsValue = 1
 
     /// R1 — title + controlled draft. Controlled-only (ADR-F4).
     public init(_ title: String, draft: Binding<PassengerDraft>) {
@@ -136,17 +154,28 @@ public struct PassengerForm: View {
                 titleHeader
             }
 
-            if !personalFields.isEmpty {
-                Fieldset(String(themeKitTravel: "Personal details")) {
-                    ForEach(personalFields, id: \.self) { field(for: $0) }
+            switch layoutValue {
+            case .stacked:
+                if !personalFields.isEmpty {
+                    section(title: resolvedPersonalTitle, fields: personalFields, chrome: true)
+                }
+                if !documentFields.isEmpty {
+                    section(title: resolvedDocumentTitle, fields: documentFields, chrome: true)
+                }
+            case .flat:
+                if !personalFields.isEmpty {
+                    section(title: resolvedPersonalTitle, fields: personalFields, chrome: false)
+                }
+                if !documentFields.isEmpty {
+                    section(title: resolvedDocumentTitle, fields: documentFields, chrome: false)
+                }
+            case .grouped:
+                if !fieldList.isEmpty {
+                    section(title: resolvedGroupedTitle, fields: fieldList, chrome: true)
                 }
             }
 
-            if !documentFields.isEmpty {
-                Fieldset(String(themeKitTravel: "Travel document")) {
-                    ForEach(documentFields, id: \.self) { field(for: $0) }
-                }
-            }
+            if let additionalFieldsSlot { additionalFieldsSlot }
 
             if let customFooter { customFooter }
         }
@@ -177,6 +206,113 @@ public struct PassengerForm: View {
             .accessibilityAddTraits(.isHeader)
     }
 
+    // MARK: Sections (layout + titles + column pairing)
+
+    /// `nil` = render the section without a title (`sectionTitles` passed "").
+    private var resolvedPersonalTitle: String? {
+        switch personalTitleOverride {
+        case nil: return String(themeKitTravel: "Personal details")
+        case "": return nil
+        case let custom: return custom
+        }
+    }
+
+    private var resolvedDocumentTitle: String? {
+        switch documentTitleOverride {
+        case nil: return String(themeKitTravel: "Travel document")
+        case "": return nil
+        case let custom: return custom
+        }
+    }
+
+    /// `.grouped` merges both sections under one `Fieldset` — an explicit
+    /// personal title wins, otherwise a merged default.
+    private var resolvedGroupedTitle: String? {
+        switch personalTitleOverride {
+        case nil: return String(themeKitTravel: "Traveler details")
+        case "": return nil
+        case let custom: return custom
+        }
+    }
+
+    /// One section: `Fieldset` chrome (or a plain labeled stack for `.flat` /
+    /// title-less sections) around the ordered, column-aware field run.
+    @ViewBuilder
+    private func section(title: String?, fields: [PassengerFormField], chrome: Bool) -> some View {
+        if chrome, let title {
+            Fieldset(title) { fieldRun(fields) }
+        } else {
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                if let title {
+                    Text(title)
+                        .textStyle(.labelBase700)
+                        .foregroundStyle(theme.text(.textPrimary))
+                        .accessibilityAddTraits(.isHeader)
+                }
+                fieldRun(fields)
+            }
+        }
+    }
+
+    /// Whether the given/family pair renders side-by-side: `columns(2)` asked
+    /// for it, both names are in the run, and the type size isn't an
+    /// accessibility size (those always stack).
+    private func pairsNames(in fields: [PassengerFormField]) -> Bool {
+        columnsValue >= 2
+            && !dynamicTypeSize.isAccessibilitySize
+            && fields.contains(.givenName)
+            && fields.contains(.familyName)
+    }
+
+    /// The ordered fields; when pairing, the two name fields collapse into one
+    /// `ViewThatFits` row at the first name's position (narrow widths fall
+    /// back to stacked automatically).
+    @ViewBuilder
+    private func fieldRun(_ fields: [PassengerFormField]) -> some View {
+        let pairing = pairsNames(in: fields)
+        let secondName: PassengerFormField? = pairing
+            ? [PassengerFormField.givenName, .familyName]
+                .max { (fields.firstIndex(of: $0) ?? 0) < (fields.firstIndex(of: $1) ?? 0) }
+            : nil
+        ForEach(fields, id: \.self) { key in
+            if pairing, key == .givenName || key == .familyName {
+                if key != secondName {   // render the pair once, skip the later twin
+                    namePairRow
+                }
+            } else {
+                field(for: key)
+            }
+        }
+    }
+
+    /// Given/family side-by-side when they fit; stacked otherwise.
+    private var namePairRow: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
+                givenNameField
+                familyNameField
+            }
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                givenNameField
+                familyNameField
+            }
+        }
+    }
+
+    /// The field's title: the `label(_:for:)` override or the built-in string.
+    private func fieldTitle(_ field: PassengerFormField) -> String {
+        if let override = labelOverrides[field] { return override }
+        switch field {
+        case .givenName: return String(themeKitTravel: "Given name")
+        case .familyName: return String(themeKitTravel: "Family name")
+        case .gender: return String(themeKitTravel: "Gender")
+        case .dateOfBirth: return String(themeKitTravel: "Date of birth")
+        case .nationality: return String(themeKitTravel: "Nationality")
+        case .documentNumber: return String(themeKitTravel: "Document number")
+        case .documentExpiry: return String(themeKitTravel: "Document expiry")
+        }
+    }
+
     @ViewBuilder
     private func field(for field: PassengerFormField) -> some View {
         switch field {
@@ -191,7 +327,7 @@ public struct PassengerForm: View {
     }
 
     private var givenNameField: some View {
-        var input = TextInput(String(themeKitTravel: "Given name"), text: $draft.givenName)
+        var input = TextInput(fieldTitle(.givenName), text: $draft.givenName)
             .keyboard(contentType: .givenName, submit: .next, capitalization: .words)
             .a11yID("passenger-form.given-name")
         if let form { input = input.field(.givenName, in: form) }
@@ -199,7 +335,7 @@ public struct PassengerForm: View {
     }
 
     private var familyNameField: some View {
-        var input = TextInput(String(themeKitTravel: "Family name"), text: $draft.familyName)
+        var input = TextInput(fieldTitle(.familyName), text: $draft.familyName)
             .keyboard(contentType: .familyName, submit: .next, capitalization: .words)
             .a11yID("passenger-form.family-name")
         if let form { input = input.field(.familyName, in: form) }
@@ -207,8 +343,8 @@ public struct PassengerForm: View {
     }
 
     private var genderField: some View {
-        var box = SelectBox(String(themeKitTravel: "Gender"),
-                            options: PassengerGender.allCases,
+        var box = SelectBox(fieldTitle(.gender),
+                            options: genderOptions,
                             selection: $draft.gender) { $0.label }
             .a11yID("passenger-form.gender")
         if let form {
@@ -219,7 +355,7 @@ public struct PassengerForm: View {
     }
 
     private var birthDateField: some View {
-        var field = DateField(String(themeKitTravel: "Date of birth"), date: $draft.dateOfBirth)
+        var field = DateField(fieldTitle(.dateOfBirth), date: $draft.dateOfBirth)
             .range(birthRange)
             .a11yID("passenger-form.date-of-birth")
         if let form {
@@ -230,7 +366,7 @@ public struct PassengerForm: View {
     }
 
     private var nationalityField: some View {
-        var box = SelectBox(String(themeKitTravel: "Nationality"),
+        var box = SelectBox(fieldTitle(.nationality),
                             options: nationalityCodes,
                             selection: $draft.nationality) { regionName($0) }
             .a11yID("passenger-form.nationality")
@@ -242,7 +378,7 @@ public struct PassengerForm: View {
     }
 
     private var documentNumberField: some View {
-        var input = TextInput(String(themeKitTravel: "Document number"), text: $draft.documentNumber)
+        var input = TextInput(fieldTitle(.documentNumber), text: $draft.documentNumber)
             .keyboard(submit: .next, capitalization: .characters)
             .required(isDocumentRequired)
             .a11yID("passenger-form.document-number")
@@ -256,7 +392,7 @@ public struct PassengerForm: View {
     }
 
     private var documentExpiryField: some View {
-        var field = DateField(String(themeKitTravel: "Document expiry"), date: $draft.documentExpiry)
+        var field = DateField(fieldTitle(.documentExpiry), date: $draft.documentExpiry)
             .range(expiryRange)   // picker prevents past dates; trip-date policy is the validator's
             .required(isDocumentRequired)
             .a11yID("passenger-form.document-expiry")
@@ -310,6 +446,47 @@ public extension PassengerForm {
 
     /// Bottom-aligned accessory area under the fieldsets.
     func footer<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.customFooter = AnyView(content()) } }
+
+    /// Overrides one field's built-in title (e.g. "First name" for
+    /// `.givenName`). Chain once per field; unset fields keep their defaults.
+    func label(_ text: String, for field: PassengerFormField) -> Self {
+        copy { $0.labelOverrides[field] = text }
+    }
+
+    /// Overrides the section titles. `nil` keeps the built-in title
+    /// ("Personal details" / "Travel document"); an empty string hides the
+    /// title while keeping the section. In `.grouped` the personal title
+    /// names the single fieldset.
+    func sectionTitles(personal: String? = nil, document: String? = nil) -> Self {
+        copy {
+            $0.personalTitleOverride = personal
+            $0.documentTitleOverride = document
+        }
+    }
+
+    /// Section chrome: `.stacked` (two `Fieldset`s, default), `.flat` (bare
+    /// fields + plain titles, no fieldset chrome), or `.grouped` (everything
+    /// in one `Fieldset`).
+    func layout(_ l: PassengerFormLayout) -> Self { copy { $0.layoutValue = l } }
+
+    /// Extra caller-owned fields appended after the document section (before
+    /// the footer) — e.g. a frequent-flyer number. The slot inherits the
+    /// subtree's `FieldStyle`/`FieldDefaults`; validation of slot fields is
+    /// the caller's.
+    func additionalFields<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.additionalFieldsSlot = AnyView(content()) }
+    }
+
+    /// The gender selector's options (default: all ``PassengerGender`` cases)
+    /// — e.g. `[.female, .male]` for carriers that don't file "Unspecified".
+    func genders(_ options: [PassengerGender]) -> Self {
+        copy { $0.genderOptions = options.isEmpty ? Array(PassengerGender.allCases) : options }
+    }
+
+    /// `2` renders given/family side-by-side (via `ViewThatFits`, so narrow
+    /// widths still stack); accessibility type sizes always fall back to
+    /// stacked. Default `1`.
+    func columns(_ n: Int) -> Self { copy { $0.columnsValue = min(2, max(1, n)) } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -391,6 +568,42 @@ public extension PassengerForm {
                         .documentRequired()
                         .nationalities(["DE", "FR", "JP", "BR", "NO"])
                         .birthDateRange(Date.distantPast...Date.now)
+                }
+                .padding()
+            }
+            .background(theme.background(.bgBase))
+        }
+    }
+    return Demo()
+}
+
+#Preview("Layouts · labels · columns · genders · extra fields") {
+    struct Demo: View {
+        @Environment(\.theme) private var theme
+        @State private var flat = PassengerDraft()
+        @State private var grouped = PassengerDraft()
+        @State private var loyalty = ""
+
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                    // Flat layout, custom labels, side-by-side names, trimmed genders.
+                    PassengerForm("Traveler 1", draft: $flat)
+                        .layout(.flat)
+                        .columns(2)
+                        .label("First name", for: .givenName)
+                        .label("Last name", for: .familyName)
+                        .genders([.female, .male])
+                        .sectionTitles(personal: "Who is flying?", document: "")
+
+                    // Grouped layout + additional caller field after the documents.
+                    PassengerForm("Traveler 2", draft: $grouped)
+                        .layout(.grouped)
+                        .sectionTitles(personal: "Traveler details")
+                        .additionalFields {
+                            TextInput("Frequent flyer number", text: $loyalty)
+                                .keyboard(capitalization: .characters)
+                        }
                 }
                 .padding()
             }

--- a/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelector.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelector.swift
@@ -24,8 +24,19 @@
 import SwiftUI
 import ThemeKit
 
-/// Layout archetype of a ``PaymentMethodSelector``: radio rows or tiles.
-public enum PaymentMethodVariant: Sendable { case list, grid }
+/// Layout archetype of a ``PaymentMethodSelector``: radio rows (`.list`),
+/// tiles (`.grid`), horizontally-snapping tiles (`.carousel`), or dense
+/// single-line rows (`.compactList`).
+public enum PaymentMethodVariant: Sendable { case list, grid, carousel, compactList }
+
+/// The per-option selected glyph: a leading `RadioButton` (`.radio`, the list
+/// default), a trailing checkmark (`.checkmark`), or nothing (`.none` — the
+/// selected chrome alone signals the choice).
+public enum SelectionIndicator: Sendable { case radio, checkmark, none }
+
+/// Strength of the selected tile stroke: `.subtle` (default — base step,
+/// hairline-and-a-half) or `.strong` (700 "strong" step, 2pt).
+public enum TileEmphasis: Sendable { case subtle, strong }
 
 /// A payment-method chooser — radio-semantic rows (or tiles) over
 /// ``PaymentMethodOption`` values, with an optional inline instalment picker
@@ -50,7 +61,17 @@ public struct PaymentMethodSelector: View {
     private var disabledIDs: Set<String> = []
     private var accent: SemanticColor?
     private var footerSlot: AnyView?
+    private var headerSlot: AnyView?
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    /// Selected glyph — `nil` = the variant's default (`.radio` for the row
+    /// variants, `.checkmark` for the tile variants).
+    private var indicatorOverride: SelectionIndicator?
+    private var columnsValue = 2
+    /// Per-option replacement (`(option, isSelected)`); nil = built-in anatomy.
+    private var optionSlot: ((PaymentMethodOption, Bool) -> AnyView)?
+    private var badgeStyleValue: BadgeStyle = .info
+    private var tileRadiusRole: Theme.RadiusRole = .field
+    private var emphasisValue: TileEmphasis = .subtle
 
     /// R1 — options + controlled selection (option id). The binding is the
     /// change channel; observe with `.onChange(of:)` at the call site.
@@ -71,11 +92,24 @@ public struct PaymentMethodSelector: View {
     }
     private var accentBase: Color { (accent ?? .primary).base }
 
+    /// The variant's effective indicator: the explicit override, or `.radio`
+    /// for row variants / `.checkmark` for tile variants.
+    private var effectiveIndicator: SelectionIndicator {
+        if let indicatorOverride { return indicatorOverride }
+        switch variantValue {
+        case .list, .compactList: return .radio
+        case .grid, .carousel: return .checkmark
+        }
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+            if let headerSlot { headerSlot }
             switch variantValue {
             case .list: listBody
             case .grid: gridBody
+            case .carousel: carouselBody
+            case .compactList: compactListBody
             }
             if let footerSlot { footerSlot }
         }
@@ -103,13 +137,25 @@ public struct PaymentMethodSelector: View {
     }
 
     @MainActor
+    @ViewBuilder
     private func row(_ option: PaymentMethodOption) -> some View {
         let isOn = selection == option.id
-        return ListRow(option.title) { select(option.id) }
+        if let optionSlot {
+            slotButton(option, isOn: isOn) { optionSlot(option, isOn) }
+        } else {
+            builtInRow(option, isOn: isOn)
+        }
+    }
+
+    @MainActor
+    private func builtInRow(_ option: PaymentMethodOption, isOn: Bool) -> some View {
+        var listRow = ListRow(option.title) { select(option.id) }
             .subtitle(option.subtitle)
             .leading {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
-                    RadioButton(isSelected: isSelectedBinding(option.id)).accent(accent)
+                    if effectiveIndicator == .radio {
+                        RadioButton(isSelected: isSelectedBinding(option.id)).accent(accent)
+                    }
                     Icon(systemName: option.systemImage)
                         .size(.sm)
                         .color(isOn ? accentBase : theme.text(.textSecondary))
@@ -117,10 +163,111 @@ public struct PaymentMethodSelector: View {
             }
             .badge(badges[option.id])
             .selected(isOn)
-            .trailing(ListRowTrailing.none)
+        if effectiveIndicator == .checkmark, isOn {
+            listRow = listRow.trailing {
+                Icon(systemName: "checkmark").size(.sm).color(accentBase)
+            }
+        } else {
+            listRow = listRow.trailing(ListRowTrailing.none)
+        }
+        return listRow
             .disabled(disabledIDs.contains(option.id))
             .accessibilityElement(children: .combine)
             .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+
+    /// Wraps `.optionContent` slot output in the selection button, preserving
+    /// tap handling, disabling and VoiceOver traits around caller content.
+    @MainActor
+    private func slotButton<Content: View>(
+        _ option: PaymentMethodOption, isOn: Bool, @ViewBuilder content: () -> Content
+    ) -> some View {
+        Button { select(option.id) } label: {
+            content().contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(disabledIDs.contains(option.id))
+        .allowsHitTesting(!isReadOnly)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+
+    // MARK: Compact-list variant — dense single-line rows
+
+    @MainActor
+    private var compactListBody: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(options.enumerated()), id: \.element.id) { index, option in
+                compactRow(option)
+                if showsInstallments(under: option) {
+                    inlineInstallments
+                        .padding(.bottom, Theme.SpacingKey.sm.value)
+                }
+                if index < options.count - 1 {
+                    DividerView().size(.small)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    @ViewBuilder
+    private func compactRow(_ option: PaymentMethodOption) -> some View {
+        let isOn = selection == option.id
+        let isDisabled = disabledIDs.contains(option.id)
+        slotButton(option, isOn: isOn) {
+            if let optionSlot {
+                optionSlot(option, isOn)
+            } else {
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    if effectiveIndicator == .radio {
+                        RadioButton(isSelected: isSelectedBinding(option.id)).accent(accent)
+                    }
+                    Icon(systemName: option.systemImage)
+                        .size(.sm)
+                        .color(isDisabled ? theme.text(.textDisabled) : (isOn ? accentBase : theme.text(.textSecondary)))
+                    Text(option.title)
+                        .textStyle(.labelBase600)
+                        .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
+                        .lineLimit(1)
+                    Spacer(minLength: Theme.SpacingKey.xs.value)
+                    if let badgeText = badges[option.id] {
+                        Badge(badgeText).badgeStyle(badgeStyleValue).variant(.soft).size(.small)
+                    }
+                    if effectiveIndicator == .checkmark, isOn {
+                        Icon(systemName: "checkmark").size(.sm).color(accentBase)
+                    }
+                }
+                .padding(.vertical, Theme.SpacingKey.xs.value)
+            }
+        }
+    }
+
+    // MARK: Carousel variant — horizontal snap tiles
+
+    @MainActor
+    @ViewBuilder
+    private var carouselBody: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                ForEach(options) { option in
+                    tile(option)
+                        .frame(width: Metrics.carouselTileWidth)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.viewAligned)
+        .scrollClipDisabled()
+        if options.contains(where: { showsInstallments(under: $0) }) {
+            inlineInstallments
+        }
+    }
+
+    /// Genuine dimensions with no semantic token — fixed tile constants.
+    private enum Metrics {
+        static let carouselTileWidth: CGFloat = 148
+        static let tileMinHeight: CGFloat = 88
     }
 
     // MARK: Grid variant — selection tiles (vertical fallback at a11y sizes)
@@ -133,7 +280,7 @@ public struct PaymentMethodSelector: View {
             VStack(spacing: gap) { ForEach(options) { tile($0) } }
         } else {
             LazyVGrid(
-                columns: [GridItem(.flexible(), spacing: gap), GridItem(.flexible(), spacing: gap)],
+                columns: Array(repeating: GridItem(.flexible(), spacing: gap), count: columnsValue),
                 spacing: gap
             ) {
                 ForEach(options) { tile($0) }
@@ -144,44 +291,64 @@ public struct PaymentMethodSelector: View {
         }
     }
 
+    /// Selected-stroke color/width from the emphasis axis — named semantic
+    /// steps only (`base` / `strong`).
+    private var selectedStroke: (color: Color, width: CGFloat) {
+        switch emphasisValue {
+        case .subtle: return (accentBase, 1.5)
+        case .strong: return ((accent ?? .primary).strong, 2)
+        }
+    }
+
     @MainActor
+    @ViewBuilder
     private func tile(_ option: PaymentMethodOption) -> some View {
         let isOn = selection == option.id
         let isDisabled = disabledIDs.contains(option.id)
-        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
-        return Button { select(option.id) } label: {
-            VStack(spacing: Theme.SpacingKey.xs.value) {
-                Icon(systemName: option.systemImage)
-                    .size(.md)
-                    .color(isDisabled ? theme.text(.textDisabled) : (isOn ? accentBase : theme.text(.textSecondary)))
-                Text(option.title)
-                    .textStyle(.labelSm600)
-                    .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
-                    .multilineTextAlignment(.center)
-                if let subtitle = option.subtitle {
-                    Text(subtitle)
-                        .textStyle(.bodySm400)
-                        .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textSecondary))
-                        .multilineTextAlignment(.center)
+        let shape = RoundedRectangle(cornerRadius: tileRadiusRole.value, style: .continuous)
+        slotButton(option, isOn: isOn) {
+            Group {
+                if let optionSlot {
+                    optionSlot(option, isOn)
+                } else {
+                    builtInTileLabel(option, isOn: isOn, isDisabled: isDisabled)
                 }
             }
-            .frame(maxWidth: .infinity, minHeight: 88)
+            .frame(maxWidth: .infinity, minHeight: Metrics.tileMinHeight)
             .padding(Theme.SpacingKey.md.value)
             .background(isOn ? (accent ?? .primary).bg : theme.background(surfaceKey), in: shape)
-            .overlay(shape.stroke(isOn ? accentBase : theme.border(.borderPrimary), lineWidth: isOn ? 1.5 : 1))
+            .overlay(shape.stroke(isOn ? selectedStroke.color : theme.border(.borderPrimary),
+                                  lineWidth: isOn ? selectedStroke.width : 1))
             .overlay(alignment: .topTrailing) {
                 if let badgeText = badges[option.id] {
-                    Badge(badgeText).badgeStyle(.info).variant(.soft).size(.small)
+                    Badge(badgeText).badgeStyle(badgeStyleValue).variant(.soft).size(.small)
                         .padding(Theme.SpacingKey.xs.value)
                 }
             }
             .contentShape(shape)
         }
-        .buttonStyle(.plain)
-        .disabled(isDisabled)
-        .allowsHitTesting(!isReadOnly)
-        .accessibilityElement(children: .combine)
-        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+
+    @MainActor
+    private func builtInTileLabel(_ option: PaymentMethodOption, isOn: Bool, isDisabled: Bool) -> some View {
+        VStack(spacing: Theme.SpacingKey.xs.value) {
+            Icon(systemName: option.systemImage)
+                .size(.md)
+                .color(isDisabled ? theme.text(.textDisabled) : (isOn ? accentBase : theme.text(.textSecondary)))
+            Text(option.title)
+                .textStyle(.labelSm600)
+                .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
+                .multilineTextAlignment(.center)
+            if let subtitle = option.subtitle {
+                Text(subtitle)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textSecondary))
+                    .multilineTextAlignment(.center)
+            }
+            if effectiveIndicator == .checkmark, isOn {
+                Icon(systemName: "checkmark.circle.fill").size(.sm).color(accentBase)
+            }
+        }
     }
 
     // MARK: Installments (composes the existing InstallmentPicker)
@@ -239,8 +406,44 @@ public struct PaymentMethodSelector: View {
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension PaymentMethodSelector {
-    /// Layout archetype: `.list` radio rows (default) or `.grid` tiles.
+    /// Layout archetype: `.list` radio rows (default), `.grid` tiles,
+    /// `.carousel` horizontal snap tiles, or `.compactList` single-line rows.
     func variant(_ v: PaymentMethodVariant) -> Self { copy { $0.variantValue = v } }
+
+    /// Selected glyph: `.radio` (row variants' default), `.checkmark`
+    /// (tile variants' default), or `.none` — the selected chrome alone
+    /// signals the choice. Tile variants ignore `.radio` (no glyph).
+    func indicator(_ i: SelectionIndicator) -> Self { copy { $0.indicatorOverride = i } }
+
+    /// Grid column count, clamped 1…4 (default 2). The accessibility-size
+    /// vertical fallback is unaffected.
+    func columns(_ n: Int) -> Self { copy { $0.columnsValue = min(4, max(1, n)) } }
+
+    /// Replaces the built-in row/tile anatomy with caller content, built per
+    /// `(option, isSelected)` in every variant. Selection tap handling,
+    /// disabling and VoiceOver traits are preserved around the slot; the tile
+    /// variants keep their selected chrome (fill/stroke/badge) around it.
+    func optionContent(@ViewBuilder _ content: @escaping (PaymentMethodOption, Bool) -> some View) -> Self {
+        copy { $0.optionSlot = { AnyView(content($0, $1)) } }
+    }
+
+    /// Style of the per-option badges (default `.info`) — applies wherever
+    /// this component draws the `Badge` itself (tiles, carousel, compact
+    /// rows); the `.list` variant's badge is drawn by `ListRow`.
+    func badgeStyle(_ s: BadgeStyle) -> Self { copy { $0.badgeStyleValue = s } }
+
+    /// Corner role for the tile variants (default `.field`).
+    func radius(_ role: Theme.RadiusRole) -> Self { copy { $0.tileRadiusRole = role } }
+
+    /// Selected-tile stroke strength: `.subtle` (default, base step) or
+    /// `.strong` (the 700 "strong" step at 2pt).
+    func emphasis(_ e: TileEmphasis) -> Self { copy { $0.emphasisValue = e } }
+
+    /// Top-aligned accessory area (canonical `.header { }` slot), mirroring
+    /// the existing `.footer` — e.g. a section title or a promo note.
+    func header<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.headerSlot = AnyView(content()) }
+    }
 
     /// Instalment plans shown inline under the selected `.card` option.
     /// `total` is required (§1.4 rev. 5) — per-month amounts derive from it
@@ -313,6 +516,60 @@ public extension PaymentMethodSelector {
                     ], initiallySelected: "transfer")
                         .accent(.success)
                         .readOnly()
+                }
+                .padding()
+            }
+        }
+    }
+    return Demo()
+}
+
+#Preview("Carousel · compact list · slots · emphasis") {
+    struct Demo: View {
+        @State private var method: String? = "card"
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                    ListSectionHeader("Carousel · strong emphasis · box radius")
+                    PaymentMethodSelector([
+                        .init(id: "card", kind: .card, title: "Card"),
+                        .init(id: "wallet", kind: .wallet, title: "Wallet"),
+                        .init(id: "transfer", kind: .transfer, title: "Transfer"),
+                        .init(id: "card2", kind: .card, title: "Corporate"),
+                    ], selection: $method)
+                        .variant(.carousel)
+                        .emphasis(.strong)
+                        .radius(.box)
+                        .badge("New", for: "wallet")
+                        .badgeStyle(.success)
+                        .header {
+                            Text("How would you like to pay?").textStyle(.headingSm)
+                        }
+
+                    ListSectionHeader("Compact list · checkmark indicator")
+                    PaymentMethodSelector([
+                        .init(id: "card", kind: .card, title: "Credit / debit card"),
+                        .init(id: "wallet", kind: .wallet, title: "Digital wallet"),
+                        .init(id: "transfer", kind: .transfer, title: "Bank transfer"),
+                    ], selection: $method)
+                        .variant(.compactList)
+                        .indicator(.checkmark)
+
+                    ListSectionHeader("Grid · 3 columns · custom option slot")
+                    PaymentMethodSelector([
+                        .init(id: "card", kind: .card, title: "Card"),
+                        .init(id: "wallet", kind: .wallet, title: "Wallet"),
+                        .init(id: "transfer", kind: .transfer, title: "Transfer"),
+                    ], selection: $method)
+                        .variant(.grid)
+                        .columns(3)
+                        .indicator(.none)
+                        .optionContent { option, isSelected in
+                            VStack(spacing: Theme.SpacingKey.xs.value) {
+                                Icon(systemName: option.systemImage).size(.lg)
+                                Text(option.title).textStyle(isSelected ? .labelSm700 : .labelSm600)
+                            }
+                        }
                 }
                 .padding()
             }

--- a/Sources/ThemeKitTravel/Components/Organisms/SavedCardsList.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SavedCardsList.swift
@@ -24,6 +24,14 @@
 import SwiftUI
 import ThemeKit
 
+/// Layout archetype of a ``SavedCardsList``: radio rows (`.list`, default) or
+/// a horizontal carousel of card-face tiles (`.wallet`).
+public enum SavedCardsVariant: Sendable { case list, wallet }
+
+/// How the delete affordance surfaces: a trailing button (`.button`), a
+/// destructive context-menu entry (`.contextMenu`), or both (default).
+public enum DeleteAffordance: Sendable { case button, contextMenu, both }
+
 /// A stored-cards chooser — radio-semantic rows over ``SavedCard`` values with
 /// optional delete and add-new affordances. Pairs with `PaymentMethodSelector`:
 /// apps typically render it when the `card` method is chosen.
@@ -46,6 +54,19 @@ public struct SavedCardsList: View {
     private var flagsExpiredValue = true
     private var accent: SemanticColor?
     private var emptyContentSlot: AnyView?
+    private var variantValue: SavedCardsVariant = .list
+    /// Per-brand glyph replacement; nil = the stock `CardBrand.icon` symbol.
+    private var brandLogoSlot: ((CardBrand) -> AnyView)?
+    /// `false` once the caller passed an explicit `nil` text — badge hidden,
+    /// auto-disable retained.
+    private var showsExpiredBadge = true
+    private var expiredBadgeText: String?
+    private var expiredBadgeStyle: BadgeStyle = .error
+    private var showsDividersValue = true
+    private var surfaceKeyOverride: Theme.BackgroundColorKey?
+    private var deleteStyleValue: DeleteAffordance = .both
+    /// Per-card row replacement (`(card, isSelected)`); nil = built-in anatomy.
+    private var rowContentSlot: ((SavedCard, Bool) -> AnyView)?
 
     /// R1 — cards + controlled selection (card id). The binding is the change
     /// channel; observe with `.onChange(of:)` at the call site.
@@ -66,12 +87,23 @@ public struct SavedCardsList: View {
     }
     private var accentBase: Color { (accent ?? .primary).base }
 
+    /// The delete affordances that actually render, per `deleteStyle(_:)`.
+    private var showsDeleteButton: Bool {
+        onDeleteAction != nil && (deleteStyleValue == .button || deleteStyleValue == .both)
+    }
+    private var showsDeleteMenu: Bool {
+        onDeleteAction != nil && (deleteStyleValue == .contextMenu || deleteStyleValue == .both)
+    }
+
     public var body: some View {
         Group {
             if cards.isEmpty {
                 emptyBody
             } else {
-                listBody
+                switch variantValue {
+                case .list: listBody
+                case .wallet: walletBody
+                }
             }
         }
         .animation(motion, value: selection)
@@ -82,43 +114,78 @@ public struct SavedCardsList: View {
     // MARK: List — ListRow anatomy with radio semantics
 
     @MainActor
+    @ViewBuilder
     private var listBody: some View {
-        VStack(spacing: 0) {
+        let stack = VStack(spacing: 0) {
             ForEach(cards) { card in
                 row(card)
-                if card.id != cards.last?.id || showsAddNewRow {
+                if showsDividersValue, card.id != cards.last?.id || showsAddNewRow {
                     DividerView().size(.small)
                 }
             }
             if showsAddNewRow { addNewRow }
         }
+        if let surfaceKeyOverride {
+            stack.background(theme.background(surfaceKeyOverride))
+        } else {
+            stack
+        }
     }
 
     @MainActor
+    @ViewBuilder
     private func row(_ card: SavedCard) -> some View {
         let isOn = selection == card.id
         let isExpiredRow = flagsExpiredValue && card.isExpired(calendar: calendar)
+        Group {
+            if let rowContentSlot {
+                // `.rowContent` slot: caller anatomy inside the selection
+                // button; auto-disable, context menu and VoiceOver preserved.
+                Button { select(card.id) } label: {
+                    rowContentSlot(card, isOn).contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .allowsHitTesting(!isReadOnly)
+            } else {
+                builtInRow(card, isOn: isOn, isExpiredRow: isExpiredRow)
+            }
+        }
+        .disabled(isExpiredRow)
+        .contextMenu { deleteMenu(for: card) }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel(for: card, isExpired: isExpiredRow))
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+
+    @MainActor
+    private func builtInRow(_ card: SavedCard, isOn: Bool, isExpiredRow: Bool) -> some View {
         var listRow = ListRow(maskedTitle(for: card)) { select(card.id) }
             .subtitle(subtitle(for: card))
             .leading {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
                     RadioButton(isSelected: isSelectedBinding(card.id)).accent(accent)
-                    Icon(systemName: card.brand.icon)
-                        .size(.sm)
-                        .color(isOn ? accentBase : theme.text(.textSecondary))
+                    brandGlyph(card.brand, isOn: isOn)
                 }
             }
             .selected(isOn)
             .trailing(ListRowTrailing.none)
-        if isExpiredRow || onDeleteAction != nil {
+        if (isExpiredRow && showsExpiredBadge) || showsDeleteButton {
             listRow = listRow.trailing { trailingAccessories(for: card, isExpired: isExpiredRow) }
         }
         return listRow
-            .disabled(isExpiredRow)
-            .contextMenu { deleteMenu(for: card) }
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(accessibilityLabel(for: card, isExpired: isExpiredRow))
-            .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+
+    /// The brand mark: the caller's `.brandLogo` slot or the stock symbol.
+    @MainActor
+    @ViewBuilder
+    private func brandGlyph(_ brand: CardBrand, isOn: Bool) -> some View {
+        if let brandLogoSlot {
+            brandLogoSlot(brand)
+        } else {
+            Icon(systemName: brand.icon)
+                .size(.sm)
+                .color(isOn ? accentBase : theme.text(.textSecondary))
+        }
     }
 
     /// Expired badge and/or the explicit delete affordance, trailing-aligned.
@@ -126,11 +193,11 @@ public struct SavedCardsList: View {
     @ViewBuilder
     private func trailingAccessories(for card: SavedCard, isExpired: Bool) -> some View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
-            if isExpired {
-                Badge(String(themeKitTravel: "Expired"))
-                    .badgeStyle(.error).variant(.soft).size(.small)
+            if isExpired, showsExpiredBadge {
+                Badge(expiredBadgeText ?? String(themeKitTravel: "Expired"))
+                    .badgeStyle(expiredBadgeStyle).variant(.soft).size(.small)
             }
-            if onDeleteAction != nil {
+            if showsDeleteButton {
                 Button { delete(card) } label: {
                     Icon(systemName: "trash")
                         .size(.sm)
@@ -148,11 +215,112 @@ public struct SavedCardsList: View {
     @MainActor
     @ViewBuilder
     private func deleteMenu(for card: SavedCard) -> some View {
-        if onDeleteAction != nil, !isReadOnly {
+        if showsDeleteMenu, !isReadOnly {
             Button(role: .destructive) { delete(card) } label: {
                 Label(String(themeKitTravel: "Remove card"), systemImage: "trash")
             }
         }
+    }
+
+    // MARK: Wallet — horizontal carousel of card-face tiles
+
+    /// Genuine dimensions with no semantic token — fixed card-face constants
+    /// (the ~1.586 bank-card aspect, sized for a phone-width carousel).
+    private enum WalletMetrics {
+        static let tileWidth: CGFloat = 200
+        static let tileHeight: CGFloat = 126
+    }
+
+    @MainActor
+    private var walletBody: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                ForEach(cards) { walletTile($0) }
+                if let onAddNewAction { addNewTile(onAddNewAction) }
+            }
+            .padding(.vertical, Theme.SpacingKey.xs.value)   // room for the lift shadow
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.viewAligned)
+        .scrollClipDisabled()
+    }
+
+    @MainActor
+    private func walletTile(_ card: SavedCard) -> some View {
+        let isOn = selection == card.id
+        let isExpiredRow = flagsExpiredValue && card.isExpired(calendar: calendar)
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+        return Button { select(card.id) } label: {
+            Group {
+                if let rowContentSlot {
+                    rowContentSlot(card, isOn)
+                } else {
+                    walletFace(card, isOn: isOn, isExpired: isExpiredRow)
+                }
+            }
+            .frame(width: WalletMetrics.tileWidth, height: WalletMetrics.tileHeight)
+            .background(theme.background(surfaceKeyOverride ?? .bgWhite), in: shape)
+            // Selection = lift + accent stroke (the checklist's wallet look).
+            .overlay(shape.strokeBorder(isOn ? accentBase : theme.border(.borderPrimary),
+                                        lineWidth: isOn ? 2 : 1))
+            .themeShadow(isOn ? .elevated : .soft)
+            .contentShape(shape)
+        }
+        .buttonStyle(.plain)
+        .disabled(isExpiredRow)
+        .allowsHitTesting(!isReadOnly)
+        .contextMenu { deleteMenu(for: card) }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel(for: card, isExpired: isExpiredRow))
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+
+    @MainActor
+    private func walletFace(_ card: SavedCard, isOn: Bool, isExpired: Bool) -> some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
+            HStack {
+                brandGlyph(card.brand, isOn: isOn)
+                Spacer(minLength: Theme.SpacingKey.xs.value)
+                if isExpired, showsExpiredBadge {
+                    Badge(expiredBadgeText ?? String(themeKitTravel: "Expired"))
+                        .badgeStyle(expiredBadgeStyle).variant(.soft).size(.small)
+                }
+            }
+            Spacer(minLength: 0)
+            Text("•••• \(card.last4)")
+                .textStyle(.labelLg600)
+                .foregroundStyle(isExpired ? theme.text(.textDisabled) : theme.text(.textPrimary))
+            if let line = subtitle(for: card) {
+                Text(line)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(theme.text(.textTertiary))
+                    .lineLimit(1)
+            }
+        }
+        .padding(Theme.SpacingKey.md.value)
+    }
+
+    @MainActor
+    private func addNewTile(_ action: @escaping () -> Void) -> some View {
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+        return Button {
+            guard !isReadOnly else { return }
+            action()
+        } label: {
+            VStack(spacing: Theme.SpacingKey.xs.value) {
+                Icon(systemName: "plus.circle.fill").size(.md).color(accentBase)
+                Text(addNewTitle ?? String(themeKitTravel: "Add new card"))
+                    .textStyle(.labelSm600)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+            .frame(width: WalletMetrics.tileWidth, height: WalletMetrics.tileHeight)
+            .background(theme.background(surfaceKeyOverride ?? .bgWhite), in: shape)
+            .overlay(shape.strokeBorder(theme.border(.borderPrimary),
+                                        style: StrokeStyle(lineWidth: 1, dash: [5, 4])))
+            .contentShape(shape)
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(.isButton)
     }
 
     // MARK: Add-new affordance
@@ -310,6 +478,46 @@ public extension SavedCardsList {
         copy { $0.emptyContentSlot = AnyView(content()) }
     }
 
+    /// Layout archetype: `.list` radio rows (default) or `.wallet` — a
+    /// horizontal carousel of card-face tiles with lift + stroke selection.
+    func variant(_ v: SavedCardsVariant) -> Self { copy { $0.variantValue = v } }
+
+    /// Replaces the stock brand symbol with caller content, built per
+    /// ``CardBrand`` — e.g. real brand artwork. Applies to both variants.
+    func brandLogo(@ViewBuilder _ content: @escaping (CardBrand) -> some View) -> Self {
+        copy { $0.brandLogoSlot = { AnyView(content($0)) } }
+    }
+
+    /// Overrides the expired flag's badge. Pass a custom `text` and/or a
+    /// `style` (default `.error`); pass `nil` text to hide the badge entirely
+    /// — expired cards still auto-disable while ``flagsExpired(_:)`` is on.
+    func expiredBadge(_ text: String?, style: BadgeStyle = .error) -> Self {
+        copy {
+            $0.showsExpiredBadge = text != nil
+            $0.expiredBadgeText = text
+            $0.expiredBadgeStyle = style
+        }
+    }
+
+    /// Show the hairline dividers between list rows (default on).
+    func showsDividers(_ on: Bool = true) -> Self { copy { $0.showsDividersValue = on } }
+
+    /// Surface token: the list's backing fill, or the wallet tiles' card-face
+    /// fill (wallet default `.bgWhite`).
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKeyOverride = key } }
+
+    /// Which delete affordances render once ``onDelete(_:)`` is wired:
+    /// `.button` (trailing trash), `.contextMenu`, or `.both` (default).
+    /// The wallet variant is context-menu only — `.button` there shows none.
+    func deleteStyle(_ s: DeleteAffordance) -> Self { copy { $0.deleteStyleValue = s } }
+
+    /// Replaces the built-in row/tile anatomy with caller content, built per
+    /// `(card, isSelected)`. Selection tap handling, expired auto-disable,
+    /// the delete context menu and VoiceOver labels are preserved around it.
+    func rowContent(@ViewBuilder _ content: @escaping (SavedCard, Bool) -> some View) -> Self {
+        copy { $0.rowContentSlot = { AnyView(content($0, $1)) } }
+    }
+
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
         mutate(&c)
@@ -351,6 +559,68 @@ public extension SavedCardsList {
                                   holder: "Alex Morgan", expiryMonth: 3, expiryYear: 2020),
                     ], initiallySelected: "old")
                         .flagsExpired(false)
+                }
+                .padding()
+            }
+        }
+    }
+    return Demo()
+}
+
+#Preview("Wallet · slots · delete styles · dividers off") {
+    struct Demo: View {
+        @State private var cardID: String? = "visa"
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                    ListSectionHeader("Wallet carousel (lift + stroke selection)")
+                    SavedCardsList([
+                        SavedCard(id: "visa", brand: .visa, last4: "4242",
+                                  holder: "Alex Morgan", expiryMonth: 8, expiryYear: 2032),
+                        SavedCard(id: "mc", brand: .mastercard, last4: "4444",
+                                  holder: "Alex Morgan", expiryMonth: 1, expiryYear: 2031),
+                        SavedCard(id: "old", brand: .amex, last4: "0005",
+                                  expiryMonth: 3, expiryYear: 2020),
+                    ], selection: $cardID)
+                        .variant(.wallet)
+                        .onDelete { _ in }
+                        .onAddNew { }
+
+                    ListSectionHeader("Brand-logo slot · custom expired badge · no dividers")
+                    SavedCardsList([
+                        SavedCard(id: "visa", brand: .visa, last4: "4242",
+                                  expiryMonth: 8, expiryYear: 2032),
+                        SavedCard(id: "old", brand: .mastercard, last4: "9999",
+                                  expiryMonth: 3, expiryYear: 2020),
+                    ], selection: $cardID)
+                        .brandLogo { brand in
+                            Badge(brand.label.isEmpty ? "Card" : brand.label)
+                                .badgeStyle(.info).size(.small)
+                        }
+                        .expiredBadge("Out of date", style: .warning)
+                        .showsDividers(false)
+                        .surface(.bgSecondaryLight)
+                        .onDelete { _ in }
+                        .deleteStyle(.contextMenu)
+
+                    ListSectionHeader("Row-content slot · hidden expired badge")
+                    SavedCardsList([
+                        SavedCard(id: "visa", brand: .visa, last4: "4242",
+                                  holder: "Alex Morgan", expiryMonth: 8, expiryYear: 2032),
+                        SavedCard(id: "old", brand: .amex, last4: "0005",
+                                  expiryMonth: 3, expiryYear: 2020),
+                    ], selection: $cardID)
+                        .expiredBadge(nil)
+                        .rowContent { card, isSelected in
+                            HStack(spacing: Theme.SpacingKey.sm.value) {
+                                Icon(systemName: isSelected ? "checkmark.circle.fill" : "creditcard")
+                                    .size(.sm)
+                                Text("\(card.brand.label) \u{2022}\u{2022}\u{2022}\u{2022} \(card.last4)")
+                                    .textStyle(.labelBase600)
+                                Spacer()
+                            }
+                            .padding(.vertical, Theme.SpacingKey.sm.value)
+                        }
                 }
                 .padding()
             }

--- a/Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift
@@ -17,6 +17,16 @@
 import SwiftUI
 import ThemeKit
 
+/// Where a ``SeatMap`` renders its legend relative to the cabin.
+public enum LegendPlacement: Sendable {
+    /// Above the cabin (below the passenger rail / deck selector).
+    case top
+    /// Below the cabin — the default.
+    case bottom
+    /// Never — suppresses a `legend()` set further up a modifier chain.
+    case hidden
+}
+
 /// A generic, token-bound seat map.
 ///
 /// ```swift
@@ -59,6 +69,13 @@ public struct SeatMap: View {
     private var aisleWidthOverride: CGFloat?
     private var tierOverrides: [SeatTier: Color] = [:]
     private var accentOverride: SemanticColor?
+    private var seatShape: SeatShape = .rounded
+    private var legendPlacement: LegendPlacement = .bottom
+    private var fuselageSurfaceKey: Theme.BackgroundColorKey = .bgSecondaryLight
+    private var deckLabelProvider: ((Int) -> String)?
+    private var zoomBinding: Binding<CGFloat>?
+    private var sectionHeaderSlot: ((String) -> AnyView)?
+    private var summarySlot: ((SeatSummary) -> AnyView)?
 
     private let gutter: CGFloat = 22
     private var passengerMode: Bool { !passengers.isEmpty && assignment != nil }
@@ -96,16 +113,36 @@ public struct SeatMap: View {
                 PassengerRail(passengers: passengers, assignment: assignment ?? .constant([:]), active: $activePassenger, accent: accentOverride)
             }
             if index.floors.count > 1 {
-                DeckSelector(floors: index.floors, active: $activeFloor, accent: accentOverride)
+                DeckSelector(floors: index.floors, active: $activeFloor, accent: accentOverride,
+                             label: deckLabelProvider ?? { (floor: Int) in String(themeKit: "Deck \(floor)") })
             }
-            cabin.modifier(PinchZoom(enabled: zoomable, zoom: $zoom))
-            if showsLegend { SeatLegend(tiers: index.tiers, palette: palette) }
-            if showsInfo {
-                SeatSummaryBar(seat: focusedSeat.flatMap { index.byId[$0] },
-                               position: focusedSeat.flatMap { index.positions[$0] },
-                               palette: palette, selectedCount: selection.count,
-                               totalPrice: totalPrice, hasPrices: index.hasPrices, currencyCode: resolvedCurrency)
-            }
+            if legendVisible, legendPlacement == .top { legendView }
+            cabin.modifier(PinchZoom(enabled: zoomable, zoom: zoomBinding ?? $zoom))
+            if legendVisible, legendPlacement == .bottom { legendView }
+            if showsInfo || summarySlot != nil { summaryView }
+        }
+    }
+
+    private var legendVisible: Bool { showsLegend && legendPlacement != .hidden }
+
+    /// The legend inherits the map's palette and seat shape so the key matches.
+    private var legendView: some View {
+        SeatLegend(tiers: index.tiers, palette: palette).swatchShape(seatShape)
+    }
+
+    /// The `summaryBar { … }` slot when provided, else the built-in bar.
+    @ViewBuilder private var summaryView: some View {
+        let focused = focusedSeat.flatMap { index.byId[$0] }
+        let position = focusedSeat.flatMap { index.positions[$0] }
+        if let summarySlot {
+            summarySlot(SeatSummary(focusedSeat: focused,
+                                    isWindow: position?.window, isAisle: position?.aisle,
+                                    selectedCount: selection.count, totalPrice: totalPrice,
+                                    hasPrices: index.hasPrices, currencyCode: resolvedCurrency))
+        } else {
+            SeatSummaryBar(seat: focused, position: position,
+                           palette: palette, selectedCount: selection.count,
+                           totalPrice: totalPrice, hasPrices: index.hasPrices, currencyCode: resolvedCurrency)
         }
     }
 
@@ -117,16 +154,18 @@ public struct SeatMap: View {
         VStack(alignment: .leading, spacing: density.scale(Theme.SpacingKey.xs.value)) {
             if showsLabels { columnHeader }
             ForEach(Array(visibleSections.enumerated()), id: \.offset) { _, section in
-                if let title = section.title { sectionHeader(title) }
+                if let title = section.title {
+                    if let sectionHeaderSlot { sectionHeaderSlot(title) } else { defaultSectionHeader(title) }
+                }
                 sectionRows(section)
             }
         }
         .dynamicTypeClamp()
         .padding(showsFuselage ? EdgeInsets(top: 46, leading: 18, bottom: 26, trailing: 18) : EdgeInsets())
-        .background { if showsFuselage { FuselageView() } }
+        .background { if showsFuselage { FuselageView(surfaceKey: fuselageSurfaceKey) } }
     }
 
-    private func sectionHeader(_ title: String) -> some View {
+    private func defaultSectionHeader(_ title: String) -> some View {
         HStack(spacing: Theme.SpacingKey.xs.value) {
             Text(title.uppercased()).textStyle(.overline500).foregroundStyle(theme.text(.textTertiary))
             Rectangle().fill(theme.border(.borderPrimary)).frame(height: 1)
@@ -178,7 +217,7 @@ public struct SeatMap: View {
         return SeatCell(seat, size: seatSize, isSelected: selected, isSelectable: isSelectable(seat),
                         isRecommended: recommended.contains(seat.id), assignedInitials: assigned,
                         display: seatDisplay, palette: palette, customContent: customContent,
-                        currencyCode: resolvedCurrency, action: {
+                        currencyCode: resolvedCurrency, shape: seatShape, action: {
             focusedSeat = seat.id
             withAnimation(Animation.snappy.ifMotionAllowed(reduceMotion)) {
                 if passengerMode { assignSeat(seat) } else { toggle(seat) }
@@ -305,6 +344,39 @@ public extension SeatMap {
     @available(*, deprecated, message: "Use tierColors(_: [SeatTier: SemanticColor]) — the token-bound overload.")
     func tierColors(_ overrides: [SeatTier: Color]) -> Self { copy { $0.tierOverrides = overrides } }
 
+    /// Token-stepped seat size (compact 36 · regular 44 · large 52 · xl 60).
+    /// Unlike the raw overload, `.compact` deliberately drops below the 44 pt
+    /// touch minimum — reserve it for read-only overview grids.
+    func seatSize(_ ramp: SeatSizeRamp) -> Self { copy { $0.seatSize = ramp.points } }
+    /// Token-fed aisle width — the gap cells take the spacing token's value.
+    func aisleWidth(_ key: Theme.SpacingKey) -> Self { copy { $0.aisleWidthOverride = key.value } }
+    /// The silhouette every seat is drawn with (`.rounded` default · `.circle` ·
+    /// `.seatback`). Forwarded to the legend so its swatches match.
+    func seatShape(_ shape: SeatShape) -> Self { copy { $0.seatShape = shape } }
+    /// Replaces the built-in cabin-section header — receives the section title.
+    func sectionHeader(@ViewBuilder _ content: @escaping (String) -> some View) -> Self {
+        copy { $0.sectionHeaderSlot = { AnyView(content($0)) } }
+    }
+    /// Replaces the built-in seat-summary bar — receives a live ``SeatSummary``
+    /// (focused seat, selection count, running total). Providing the slot shows
+    /// the bar even without `showsSeatInfo()`.
+    func summaryBar(@ViewBuilder _ content: @escaping (SeatSummary) -> some View) -> Self {
+        copy { $0.summarySlot = { AnyView(content($0)) } }
+    }
+    /// Where the legend renders relative to the cabin: `.top` · `.bottom`
+    /// (default) · `.hidden` (suppresses a `legend()` set upstream).
+    func legendPlacement(_ placement: LegendPlacement) -> Self { copy { $0.legendPlacement = placement } }
+    /// Surface fill of the fuselage frame (default `.bgSecondaryLight`).
+    func fuselageSurface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.fuselageSurfaceKey = key } }
+    /// Custom deck-pill titles for multi-deck cabins, e.g. `{ $0 == 1 ? "Main" : "Upper" }`.
+    func deckLabel(_ label: @escaping (Int) -> String) -> Self { copy { $0.deckLabelProvider = label } }
+    /// Pinch-to-zoom with the zoom scale exposed through the caller's binding —
+    /// drive it from zoom buttons, or persist it. Pass `nil` to keep the
+    /// internal state (same as ``zoomable(_:)``).
+    func zoomable(_ on: Bool = true, zoom: Binding<CGFloat>?) -> Self {
+        copy { $0.zoomable = on; $0.zoomBinding = zoom }
+    }
+
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
         mutate(&c)
@@ -396,6 +468,8 @@ private struct DeckSelector: View {
     let floors: [Int]
     @Binding var active: Int?
     let accent: SemanticColor?
+    /// Pill title per floor — `SeatMap.deckLabel(_:)` or the localized default.
+    let label: (Int) -> String
 
     private var activeFill: Color { accent?.solid ?? theme.foreground(.fgHero) }
     private var activeContent: Color { accent?.onSolid ?? theme.text(.textSecondaryInverse) }
@@ -405,13 +479,13 @@ private struct DeckSelector: View {
             ForEach(floors, id: \.self) { floor in
                 let isActive = (active ?? floors.first) == floor
                 Button { active = floor } label: {
-                    Text(String(themeKit: "Deck \(floor)")).textStyle(.labelSm600)
+                    Text(label(floor)).textStyle(.labelSm600)
                         .foregroundStyle(isActive ? activeContent : theme.text(.textPrimary))
                         .padding(.horizontal, 14).padding(.vertical, 6)
                         .background(isActive ? activeFill : theme.background(.bgSecondaryLight), in: Capsule())
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(String(themeKit: "Deck \(floor)"))
+                .accessibilityLabel(label(floor))
                 .accessibilityAddTraits(isActive ? .isSelected : [])
             }
         }
@@ -496,11 +570,13 @@ private struct ExitBand: View {
 }
 
 /// The aircraft body used by `SeatMap.fuselage()` — a tapered nose + cockpit hint.
+/// `surfaceKey` comes from `SeatMap.fuselageSurface(_:)` (default `.bgSecondaryLight`).
 private struct FuselageView: View {
     @Environment(\.theme) private var theme
+    var surfaceKey: Theme.BackgroundColorKey = .bgSecondaryLight
     var body: some View {
         FuselageShape()
-            .fill(theme.background(.bgSecondaryLight))
+            .fill(theme.background(surfaceKey))
             .overlay(FuselageShape().stroke(theme.border(.borderPrimary), lineWidth: 1.5))
             .overlay(alignment: .top) {
                 Capsule().fill(theme.border(.borderPrimary)).frame(width: 34, height: 4).padding(.top, 14)
@@ -551,6 +627,8 @@ private struct PinchZoom: ViewModifier {
     struct Demo: View {
         @State private var picked: Set<String> = ["12C"]
         @State private var accentPicked: Set<String> = []
+        @State private var shapePicked: Set<String> = ["10C"]
+        @State private var zoomLevel: CGFloat = 1
         @State private var assignment: [String: String] = [:]
         private let sold: Set<String> = ["12B", "13E", "16A"]
         var body: some View {
@@ -565,12 +643,50 @@ private struct PinchZoom: ViewModifier {
                 .tierColors([.extraLegroom: .purple]).padding()
 
                 // Accent override — passenger rail + deck selector pick up the token.
+                // Custom deck-pill titles via `.deckLabel`.
                 SeatMap(columns: "AB CD", rows: Array(1...3), selection: $accentPicked) { _, row, _ in
                     SeatInfo(floor: row <= 2 ? 1 : 2)
                 }
                 .passengers([Passenger(id: "p1", initials: "AB"), Passenger(id: "p2", initials: "CD")],
                             assignment: $assignment)
                 .accent(.accent)
+                .deckLabel { $0 == 1 ? String(themeKit: "Main deck") : String(themeKit: "Upper deck") }
+                .padding()
+
+                // Full-flex axes: seatback silhouette, large ramp size, tight
+                // token aisle, legend on top, custom section header + summary bar.
+                SeatMap(sections: [SeatSection("Business", columns: "AB CD", rows: [1, 2]),
+                                   SeatSection("Economy", columns: "ABC DEF", rows: Array(10...12))],
+                        selection: $shapePicked)
+                    .seatShape(.seatback)
+                    .seatSize(.large)
+                    .aisleWidth(.lg)
+                    .legend().legendPlacement(.top)
+                    .fuselage().fuselageSurface(.bgBase)
+                    .sectionHeader { title in
+                        Badge(title).badgeStyle(.info).size(.small)
+                    }
+                    .summaryBar { summary in
+                        HStack {
+                            Text(summary.focusedSeat.map { String(themeKit: "Seat \($0.id)") }
+                                    ?? String(themeKit: "Pick a seat"))
+                                .textStyle(.labelBase700)
+                            Spacer()
+                            Text(String(themeKit: "\(summary.selectedCount) selected")).textStyle(.bodySm400)
+                        }
+                        .padding(Theme.SpacingKey.md.value)
+                        .background(Theme.shared.background(.bgSecondaryLight),
+                                    in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+                    }
+                    .padding()
+
+                // Controlled zoom binding — the slider drives the same scale as the pinch.
+                VStack {
+                    Slider(value: $zoomLevel, in: 1...2.5)
+                    SeatMap(columns: "AB", rows: Array(1...2), selection: $shapePicked)
+                        .seatShape(.circle)
+                        .zoomable(true, zoom: $zoomLevel)
+                }
                 .padding()
             }
         }

--- a/Sources/ThemeKitTravel/Components/Organisms/SeatMapModels.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SeatMapModels.swift
@@ -230,6 +230,104 @@ public enum SeatDisplay: Sendable {
     case initialsAndNumber
 }
 
+/// The silhouette a seat cell — and its matching legend swatch — is drawn with.
+/// Shared by ``SeatCell``, ``SeatLegend`` and ``SeatMap`` so the key always
+/// matches the map (`SeatMap.seatShape(_:)` forwards it to both).
+public enum SeatShape: Sendable, Hashable, CaseIterable {
+    /// A continuous-corner rounded square (the default).
+    case rounded
+    /// A circle.
+    case circle
+    /// A squircle with a concave backrest notch cut into its top edge — the
+    /// seat-back silhouette.
+    case seatback
+
+    /// The concrete shape, type-erased. `.rounded` takes the caller's corner
+    /// radius (``SeatCell`` passes the selector role's value; ``SeatLegend``
+    /// its smaller swatch radius); the other silhouettes ignore it.
+    func anyShape(cornerRadius: CGFloat) -> AnyShape {
+        switch self {
+        case .rounded: return AnyShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        case .circle: return AnyShape(Circle())
+        case .seatback: return AnyShape(SeatbackShape())
+        }
+    }
+}
+
+/// A squircle with a shallow concave notch cut out of its top edge — the
+/// backrest between two "shoulders". Cut by path subtraction (like the ticket
+/// notches), so fill *and* stroke both follow the notch. Symmetric, so it needs
+/// no RTL handling.
+private struct SeatbackShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let radius = min(rect.width, rect.height) * 0.28
+        let body = RoundedRectangle(cornerRadius: radius, style: .continuous).path(in: rect)
+        let notchWidth = rect.width * 0.52
+        let notchHeight = rect.height * 0.24
+        var notch = Path()
+        notch.addEllipse(in: CGRect(x: rect.midX - notchWidth / 2, y: rect.minY - notchHeight / 2,
+                                    width: notchWidth, height: notchHeight))
+        return body.subtracting(notch)
+    }
+}
+
+/// Token-stepped seat sizes — the ramp alternative to a raw point size, shared
+/// by `SeatMap.seatSize(_:)`, `SeatCell(_, size:)` and `SeatLegend.swatchSize(_:)`.
+public enum SeatSizeRamp: Sendable, Hashable, CaseIterable {
+    /// 36 pt — dense overview / mini-map grids. Below the 44 pt HIG touch
+    /// minimum, so reserve it for read-only contexts.
+    case compact
+    /// 44 pt — the HIG minimum touch target (the default seat size).
+    case regular
+    /// 52 pt.
+    case large
+    /// 60 pt — hero pickers and large-canvas layouts.
+    case xl
+
+    /// The seat square's side, in points. Internal — the public surface stays
+    /// token-typed; only the family's own views resolve the ramp.
+    var points: CGFloat {
+        switch self {
+        case .compact: return 36
+        case .regular: return 44
+        case .large: return 52
+        case .xl: return 60
+        }
+    }
+}
+
+/// A snapshot of a ``SeatMap``'s selection state, handed to a custom
+/// `summaryBar { summary in … }` slot so brands can render their own footer
+/// without re-deriving totals.
+public struct SeatSummary: Sendable {
+    /// The last-tapped seat, if any.
+    public let focusedSeat: Seat?
+    /// Whether the focused seat is a window seat (`nil` when nothing is focused).
+    public let isWindow: Bool?
+    /// Whether the focused seat is on an aisle (`nil` when nothing is focused).
+    public let isAisle: Bool?
+    /// How many seats are currently selected (or assigned, in passenger mode).
+    public let selectedCount: Int
+    /// The running total of the selected seats' prices.
+    public let totalPrice: Decimal
+    /// Whether any seat in the cabin carries a price.
+    public let hasPrices: Bool
+    /// The resolved currency code the map is formatting with.
+    public let currencyCode: String
+
+    public init(focusedSeat: Seat? = nil, isWindow: Bool? = nil, isAisle: Bool? = nil,
+                selectedCount: Int = 0, totalPrice: Decimal = 0,
+                hasPrices: Bool = false, currencyCode: String = "USD") {
+        self.focusedSeat = focusedSeat
+        self.isWindow = isWindow
+        self.isAisle = isAisle
+        self.selectedCount = selectedCount
+        self.totalPrice = totalPrice
+        self.hasPrices = hasPrices
+        self.currencyCode = currencyCode
+    }
+}
+
 /// The state handed to a custom `seatLabel { … }` builder so it can render its own UI.
 public struct SeatContext: Sendable {
     public let seat: Seat

--- a/Sources/ThemeKitTravel/Components/Organisms/StickyBookingBar.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/StickyBookingBar.swift
@@ -30,6 +30,7 @@ public struct StickyBookingBar: View {
     @Environment(\.barStyle) private var barStyle
     @Environment(\.formatDefaults) private var formatDefaults
     @Environment(\.locale) private var locale
+    @Environment(\.controlSize) private var controlSize   // R3 — native size axis
 
     private let ctaTitle: String
     private let action: () -> Void
@@ -49,6 +50,11 @@ public struct StickyBookingBar: View {
     /// keeps its own shadow; set via `showsShadow(_:)`, which wins over both.
     private var showsShadowOverride: Bool?
     private var leadingSlot: AnyView?
+    private var trailingSlot: AnyView?
+    private var secondaryTitle: String?
+    private var onSecondary: (() -> Void)?
+    private var onPriceTapAction: (() -> Void)?
+    private var isLoading = false
 
     public init(_ ctaTitle: String, action: @escaping () -> Void) {   // R1
         self.ctaTitle = ctaTitle
@@ -92,7 +98,11 @@ public struct StickyBookingBar: View {
                 priceBlock
             }
             Spacer(minLength: 8)
-            button
+            if let trailingSlot {
+                trailingSlot
+            } else {
+                ctaArea
+            }
         }
         .padding(.horizontal, density.scale(Theme.SpacingKey.md.value))
         .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
@@ -100,7 +110,22 @@ public struct StickyBookingBar: View {
     }
 
     @ViewBuilder private var priceBlock: some View {
-        if let priceBreakdown { priceBreakdown }
+        if let onPriceTapAction {
+            Button { onPriceTapAction() } label: {
+                HStack(spacing: Theme.SpacingKey.xs.value) {
+                    if let priceBreakdown { priceBreakdown }
+                    Image(systemName: "chevron.up")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(theme.text(.textSecondary))
+                        .accessibilityHidden(true)   // decorative disclosure glyph
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(themeKit: "Price details"))
+        } else if let priceBreakdown {
+            priceBreakdown
+        }
     }
     private var priceBreakdown: PriceBreakdown? {
         guard let price else { return nil }
@@ -111,13 +136,37 @@ public struct StickyBookingBar: View {
         return b
     }
 
+    /// The action cluster: an optional outline secondary button beside the CTA.
+    private var ctaArea: some View {
+        HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
+            if let secondaryTitle, let onSecondary {
+                ThemeButton(secondaryTitle) { onSecondary() }
+                    .color(accentSemantic).variant(.outline).size(ctaSize)
+                    .disabled(!isEnabled)
+            }
+            button
+        }
+    }
+
     private var button: some View {
         themeButton.disabled(!isEnabled)
     }
     private var themeButton: ThemeButton {
-        var b = ThemeButton(ctaTitle) { action() }.color(accentSemantic).size(.large)
+        var b = ThemeButton(ctaTitle) { action() }.color(accentSemantic).size(ctaSize).loading(isLoading)
         if let ctaIcon { b = b.icon(trailing: ctaIcon) }
         return b
+    }
+
+    /// Native `.controlSize(_:)` → the CTA's `ButtonSize`. The environment
+    /// default (`.regular`) keeps the bar's classic `.large` footprint; set
+    /// `.controlSize(.small)` / `.mini` on the bar to compact both buttons.
+    private var ctaSize: ButtonSize {
+        switch controlSize {
+        case .mini: return .xxsmall
+        case .small: return .small
+        case .regular, .large, .extraLarge: return .large
+        @unknown default: return .large
+        }
     }
 }
 
@@ -150,6 +199,18 @@ public extension StickyBookingBar {
     func showsShadow(_ on: Bool) -> Self { copy { $0.showsShadowOverride = on } }
     /// Replace the left price block with fully custom content.
     func leading<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.leadingSlot = AnyView(content()) } }
+    /// Replace the CTA area with fully custom content (partner to ``leading(_:)``).
+    func trailing<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.trailingSlot = AnyView(content()) } }
+    /// An outline secondary action beside the primary CTA (e.g. "Hold fare").
+    func secondaryAction(_ title: String, action: @escaping () -> Void) -> Self {
+        copy { $0.secondaryTitle = title; $0.onSecondary = action }
+    }
+    /// Makes the price block tappable (adds a disclosure chevron) — open a
+    /// fare-breakdown sheet from the bar.
+    func onPriceTap(_ action: @escaping () -> Void) -> Self { copy { $0.onPriceTapAction = action } }
+    /// Show the CTA's loading spinner and block taps while `on` (forwarded to
+    /// `ThemeButton.loading(_:)`).
+    func loading(_ on: Bool = true) -> Self { copy { $0.isLoading = on } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -159,13 +220,35 @@ public extension StickyBookingBar {
 }
 
 #Preview {
-    VStack {
-        Spacer()
-        StickyBookingBar("Book now") { }
-            .note("2 rooms · 4 nights").original(12_000).discountBadge("-20%").price(9_600).ctaIcon("arrow.right")
-        StickyBookingBar("Book now") { }
-            .note("BarStyle demo").price(9_600)
-            .barStyle(.floating)
-            .padding(.top, 24)
+    ScrollView {
+        VStack(spacing: 20) {
+            StickyBookingBar("Book now") { }
+                .note("2 rooms · 4 nights").original(12_000).discountBadge("-20%").price(9_600).ctaIcon("arrow.right")
+            StickyBookingBar("Book now") { }
+                .note("BarStyle demo").price(9_600)
+                .barStyle(.floating)
+            // Tappable price (chevron) + outline secondary action.
+            StickyBookingBar("Continue") { }
+                .price(4_320).note("2 travellers")
+                .onPriceTap { }
+                .secondaryAction("Hold fare") { }
+            // Loading CTA blocks taps; spinner replaces the label.
+            StickyBookingBar("Booking…") { }
+                .price(9_600).loading()
+            // Native controlSize compacts both buttons.
+            StickyBookingBar("Book") { }
+                .price(9_600).secondaryAction("Hold") { }
+                .controlSize(.small)
+            // Trailing slot replaces the CTA area entirely.
+            StickyBookingBar("Unused") { }
+                .price(2_150)
+                .trailing {
+                    HStack(spacing: Theme.SpacingKey.sm.value) {
+                        ThemeButton { }.icon(leading: "heart").variant(.soft).shape(.circle)
+                        ThemeButton("Reserve") { }.size(.small)
+                    }
+                }
+        }
+        .padding(.vertical, 24)
     }
 }

--- a/Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCard.swift
@@ -27,8 +27,17 @@
 import SwiftUI
 import ThemeKit
 
-/// Layout archetype of a ``TransportCrossSellCard``: notched strip or flat row.
-public enum TransportCrossSellVariant: Sendable { case ribbon, inline }
+/// Layout archetype of a ``TransportCrossSellCard``: notched strip (`.ribbon`),
+/// flat row (`.inline`), or a compact vertical card for grids (`.tile`).
+public enum TransportCrossSellVariant: Sendable { case ribbon, inline, tile }
+
+/// Size ramp of a ``TransportCrossSellCard`` — scales the mode glyph, the
+/// `PriceTag` and the paddings together.
+public enum TransportCrossSellSize: Sendable { case small, medium }
+
+/// The ribbon's tear-line chrome: the TicketStub-style `.notched` cut with a
+/// dashed perforation (default), or a `.plain` rounded strip with no cut.
+public enum TearStyle: Sendable { case notched, plain }
 
 /// A cross-sell for an alternative transport mode — "No flights? Take the
 /// bus/train" — with a mode glyph, route endpoints, a lead-in price and a CTA.
@@ -84,6 +93,11 @@ public struct TransportCrossSellCard: View {
     private let mode: Mode
     private let from: String
     private let to: String
+    /// Custom-mode overrides — set only by the `customMode` init; when set
+    /// they win over every `Mode`-derived value.
+    private var customGlyph: String?
+    private var customLabel: String?
+    private var customAccent: SemanticColor?
 
     // Config — mutated only through the modifiers below (R2).
     private var priceAmount: Decimal?
@@ -98,6 +112,12 @@ public struct TransportCrossSellCard: View {
     private var accentOverride: SemanticColor?
     private var logoSlot: AnyView?
     private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    private var sizeValue: TransportCrossSellSize = .medium
+    private var tearStyleValue: TearStyle = .notched
+    private var badgeFillValue: FillVariant = .soft
+    /// Replaces the ribbon CTA button's built-in label (action preserved).
+    private var ctaLabelSlot: AnyView?
+    private var shadowStyleValue: ThemeKitCore.ShadowStyle = .soft
 
     /// Bespoke coupon geometry (TicketStub-class chrome) — fixed constants,
     /// not knobs: the notch cut radius and the dash inset past the notch.
@@ -111,16 +131,39 @@ public struct TransportCrossSellCard: View {
         self.to = to
     }
 
-    private var accent: SemanticColor { accentOverride ?? mode.defaultAccent }
+    /// R1 overload — a transport mode beyond the built-in four (shuttle,
+    /// funicular, ride-share…): its glyph, display label and default accent
+    /// come from the caller; everything else behaves like a stock mode.
+    public init(customMode systemImage: String, label: String, accent: SemanticColor,
+                from: String, to: String) {
+        self.mode = .bus   // inert — every mode-derived value is overridden
+        self.from = from
+        self.to = to
+        self.customGlyph = systemImage
+        self.customLabel = label
+        self.customAccent = accent
+    }
+
+    private var accent: SemanticColor { accentOverride ?? customAccent ?? mode.defaultAccent }
+    private var modeGlyph: String { customGlyph ?? mode.systemImage }
+    private var modeLabel: String { customLabel ?? mode.displayName }
     private var motion: Animation? {
         MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion)
     }
+
+    /// The size ramp, resolved once (token-fed paddings; Icon/PriceTag enums).
+    private var glyphIconSize: IconSize { sizeValue == .small ? .md : .lg }
+    private var sectionPad: CGFloat {
+        sizeValue == .small ? Theme.SpacingKey.sm.value : Theme.SpacingKey.md.value
+    }
+    private var ribbonPriceSize: PriceSize { sizeValue == .small ? .small : .medium }
 
     public var body: some View {
         Group {
             switch variantValue {
             case .ribbon: ribbon
             case .inline: inline
+            case .tile: tile
             }
         }
         .animation(motion, value: priceAmount)
@@ -132,14 +175,14 @@ public struct TransportCrossSellCard: View {
     private var ribbon: some View {
         HStack(spacing: 0) {
             glyphSection
-                .padding(Theme.SpacingKey.md.value)
+                .padding(sectionPad)
             // A zero-width marker whose center is the tear line, reported up so
             // the background carves its notches at exactly this x (mirrors under
             // RTL by construction — the anchor resolves after layout).
             Color.clear.frame(width: 0)
                 .anchorPreference(key: TearXAnchorKey.self, value: .center) { $0 }
             contentSection
-                .padding(Theme.SpacingKey.md.value)
+                .padding(sectionPad)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .backgroundPreferenceValue(TearXAnchorKey.self) { anchor in
@@ -157,14 +200,14 @@ public struct TransportCrossSellCard: View {
                 if let logoSlot {
                     logoSlot
                 } else {
-                    Icon(systemName: mode.systemImage)
-                        .size(.lg)
+                    Icon(systemName: modeGlyph)
+                        .size(glyphIconSize)
                         .accent(accent)
                 }
             }
             .padding(Theme.SpacingKey.sm.value)
             .background(Circle().fill(accent.soft))
-            Text(mode.displayName)
+            Text(modeLabel)
                 .textStyle(.labelSm600)
                 .foregroundStyle(theme.text(.textSecondary))
         }
@@ -176,7 +219,7 @@ public struct TransportCrossSellCard: View {
             HStack(spacing: Theme.SpacingKey.xs.value) {
                 routeLine
                 if let badgeText {
-                    Badge(badgeText).badgeStyle(badgeStyle).size(.small)
+                    Badge(badgeText).badgeStyle(badgeStyle).variant(badgeFillValue).size(.small)
                 }
             }
             if let metaLine {
@@ -186,15 +229,30 @@ public struct TransportCrossSellCard: View {
             }
             if priceAmount != nil || ctaAction != nil {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
-                    if priceAmount != nil { priceTag(size: .medium) }
+                    if priceAmount != nil { priceTag(size: ribbonPriceSize) }
                     Spacer(minLength: 0)
-                    if let ctaTitle, ctaAction != nil {
-                        ThemeButton(ctaTitle) { select() }
-                            .color(accent)
-                            .size(.small)
+                    if ctaAction != nil {
+                        ctaControl
                     }
                 }
             }
+        }
+    }
+
+    /// The ribbon CTA: the caller's `.ctaLabel { }` content wrapped in the
+    /// same select action, or the stock `ThemeButton`.
+    @ViewBuilder
+    private var ctaControl: some View {
+        if let ctaLabelSlot {
+            Button { select() } label: {
+                ctaLabelSlot.contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityAddTraits(.isButton)
+        } else if let ctaTitle {
+            ThemeButton(ctaTitle) { select() }
+                .color(accent)
+                .size(sizeValue == .small ? .xsmall : .small)
         }
     }
 
@@ -212,15 +270,17 @@ public struct TransportCrossSellCard: View {
     /// The coupon surface: rounded fill, two `destinationOut` semicircular
     /// notches on the top/bottom edges at the tear x, and a vertical dashed
     /// perforation between them (TicketStub's drawing approach, rotated 90°).
+    /// `.tearStyle(.plain)` skips the cut and the perforation entirely.
     private func ribbonSurface(tearX: CGFloat?, size: CGSize) -> some View {
         let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+        let notched = tearStyleValue == .notched
         return ZStack {
             shape
                 .fill(theme.background(surfaceKey))
-                .overlay { if let tearX { notches(tearX: tearX, height: size.height) } }
+                .overlay { if notched, let tearX { notches(tearX: tearX, height: size.height) } }
                 .compositingGroup()                       // scope the destinationOut cut
-                .themeShadow(.soft)
-            if let tearX {
+                .themeShadow(shadowStyleValue)
+            if notched, let tearX {
                 dashedLine(x: tearX, height: size.height)
             }
         }
@@ -256,8 +316,8 @@ public struct TransportCrossSellCard: View {
                     if let logoSlot {
                         logoSlot
                     } else {
-                        Icon(systemName: mode.systemImage)
-                            .size(.md)
+                        Icon(systemName: modeGlyph)
+                            .size(sizeValue == .small ? .sm : .md)
                             .accent(accent)
                     }
                 }
@@ -276,6 +336,58 @@ public struct TransportCrossSellCard: View {
             }
             .accessibilityElement(children: .contain)
             .accessibilityLabel(accessibilityText)
+    }
+
+    // MARK: - Tile variant — compact vertical card for grids
+
+    private var tile: some View {
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+        let face = VStack(spacing: Theme.SpacingKey.xs.value) {
+            Group {
+                if let logoSlot {
+                    logoSlot
+                } else {
+                    Icon(systemName: modeGlyph)
+                        .size(glyphIconSize)
+                        .accent(accent)
+                }
+            }
+            .padding(Theme.SpacingKey.sm.value)
+            .background(Circle().fill(accent.soft))
+            Text(modeLabel)
+                .textStyle(.labelSm600)
+                .foregroundStyle(theme.text(.textSecondary))
+            Text("\(from) – \(to)")   // en dash — direction-neutral under RTL
+                .textStyle(sizeValue == .small ? .labelSm600 : .labelBase600)
+                .foregroundStyle(theme.text(.textPrimary))
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+            if let badgeText {
+                Badge(badgeText).badgeStyle(badgeStyle).variant(badgeFillValue).size(.small)
+            }
+            if priceAmount != nil {
+                priceTag(size: sizeValue == .small ? .small : .medium)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(sectionPad)
+        .background(theme.background(surfaceKey), in: shape)
+        .themeShadow(shadowStyleValue)
+
+        return Group {
+            if ctaAction != nil {
+                Button { select() } label: {
+                    face.contentShape(shape)
+                }
+                .buttonStyle(.plain)
+                .allowsHitTesting(!isReadOnly)
+                .accessibilityAddTraits(.isButton)
+            } else {
+                face
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityText)
     }
 
     // MARK: - Shared pieces
@@ -312,7 +424,7 @@ public struct TransportCrossSellCard: View {
 
     private var accessibilityText: String {
         var parts: [String] = [
-            String(themeKitTravel: "\(mode.displayName) from \(from) to \(to)")
+            String(themeKitTravel: "\(modeLabel) from \(from) to \(to)")
         ]
         if let durationText { parts.append(durationText) }
         if let departuresNote { parts.append(departuresNote) }
@@ -354,8 +466,27 @@ public extension TransportCrossSellCard {
     ) -> Self {
         copy { $0.ctaTitle = title; $0.ctaAction = action }
     }
-    /// Layout archetype: `.ribbon` (default, notched strip) or `.inline` (flat row).
+    /// Layout archetype: `.ribbon` (default, notched strip), `.inline` (flat
+    /// row), or `.tile` (compact vertical card for grids).
     func variant(_ v: TransportCrossSellVariant) -> Self { copy { $0.variantValue = v } }
+    /// Size ramp: `.medium` (default) or `.small` — scales the mode glyph,
+    /// the `PriceTag` and the paddings together.
+    func size(_ s: TransportCrossSellSize) -> Self { copy { $0.sizeValue = s } }
+    /// Ribbon tear-line chrome: `.notched` (default — the TicketStub cut +
+    /// dashed perforation) or `.plain` (an uncut rounded strip).
+    func tearStyle(_ t: TearStyle) -> Self { copy { $0.tearStyleValue = t } }
+    /// Fill variant of the badge (`.soft` default, `.solid`, `.outline`,
+    /// `.ghost`); its color keeps following the accent→style mapping.
+    func badgeVariant(_ v: FillVariant) -> Self { copy { $0.badgeFillValue = v } }
+    /// Replaces the ribbon CTA button's label with caller content — the
+    /// select action, accent gating and read-only behavior are preserved.
+    /// `.inline` and `.tile` draw no CTA button, so they ignore this slot
+    /// (documented no-op).
+    func ctaLabel<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.ctaLabelSlot = AnyView(content()) }
+    }
+    /// Shadow token under the ribbon/tile surface (default `.soft`).
+    func shadow(_ style: ThemeKitCore.ShadowStyle) -> Self { copy { $0.shadowStyleValue = style } }
     /// Overrides the mode-tinted accent (bus `.warning`, train `.info`,
     /// ferry `.turquoise`, car `.neutral`); `nil` restores the default.
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accentOverride = color } }
@@ -438,6 +569,53 @@ private struct TearXAnchorKey: PreferenceKey {
             .onSelect {}
     }
     .padding()
+}
+
+#Preview("Tiles · custom mode · sizes · tear/badge/shadow/ctaLabel") {
+    ScrollView {
+        VStack(spacing: Theme.SpacingKey.md.value) {
+            // Tile grid — including a custom mode beyond the 4-case enum.
+            HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
+                TransportCrossSellCard(.train, from: "Riverton", to: "Lakeside")
+                    .variant(.tile)
+                    .price(34)
+                    .badge("Fastest")
+                    .onSelect {}
+                TransportCrossSellCard(customMode: "figure.wave", label: "Shuttle",
+                                       accent: .purple, from: "Airport", to: "Center")
+                    .variant(.tile)
+                    .price(9)
+                    .onSelect {}
+                TransportCrossSellCard(.ferry, from: "Harbor", to: "North Isle")
+                    .variant(.tile)
+                    .size(.small)
+                    .price(12)
+            }
+            // Plain tear + solid badge + elevated shadow + custom CTA label.
+            TransportCrossSellCard(.bus, from: "Riverton", to: "Lakeside")
+                .price(19)
+                .duration("6h 30m")
+                .badge("Cheapest")
+                .badgeVariant(.solid)
+                .tearStyle(.plain)
+                .shadow(.elevated)
+                .onSelect {}
+                .ctaLabel {
+                    HStack(spacing: Theme.SpacingKey.xs.value) {
+                        Text("Book now").textStyle(.labelSm700)
+                        Icon(systemName: "arrow.forward").size(.xs)
+                    }
+                }
+            // Small ribbon ramp.
+            TransportCrossSellCard(.train, from: "Riverton", to: "Lakeside")
+                .size(.small)
+                .price(28)
+                .duration("3h 40m")
+                .onSelect {}
+        }
+        .padding()
+    }
+    .background(Theme.shared.background(.bgSecondaryLight))
 }
 
 #Preview("RTL") {

--- a/Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift
@@ -34,9 +34,15 @@ import ThemeKit
 // MARK: - Variant
 
 /// How ``TripSearchCard`` presents: the standard `.card`, a larger `.hero`
-/// treatment for landing headers, or a `.compact` collapsed summary row that
-/// expands into the full editor on tap.
-public enum TripSearchVariant: Sendable { case card, hero, compact }
+/// treatment for landing headers, a `.compact` collapsed summary row that
+/// expands into the full editor on tap, or an `.inlineBar` — a single-row
+/// horizontal bar for wide/iPad headers (narrow widths fall back to the
+/// stacked editor via `ViewThatFits`).
+public enum TripSearchVariant: Sendable { case card, hero, compact, inlineBar }
+
+/// Vertical density of the editor: `.regular` (default) or `.compact` —
+/// tighter stacks resolved from spacing tokens.
+public enum TripSearchDensity: Sendable { case compact, regular }
 
 // MARK: - TripSearchCard
 
@@ -88,6 +94,19 @@ public struct TripSearchCard: View {
     /// internal to that module); evaluated immediately at the modifier call
     /// site, so nothing escapes.
     private var promoContent: AnyView?
+    /// Header slot above the editor (distinct from `.promo`).
+    private var headerContent: AnyView?
+    /// Footer slot below the editor (after `.promo`).
+    private var footerContent: AnyView?
+    /// Replaces the CTA button's built-in label; submit + disable wiring stay.
+    private var ctaLabelContent: AnyView?
+    private var densityValue: TripSearchDensity = .regular
+    private var originIconName: String?
+    private var destinationIconName: String?
+    private var departureIconName: String?
+    private var passengersIconName: String?
+    private var showsSwapValue = true
+    private var passengerDetents: [BottomSheetDetent] = [.medium]
 
     /// UI-only state (house rule 1): sheet + compact-expansion + swap spin.
     @State private var isPassengerSheetPresented = false
@@ -148,25 +167,62 @@ public struct TripSearchCard: View {
         if variant == .compact && !isExpanded {
             summaryRow
         } else {
-            form
+            VStack(alignment: .leading, spacing: stackSpacing) {
+                if variant == .compact { collapseHeader }
+                if let headerContent { headerContent }
+                if variant == .inlineBar { inlineRun } else { editorStack }
+                if let promoContent { promoContent }
+                if let footerContent { footerContent }
+            }
+            // `.oneWay` hides the return field; gated by `microAnimations` + Reduce Motion.
+            .animation(motion, value: draft.tripType)
         }
     }
 
-    // MARK: - Form (the full editor)
+    /// Stack gap from the density axis (token-fed).
+    private var stackSpacing: CGFloat {
+        densityValue == .compact ? Theme.SpacingKey.sm.value : Theme.SpacingKey.md.value
+    }
 
-    private var form: some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
-            if variant == .compact { collapseHeader }
+    // MARK: - Form (the full stacked editor)
+
+    private var editorStack: some View {
+        VStack(alignment: .leading, spacing: stackSpacing) {
             if showsTripType { tripTypeToggle }
             routeFields
             dateFields
             passengersTrigger
             if showsCabinPicker { cabinSection }
-            cta
-            if let promoContent { promoContent }
+            cta(fullWidth: true)
         }
-        // `.oneWay` hides the return field; gated by `microAnimations` + Reduce Motion.
-        .animation(motion, value: draft.tripType)
+    }
+
+    // MARK: - Inline bar (single-row editor for wide/iPad headers)
+
+    /// One horizontal run of the core fields; when the row can't fit (narrow
+    /// widths, accessibility type sizes) `ViewThatFits` falls back to the
+    /// stacked editor — nothing is ever clipped. Trip type and cabin stay
+    /// draft-driven (no room in one row); toggle them with the modifiers on
+    /// a wrapping toolbar if needed.
+    private var inlineRun: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
+                originPicker
+                if showsSwapValue { swapControl("arrow.left.arrow.right") }
+                destinationPicker
+                DateField(String(themeKitTravel: "Departure"), date: $draft.departureDate)
+                    .range(effectiveDateRange)
+                    .icon(departureIconName ?? "calendar")
+                if showsReturnDate {
+                    DateField(String(themeKitTravel: "Return"), date: $draft.returnDate)
+                        .range(returnDateRange)
+                        .icon(departureIconName ?? "calendar")
+                }
+                passengersTrigger
+                cta(fullWidth: false)
+            }
+            editorStack
+        }
     }
 
     // MARK: Trip type (TripTypeToggle wrap — TripType ⇄ index)
@@ -199,7 +255,7 @@ public struct TripSearchCard: View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: Theme.SpacingKey.sm.value) {
                 originPicker
-                swapControl("arrow.left.arrow.right")
+                if showsSwapValue { swapControl("arrow.left.arrow.right") }
                 destinationPicker
             }
             VStack(spacing: Theme.SpacingKey.xs.value) {
@@ -207,31 +263,39 @@ public struct TripSearchCard: View {
                 destinationPicker
             }
             .overlay(alignment: .trailing) {
-                swapControl("arrow.up.arrow.down")
-                    .padding(.trailing, Theme.SpacingKey.lg.value)
+                if showsSwapValue {
+                    swapControl("arrow.up.arrow.down")
+                        .padding(.trailing, Theme.SpacingKey.lg.value)
+                }
             }
         }
     }
 
     private var originPicker: some View {
-        airportPicker(selection: $draft.origin, placeholder: String(themeKitTravel: "From"))
+        airportPicker(selection: $draft.origin,
+                      placeholder: String(themeKitTravel: "From"),
+                      icon: originIconName)
     }
 
     private var destinationPicker: some View {
-        airportPicker(selection: $draft.destination, placeholder: String(themeKitTravel: "To"))
+        airportPicker(selection: $draft.destination,
+                      placeholder: String(themeKitTravel: "To"),
+                      icon: destinationIconName)
     }
 
     /// The embedded §9.4 picker — sheet presentation (FieldButton trigger),
     /// fed by the caller-owned dataset plumbed through `airports(…)` /
     /// `onAirportQuery(_:)`. The picker owns the query debounce; this card
     /// never spawns work of its own.
-    private func airportPicker(selection: Binding<Airport?>, placeholder: String) -> some View {
+    private func airportPicker(selection: Binding<Airport?>, placeholder: String,
+                               icon: String?) -> some View {
         var picker = AirportPicker(selection: selection, suggestions: suggestions)
             .presentation(.sheet)
             .placeholder(placeholder)
             .recent(recentAirports)
             .popular(popularAirports)
             .accent(accentColor)
+        if let icon { picker = picker.triggerIcon(icon) }
         if let airportQueryAction { picker = picker.onQueryChange(airportQueryAction) }
         return picker
     }
@@ -258,11 +322,11 @@ public struct TripSearchCard: View {
         HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
             DateField(String(themeKitTravel: "Departure"), date: $draft.departureDate)
                 .range(effectiveDateRange)
-                .icon("calendar")
+                .icon(departureIconName ?? "calendar")
             if showsReturnDate {
                 DateField(String(themeKitTravel: "Return"), date: $draft.returnDate)
                     .range(returnDateRange)
-                    .icon("calendar")
+                    .icon(departureIconName ?? "calendar")
                     .transition(.opacity.combined(with: .move(edge: .trailing)))
             }
         }
@@ -291,8 +355,8 @@ public struct TripSearchCard: View {
     private var passengersTrigger: some View {
         FieldButton(passengerSummary) { isPassengerSheetPresented = true }
             .label(String(themeKitTravel: "Passengers"))
-            .icon("person.2")
-            .bottomSheet(isPresented: $isPassengerSheetPresented, detents: [.medium]) {
+            .icon(passengersIconName ?? "person.2")
+            .bottomSheet(isPresented: $isPassengerSheetPresented, detents: passengerDetents) {
                 passengerSheet
             }
     }
@@ -347,15 +411,34 @@ public struct TripSearchCard: View {
 
     // MARK: CTA
 
-    private var cta: some View {
-        PrimaryButton(ctaTitle) {
-            guard !isReadOnly else { return }   // E1 — read-only never submits
-            onSearch(draft)
+    /// The submit control. A `.ctaLabel { }` slot replaces the button's look
+    /// (caller-styled label inside a plain button) while the submit guard and
+    /// completeness-driven `.disabled` wiring stay intact.
+    @ViewBuilder
+    private func cta(fullWidth: Bool) -> some View {
+        if let ctaLabelContent {
+            Button {
+                guard !isReadOnly else { return }   // E1 — read-only never submits
+                onSearch(draft)
+            } label: {
+                ctaLabelContent
+                    .frame(maxWidth: fullWidth ? .infinity : nil)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!isDraftComplete)
+            .allowsHitTesting(!isReadOnly)
+            .accessibilityAddTraits(.isButton)
+        } else {
+            PrimaryButton(ctaTitle) {
+                guard !isReadOnly else { return }   // E1 — read-only never submits
+                onSearch(draft)
+            }
+            .size(variant == .hero ? .large : .medium)
+            .fullWidth(fullWidth)
+            .disabled(!isDraftComplete)
+            .allowsHitTesting(!isReadOnly)
         }
-        .size(variant == .hero ? .large : .medium)
-        .fullWidth()
-        .disabled(!isDraftComplete)
-        .allowsHitTesting(!isReadOnly)
     }
 
     // MARK: Compact (collapsed summary row → expands to the full editor)
@@ -497,6 +580,50 @@ public extension TripSearchCard {
         copy { $0.promoContent = AnyView(content()) }
     }
 
+    /// Header slot above the editor (canonical `.header { }`) — e.g. a title
+    /// or a route breadcrumb. Distinct from `.promo` (which sits under the CTA).
+    func header<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.headerContent = AnyView(content()) }
+    }
+
+    /// Footer slot below the editor and the promo (canonical `.footer { }`) —
+    /// e.g. a fare-rules note.
+    func footer<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.footerContent = AnyView(content()) }
+    }
+
+    /// Replaces the CTA button's built-in label with caller content. The
+    /// submit action, read-only guard and completeness-driven disabling are
+    /// preserved; the caller owns the label's look entirely.
+    func ctaLabel<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.ctaLabelContent = AnyView(content()) }
+    }
+
+    /// Editor density: `.regular` (default) or `.compact` — tighter stacks
+    /// resolved from spacing tokens.
+    func density(_ d: TripSearchDensity) -> Self { copy { $0.densityValue = d } }
+
+    /// Overrides the field icons (SF Symbol names); `nil` keeps each field's
+    /// stock symbol (origin/destination "airplane", departure "calendar",
+    /// passengers "person.2"). The departure icon also styles the return field.
+    func fieldIcons(origin: String? = nil, destination: String? = nil,
+                    departure: String? = nil, passengers: String? = nil) -> Self {
+        copy {
+            $0.originIconName = origin
+            $0.destinationIconName = destination
+            $0.departureIconName = departure
+            $0.passengersIconName = passengers
+        }
+    }
+
+    /// Show the origin/destination swap affordance (default on).
+    func showsSwap(_ on: Bool = true) -> Self { copy { $0.showsSwapValue = on } }
+
+    /// Detents for the passengers bottom sheet (default `[.medium]`).
+    func passengerSheetDetents(_ detents: [BottomSheetDetent]) -> Self {
+        copy { $0.passengerDetents = detents.isEmpty ? [.medium] : detents }
+    }
+
     /// Seeds the compact variant expanded (previews/snapshots only).
     internal func seedExpanded(_ on: Bool = true) -> Self {
         copy { $0._isExpanded = State(initialValue: on) }
@@ -582,6 +709,51 @@ private func previewDraft(roundTrip: Bool = true) -> TripSearchDraft {
                 }
                 .padding()
             }
+        }
+    }
+    return Demo()
+}
+
+#Preview("Inline bar · slots · density · icons · detents") {
+    struct Demo: View {
+        @Environment(\.theme) private var theme
+        @State private var bar = previewDraft()
+        @State private var dense = previewDraft(roundTrip: false)
+        var body: some View {
+            ScrollView {
+                VStack(spacing: 24) {
+                    // Single-row bar for wide hosts (stacks when it can't fit).
+                    TripSearchCard(draft: $bar) { _ in }
+                        .variant(.inlineBar)
+                        .showsSwap(false)
+                        .header {
+                            Text("Find your next flight").textStyle(.headingSm)
+                        }
+
+                    // Compact density + custom field icons + custom CTA label
+                    // + footer + tall passenger sheet.
+                    TripSearchCard(draft: $dense) { _ in }
+                        .density(.compact)
+                        .fieldIcons(origin: "airplane.departure",
+                                    destination: "airplane.arrival",
+                                    departure: "calendar.badge.clock",
+                                    passengers: "person.3")
+                        .passengerSheetDetents([.large])
+                        .ctaLabel {
+                            HStack(spacing: Theme.SpacingKey.xs.value) {
+                                Icon(systemName: "magnifyingglass").size(.sm)
+                                Text("Let's go").textStyle(.labelBase700)
+                            }
+                            .padding(Theme.SpacingKey.sm.value)
+                        }
+                        .footer {
+                            Text("Prices include all taxes and fees.")
+                                .textStyle(.bodySm400)
+                        }
+                }
+                .padding()
+            }
+            .background(theme.background(.bgBase))
         }
     }
     return Demo()


### PR DESCRIPTION
## What
Brings **every** ThemeKitTravel component to maximum style/knob flexibility. All changes are **additive** (api-breakage gate safe) and **token-fed** (`SemanticColor`/`Theme.RadiusRole`/`Theme.SpacingKey`/ramp enums — no raw `Color`/`CGFloat` knobs).

Driven by a 3-agent flexibility audit; implemented by 4 parallel `sr-ios-dev` agents on disjoint files, then integrated + build-fixed + lint-polished.

## Highlights
- **Accent axes** on every card/row organism; **size ramps** where meaningful; token-fed **surface / radius / shadow** overrides.
- **Slots**: `.header{}` / `.footer{}` / `.trailing{}` / `.leading{}` and new **data-parameterized (value-in) slots** (`.rowContent{item,isSelected in}`, `.optionContent`, `.brandLogo`, `.progressContent`, `.cell`, `.summaryBar`, `.sectionHeader`).
- **New variants**: `FareFamilyCard.layout(.column)` · `PaymentMethodSelector {.carousel,.compactList}` · `SavedCardsList {.list,.wallet}` · `FlightTracker {.board,.compact}` · `TransportCrossSell.tile` · `CabinClassSelector.cards` · `RecentSearchRow`/`LayoverRow`/`TripTypeToggle` variant enums · `FilterChipStyle.ghost` · `AirportPicker` presentation `{.popover,.fullScreenCover}`.
- **FlightListItem style system**: 3 new archetypes (`.tile` / `.hero` / `.receipt`), cross-style `accent`/`radius`/`density` Configuration fields, controlled fare/time selection (`.selectedFare($)`).
- **Seat cluster**: shared `SeatShape` (incl. `seatback`), `SeatSizeRamp`, summary/section-header slots, `SeatLegend` R2 modifier migration + orientation.
- **State**: controlled/uncontrolled pairs via `@ControllableState` (FareSummary `.expandable`, AncillaryCard, TripTypeToggle, PassengerRow `.selectable`, …).
- **Reduce-Motion**: gated previously-ungated animations (FlightListItem expand, TripTypeToggle, FilterBar collapse) via `MicroMotion`.
- Filter chips gained `systemImage` + `count`; token-hygiene fixes (raw-CGFloat spacing deprecated-forward, opacity literal → `accent.bg`).

## Deliberately NOT changed (honesty)
- **Semantic-fixed hues** stay fixed — `FlightStatusBadge` status colors, `SeatCell`/`SeatMap` selected/occupied (palette is the sanctioned override), `FareSummary` discount/total money colors. No free accent there.
- **SeatCell COW migration** deferred to the next major (per the compliance audit) — its new knobs ship as **defaulted init params**, so they survive the eventual modifier migration unchanged.
- `FlightTicketCard`/`BoardingPass` accent-fallback unification skipped (visually breaking) — marked `// deferred`.

## Verification (local, in an isolated worktree)
- `swift build` → **0 errors**
- `swift test` → **pass**
- `swiftlint lint --quiet` → **0 branch-added violations** (branch added zero >140-char lines; a few pre-existing warnings remain out of scope)

The 371 first-integration compile errors were 3 root causes (a `ShadowStyle`/SwiftUI ambiguity cascading to 175, a `Sendable` enum with a non-Sendable associated value, and one type-checker-timeout body) — all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)