### PR TITLE
docs(travel): ADR-0004 — per-component Style protocols across the ThemeKitTravel suite

### DIFF
--- a/docs/ADR-0004-travel-style-protocols.md
+++ b/docs/ADR-0004-travel-style-protocols.md
@@ -1,0 +1,400 @@
+# ADR-0004 — ThemeKitTravel style census & Style-protocol promotions
+
+- **Status:** **Proposed** (2026-07-12)
+- **Date:** 2026-07-12
+- **Deciders:** ThemeKit architecture (ios-architect); implementation pressure-test by sr-ios-dev
+- **Context source:** full read of `Sources/ThemeKitTravel/Components/**` (29 components, branch `main`), `THEMEKITTRAVEL_ARCHITECTURE.md` §6 (ADR-F5), `docs/ADR-0001-core-kind-in-init.md`, `.claude/skills/themekit-authoring/SKILL.md`
+- **Question answered:** how many styles do the ThemeKitTravel components have *today*, how many *could* they have, and which components earn a **new full Style protocol**.
+- **Governing rule (ADR-F5, `THEMEKITTRAVEL_ARCHITECTURE.md:459`):** *"a component starts at the lowest rung that fits and may only be promoted to a full Style protocol after **three shipped archetypes with distinct anatomy** exist as demand (audit-verified, like FlightListItem's did). Never speculatively."* Reinforced by ADR-0001 (`docs/ADR-0001-core-kind-in-init.md:40–41`): *"3+ archetypes → neither [init enum nor variant switch]; use the style protocol."*
+
+## Context
+
+The edition has exactly **one** full Style protocol: `FlightListItemStyle`
+(`Sources/ThemeKitTravel/Components/Organisms/FlightListItemStyle.swift`), with the
+complete house anatomy — a data-rich `FlightListItemConfiguration`
+(`FlightListItemStyle.swift:38`), 12 preset structs (`:12–23`), `where Self ==`
+accessors (`:1264–1309`), `AnyFlightListItemStyle` erasure (`:1316`), an
+`EnvironmentValues` key (`:1324–1330`) and a `.flightListItemStyle(_:)` modifier
+(`:1338`). Everything else styles itself through **variant/layout enums**, through
+**delegation** to the mothership's `CardStyle`/`BarStyle`/`FieldStyle`, or is a
+deliberate **single look**.
+
+Meanwhile the HeroUI flexibility sweep grew several variant enums past the sizes
+ADR-F5 originally assigned (`THEMEKITTRAVEL_ARCHITECTURE.md:455` assigned
+PaymentMethodSelector `.list/.grid`; it now ships four cases). This ADR is the
+census that decides, adversarially, whether any of that growth has crossed the
+promotion bar — and freezes the answer so the next sweep doesn't promote by drift.
+
+### Counting rules (strict)
+
+- A **style** is a selectable *look*: a Style-protocol preset, or a case of a
+  layout-switching `.variant(_:)` / `.layout(_:)` enum.
+- An **anatomy** is a layout *skeleton*. Enum cases that share row/tile builders
+  count as **one** anatomy family, however many cases arrange them.
+- **Knob enums are not styles**: fill emphasis (`FlightStatusEmphasis`,
+  `FilterChipStyle`, `TileEmphasis`), silhouettes (`SeatShape`,
+  `SeatMapModels.swift:236`), orientation (`SeatLegendOrientation`), presentation
+  (`AirportPickerPresentation`), sub-area arrangement (`BoardingPass.DetailsLayout`,
+  `DockLayout`, `CheckInProgressStyle`), indicators (`SelectionIndicator`,
+  `PassengerAccessory`, `DeleteAffordance`), chrome toggles (`TearStyle`,
+  `LayoverLineStyle`). They repaint or rearrange a detail of the *same* skeleton.
+- **Delegated shells** (`CardStyle` / `BarStyle` / `FieldStyle` from ThemeKit) are
+  inherited axes, not the component's own styles.
+
+## 1. Inventory — the styles that exist today
+
+Census base: **29 components** under `Sources/ThemeKitTravel/Components`
+(2 atoms, 8 molecules, 19 organisms; `FlightModels.swift`, `SeatMapModels.swift`
+and `FlightListItemStyle.swift` are support files, and
+`FlightListItem` + `FlightListItemStyle` count as one component).
+
+**Headline: 50 selectable styles today** — 12 protocol presets + 38 variant-enum
+cases across 13 enum axes — on 14 styled components; the other 15 components are
+single-look (most with appearance knobs and/or a delegated shell).
+
+| # | Component | Layer | Current style surface | Looks |
+|---|---|---|---|---|
+| 1 | FlightListItem | Org | **Full protocol** `FlightListItemStyle` — `.compact .timeline .fareBoard .deal .ticket .journey .slices .timetable .tray .tile .hero .receipt` | **12** |
+| 2 | TripSearchCard | Org | variant enum `TripSearchVariant {card, hero, compact, inlineBar}` (`TripSearchCard.swift:41`) | 4 |
+| 3 | PaymentMethodSelector | Org | variant enum `PaymentMethodVariant {list, grid, carousel, compactList}` (`PaymentMethodSelector.swift:30`) | 4 |
+| 4 | CabinClassSelector | Mol | variant enum `CabinClassVariant {segmented, chips, list, cards}` (`CabinClassSelector.swift:21`) | 4 |
+| 5 | FlightRoute | Mol | track enum `FlightRouteTrack {path, inline, arc, dots}` (`FlightRoute.swift:19–30`) | 4 |
+| 6 | TransportCrossSellCard | Org | variant enum `{ribbon, inline, tile}` (`TransportCrossSellCard.swift:32`) | 3 |
+| 7 | LayoverRow | Mol | variant enum `LayoverVariant {line, pill, banner}` (`LayoverRow.swift:19`) | 3 |
+| 8 | RecentSearchRow | Mol | variant enum `{plain, bordered, pill}` (`RecentSearchRow.swift:22`) | 3 |
+| 9 | PassengerForm | Org | layout enum `PassengerFormLayout {stacked, flat, grouped}` (`PassengerForm.swift:50`) | 3 |
+| 10 | FlightTracker | Org | variant enum `{board, compact}` (`FlightTracker.swift:41`) | 2 |
+| 11 | SavedCardsList | Org | variant enum `{list, wallet}` (`SavedCardsList.swift:29`) | 2 |
+| 12 | FareFamilyCard | Org | layout enum `FareFamilyLayout {stacked, column}` (`FareFamilyCard.swift:22`) | 2 |
+| 13 | DatePriceStrip | Mol | layout enum `DatePriceLayout {grid(columns:), strip}` (`DatePriceStrip.swift:36`) | 2 |
+| 14 | TripTypeToggle | Mol | variant enum `{pill, underline}` (`TripTypeToggle.swift:48`) | 2 |
+| 15 | FlightStatusBadge | Atom | single look — `FlightStatusEmphasis {soft solid outline dot}` + size ramp are knobs | 1 |
+| 16 | SeatCell | Atom | single look — `SeatShape` / `SeatSelectionEmphasis` / display are knobs | 1 |
+| 17 | PassengerRow | Mol | single look — badge/seat/status/accessory knobs | 1 |
+| 18 | SeatLegend | Mol | single look — `SeatLegendOrientation {rows vertical inline}` is orientation | 1 |
+| 19 | AirportPicker | Org | single anatomy — `AirportPickerPresentation {inline sheet popover fullScreenCover}` is presentation; source itself pre-commits: *"Rows are fixed anatomy … no Style protocol until real archetypes exist"* (`AirportPicker.swift:21–23`) | 1 |
+| 20 | AncillaryCard | Org | single look — shell delegated to `CardStyle` (`AncillaryCard.swift:14–18`) | 1 |
+| 21 | BoardingPass | Org | single look — **style-exempt** (TicketStub notch chrome, `BoardingPass.swift:10–16`); `DetailsLayout {row grid}` is a cell-arrangement knob | 1 |
+| 22 | CheckInFlow | Org | single look — **exempt scaffold**; `DockLayout` / `CheckInProgressStyle` are knobs | 1 |
+| 23 | FareSummary | Org | single look — breakdown table with slots | 1 |
+| 24 | FilterBar | Org | single anatomy — `FilterChipStyle {solid outlined ghost}` is chip fill emphasis | 1 |
+| 25 | FlightCard | Org | single look — shell delegated to `CardStyle` (`FlightCard.swift:9–14`) | 1 |
+| 26 | FlightResultRow | Org | single look — shell delegated to `CardStyle` (`FlightResultRow.swift:10–15`) | 1 |
+| 27 | FlightTicketCard | Org | single look — **style-exempt** (TicketStub chrome, `FlightTicketCard.swift:10–16`) | 1 |
+| 28 | SeatMap | Org | single anatomy — cabin layout is *data* (column patterns/sections), not style | 1 |
+| 29 | StickyBookingBar | Org | single look — chrome delegated to `BarStyle` (`StickyBookingBar.swift:10–17`) | 1 |
+
+## 2. Ceiling — how many styles each *could* plausibly carry
+
+"Ceiling" = the maximum count of **genuinely distinct layout anatomies** with a
+nameable industry archetype behind them. A bigger ceiling is *not* a mandate —
+ADR-F5 promotes on shipped demand, not on plausibility.
+
+### 2.1 The styled components
+
+| Component | Today | Ceiling | The archetypes that would fill the gap | Verdict |
+|---|---|---|---|---|
+| FlightListItem | 12 | **12 (hard cap)** | The containment rule (`THEMEKITTRAVEL_ARCHITECTURE.md:461`) makes 12 a ceiling, not a floor; new needs enter as additive `Configuration` fields | **Stay** — closed |
+| TripSearchCard | 4 looks / **3 anatomies** (see §3.1) | **6** | + `.pill` — floating collapsed search pill that expands (Airbnb/Skyscanner home header); + `.split` — two-pane hero for iPad/Mac landing (fields left, promo right) | **PROMOTE** (§4) |
+| PaymentMethodSelector | 4 looks / **2 anatomy families** — `.list`/`.compactList` share the row family (`PaymentMethodSelector.swift:141,215`), `.grid`/`.carousel` share one `tile(_:)` builder (`:305`) | 3 | + `.sectioned` — grouped rows (cards / wallets / other) — still the row family | **Stay enum** — the bar counts anatomies, not cases; two families ≠ three anatomies. Brand-custom option looks are already served by the `optionContent` slot (`:426`) |
+| CabinClassSelector | 4 | 4 | none — every case *delegates* its anatomy to an existing component (SegmentedControl / Chip / rows / cards); a style protocol here would just re-erase other components' styles | **Stay enum** (ADR-F5 assigned it exactly this, `:455`) |
+| FlightRoute | 4 tracks | 5 | + `.progress` — plane-position track for live tracking (feeds FlightTracker) | **Stay enum** — the track is a sub-element swap inside one time-col → track → time-col skeleton; anatomy never changes |
+| TransportCrossSellCard | 3 | 4 | + `.banner` — full-bleed promo strip | **Stay enum** — 3 anatomies exist, but the `.ribbon` identity is TicketStub notch chrome cut with `destinationOut` (`TransportCrossSellCard.swift:13–16`), the exemption class ADR-F5 `:457` names: a protocol would force custom styles to reimplement or lose the tear line. Promotion actively harms here |
+| LayoverRow | 3 | 3 | — | **Stay** — 161-line molecule; protocol overhead ≫ benefit |
+| RecentSearchRow | 3 | 4 | + `.card` — tile for a recents carousel | **Stay** — plain/bordered/pill share one row skeleton (chrome deltas) |
+| PassengerForm | 3 | 3 | — | **Stay** — forms are the ADR-F5 exempt class (`:457`); the three layouts arrange the same field set |
+| FlightTracker | 2 | **4** | + `.timeline` — phase-first vertical journey (flight-tracker apps' detail view); + `.banner` — status-tone strip for push-style surfaces | **Grow enum** (§5.1) |
+| SavedCardsList | 2 | **4** | + `.stack` — overlapping pass-book stack (Apple Wallet); + `.grid` tiles | **Grow enum** (§5.2) |
+| FareFamilyCard | 2 | **4** | + `.row` — horizontal comparison strip for narrow screens; + `.accordion` — collapsed expandable tier | **Grow enum** (§5.3) |
+| DatePriceStrip | 2 | 3 | + a month price-calendar (Hopper heat-map) — but a month grid with its own selection model is a **sibling component** (`PriceCalendar`), not a third case of a strip | **Stay** |
+| TripTypeToggle | 2 | 3 | + `.menu` — dropdown for dense headers | **Stay** — wait for demand |
+
+### 2.2 The single-look components — honest NOs
+
+- **Semantic-fixed atoms** (`FlightStatusBadge`, `SeatCell`): their identity *is*
+  the fixed anatomy; emphasis/shape knobs already cover brand variance. Ceiling 1.
+- **TicketStub-chrome organisms** (`BoardingPass`, `FlightTicketCard`): style-exempt
+  by documented decision in their own headers; the perforated shell is inseparable
+  from the layout. A horizontal-pass variant would be a knob-level rearrangement at
+  most. Ceiling 1–2, exemption blocks promotion regardless.
+- **Structure/scaffold organisms** (`CheckInFlow`, `PassengerForm`, `SeatMap`,
+  `AirportPicker`, `FilterBar`): the "layout" is data- or flow-driven;
+  `AirportPicker.swift:21–23` already records the no-protocol decision in source.
+- **CardStyle/BarStyle delegates** (`FlightCard`, `FlightResultRow`,
+  `AncillaryCard`, `FareSummary`, `StickyBookingBar`): re-skinning arrives through
+  the mothership's shell protocols. Crucially, *list-item archetype* demand around
+  `FlightCard`/`FlightResultRow` is already served by `FlightListItem`'s 12 presets
+  (`FlightListItem.swift:17–20` exists precisely to absorb it) — a second flight-row
+  style protocol would fork that surface.
+- **Row/legend molecules** (`PassengerRow`, `SeatLegend`): one skeleton plus knobs.
+
+**Ceiling headline:** across the library, honest maximum ≈ **62 looks**
+(50 today + ~12 nameable new archetypes), of which this ADR proposes shipping
+**4** and rejects the rest as speculative.
+
+## 3. Decision
+
+1. **Promote exactly one component to a full Style protocol: `TripSearchCard` →
+   `TripSearchStyle`** with four parity presets (`.card .hero .compact .inlineBar`)
+   and one demand-gated fifth (`.pill`). Rationale in §3.1, design in §4.
+2. **Grow three variant enums by one case each** (staying enums): `FlightTracker`
+   `+ .timeline`, `SavedCardsList` `+ .stack`, `FareFamilyCard` `+ .row` (§5).
+3. **Everything else stays as-is.** In particular `PaymentMethodSelector`,
+   `TransportCrossSellCard` and `CabinClassSelector` — the three other 3-or-4-case
+   enums — are ratified **non-promotions** with the reasons recorded in §2.1, so
+   future sweeps don't promote them by case-count alone.
+4. **Net-new archetypes proposed: 4** (3 variant cases + 1 gated preset). The
+   promotion itself is look-for-look (4 presets replacing 4 enum cases, zero new
+   looks at parity).
+
+### 3.1 Why TripSearchCard is the one that clears the bar
+
+- **≥3 shipped, distinct anatomies.** The body dispatches three skeletons: the
+  collapsed `summaryRow` (`TripSearchCard.swift:167,446`), the single-row
+  `inlineRun` with a `ViewThatFits` fallback (`:207–208`), and the stacked
+  `editorStack` (`:189`). These are different layout structures, not paint.
+  (`.hero` is honestly *not* a fourth anatomy — it is `contentPadding .lg` +
+  `.elevated` + a large CTA on the same stack (`:128–131,157`); it rides along as
+  a preset only for 1:1 source mapping.)
+- **Demand is real, not projected.** All four cases shipped because screens needed
+  them (F2.3 capstone + flexibility sweep), and the search card is the single most
+  brand-differentiated surface in travel apps — the place consumers will want an
+  archetype the built-ins can't express (pill, split-pane). A protocol makes that
+  a custom style instead of a fork of a 778-line organism.
+- **ADR-0001 mandates it.** *"Never both a `variant` … and a giant `switch` in the
+  body: 3+ archetypes use the style-protocol pattern"* (`ADR-0001:30,40–41`). The
+  component is at 4 cases and growing; the enum rung no longer "fits", so the
+  promotion rule's "lowest rung that fits" moves up.
+- Contrast the honest NOs: PaymentMethodSelector's four cases collapse to two
+  shared builder families (§2.1) — its rung still fits; TransportCrossSellCard's
+  three anatomies are welded to exempt chrome.
+
+## 4. Promotion design — `TripSearchStyle`
+
+Maps onto the `FlightListItemStyle` reference pattern, with one deliberate
+difference: FlightListItem's configuration hands styles **typed data** to lay out;
+a search card's content is **live, stateful field controls** (pickers, sheets,
+debounced queries). Rebuilding those per style would duplicate interaction logic
+12 ways — so the configuration hands styles **pre-wired field units** (the slot
+idiom, precedented by `logo`/`accessory`/`footer: AnyView?` in
+`FlightListItemConfiguration`, `FlightListItemStyle.swift:46,101,103`) plus typed
+signals for arrangement decisions. Styles own *arrangement and shell*; the
+component keeps *all* interaction (draft bindings, sheets, debounce, submit guard).
+
+### 4.1 Protocol + configuration (new file `Organisms/TripSearchStyle.swift`)
+
+```swift
+/// The pre-wired building blocks a ``TripSearchStyle`` arranges. Field units are
+/// fully interactive (bindings, sheets, a11y fallbacks included); a style decides
+/// where they go, never how they work. Nil units were switched off by modifier
+/// (`.tripType(false)`, `.cabinPicker(false)`) or are empty slots.
+public struct TripSearchStyleConfiguration {
+    // Field units (type-erased, immediately evaluated — the SlotContent idiom).
+    public let tripType: AnyView?          // TripTypeToggle, wired to the draft
+    public let routeFields: AnyView        // origin + swap + destination (ViewThatFits a11y fallback inside)
+    public let dateFields: AnyView         // departure (+ animated return for round trips)
+    public let passengersField: AnyView    // FieldButton → GuestSelector bottom sheet
+    public let cabinField: AnyView?        // CabinClassSelector section
+    public let cta: AnyView                // submit button, completeness-disabled, read-only-guarded
+    public let header: AnyView?            // .header { } slot
+    public let promo: AnyView?             // .promo { } slot
+    public let footer: AnyView?            // .footer { } slot
+
+    // Typed signals for arrangement decisions.
+    public let draft: TripSearchDraft      // read-only snapshot (routes, dates, counts)
+    public let isDraftComplete: Bool
+    public let isExpanded: Bool            // collapsed-summary styles read this…
+    public let toggleExpand: () -> Void    // …and flip it (animated, MicroMotion-gated)
+    public let accent: SemanticColor?
+    public let surfaceKey: Theme.BackgroundColorKey?   // resolve via surface(default:)
+    public let elevation: CardElevation?   // explicit .elevation(_:) override, or nil
+    public let density: ComponentDensity
+    public let locale: Locale
+
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat        // density-scaled
+    public func routeSummary() -> String   // "IST → LHR" / placeholder — for collapsed styles
+    public func detailSummary() -> String  // "18 Jul – 25 Jul · 2 adults · Economy"
+}
+
+public protocol TripSearchStyle {
+    associatedtype Body: View
+    @MainActor @ViewBuilder func makeBody(configuration: TripSearchStyleConfiguration) -> Body
+}
+```
+
+**Shell ownership:** the style draws its own shell — built-ins compose the neutral
+`Card` (so `CardStyle` delegation is preserved *transitively*, exactly as today's
+body does at `TripSearchCard.swift:156–158`), while custom styles may go shell-less
+(a nav-header pill or inline bar must not be forced into a card). This is the same
+"style owns the whole layout" stance as `FlightListItemStyle`.
+
+### 4.2 Presets (4 at parity + 1 gated)
+
+| Preset | Maps | Anatomy |
+|---|---|---|
+| `CardTripSearchStyle` (**default**) | `.card` | `Card { editor stack }`, `.md` padding, `.soft` elevation — pixel-identical to today |
+| `HeroTripSearchStyle` | `.hero` | same stack, `.lg` padding, `.elevated`, large CTA |
+| `CompactTripSearchStyle` | `.compact` | collapsed summary row ⇄ expanding editor via `isExpanded`/`toggleExpand` |
+| `InlineBarTripSearchStyle` | `.inlineBar` | one horizontal run of the units, `ViewThatFits` fallback to the stack |
+| `PillTripSearchStyle` — **gated**, ships only on audit-verified demand | — | floating capsule (`routeSummary` + glyph) that expands to the editor in an overlay/sheet; the Airbnb/Skyscanner home-header archetype `.compact` cannot express (capsule chrome, detached expansion) |
+
+Cross-preset building blocks (the summary row, the collapse header at
+`TripSearchCard.swift:478`) become shared `private` sub-views in the style file,
+per the SKILL's style-driven pattern.
+
+### 4.3 Wiring + accessors (verbatim FlightListItemStyle shape)
+
+```swift
+public extension TripSearchStyle where Self == CardTripSearchStyle {
+    static var card: Self { .init() }
+}
+// … .hero / .compact / .inlineBar (…and .pill when gated in)
+
+struct AnyTripSearchStyle: TripSearchStyle {                     // internal erasure
+    private let _makeBody: @MainActor (TripSearchStyleConfiguration) -> AnyView
+    init<S: TripSearchStyle>(_ style: sending S) { … }
+    func makeBody(configuration: TripSearchStyleConfiguration) -> AnyView { … }
+}
+
+private struct TripSearchStyleKey: EnvironmentKey {
+    static let defaultValue = AnyTripSearchStyle(CardTripSearchStyle())
+}
+extension EnvironmentValues { var tripSearchStyle: AnyTripSearchStyle { … } }
+
+public extension View {
+    /// Sets the search-card archetype for this subtree.
+    func tripSearchStyle<S: TripSearchStyle>(_ style: sending S) -> some View {
+        environment(\.tripSearchStyle, AnyTripSearchStyle(style))
+    }
+}
+```
+
+`TripSearchCard.body` becomes: build the configuration from its existing private
+field builders (`editorStack`'s pieces at `:228–443` are already factored as
+`tripTypeToggle` / `routeFields` / `dateFields` / `passengersTrigger` /
+`cabinSection` / `cta(fullWidth:)`), then
+`AnyView(style.makeBody(configuration: config))`. `@State isExpanded` and the
+sheet/swap state stay in the component; styles only see `isExpanded` +
+`toggleExpand`.
+
+### 4.4 API safety & migration
+
+- **Purely additive.** New protocol + env key + modifier; default =
+  `CardTripSearchStyle` reproduces today's default exactly.
+- **Deprecate-forward, never break:**
+  ```swift
+  @available(*, deprecated, message: "Use .tripSearchStyle(.card/.hero/.compact/.inlineBar)")
+  func variant(_ v: TripSearchVariant) -> Self   // TripSearchCard.swift:562 today
+  ```
+  During deprecation the stored variant, when explicitly set, wins over the
+  environment style (last-writer-wins at the call site is impossible to detect,
+  so: explicit `.variant(_:)` maps to the matching preset internally).
+  `TripSearchVariant` itself deprecates with the modifier and is removed at the
+  next major.
+- **Naming stays on the ADR-F5 triad** (`THEMEKITTRAVEL_ARCHITECTURE.md:463`):
+  `.accent(_:)` untouched, sizes native, no CGFloat knobs enter the configuration.
+
+### 4.5 Risks
+
+- **AnyView field units & identity** — the SKILL's `.id` rule: the return
+  `DateField` appears/disappears inside `dateFields`; keep the insert/remove
+  transition by building that unit with stable identity inside the *component*
+  (as today, `:319–333`) so styles inherit correct animation for free.
+- **Configuration weight** — 9 erased units per render. Same order as
+  FlightListItem's erased slots; fields re-erase per render already (SlotContent
+  semantics), and state lives in the component/bindings, so diffing behavior is
+  unchanged. sr-ios-dev should still profile the compact expand/collapse.
+- **Containment** — adopt a FlightListItem-style rule at birth: **5 presets are
+  the cap** (`.pill` included); new needs enter as additive configuration fields.
+
+### 4.6 Verification hooks
+
+- `#Preview("TripSearchStyle matrix")` iterating all presets × light/dark via
+  `PreviewMatrix`, plus one custom in-preview style proving the protocol is
+  implementable from outside.
+- Demo: `xcrun simctl launch <bundle> -startTab 0 -openDemo "Trip Search Card"` —
+  gallery gains a style switcher; screenshot at parity before/after the migration
+  PR (the `.card` default must be pixel-identical).
+
+## 5. Variant-case additions (staying enums)
+
+Each is one case in an existing enum + one branch on shared sub-views — no new
+protocol, no new axis. All are **P2, demand-tagged**: ship when a consumer screen
+(Demo counts) actually needs them; delete from the backlog after two quiet quarters.
+
+1. **`FlightTrackerVariant.timeline`** — phase-first vertical layout: the `Steps`
+   phase timeline (already composed in `.board`) becomes the spine, with
+   schedule/gate facts attached per phase. Distinct skeleton from both `.board`
+   (facts-first card) and `.compact` (one-row strip); the flight-tracker-app
+   detail archetype. Takes the enum to 3 looks / 3 anatomies — *at* the promotion
+   bar; §6 records why it still stays an enum.
+2. **`SavedCardsVariant.stack`** — overlapping pass-book stack of the existing
+   wallet card-face tiles (Apple Wallet archetype); tap fans out to select.
+   Reuses the `.wallet` tile builder; new arrangement only.
+3. **`FareFamilyLayout.row`** — horizontal strip: chip + condensed features
+   leading, price + select trailing; the narrow-screen fare-tier list where
+   `.column` matrices don't fit. Third arrangement of the shared
+   chip/features/price sub-views.
+
+## 6. Rejected alternatives
+
+- **Promote every 3+-case enum (PaymentMethodSelector, CabinClassSelector,
+  TransportCrossSellCard, LayoverRow, RecentSearchRow, PassengerForm — and
+  FlightTracker/SavedCardsList/FareFamilyCard after §5).** Rejected per component
+  in §2. The general failure: case-count ≠ anatomy-count. Payment's four cases are
+  two builder families; CabinClass delegates its anatomies; CrossSell's chrome is
+  exemption-class; the molecules are one-skeleton; and §5's enums reach 3 looks by
+  *reusing* builders — their rung still fits. Cost of over-promotion: ~6 protocols
+  × (Configuration + erasure + env key + accessors + docs + demo) ≈ hundreds of
+  public API points nobody asked for, each a permanent source-compat liability.
+- **A generic `TravelComponentStyle` / one mega-protocol.** A style is only useful
+  because its `Configuration` is *typed to the component*; a shared configuration
+  degenerates into `[AnyView]` + stringly keys — render-props by another name,
+  explicitly off-idiom.
+- **Growing `TripSearchVariant` instead (add `.pill`, `.split` as cases).** Keeps
+  the 778-line organism accreting a switch that ADR-0001 names an anti-pattern,
+  and still gives consumers no custom-archetype escape short of forking. The enum
+  rung demonstrably no longer fits.
+- **`FlightListItemStyle`-style typed-data configuration for TripSearchStyle**
+  (hand styles the raw `Binding<TripSearchDraft>` + airport datasets + callbacks).
+  Every style would rebuild pickers, sheets, debounce and submit guards —
+  duplicated interaction logic, divergent a11y. Field-unit slots keep behavior in
+  one place; this is the deliberate delta from the reference pattern, precedented
+  by the reference's own `AnyView` slots.
+- **Promote `DatePriceStrip` via a `.calendar` case/preset.** A month heat-map
+  calendar has its own data model (month windows, per-day availability) and
+  selection semantics — that's a sibling `PriceCalendar` component (and overlaps
+  the ThemeKitCalendar add-on), not a third look of a strip.
+
+## 7. Sequenced build plan (PR-per-unit, sr-ios-dev)
+
+| # | PR | Contents | Effort | Gate |
+|---|---|---|---|---|
+| 1 | `feat(travel): TripSearchStyle protocol + .card default` | New `TripSearchStyle.swift` (protocol, configuration, erasure, env key, modifier, `CardTripSearchStyle`); `TripSearchCard` renders through the env style; `.variant(_:)` maps internally; previews + parity screenshot via `-openDemo "Trip Search Card"` | **M** | `.card` pixel-parity |
+| 2 | `feat(travel): hero/compact/inlineBar presets + variant deprecation` | Three presets extracted from today's branches; `@available(deprecated)` on `.variant(_:)` + `TripSearchVariant`; demo style switcher; llms/docs regen (`tools/gen_skill.py`) | **M** | all four presets verified by deep-link, RTL + a11y-size pass on `.inlineBar` fallback |
+| 3 | `docs: ratify ADR-0004` | Merge this ADR; add the §2.1 non-promotion verdicts to `THEMEKITTRAVEL_ARCHITECTURE.md` §6 so the ladder table stays the single source | **S** | — |
+| 4* | `feat(travel): PillTripSearchStyle` | Gated on demand evidence | **M** | demand note in PR body |
+| 5* | `feat(travel): FlightTracker .timeline` | §5.1 | **S/M** | demand-tagged |
+| 6* | `feat(travel): SavedCardsList .stack` | §5.2 | **S** | demand-tagged |
+| 7* | `feat(travel): FareFamilyCard .row` | §5.3 | **S** | demand-tagged |
+
+\* = demand-gated backlog, not sprint-committed.
+
+## 8. Open questions for sr-ios-dev (pressure-test with call sites)
+
+1. **Deprecation precedence** — when a call site has both `.variant(.hero)` and an
+   ancestor `.tripSearchStyle(.compact)`, the explicit modifier should win for
+   source-behavior stability. Confirm with a call-site matrix that the internal
+   mapping doesn't surprise (esp. Demo screens that set both during migration).
+2. **`isExpanded` semantics for non-collapsing styles** — `CompactTripSearchStyle`
+   is the only consumer today; decide whether the configuration documents
+   "always true unless the style collapses" or exposes a
+   `supportsCollapse` hint. Prefer documentation over API.
+3. **Field-unit granularity** — is `routeFields` one unit (origin+swap+destination
+   welded) enough for `.split`/`.pill`, or do custom styles need
+   `originField`/`swapControl`/`destinationField` separately? Start welded
+   (additive to split later; splitting first can never be unsplit).
+4. **§5 demand ledger** — where do "audit-verified demand" notes live so gates are
+   checkable? Proposal: a `Demand:` line in the component header doc, cited in the
+   PR body.

--- a/docs/ADR-0004-travel-style-protocols.md
+++ b/docs/ADR-0004-travel-style-protocols.md
@@ -1,400 +1,411 @@
-# ADR-0004 — ThemeKitTravel style census & Style-protocol promotions
+# ADR-0004 — Per-component Style protocols across ThemeKitTravel
 
-- **Status:** **Proposed** (2026-07-12)
+- **Status:** **Proposed** (2026-07-12) — supersedes the v1 draft's single-promotion decision
 - **Date:** 2026-07-12
-- **Deciders:** ThemeKit architecture (ios-architect); implementation pressure-test by sr-ios-dev
+- **Deciders:** user directive (explicit override) + ThemeKit architecture (ios-architect); implementation pressure-test by sr-ios-dev
 - **Context source:** full read of `Sources/ThemeKitTravel/Components/**` (29 components, branch `main`), `THEMEKITTRAVEL_ARCHITECTURE.md` §6 (ADR-F5), `docs/ADR-0001-core-kind-in-init.md`, `.claude/skills/themekit-authoring/SKILL.md`
-- **Question answered:** how many styles do the ThemeKitTravel components have *today*, how many *could* they have, and which components earn a **new full Style protocol**.
-- **Governing rule (ADR-F5, `THEMEKITTRAVEL_ARCHITECTURE.md:459`):** *"a component starts at the lowest rung that fits and may only be promoted to a full Style protocol after **three shipped archetypes with distinct anatomy** exist as demand (audit-verified, like FlightListItem's did). Never speculatively."* Reinforced by ADR-0001 (`docs/ADR-0001-core-kind-in-init.md:40–41`): *"3+ archetypes → neither [init enum nor variant switch]; use the style protocol."*
+- **Question answered:** how many styles the ThemeKitTravel components have today, how many they could have, and the design for giving **every** travel component its own full Style protocol.
+- **⚠ Rule override:** ADR-F5's anti-sprawl promotion rule (*"≥3 shipped distinct-anatomy archetypes, never speculatively"*, `THEMEKITTRAVEL_ARCHITECTURE.md:459`) is **intentionally overridden by explicit user request** for this initiative (same authority as the earlier full-flexibility sweep): the goal is *maximum uniform restyleability* — `FlightCard().flightCardStyle(…)`, `SeatMap(…).seatMapStyle(…)` — across the whole suite. §6's ladder remains the default law for components *born after* this initiative.
 
 ## Context
 
-The edition has exactly **one** full Style protocol: `FlightListItemStyle`
-(`Sources/ThemeKitTravel/Components/Organisms/FlightListItemStyle.swift`), with the
+The edition has exactly **one** full Style protocol today: `FlightListItemStyle`
+(`Sources/ThemeKitTravel/Components/Organisms/FlightListItemStyle.swift`) with the
 complete house anatomy — a data-rich `FlightListItemConfiguration`
 (`FlightListItemStyle.swift:38`), 12 preset structs (`:12–23`), `where Self ==`
 accessors (`:1264–1309`), `AnyFlightListItemStyle` erasure (`:1316`), an
 `EnvironmentValues` key (`:1324–1330`) and a `.flightListItemStyle(_:)` modifier
-(`:1338`). Everything else styles itself through **variant/layout enums**, through
-**delegation** to the mothership's `CardStyle`/`BarStyle`/`FieldStyle`, or is a
-deliberate **single look**.
+(`:1338`). Everything else styles itself through variant/layout enums, delegation
+to the mothership's `CardStyle`/`BarStyle`/`FieldStyle`, or a single fixed look.
 
-Meanwhile the HeroUI flexibility sweep grew several variant enums past the sizes
-ADR-F5 originally assigned (`THEMEKITTRAVEL_ARCHITECTURE.md:455` assigned
-PaymentMethodSelector `.list/.grid`; it now ships four cases). This ADR is the
-census that decides, adversarially, whether any of that growth has crossed the
-promotion bar — and freezes the answer so the next sweep doesn't promote by drift.
+This ADR (1) records the census as ground truth, then (2) designs the promotion of
+**all 28 remaining components** to the same protocol anatomy, seeding each
+protocol's presets from its existing variant/layout enum cases (which
+deprecate-forward) plus the ceiling archetypes identified per component.
 
-### Counting rules (strict)
+### Counting rules (unchanged ground truth)
 
 - A **style** is a selectable *look*: a Style-protocol preset, or a case of a
   layout-switching `.variant(_:)` / `.layout(_:)` enum.
-- An **anatomy** is a layout *skeleton*. Enum cases that share row/tile builders
-  count as **one** anatomy family, however many cases arrange them.
-- **Knob enums are not styles**: fill emphasis (`FlightStatusEmphasis`,
-  `FilterChipStyle`, `TileEmphasis`), silhouettes (`SeatShape`,
-  `SeatMapModels.swift:236`), orientation (`SeatLegendOrientation`), presentation
-  (`AirportPickerPresentation`), sub-area arrangement (`BoardingPass.DetailsLayout`,
-  `DockLayout`, `CheckInProgressStyle`), indicators (`SelectionIndicator`,
-  `PassengerAccessory`, `DeleteAffordance`), chrome toggles (`TearStyle`,
-  `LayoverLineStyle`). They repaint or rearrange a detail of the *same* skeleton.
-- **Delegated shells** (`CardStyle` / `BarStyle` / `FieldStyle` from ThemeKit) are
-  inherited axes, not the component's own styles.
+- An **anatomy** is a layout *skeleton*; enum cases sharing row/tile builders are
+  one anatomy family.
+- **Knob enums** (fill emphasis, silhouettes, orientation, presentation,
+  sub-area arrangement, indicators, chrome toggles) are not styles *today* —
+  though this initiative deliberately promotes a handful of them
+  (`FlightStatusEmphasis`, `SeatShape`, `SeatLegendOrientation`,
+  `CheckInProgressStyle`, `AirportPickerDensity`) into presets where they are the
+  component's only look axis, so atoms/molecules join the uniform surface.
+- **Delegated shells** (`CardStyle`/`BarStyle`/`FieldStyle`) are inherited axes;
+  they *compose with* (not compete with) the new per-component protocols — see §6.
 
 ## 1. Inventory — the styles that exist today
 
 Census base: **29 components** under `Sources/ThemeKitTravel/Components`
-(2 atoms, 8 molecules, 19 organisms; `FlightModels.swift`, `SeatMapModels.swift`
-and `FlightListItemStyle.swift` are support files, and
-`FlightListItem` + `FlightListItemStyle` count as one component).
+(2 atoms, 8 molecules, 19 organisms; `FlightModels.swift`, `SeatMapModels.swift`,
+`FlightListItemStyle.swift` are support files; `FlightListItem` +
+`FlightListItemStyle` count as one component).
 
-**Headline: 50 selectable styles today** — 12 protocol presets + 38 variant-enum
-cases across 13 enum axes — on 14 styled components; the other 15 components are
-single-look (most with appearance knobs and/or a delegated shell).
+**Headline today: 50 selectable styles** — 12 protocol presets + 38 variant-enum
+cases across 13 enum axes — on 14 styled components; 15 components are single-look.
 
 | # | Component | Layer | Current style surface | Looks |
 |---|---|---|---|---|
-| 1 | FlightListItem | Org | **Full protocol** `FlightListItemStyle` — `.compact .timeline .fareBoard .deal .ticket .journey .slices .timetable .tray .tile .hero .receipt` | **12** |
-| 2 | TripSearchCard | Org | variant enum `TripSearchVariant {card, hero, compact, inlineBar}` (`TripSearchCard.swift:41`) | 4 |
-| 3 | PaymentMethodSelector | Org | variant enum `PaymentMethodVariant {list, grid, carousel, compactList}` (`PaymentMethodSelector.swift:30`) | 4 |
-| 4 | CabinClassSelector | Mol | variant enum `CabinClassVariant {segmented, chips, list, cards}` (`CabinClassSelector.swift:21`) | 4 |
-| 5 | FlightRoute | Mol | track enum `FlightRouteTrack {path, inline, arc, dots}` (`FlightRoute.swift:19–30`) | 4 |
-| 6 | TransportCrossSellCard | Org | variant enum `{ribbon, inline, tile}` (`TransportCrossSellCard.swift:32`) | 3 |
-| 7 | LayoverRow | Mol | variant enum `LayoverVariant {line, pill, banner}` (`LayoverRow.swift:19`) | 3 |
-| 8 | RecentSearchRow | Mol | variant enum `{plain, bordered, pill}` (`RecentSearchRow.swift:22`) | 3 |
-| 9 | PassengerForm | Org | layout enum `PassengerFormLayout {stacked, flat, grouped}` (`PassengerForm.swift:50`) | 3 |
-| 10 | FlightTracker | Org | variant enum `{board, compact}` (`FlightTracker.swift:41`) | 2 |
-| 11 | SavedCardsList | Org | variant enum `{list, wallet}` (`SavedCardsList.swift:29`) | 2 |
-| 12 | FareFamilyCard | Org | layout enum `FareFamilyLayout {stacked, column}` (`FareFamilyCard.swift:22`) | 2 |
-| 13 | DatePriceStrip | Mol | layout enum `DatePriceLayout {grid(columns:), strip}` (`DatePriceStrip.swift:36`) | 2 |
-| 14 | TripTypeToggle | Mol | variant enum `{pill, underline}` (`TripTypeToggle.swift:48`) | 2 |
-| 15 | FlightStatusBadge | Atom | single look — `FlightStatusEmphasis {soft solid outline dot}` + size ramp are knobs | 1 |
-| 16 | SeatCell | Atom | single look — `SeatShape` / `SeatSelectionEmphasis` / display are knobs | 1 |
-| 17 | PassengerRow | Mol | single look — badge/seat/status/accessory knobs | 1 |
-| 18 | SeatLegend | Mol | single look — `SeatLegendOrientation {rows vertical inline}` is orientation | 1 |
-| 19 | AirportPicker | Org | single anatomy — `AirportPickerPresentation {inline sheet popover fullScreenCover}` is presentation; source itself pre-commits: *"Rows are fixed anatomy … no Style protocol until real archetypes exist"* (`AirportPicker.swift:21–23`) | 1 |
-| 20 | AncillaryCard | Org | single look — shell delegated to `CardStyle` (`AncillaryCard.swift:14–18`) | 1 |
-| 21 | BoardingPass | Org | single look — **style-exempt** (TicketStub notch chrome, `BoardingPass.swift:10–16`); `DetailsLayout {row grid}` is a cell-arrangement knob | 1 |
-| 22 | CheckInFlow | Org | single look — **exempt scaffold**; `DockLayout` / `CheckInProgressStyle` are knobs | 1 |
-| 23 | FareSummary | Org | single look — breakdown table with slots | 1 |
-| 24 | FilterBar | Org | single anatomy — `FilterChipStyle {solid outlined ghost}` is chip fill emphasis | 1 |
-| 25 | FlightCard | Org | single look — shell delegated to `CardStyle` (`FlightCard.swift:9–14`) | 1 |
-| 26 | FlightResultRow | Org | single look — shell delegated to `CardStyle` (`FlightResultRow.swift:10–15`) | 1 |
-| 27 | FlightTicketCard | Org | single look — **style-exempt** (TicketStub chrome, `FlightTicketCard.swift:10–16`) | 1 |
-| 28 | SeatMap | Org | single anatomy — cabin layout is *data* (column patterns/sections), not style | 1 |
-| 29 | StickyBookingBar | Org | single look — chrome delegated to `BarStyle` (`StickyBookingBar.swift:10–17`) | 1 |
+| 1 | FlightListItem | Org | **Full protocol** — `.compact .timeline .fareBoard .deal .ticket .journey .slices .timetable .tray .tile .hero .receipt` | **12** |
+| 2 | TripSearchCard | Org | `TripSearchVariant {card, hero, compact, inlineBar}` (`TripSearchCard.swift:41`) | 4 |
+| 3 | PaymentMethodSelector | Org | `PaymentMethodVariant {list, grid, carousel, compactList}` (`PaymentMethodSelector.swift:30`) | 4 |
+| 4 | CabinClassSelector | Mol | `CabinClassVariant {segmented, chips, list, cards}` (`CabinClassSelector.swift:21`) | 4 |
+| 5 | FlightRoute | Mol | `FlightRouteTrack {path, inline, arc, dots}` (`FlightRoute.swift:19–30`) | 4 |
+| 6 | TransportCrossSellCard | Org | `{ribbon, inline, tile}` (`TransportCrossSellCard.swift:32`) | 3 |
+| 7 | LayoverRow | Mol | `LayoverVariant {line, pill, banner}` (`LayoverRow.swift:19`) | 3 |
+| 8 | RecentSearchRow | Mol | `{plain, bordered, pill}` (`RecentSearchRow.swift:22`) | 3 |
+| 9 | PassengerForm | Org | `PassengerFormLayout {stacked, flat, grouped}` (`PassengerForm.swift:50`) | 3 |
+| 10 | FlightTracker | Org | `{board, compact}` (`FlightTracker.swift:41`) | 2 |
+| 11 | SavedCardsList | Org | `{list, wallet}` (`SavedCardsList.swift:29`) | 2 |
+| 12 | FareFamilyCard | Org | `FareFamilyLayout {stacked, column}` (`FareFamilyCard.swift:22`) | 2 |
+| 13 | DatePriceStrip | Mol | `DatePriceLayout {grid(columns:), strip}` (`DatePriceStrip.swift:36`) | 2 |
+| 14 | TripTypeToggle | Mol | `{pill, underline}` (`TripTypeToggle.swift:48`) | 2 |
+| 15–29 | FlightStatusBadge, SeatCell, PassengerRow, SeatLegend, AirportPicker, AncillaryCard, BoardingPass, CheckInFlow, FareSummary, FilterBar, FlightCard, FlightResultRow, FlightTicketCard, SeatMap, StickyBookingBar | — | single look (knob enums and/or delegated `CardStyle`/`BarStyle` shells; BoardingPass/FlightTicketCard carry the documented TicketStub chrome exemption, `BoardingPass.swift:10–16`, `FlightTicketCard.swift:10–16`) | 1 each |
 
-## 2. Ceiling — how many styles each *could* plausibly carry
+## 2. Decision
 
-"Ceiling" = the maximum count of **genuinely distinct layout anatomies** with a
-nameable industry archetype behind them. A bigger ceiling is *not* a mandate —
-ADR-F5 promotes on shipped demand, not on plausibility.
+**Every travel component gets its own full Style protocol** following the
+`FlightListItemStyle` reference anatomy verbatim — protocol + typed
+`Configuration` + `AnyXStyle` erasure + `EnvironmentValues` key + `where Self ==`
+accessors + preset structs + `.xStyle(_:)` modifier.
 
-### 2.1 The styled components
+- **29 components → 29 protocols** (28 new + `FlightListItemStyle` unchanged).
+- **Presets: 109 total** across the suite — **74 existing-mapped** (the 12
+  FlightListItem presets, all 38 variant-enum cases, 14 promoted knob-looks, and
+  10 single-look defaults) + **35 net-new archetypes** from the ceiling analysis.
+- Every existing `.variant(_:)`/`.layout(_:)`/knob modifier **deprecate-forwards**
+  to the new style accessors; each protocol's default preset reproduces today's
+  render pixel-for-pixel.
 
-| Component | Today | Ceiling | The archetypes that would fill the gap | Verdict |
-|---|---|---|---|---|
-| FlightListItem | 12 | **12 (hard cap)** | The containment rule (`THEMEKITTRAVEL_ARCHITECTURE.md:461`) makes 12 a ceiling, not a floor; new needs enter as additive `Configuration` fields | **Stay** — closed |
-| TripSearchCard | 4 looks / **3 anatomies** (see §3.1) | **6** | + `.pill` — floating collapsed search pill that expands (Airbnb/Skyscanner home header); + `.split` — two-pane hero for iPad/Mac landing (fields left, promo right) | **PROMOTE** (§4) |
-| PaymentMethodSelector | 4 looks / **2 anatomy families** — `.list`/`.compactList` share the row family (`PaymentMethodSelector.swift:141,215`), `.grid`/`.carousel` share one `tile(_:)` builder (`:305`) | 3 | + `.sectioned` — grouped rows (cards / wallets / other) — still the row family | **Stay enum** — the bar counts anatomies, not cases; two families ≠ three anatomies. Brand-custom option looks are already served by the `optionContent` slot (`:426`) |
-| CabinClassSelector | 4 | 4 | none — every case *delegates* its anatomy to an existing component (SegmentedControl / Chip / rows / cards); a style protocol here would just re-erase other components' styles | **Stay enum** (ADR-F5 assigned it exactly this, `:455`) |
-| FlightRoute | 4 tracks | 5 | + `.progress` — plane-position track for live tracking (feeds FlightTracker) | **Stay enum** — the track is a sub-element swap inside one time-col → track → time-col skeleton; anatomy never changes |
-| TransportCrossSellCard | 3 | 4 | + `.banner` — full-bleed promo strip | **Stay enum** — 3 anatomies exist, but the `.ribbon` identity is TicketStub notch chrome cut with `destinationOut` (`TransportCrossSellCard.swift:13–16`), the exemption class ADR-F5 `:457` names: a protocol would force custom styles to reimplement or lose the tear line. Promotion actively harms here |
-| LayoverRow | 3 | 3 | — | **Stay** — 161-line molecule; protocol overhead ≫ benefit |
-| RecentSearchRow | 3 | 4 | + `.card` — tile for a recents carousel | **Stay** — plain/bordered/pill share one row skeleton (chrome deltas) |
-| PassengerForm | 3 | 3 | — | **Stay** — forms are the ADR-F5 exempt class (`:457`); the three layouts arrange the same field set |
-| FlightTracker | 2 | **4** | + `.timeline` — phase-first vertical journey (flight-tracker apps' detail view); + `.banner` — status-tone strip for push-style surfaces | **Grow enum** (§5.1) |
-| SavedCardsList | 2 | **4** | + `.stack` — overlapping pass-book stack (Apple Wallet); + `.grid` tiles | **Grow enum** (§5.2) |
-| FareFamilyCard | 2 | **4** | + `.row` — horizontal comparison strip for narrow screens; + `.accordion` — collapsed expandable tier | **Grow enum** (§5.3) |
-| DatePriceStrip | 2 | 3 | + a month price-calendar (Hopper heat-map) — but a month grid with its own selection model is a **sibling component** (`PriceCalendar`), not a third case of a strip | **Stay** |
-| TripTypeToggle | 2 | 3 | + `.menu` — dropdown for dense headers | **Stay** — wait for demand |
+### 2.1 Naming law
 
-### 2.2 The single-look components — honest NOs
+**Protocol = component type name + `Style`, verbatim; modifier = lowerCamel of
+the protocol name.** No abbreviations (`PaymentMethodSelectorStyle`, not
+`PaymentStyle`): mechanical, grep-able, collision-free, and doc-generation
+(`tools/gen_skill.py`) can derive it. Matches the existing precedent
+(`FlightListItem` → `FlightListItemStyle` → `.flightListItemStyle(_:)`).
+Implementation gate: grep ThemeKit core for name collisions before each wave
+(none found in this audit; nearest neighbours `FilterChipStyle`,
+`CheckInProgressStyle`, `LayoverLineStyle`, `TearStyle` are enums that remain
+knobs or deprecate).
 
-- **Semantic-fixed atoms** (`FlightStatusBadge`, `SeatCell`): their identity *is*
-  the fixed anatomy; emphasis/shape knobs already cover brand variance. Ceiling 1.
-- **TicketStub-chrome organisms** (`BoardingPass`, `FlightTicketCard`): style-exempt
-  by documented decision in their own headers; the perforated shell is inseparable
-  from the layout. A horizontal-pass variant would be a knob-level rearrangement at
-  most. Ceiling 1–2, exemption blocks promotion regardless.
-- **Structure/scaffold organisms** (`CheckInFlow`, `PassengerForm`, `SeatMap`,
-  `AirportPicker`, `FilterBar`): the "layout" is data- or flow-driven;
-  `AirportPicker.swift:21–23` already records the no-protocol decision in source.
-- **CardStyle/BarStyle delegates** (`FlightCard`, `FlightResultRow`,
-  `AncillaryCard`, `FareSummary`, `StickyBookingBar`): re-skinning arrives through
-  the mothership's shell protocols. Crucially, *list-item archetype* demand around
-  `FlightCard`/`FlightResultRow` is already served by `FlightListItem`'s 12 presets
-  (`FlightListItem.swift:17–20` exists precisely to absorb it) — a second flight-row
-  style protocol would fork that surface.
-- **Row/legend molecules** (`PassengerRow`, `SeatLegend`): one skeleton plus knobs.
+### 2.2 Two configuration classes
 
-**Ceiling headline:** across the library, honest maximum ≈ **62 looks**
-(50 today + ~12 nameable new archetypes), of which this ADR proposes shipping
-**4** and rejects the rest as speculative.
+All 29 protocols share one anatomy but split into two configuration shapes,
+depending on what the component owns:
 
-## 3. Decision
+- **Class A — typed-data configuration** (the `FlightListItemStyle` shape
+  verbatim): the component owns *data*; the style lays it out. Fields are typed
+  values + resolved axes (`accent`, `surfaceKey`, `density`, `locale`) + optional
+  `AnyView` slots + action closures, with the same helper conventions
+  (`surface(default:)`, `spacing(_:)`, accent resolvers, shared formatters —
+  `FlightListItemStyle.swift:121–150`). Applies to 23 components (all cards,
+  rows, badges, cells, legends, selectors over value arrays).
+- **Class B — field-unit configuration**: the component owns *live interactive
+  controls* (bindings, sheets, debounce, focus). Rebuilding those per style would
+  duplicate interaction logic, so the configuration hands styles **pre-wired,
+  type-erased field units** plus typed signals; styles arrange, never re-wire.
+  (Slot precedent: `logo`/`accessory`/`footer: AnyView?` in
+  `FlightListItemConfiguration`, `FlightListItemStyle.swift:46,101,103`.)
+  Applies to 6 components: TripSearchCard, PassengerForm, AirportPicker,
+  CheckInFlow, SeatMap, StickyBookingBar.
 
-1. **Promote exactly one component to a full Style protocol: `TripSearchCard` →
-   `TripSearchStyle`** with four parity presets (`.card .hero .compact .inlineBar`)
-   and one demand-gated fifth (`.pill`). Rationale in §3.1, design in §4.
-2. **Grow three variant enums by one case each** (staying enums): `FlightTracker`
-   `+ .timeline`, `SavedCardsList` `+ .stack`, `FareFamilyCard` `+ .row` (§5).
-3. **Everything else stays as-is.** In particular `PaymentMethodSelector`,
-   `TransportCrossSellCard` and `CabinClassSelector` — the three other 3-or-4-case
-   enums — are ratified **non-promotions** with the reasons recorded in §2.1, so
-   future sweeps don't promote them by case-count alone.
-4. **Net-new archetypes proposed: 4** (3 variant cases + 1 gated preset). The
-   promotion itself is look-for-look (4 presets replacing 4 enum cases, zero new
-   looks at parity).
-
-### 3.1 Why TripSearchCard is the one that clears the bar
-
-- **≥3 shipped, distinct anatomies.** The body dispatches three skeletons: the
-  collapsed `summaryRow` (`TripSearchCard.swift:167,446`), the single-row
-  `inlineRun` with a `ViewThatFits` fallback (`:207–208`), and the stacked
-  `editorStack` (`:189`). These are different layout structures, not paint.
-  (`.hero` is honestly *not* a fourth anatomy — it is `contentPadding .lg` +
-  `.elevated` + a large CTA on the same stack (`:128–131,157`); it rides along as
-  a preset only for 1:1 source mapping.)
-- **Demand is real, not projected.** All four cases shipped because screens needed
-  them (F2.3 capstone + flexibility sweep), and the search card is the single most
-  brand-differentiated surface in travel apps — the place consumers will want an
-  archetype the built-ins can't express (pill, split-pane). A protocol makes that
-  a custom style instead of a fork of a 778-line organism.
-- **ADR-0001 mandates it.** *"Never both a `variant` … and a giant `switch` in the
-  body: 3+ archetypes use the style-protocol pattern"* (`ADR-0001:30,40–41`). The
-  component is at 4 cases and growing; the enum rung no longer "fits", so the
-  promotion rule's "lowest rung that fits" moves up.
-- Contrast the honest NOs: PaymentMethodSelector's four cases collapse to two
-  shared builder families (§2.1) — its rung still fits; TransportCrossSellCard's
-  three anatomies are welded to exempt chrome.
-
-## 4. Promotion design — `TripSearchStyle`
-
-Maps onto the `FlightListItemStyle` reference pattern, with one deliberate
-difference: FlightListItem's configuration hands styles **typed data** to lay out;
-a search card's content is **live, stateful field controls** (pickers, sheets,
-debounced queries). Rebuilding those per style would duplicate interaction logic
-12 ways — so the configuration hands styles **pre-wired field units** (the slot
-idiom, precedented by `logo`/`accessory`/`footer: AnyView?` in
-`FlightListItemConfiguration`, `FlightListItemStyle.swift:46,101,103`) plus typed
-signals for arrangement decisions. Styles own *arrangement and shell*; the
-component keeps *all* interaction (draft bindings, sheets, debounce, submit guard).
-
-### 4.1 Protocol + configuration (new file `Organisms/TripSearchStyle.swift`)
+#### Class A exemplar — `FlightCardStyle` (new file `Organisms/FlightCardStyle.swift`)
 
 ```swift
-/// The pre-wired building blocks a ``TripSearchStyle`` arranges. Field units are
-/// fully interactive (bindings, sheets, a11y fallbacks included); a style decides
-/// where they go, never how they work. Nil units were switched off by modifier
-/// (`.tripType(false)`, `.cabinPicker(false)`) or are empty slots.
-public struct TripSearchStyleConfiguration {
-    // Field units (type-erased, immediately evaluated — the SlotContent idiom).
-    public let tripType: AnyView?          // TripTypeToggle, wired to the draft
-    public let routeFields: AnyView        // origin + swap + destination (ViewThatFits a11y fallback inside)
-    public let dateFields: AnyView         // departure (+ animated return for round trips)
-    public let passengersField: AnyView    // FieldButton → GuestSelector bottom sheet
-    public let cabinField: AnyView?        // CabinClassSelector section
-    public let cta: AnyView                // submit button, completeness-disabled, read-only-guarded
-    public let header: AnyView?            // .header { } slot
-    public let promo: AnyView?             // .promo { } slot
-    public let footer: AnyView?            // .footer { } slot
-
-    // Typed signals for arrangement decisions.
-    public let draft: TripSearchDraft      // read-only snapshot (routes, dates, counts)
-    public let isDraftComplete: Bool
-    public let isExpanded: Bool            // collapsed-summary styles read this…
-    public let toggleExpand: () -> Void    // …and flip it (animated, MicroMotion-gated)
+public struct FlightCardConfiguration {
+    public let airline: String
+    public let legs: [FlightLeg]              // single- or multi-leg (FlightCard.swift:27)
+    public let logo: AnyView?
+    public let priceAmount: Decimal?
+    public let currencyCode: String?          // nil → FormatDefaults chain
+    public let badge: String?
+    public let scarcity: Int?                 // "5 seats left"
+    public let stops: Int
+    public let isSelected: Bool
+    public let onSelect: (() -> Void)?
     public let accent: SemanticColor?
-    public let surfaceKey: Theme.BackgroundColorKey?   // resolve via surface(default:)
-    public let elevation: CardElevation?   // explicit .elevation(_:) override, or nil
+    public let surfaceKey: Theme.BackgroundColorKey?
     public let density: ComponentDensity
     public let locale: Locale
-
     public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey
-    public func spacing(_ key: Theme.SpacingKey) -> CGFloat        // density-scaled
-    public func routeSummary() -> String   // "IST → LHR" / placeholder — for collapsed styles
-    public func detailSummary() -> String  // "18 Jul – 25 Jul · 2 adults · Economy"
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat
+    public func time(_ date: Date) -> String  // shared locale-captured formatters
 }
 
-public protocol TripSearchStyle {
+public protocol FlightCardStyle {
     associatedtype Body: View
-    @MainActor @ViewBuilder func makeBody(configuration: TripSearchStyleConfiguration) -> Body
-}
-```
-
-**Shell ownership:** the style draws its own shell — built-ins compose the neutral
-`Card` (so `CardStyle` delegation is preserved *transitively*, exactly as today's
-body does at `TripSearchCard.swift:156–158`), while custom styles may go shell-less
-(a nav-header pill or inline bar must not be forced into a card). This is the same
-"style owns the whole layout" stance as `FlightListItemStyle`.
-
-### 4.2 Presets (4 at parity + 1 gated)
-
-| Preset | Maps | Anatomy |
-|---|---|---|
-| `CardTripSearchStyle` (**default**) | `.card` | `Card { editor stack }`, `.md` padding, `.soft` elevation — pixel-identical to today |
-| `HeroTripSearchStyle` | `.hero` | same stack, `.lg` padding, `.elevated`, large CTA |
-| `CompactTripSearchStyle` | `.compact` | collapsed summary row ⇄ expanding editor via `isExpanded`/`toggleExpand` |
-| `InlineBarTripSearchStyle` | `.inlineBar` | one horizontal run of the units, `ViewThatFits` fallback to the stack |
-| `PillTripSearchStyle` — **gated**, ships only on audit-verified demand | — | floating capsule (`routeSummary` + glyph) that expands to the editor in an overlay/sheet; the Airbnb/Skyscanner home-header archetype `.compact` cannot express (capsule chrome, detached expansion) |
-
-Cross-preset building blocks (the summary row, the collapse header at
-`TripSearchCard.swift:478`) become shared `private` sub-views in the style file,
-per the SKILL's style-driven pattern.
-
-### 4.3 Wiring + accessors (verbatim FlightListItemStyle shape)
-
-```swift
-public extension TripSearchStyle where Self == CardTripSearchStyle {
-    static var card: Self { .init() }
-}
-// … .hero / .compact / .inlineBar (…and .pill when gated in)
-
-struct AnyTripSearchStyle: TripSearchStyle {                     // internal erasure
-    private let _makeBody: @MainActor (TripSearchStyleConfiguration) -> AnyView
-    init<S: TripSearchStyle>(_ style: sending S) { … }
-    func makeBody(configuration: TripSearchStyleConfiguration) -> AnyView { … }
+    @MainActor @ViewBuilder func makeBody(configuration: FlightCardConfiguration) -> Body
 }
 
-private struct TripSearchStyleKey: EnvironmentKey {
-    static let defaultValue = AnyTripSearchStyle(CardTripSearchStyle())
+public struct StandardFlightCardStyle: FlightCardStyle { … }   // today's look, verbatim
+public extension FlightCardStyle where Self == StandardFlightCardStyle {
+    static var standard: Self { .init() }
 }
-extension EnvironmentValues { var tripSearchStyle: AnyTripSearchStyle { … } }
+// …CondensedFlightCardStyle (.condensed), TileFlightCardStyle (.tile)
 
+struct AnyFlightCardStyle: FlightCardStyle { … }               // internal erasure, sending init
+private struct FlightCardStyleKey: EnvironmentKey {
+    static let defaultValue = AnyFlightCardStyle(StandardFlightCardStyle())
+}
+extension EnvironmentValues { var flightCardStyle: AnyFlightCardStyle { … } }
 public extension View {
-    /// Sets the search-card archetype for this subtree.
-    func tripSearchStyle<S: TripSearchStyle>(_ style: sending S) -> some View {
-        environment(\.tripSearchStyle, AnyTripSearchStyle(style))
+    func flightCardStyle<S: FlightCardStyle>(_ style: sending S) -> some View {
+        environment(\.flightCardStyle, AnyFlightCardStyle(style))
     }
 }
 ```
 
-`TripSearchCard.body` becomes: build the configuration from its existing private
-field builders (`editorStack`'s pieces at `:228–443` are already factored as
-`tripTypeToggle` / `routeFields` / `dateFields` / `passengersTrigger` /
-`cabinSection` / `cta(fullWidth:)`), then
-`AnyView(style.makeBody(configuration: config))`. `@State isExpanded` and the
-sheet/swap state stay in the component; styles only see `isExpanded` +
-`toggleExpand`.
+Default presets that are card-shaped keep composing the neutral `Card`, so
+`CardStyle` shell delegation (`FlightCard.swift:9–14`) is preserved
+*transitively*; custom/non-card presets may go shell-less.
 
-### 4.4 API safety & migration
+#### Class B exemplar — `TripSearchCardStyle` (new file `Organisms/TripSearchCardStyle.swift`)
 
-- **Purely additive.** New protocol + env key + modifier; default =
-  `CardTripSearchStyle` reproduces today's default exactly.
+```swift
+public struct TripSearchCardConfiguration {
+    // Pre-wired field units — fully interactive; styles arrange, never re-wire.
+    public let tripType: AnyView?          // TripTypeToggle bound to the draft (TripSearchCard.swift:228)
+    public let routeFields: AnyView        // origin + swap + destination, a11y fallback inside (:249)
+    public let dateFields: AnyView         // departure (+ animated return) (:319)
+    public let passengersField: AnyView    // FieldButton → GuestSelector sheet (:335)
+    public let cabinField: AnyView?        // (:396)
+    public let cta: AnyView                // completeness-disabled submit (:412–443)
+    public let header: AnyView?; public let promo: AnyView?; public let footer: AnyView?
+    // Typed signals for arrangement decisions.
+    public let draft: TripSearchDraft      // read-only snapshot
+    public let isDraftComplete: Bool
+    public let isExpanded: Bool            // collapsed styles read…
+    public let toggleExpand: () -> Void    // …and flip (MicroMotion-gated)
+    public let accent: SemanticColor?
+    public let surfaceKey: Theme.BackgroundColorKey?
+    public let elevation: CardElevation?
+    public let density: ComponentDensity
+    public let locale: Locale
+    public func routeSummary() -> String   // "IST → LHR" (for collapsed/pill styles)
+    public func detailSummary() -> String  // "18 Jul – 25 Jul · 2 adults · Economy"
+    public func surface(default: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat
+}
+
+public protocol TripSearchCardStyle {
+    associatedtype Body: View
+    @MainActor @ViewBuilder func makeBody(configuration: TripSearchCardConfiguration) -> Body
+}
+// CardTripSearchCardStyle (.card, default) / .hero / .compact / .inlineBar / .pill
+// + AnyTripSearchCardStyle, env key, .tripSearchCardStyle(_:) — same wiring as Class A.
+```
+
+`@State` (expansion, sheets, swap spin) stays in the component; styles see
+`isExpanded`/`toggleExpand` only. Same split for the other Class B components:
+PassengerForm hands wired field units + validator state; AirportPicker hands the
+search field + built section lists; CheckInFlow hands the `Steps` header unit,
+the current page, and the wired dock; SeatMap hands the built cabin grid, rail,
+deck selector, legend and summary units; StickyBookingBar hands the price block
+and CTA units (its `BarStyle` chrome delegation stays outside the new protocol).
+
+## 3. Per-component style matrix (the catalog)
+
+Default preset first — always today's render, pixel-for-pixel. *(m)* = mapped
+from an existing enum case / knob / single look; *(new)* = net-new archetype from
+the ceiling analysis, grounded in a named industry pattern.
+
+### Organisms
+
+| Component | Protocol → modifier | Presets | Count (m+new) |
+|---|---|---|---|
+| FlightListItem | `FlightListItemStyle` → `.flightListItemStyle(_:)` — **exists, unchanged** | `.timeline`(m, default) `.compact` `.fareBoard` `.deal` `.ticket` `.journey` `.slices` `.timetable` `.tray` `.tile` `.hero` `.receipt` (all m) | **12** (12+0) |
+| TripSearchCard | `TripSearchCardStyle` → `.tripSearchCardStyle(_:)` | `.card`(m, default — stacked editor, `TripSearchCard.swift:189`) `.hero`(m — `.lg` padding + elevated + large CTA, `:128–131,157`) `.compact`(m — collapsed summary ⇄ editor, `:167,446`) `.inlineBar`(m — one-row run w/ ViewThatFits fallback, `:207–208`) `.pill`(new — floating capsule that expands; Airbnb/Skyscanner home header) | **5** (4+1) |
+| PaymentMethodSelector | `PaymentMethodSelectorStyle` → `.paymentMethodSelectorStyle(_:)` | `.list`(m, default — ListRow radio rows, `:141`) `.grid`(m — tile grid, `:273`) `.carousel`(m — snap tiles, `:246`) `.compactList`(m — dense rows, `:215`) `.sectioned`(new — grouped rows: cards / wallets / other, with section headers) | **5** (4+1) |
+| SavedCardsList | `SavedCardsListStyle` → `.savedCardsListStyle(_:)` | `.list`(m, default — radio rows) `.wallet`(m — card-face tile carousel) `.stack`(new — overlapping pass-book stack that fans out; Apple Wallet) `.grid`(new — card-face tile grid) | **4** (2+2) |
+| FlightTracker | `FlightTrackerStyle` → `.flightTrackerStyle(_:)` | `.board`(m, default — badge + route/progress + facts + phase timeline) `.compact`(m — one-row strip) `.timeline`(new — phase-first vertical spine w/ per-phase facts; tracker-app detail) `.banner`(new — status-tone strip for push-style surfaces) | **4** (2+2) |
+| FareFamilyCard | `FareFamilyCardStyle` → `.fareFamilyCardStyle(_:)` | `.stacked`(m, default — chip, features, price footer) `.column`(m — comparison-matrix column) `.row`(new — horizontal strip: chip+features leading, price+select trailing) `.accordion`(new — collapsed tier that expands its feature list) | **4** (2+2) |
+| TransportCrossSellCard | `TransportCrossSellCardStyle` → `.transportCrossSellCardStyle(_:)` | `.ribbon`(m, default — notched TicketStub strip, `TransportCrossSellCard.swift:7–13`) `.inline`(m — flat ListRow) `.tile`(m — vertical grid card) `.banner`(new — full-bleed mode-tinted promo strip) | **4** (3+1) |
+| PassengerForm | `PassengerFormStyle` → `.passengerFormStyle(_:)` | `.stacked`(m, default) `.flat`(m) `.grouped`(m) `.carded`(new — each section in its own Card) | **4** (3+1) |
+| FlightCard | `FlightCardStyle` → `.flightCardStyle(_:)` | `.standard`(m, default — airline header + route + price/CTA footer) `.condensed`(new — one-line route summary + trailing price, no header row) `.tile`(new — vertical card for destination carousels) | **3** (1+2) |
+| FlightResultRow | `FlightResultRowStyle` → `.flightResultRowStyle(_:)` | `.row`(m, default — identity / route / price+CTA columns) `.stacked`(new — identity above route for narrow widths) `.minimal`(new — no CTA, whole-row tap + chevron) | **3** (1+2) |
+| FlightTicketCard | `FlightTicketCardStyle` → `.flightTicketCardStyle(_:)` | `.classic`(m, default — route header + dashed timeline + horizontal tear + stub) `.horizontal`(new — stub trailing behind a vertical tear; reuses the CrossSell vertical-tear technique, `TransportCrossSellCard.swift:16–21`) `.flat`(new — tearless plain card for dense lists) | **3** (1+2) |
+| BoardingPass | `BoardingPassStyle` → `.boardingPassStyle(_:)` | `.classic`(m, default — header/passenger/route/details + barcode stub) `.wallet`(new — QR-dominant vertical, two-column details; Apple Wallet pass) `.strip`(new — one-row gate strip: name/seat/mini-QR) | **3** (1+2) |
+| AncillaryCard | `AncillaryCardStyle` → `.ancillaryCardStyle(_:)` | `.row`(m, default — icon/title/price + stepper or toggle) `.tile`(new — vertical grid tile, stepper bottom) `.banner`(new — thumbnail-led full-width upsell) | **3** (1+2) |
+| FareSummary | `FareSummaryStyle` → `.fareSummaryStyle(_:)` | `.list`(m, default — labeled lines + hero total) `.receipt`(new — dotted leaders, overline labels, dashed rules) `.collapsed`(new — total-first row with disclosure to the lines) | **3** (1+2) |
+| StickyBookingBar | `StickyBookingBarStyle` → `.stickyBookingBarStyle(_:)` | `.standard`(m, default — price left / CTA right) `.stacked`(new — note+price above a full-width CTA) `.split`(new — secondary + primary action pair) — arranges *content*; `BarStyle` keeps drawing bar chrome (`StickyBookingBar.swift:10–17`) | **3** (1+2) |
+| CheckInFlow | `CheckInFlowStyle` → `.checkInFlowStyle(_:)` | `.steps`(m, default — `Steps` header + dock) `.bar`(m — promotes `CheckInProgressStyle.bar`, `CheckInFlow.swift:53`) `.paged`(new — page-dot pager, minimal header) | **3** (2+1) |
+| AirportPicker | `AirportPickerStyle` → `.airportPickerStyle(_:)` | `.list`(m, default — sectioned rows: IATA chip + city/airport, `AirportPicker.swift:21–23`) `.compact`(m — promotes `AirportPickerDensity.compact`, `:37`) `.codeGrid`(new — IATA chip grid for nearby/popular sections) — `AirportPickerPresentation` stays orthogonal (presentation ≠ style) | **3** (2+1) |
+| FilterBar | `FilterBarStyle` → `.filterBarStyle(_:)` | `.chips`(m, default — pinned actions + scrolling chips) `.segmented`(new — fixed equal segments, no scroll) `.stacked`(new — actions row above a wrapping chip row) — `FilterChipStyle` remains a knob within row-based presets | **3** (1+2) |
+| SeatMap | `SeatMapStyle` → `.seatMapStyle(_:)` | `.cabin`(m, default — rail + deck selector + grid + legend + summary) `.grid`(new — bare seat grid, chrome-less; venue-picker style) `.schematic`(new — fuselage-silhouette wrapper with wing/exit markers) | **3** (1+2) |
+
+### Molecules
+
+| Component | Protocol → modifier | Presets | Count (m+new) |
+|---|---|---|---|
+| CabinClassSelector | `CabinClassSelectorStyle` → `.cabinClassSelectorStyle(_:)` | `.segmented`(m, default) `.chips`(m) `.list`(m) `.cards`(m) — each preset keeps delegating to SegmentedControl/Chip/rows/cards | **4** (4+0) |
+| FlightRoute | `FlightRouteStyle` → `.flightRouteStyle(_:)` | `.path`(m, default) `.inline`(m) `.arc`(m) `.dots`(m) — promotes `FlightRouteTrack`; `Path`-drawing presets keep `.flipsForRightToLeftLayoutDirection(true)` | **4** (4+0) |
+| RecentSearchRow | `RecentSearchRowStyle` → `.recentSearchRowStyle(_:)` | `.plain`(m, default) `.bordered`(m) `.pill`(m) `.card`(new — vertical tile for a recents carousel) | **4** (3+1) |
+| LayoverRow | `LayoverRowStyle` → `.layoverRowStyle(_:)` | `.line`(m, default) `.pill`(m) `.banner`(m) | **3** (3+0) |
+| DatePriceStrip | `DatePriceStripStyle` → `.datePriceStripStyle(_:)` | `.grid`(m, default — `grid(columns:)` folds column count into the preset: `.grid(columns: 3)`) `.strip`(m — scrollable pills) `.chart`(new — price-bar histogram, bar height ∝ price; Google Flights price graph) | **3** (2+1) |
+| PassengerRow | `PassengerRowStyle` → `.passengerRowStyle(_:)` | `.row`(m, default) `.card`(new — bordered card, prominent edit/remove) `.compact`(new — single-line name+seat+chevron) | **3** (1+2) |
+| SeatLegend | `SeatLegendStyle` → `.seatLegendStyle(_:)` | `.rows`(m, default) `.vertical`(m) `.inline`(m) — promotes `SeatLegendOrientation` (`SeatLegend.swift:16–23`); `perRow` folds into `.rows(perRow:)` | **3** (3+0) |
+| TripTypeToggle | `TripTypeToggleStyle` → `.tripTypeToggleStyle(_:)` | `.pill`(m, default) `.underline`(m) `.menu`(new — Dropdown-composed for dense headers) | **3** (2+1) |
+
+### Atoms
+
+Honest note: atoms have no layout anatomy to swap — their "styles" are the
+emphasis/shape looks they already own as knob enums. We promote those knobs to
+presets **for suite uniformity only** (one mental model: everything answers to
+`.xStyle(_:)`, settable once per screen via the environment — the knob modifiers
+never could be). Remaining knobs (size ramps, palettes, display content) stay
+configuration fields, not presets.
+
+| Component | Protocol → modifier | Presets | Count (m+new) |
+|---|---|---|---|
+| FlightStatusBadge | `FlightStatusBadgeStyle` → `.flightStatusBadgeStyle(_:)` | `.soft`(m, default) `.solid`(m) `.outline`(m) `.dot`(m) — promotes `FlightStatusEmphasis` (`FlightStatusBadge.swift:20–29`); status hue stays semantic per status | **4** (4+0) |
+| SeatCell | `SeatCellStyle` → `.seatCellStyle(_:)` | `.rounded`(m, default) `.circle`(m) `.seatback`(m) — promotes `SeatShape` (`SeatMapModels.swift:236`); `SeatSelectionEmphasis`/palette/display stay config fields. Doubles as the pre-COW atom's modernization path (`SeatCell.swift:10–12`): the `shape:` init param deprecates toward the env style, no major needed | **3** (3+0) |
+
+**Totals: 29 protocols · 109 presets = 74 existing-mapped + 35 net-new.**
+Per-tier: organisms 19 protocols / 67 presets, molecules 8 / 27, atoms 2 / 7.
+
+## 4. Configuration essentials per cluster
+
+Shared rules for all 28 new configurations (implementation checklist):
+
+- Public `let` fields, internal memberwise init — additive-safe forever
+  (the `FlightListItemConfiguration.isFavorite` precedent,
+  `FlightListItemStyle.swift:79–83`): new needs enter as optional fields every
+  style may ignore, **never** as new presets without a demand note.
+- Always carried: `accent: SemanticColor?`, `surfaceKey:
+  Theme.BackgroundColorKey?` + `surface(default:)`, `density: ComponentDensity` +
+  `spacing(_:)`, `locale: Locale` + shared formatters. Radius via
+  `Theme.RadiusRole` where the component exposes it. No raw `Color`/`CGFloat` in
+  any configuration or preset signature (token rule).
+- Motion: components resolve `MicroMotion`/Reduce Motion *before* calling styles
+  (pass resolved `Animation?` or act in the component, as FlightListItem does for
+  `toggleExpand`/`toggleFavorite`) — styles never read motion env themselves.
+- Selection/expansion follow ADR-F4: configurations expose read state + toggle
+  closures; `ControllableState` stays in the component.
+- TicketStub-chrome components (`BoardingPass`, `FlightTicketCard`,
+  `TransportCrossSellCard.ribbon`): the former blanket exemption dissolves —
+  default presets *own* the TicketStub chrome inside `makeBody`, and the tear
+  helpers stay available to custom styles (TicketStub is already a public
+  ThemeKit component). `.cardStyle(_:)` remains a no-op on these presets, now
+  documented per-preset instead of per-component.
+- Cross-preset building blocks (summary rows, tear lines, tile builders like
+  `PaymentMethodSelector.tile(_:)` (`:305`)) become shared `private` sub-views in
+  the `<Component>Style.swift` file, per the SKILL's style-driven pattern.
+
+## 5. API safety & versioning
+
+- **Additive, minor-eligible:** 28 new protocols + configurations + erasures +
+  env keys + accessors + ~97 new preset structs; zero removals. Every default
+  preset is extracted verbatim from today's body → pixel parity, verified per
+  wave by demo screenshot.
 - **Deprecate-forward, never break:**
   ```swift
-  @available(*, deprecated, message: "Use .tripSearchStyle(.card/.hero/.compact/.inlineBar)")
-  func variant(_ v: TripSearchVariant) -> Self   // TripSearchCard.swift:562 today
+  @available(*, deprecated, message: "Use .paymentMethodSelectorStyle(.grid)")
+  func variant(_ v: PaymentMethodVariant) -> Self   // maps to the matching preset
   ```
-  During deprecation the stored variant, when explicitly set, wins over the
-  environment style (last-writer-wins at the call site is impossible to detect,
-  so: explicit `.variant(_:)` maps to the matching preset internally).
-  `TripSearchVariant` itself deprecates with the modifier and is removed at the
-  next major.
-- **Naming stays on the ADR-F5 triad** (`THEMEKITTRAVEL_ARCHITECTURE.md:463`):
-  `.accent(_:)` untouched, sizes native, no CGFloat knobs enter the configuration.
+  Applies to all 13 variant/layout enums, plus the promoted knobs
+  (`FlightStatusBadge` emphasis, `SeatCell` `shape:` init param, `SeatLegend`
+  orientation, `CheckInFlow` progress style, `AirportPicker` density). An
+  explicitly-set deprecated modifier **wins over the environment style**
+  (source-behavior stability); the enums themselves deprecate and are removed at
+  the next major together with the already-deferred SeatCell COW migration.
+- **The one real cost, flagged:** this is a *large* public-surface expansion —
+  roughly **+400 public symbols** (~28 × [protocol + config (~8–25 fields) +
+  modifier + 3–5 presets + accessors]). Each is a permanent API-stability
+  liability under `docs/API-STABILITY.md`. It fits a **minor** release
+  mechanically, but the recommendation is to ship all waves inside **one minor
+  train** (single changelog story, one docs/llms regeneration, one deprecation
+  epoch) rather than dribbling across releases — and to accept that the *next
+  major* is when the 13 enums and knob params actually disappear.
 
-### 4.5 Risks
+## 6. Interaction with the shell protocols
 
-- **AnyView field units & identity** — the SKILL's `.id` rule: the return
-  `DateField` appears/disappears inside `dateFields`; keep the insert/remove
-  transition by building that unit with stable identity inside the *component*
-  (as today, `:319–333`) so styles inherit correct animation for free.
-- **Configuration weight** — 9 erased units per render. Same order as
-  FlightListItem's erased slots; fields re-erase per render already (SlotContent
-  semantics), and state lives in the component/bindings, so diffing behavior is
-  unchanged. sr-ios-dev should still profile the compact expand/collapse.
-- **Containment** — adopt a FlightListItem-style rule at birth: **5 presets are
-  the cap** (`.pill` included); new needs enter as additive configuration fields.
+`CardStyle`/`BarStyle`/`FieldStyle` remain the *chrome* axes; the new protocols
+are the *arrangement* axes. Card-shaped presets compose the neutral `Card`
+(chrome keeps routing through `\.cardStyle` — today's behavior at
+`FlightCard.swift:9–14`, `AncillaryCard.swift:14–18`, `TripSearchCard.swift:156–158`);
+`StickyBookingBar` presets hand their arranged row to the active `BarStyle`;
+form/field components keep `FieldStyle` transitively. One law, documented in each
+style file's header: **component style arranges content; shell style paints
+chrome; token theme colors everything.**
 
-### 4.6 Verification hooks
+## 7. Rejected alternatives
 
-- `#Preview("TripSearchStyle matrix")` iterating all presets × light/dark via
-  `PreviewMatrix`, plus one custom in-preview style proving the protocol is
-  implementable from outside.
-- Demo: `xcrun simctl launch <bundle> -startTab 0 -openDemo "Trip Search Card"` —
-  gallery gains a style switcher; screenshot at parity before/after the migration
-  PR (the `.card` default must be pixel-identical).
+- **One universal cross-cutting `.travelStyle(_:)` design-language axis** (a
+  single `TravelStyle` protocol every component reads, presets like
+  `.classic`/`.modern`/`.dense`). Rejected: a style is only implementable because
+  its `Configuration` is *typed to the component* — a universal configuration
+  degenerates into `[AnyView]` + stringly keys (render-props by another name,
+  explicitly off-idiom), and a "design language" that must describe both a
+  `SeatCell` and a `CheckInFlow` can only carry paint, which is what the *theme*
+  already does. Cross-component cohesion is instead achieved the ThemeKit way:
+  set many `.xStyle(_:)` modifiers once at the screen root (they are all
+  environment keys — one `ThemeProvider`-style wrapper in the app can bundle
+  them), plus the existing `CardStyle`/`BarStyle` shells for shared chrome.
+- **Protocols only where anatomy exists (the v1 draft / ADR-F5 ladder):** one
+  promotion (TripSearchCard), three enum growths, everything else as-is.
+  Superseded by explicit user override; recorded here so the reasoning isn't
+  lost — the ladder still governs *future* components, and §3's (m)/(new) tags
+  preserve which presets are demand-proven vs. initiative-driven.
+- **Skipping the atoms** (leave `FlightStatusBadge`/`SeatCell` on knob enums).
+  Rejected for this initiative: the user's goal is a *uniformly* restyleable
+  suite; the honest handling is §3's — promote only the knob that *is* the look
+  (emphasis, shape), keep every other knob a configuration field, and say plainly
+  that these two protocols buy env-level set-once and custom-look extensibility
+  (e.g. a brand's own seat silhouette as a custom `SeatCellStyle`), not new
+  anatomy.
+- **A macro/codegen shortcut** (`@Styleable` generating the boilerplate).
+  Tempting at 28 protocols, but a macro dependency violates the zero-dependency
+  contract and hides the one thing that must stay reviewable per component: the
+  configuration's typed field list. The erasure/env-key/accessor boilerplate is
+  mechanical enough for a shared reference file + review checklist.
 
-## 5. Variant-case additions (staying enums)
+## 8. Sequenced build plan — 6 waves, PR-per-wave, disjoint files
 
-Each is one case in an existing enum + one branch on shared sub-views — no new
-protocol, no new axis. All are **P2, demand-tagged**: ship when a consumer screen
-(Demo counts) actually needs them; delete from the backlog after two quiet quarters.
+Parallelizable by the proven 4-agent pattern (each wave touches only its own
+component files + one new `<Component>Style.swift` per component; no file is in
+two waves). Every wave carries the same gates: pixel-parity screenshot of each
+default preset, `#Preview` matrix iterating all presets × light/dark
+(`PreviewMatrix`), one custom in-preview style proving external implementability,
+RTL + a11y-size spot-checks on layout-switching presets, demo style-switcher +
+`-openDemo "<Component>"` verification, llms/docs regen (`tools/gen_skill.py`).
 
-1. **`FlightTrackerVariant.timeline`** — phase-first vertical layout: the `Steps`
-   phase timeline (already composed in `.board`) becomes the spine, with
-   schedule/gate facts attached per phase. Distinct skeleton from both `.board`
-   (facts-first card) and `.compact` (one-row strip); the flight-tracker-app
-   detail archetype. Takes the enum to 3 looks / 3 anatomies — *at* the promotion
-   bar; §6 records why it still stays an enum.
-2. **`SavedCardsVariant.stack`** — overlapping pass-book stack of the existing
-   wallet card-face tiles (Apple Wallet archetype); tap fans out to select.
-   Reuses the `.wallet` tile builder; new arrangement only.
-3. **`FareFamilyLayout.row`** — horizontal strip: chip + condensed features
-   leading, price + select trailing; the narrow-screen fare-tier list where
-   `.column` matrices don't fit. Third arrangement of the shared
-   chip/features/price sub-views.
-
-## 6. Rejected alternatives
-
-- **Promote every 3+-case enum (PaymentMethodSelector, CabinClassSelector,
-  TransportCrossSellCard, LayoverRow, RecentSearchRow, PassengerForm — and
-  FlightTracker/SavedCardsList/FareFamilyCard after §5).** Rejected per component
-  in §2. The general failure: case-count ≠ anatomy-count. Payment's four cases are
-  two builder families; CabinClass delegates its anatomies; CrossSell's chrome is
-  exemption-class; the molecules are one-skeleton; and §5's enums reach 3 looks by
-  *reusing* builders — their rung still fits. Cost of over-promotion: ~6 protocols
-  × (Configuration + erasure + env key + accessors + docs + demo) ≈ hundreds of
-  public API points nobody asked for, each a permanent source-compat liability.
-- **A generic `TravelComponentStyle` / one mega-protocol.** A style is only useful
-  because its `Configuration` is *typed to the component*; a shared configuration
-  degenerates into `[AnyView]` + stringly keys — render-props by another name,
-  explicitly off-idiom.
-- **Growing `TripSearchVariant` instead (add `.pill`, `.split` as cases).** Keeps
-  the 778-line organism accreting a switch that ADR-0001 names an anti-pattern,
-  and still gives consumers no custom-archetype escape short of forking. The enum
-  rung demonstrably no longer fits.
-- **`FlightListItemStyle`-style typed-data configuration for TripSearchStyle**
-  (hand styles the raw `Binding<TripSearchDraft>` + airport datasets + callbacks).
-  Every style would rebuild pickers, sheets, debounce and submit guards —
-  duplicated interaction logic, divergent a11y. Field-unit slots keep behavior in
-  one place; this is the deliberate delta from the reference pattern, precedented
-  by the reference's own `AnyView` slots.
-- **Promote `DatePriceStrip` via a `.calendar` case/preset.** A month heat-map
-  calendar has its own data model (month windows, per-day availability) and
-  selection semantics — that's a sibling `PriceCalendar` component (and overlaps
-  the ThemeKitCalendar add-on), not a third look of a strip.
-
-## 7. Sequenced build plan (PR-per-unit, sr-ios-dev)
-
-| # | PR | Contents | Effort | Gate |
+| Wave | Cluster (disjoint files) | Protocols | Presets | Effort |
 |---|---|---|---|---|
-| 1 | `feat(travel): TripSearchStyle protocol + .card default` | New `TripSearchStyle.swift` (protocol, configuration, erasure, env key, modifier, `CardTripSearchStyle`); `TripSearchCard` renders through the env style; `.variant(_:)` maps internally; previews + parity screenshot via `-openDemo "Trip Search Card"` | **M** | `.card` pixel-parity |
-| 2 | `feat(travel): hero/compact/inlineBar presets + variant deprecation` | Three presets extracted from today's branches; `@available(deprecated)` on `.variant(_:)` + `TripSearchVariant`; demo style switcher; llms/docs regen (`tools/gen_skill.py`) | **M** | all four presets verified by deep-link, RTL + a11y-size pass on `.inlineBar` fallback |
-| 3 | `docs: ratify ADR-0004` | Merge this ADR; add the §2.1 non-promotion verdicts to `THEMEKITTRAVEL_ARCHITECTURE.md` §6 so the ladder table stays the single source | **S** | — |
-| 4* | `feat(travel): PillTripSearchStyle` | Gated on demand evidence | **M** | demand note in PR body |
-| 5* | `feat(travel): FlightTracker .timeline` | §5.1 | **S/M** | demand-tagged |
-| 6* | `feat(travel): SavedCardsList .stack` | §5.2 | **S** | demand-tagged |
-| 7* | `feat(travel): FareFamilyCard .row` | §5.3 | **S** | demand-tagged |
+| 0 | **Infrastructure**: reference doc (`docs/style-protocol-checklist.md`), demo style-switcher harness, name-collision grep, API-STABILITY note | 0 | 0 | S |
+| 1 | **Flight results**: FlightCard, FlightResultRow, FlightTicketCard, FlightRoute, FlightStatusBadge | 5 | 17 | M |
+| 2 | **Search**: TripSearchCard, AirportPicker, RecentSearchRow, TripTypeToggle, CabinClassSelector, DatePriceStrip | 6 | 22 | L (TripSearchCard is the hardest single item — Class B, 778 lines) |
+| 3 | **Booking & payment**: PaymentMethodSelector, SavedCardsList, FareFamilyCard, FareSummary, AncillaryCard, StickyBookingBar | 6 | 22 | L |
+| 4 | **Passenger & day-of-travel**: PassengerForm, PassengerRow, CheckInFlow, BoardingPass, FlightTracker, LayoverRow | 6 | 20 | L |
+| 5 | **Seats & filters**: SeatMap, SeatCell, SeatLegend, FilterBar, TransportCrossSellCard | 5 | 16 | M/L (SeatMap Class B; CrossSell tear chrome) |
 
-\* = demand-gated backlog, not sprint-committed.
+Wave order rationale: Wave 1 establishes the Class A template on the simplest
+cluster; Wave 2 lands the Class B exemplar early (highest-risk shape gets the
+longest soak); Waves 3–5 are parallel-safe after Wave 1 merges the template.
+FlightListItem ships nothing (already conformant) but its style file is the
+review baseline for every wave.
 
-## 8. Open questions for sr-ios-dev (pressure-test with call sites)
+## 9. Open questions for sr-ios-dev (pressure-test with call sites)
 
-1. **Deprecation precedence** — when a call site has both `.variant(.hero)` and an
-   ancestor `.tripSearchStyle(.compact)`, the explicit modifier should win for
-   source-behavior stability. Confirm with a call-site matrix that the internal
-   mapping doesn't surprise (esp. Demo screens that set both during migration).
-2. **`isExpanded` semantics for non-collapsing styles** — `CompactTripSearchStyle`
-   is the only consumer today; decide whether the configuration documents
-   "always true unless the style collapses" or exposes a
-   `supportsCollapse` hint. Prefer documentation over API.
-3. **Field-unit granularity** — is `routeFields` one unit (origin+swap+destination
-   welded) enough for `.split`/`.pill`, or do custom styles need
-   `originField`/`swapControl`/`destinationField` separately? Start welded
-   (additive to split later; splitting first can never be unsplit).
-4. **§5 demand ledger** — where do "audit-verified demand" notes live so gates are
-   checkable? Proposal: a `Demand:` line in the component header doc, cited in the
-   PR body.
+1. **Deprecation precedence mechanics** — explicit `.variant(_:)` beating an
+   ancestor `.xStyle(_:)`: confirm the internal mapping (stored optional variant
+   overrides env style when non-nil) reads sanely at mixed call sites during
+   migration, especially Demo screens setting both.
+2. **Class B unit granularity** — is `routeFields` (welded
+   origin+swap+destination) enough for `.pill`/custom search styles, or do styles
+   need the three units separately? Start welded; splitting later is additive.
+3. **`DatePriceStripStyle.grid(columns:)` / `SeatLegendStyle.rows(perRow:)`** —
+   parameterized presets (struct with a stored property) vs. keeping
+   `columns`/`perRow` as configuration fields. Prefer parameterized preset
+   structs (matches `where Self ==` accessors taking arguments); verify ergonomics.
+4. **AnyView diffing at scale** — the SKILL's `.id` rule for slot-type stability:
+   audit the Class B units that alternate view types (return date field,
+   compact expansion) for branch-identity loss; profile SeatMap `.grid` with
+   large cabins (erased grid unit).
+5. **Symbol-count check** — after Wave 1, measure the real public-symbol and
+   binary-size delta; if the ~400-symbol projection is materially exceeded,
+   surface it before Waves 3–5 rather than after.


### PR DESCRIPTION
## What
Architect (`ios-architect`) catalog answering the user's directive: **every travel component gets its own full Style protocol** (like `FlightListItemStyle`), so the entire suite is uniformly restyleable. The §6 anti-sprawl rule is **intentionally overridden** by explicit user request for this initiative (it stays the default law for future components). Planning doc only — no component source touched.

## The catalog
- **29 / 29 components get a Style protocol** — 28 new + `FlightListItemStyle` (unchanged). Naming law = component name + `Style`: `.flightCardStyle(_:)`, `.paymentMethodSelectorStyle(_:)`, `.seatMapStyle(_:)`, `.tripSearchCardStyle(_:)`, …
- **109 presets suite-wide**: **74 existing-mapped** (12 FlightListItem + all 38 variant-enum cases deprecate-forwarded + 14 promoted knob-looks + 10 single-look defaults) + **35 net-new distinct-anatomy archetypes** (e.g. TripSearch `.pill`, SavedCards `.stack`, Tracker `.timeline`/`.banner`, BoardingPass `.wallet`/`.strip`, FareSummary `.receipt`, SeatMap `.grid`/`.schematic`).
- Per-tier: organisms 19 protocols / 67 presets · molecules 8 / 27 · atoms 2 / 7 (atoms handled honestly — knob-promotion for uniformity).

## How it stays implementable
- **Two configuration classes**: **A — typed-data** (FlightListItemStyle verbatim, 23 components; `FlightCardStyle` exemplar) and **B — field-unit** (pre-wired interactive `AnyView` units so styles arrange but the component keeps all interaction/state; 6 components: TripSearchCard, PassengerForm, AirportPicker, CheckInFlow, SeatMap, StickyBookingBar; `TripSearchCardStyle` exemplar).
- **API-safe / minor-eligible** (~+400 public symbols — flagged as the real cost). Every default preset is pixel-parity; all 13 variant enums + 5 knobs **deprecate-forward** to the style accessors (explicit-modifier-wins), removed only at the next major.

## Plan
6-wave, PR-per-wave, disjoint files (4-parallel-`sr-ios-dev`-agent safe): Wave 0 infra → Flight results (5/17) → Search (6/22) → Booking & payment (6/22) → Passenger & day-of-travel (6/20) → Seats & filters (5/16). Rejected alternatives (universal `.travelStyle(_:)` axis, atom-skipping, `@Styleable` macro) + 5 open questions for call-site pressure-testing.

Status: **Proposed** — no implementation yet. `docs/ADR-0004-travel-style-protocols.md` (411 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)