### PR TITLE
docs(l10n): align website guide to ThemeKitStrings.register(bundle:table:)

### DIFF
--- a/website/src/content/docs/guides/localization.md
+++ b/website/src/content/docs/guides/localization.md
@@ -111,6 +111,20 @@ LanguageSwitcher([.init(code: "en"), .init(code: "tr")],
 Flip the picker and the entire library — View strings and non-View enum strings
 alike — switches language instantly, with no relaunch.
 
+## Loading the file from elsewhere (extensions / frameworks)
+
+Zero-config assumes `Bundle.main` + table `"ThemeKit"`. If your catalog ships in an app
+**extension** (whose `.main` is the extension), in a **framework** that embeds ThemeKit,
+or under a different table name, point ThemeKit at it once at launch:
+
+```swift
+ThemeKitStrings.register(bundle: .myFrameworkBundle, table: "ThemeKit")
+```
+
+`register(bundle:table:)` is the public entry point — the `bundle`/`table` are not
+settable individually. Call it before the first ThemeKit view renders (e.g. in your
+`App.init()` or `application(_:didFinishLaunching…)`).
+
 ## Precedence — highest wins
 
 1. **Per-component parameters** you pass in code (`Component(title: "…")`,


### PR DESCRIPTION
Follow-up to #282. The website localization guide didn't cover the extensions/frameworks case, and its earlier draft referenced `ThemeKitStrings.bundle`/`.table` — which are **not** public (they live behind the state lock). Aligns the guide with the README by documenting the actual public entry point.

- Adds a **"Loading the file from elsewhere (extensions / frameworks)"** section using `ThemeKitStrings.register(bundle:table:)` — for catalogs not in `Bundle.main` (app extensions, ThemeKit-embedding frameworks, custom table names).
- Notes that `bundle`/`table` are not individually settable and that `register(...)` must run before the first ThemeKit view renders.

Verified: website (Starlight) builds — `/guides/localization/` renders; `scripts/ci.sh` all gates green (SwiftLint, Neutrality, Build, Test 312).

🤖 Generated with [Claude Code](https://claude.com/claude-code)