### PR TITLE
feat(travel): Style-protocol Wave 2 — Search cluster + Class-B exemplar (ADR-0004)

### DIFF
--- a/Sources/ThemeKitTravel/Components/Molecules/CabinClassSelector.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/CabinClassSelector.swift
@@ -5,8 +5,9 @@
 //  Edition molecule (F2.1 · §9.5): economy / premium economy / business / first
 //  selection. A pure wrapper — zero bespoke chrome — over the neutral kit's
 //  `SegmentedControl` (default), `Chip` row, or `RadioGroup` (`.list`, for
-//  sheet contexts), keyed by the canonical `CabinClass` model. Maps
-//  `CabinClass` ⇄ index internally for the segmented control's `Binding<Int>`.
+//  sheet contexts), keyed by the canonical `CabinClass` model. Presentation is
+//  style-driven (``CabinClassSelectorStyle``, ADR-0004) — set once per screen
+//  via `.cabinClassSelectorStyle(_:)`.
 //
 
 import SwiftUI
@@ -18,6 +19,11 @@ import ThemeKit
 /// (default), a horizontally-scrolling `Chip` row, `RadioGroup`-style rows
 /// for sheet contexts, or a 2×2 grid of selectable `.cards` (glyph + label +
 /// optional description).
+///
+/// Superseded by ``CabinClassSelectorStyle`` (each case maps 1:1 to a preset —
+/// `.segmented`/`.chips`/`.list`/`.cards`); kept for source compatibility until
+/// the next major, together with the deprecated ``CabinClassSelector/variant(_:)``
+/// modifier.
 public enum CabinClassVariant: Sendable { case segmented, chips, list, cards }
 
 /// Control-size ramp forwarded to the wrapped kit controls (`SegmentedControl`
@@ -60,18 +66,18 @@ public enum CabinClassSelectorSize: Sendable {
 ///
 ///     CabinClassSelector(selection: $draft.cabin)
 ///         .classes([.economy, .business])   // e.g. domestic network
-///         .variant(.chips)
+///         .cabinClassSelectorStyle(.chips)
 public struct CabinClassSelector: View {
     @Environment(\.isEnabled) private var isEnabled     // R3 — set natively by `.disabled(_:)`
     @Environment(\.isReadOnly) private var isReadOnly   // E1 — normal chrome, selection blocked
-    @Environment(\.theme) private var theme
-    @Environment(\.layoutDirection) private var layoutDirection
+    @Environment(\.cabinClassSelectorStyle) private var envStyle
+    @Environment(\.componentDensity) private var density
+    @Environment(\.locale) private var locale
 
     @ControllableState private var selection: CabinClass
 
     // Appearance/config — mutated only through the modifiers below (R2).
     private var classes: [CabinClass] = CabinClass.allCases
-    private var variant: CabinClassVariant = .segmented
     private var showsGlyphs = false
     private var accent: SemanticColor? = nil
     private var sizeOverride: CabinClassSelectorSize?
@@ -79,6 +85,10 @@ public struct CabinClassSelector: View {
     private var labelOverride: ((CabinClass) -> String)?
     private var glyphOverride: ((CabinClass) -> String)?
     private var descriptionProvider: ((CabinClass) -> String?)?
+    /// Set by the deprecated ``variant(_:)`` modifier — an explicitly chosen
+    /// per-instance style wins over an ancestor's `.cabinClassSelectorStyle(_:)`
+    /// (source-behavior stability during the enum's deprecation window).
+    private var explicitStyle: AnyCabinClassSelectorStyle?
 
     /// Controlled — reads and writes flow through the caller's binding.
     public init(selection: Binding<CabinClass>) {   // R1
@@ -93,137 +103,30 @@ public struct CabinClassSelector: View {
     /// Never render an empty control: an empty `classes` list falls back to all four.
     private var displayedClasses: [CabinClass] { classes.isEmpty ? CabinClass.allCases : classes }
 
-    // Per-cabin content resolution — overrides win, the canonical model is the fallback.
-    private func label(for cabin: CabinClass) -> String { labelOverride?(cabin) ?? cabin.label }
-    private func glyph(for cabin: CabinClass) -> String { glyphOverride?(cabin) ?? cabin.glyph }
-    private func description(for cabin: CabinClass) -> String? { descriptionProvider?(cabin) }
-
     public var body: some View {
-        Group {
-            switch variant {
-            case .segmented: segmented
-            case .chips: chipRow
-            case .list: radioList
-            case .cards: cardGrid
-            }
-        }
-        .allowsHitTesting(!isReadOnly)   // E1 — read-only keeps chrome + VoiceOver value
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(String(themeKitTravel: "Cabin class"))
-    }
-
-    // MARK: .segmented — SegmentedControl wrap (CabinClass ⇄ index)
-
-    /// A selection outside `classes` displays as the first option until the
-    /// user picks; writes always land on a real member.
-    private var indexBinding: Binding<Int> {
-        Binding(
-            get: { displayedClasses.firstIndex(of: selection) ?? 0 },
-            set: { index in
-                guard displayedClasses.indices.contains(index) else { return }
-                selection = displayedClasses[index]
-            }
+        // Capture the projected binding, not `self` — writes route through
+        // `ControllableState` to whichever storage (internal / caller's) is live.
+        let selectionBinding = $selection
+        let labelOverride = labelOverride
+        let glyphOverride = glyphOverride
+        let configuration = CabinClassSelectorConfiguration(
+            classes: displayedClasses,
+            selected: selection,
+            select: { selectionBinding.wrappedValue = $0 },
+            showsGlyphs: showsGlyphs,
+            labelProvider: { labelOverride?($0) ?? $0.label },
+            glyphProvider: { glyphOverride?($0) ?? $0.glyph },
+            descriptionProvider: descriptionProvider ?? { _ in nil },
+            size: sizeOverride,
+            chipsWrap: chipsWrap,
+            accent: accent,
+            density: density,
+            locale: locale
         )
-    }
-
-    @ViewBuilder private var segmented: some View {
-        let base = SegmentedControl(
-            displayedClasses.map { SegmentItem(label(for: $0), systemImage: showsGlyphs ? glyph(for: $0) : nil) },
-            selection: indexBinding
-        )
-        let control = sizeOverride.map { base.size($0.segmented) } ?? base
-        // Spec mapping: accent → the thumbless `.tinted` selection style; the
-        // stock raised thumb keeps its neutral chroma when no accent is set.
-        if let accent { control.tinted(accent) } else { control }
-    }
-
-    // MARK: .chips — Chip row (radio semantics: tapping the selected chip keeps it)
-
-    @ViewBuilder private var chipRow: some View {
-        // Accent flows down the standard ComponentDefaults cascade so
-        // accent-aware `ChipStyle`s resolve it; the built-in tonal/solid
-        // chip chroma stays hero-tinted by design.
-        if chipsWrap {
-            // Wrapping FlowLayout — RTL-aware via the injected layout direction.
-            FlowLayout(spacing: Theme.SpacingKey.sm.value,
-                       lineSpacing: Theme.SpacingKey.sm.value,
-                       layoutDirection: layoutDirection) {
-                chipItems
-            }
-            .componentDefaults(accent: accent)
-        } else {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.SpacingKey.sm.value) { chipItems }
-            }
-            .componentDefaults(accent: accent)
-        }
-    }
-
-    private var chipItems: some View {
-        ForEach(displayedClasses, id: \.self) { cabin in
-            let chip = Chip(label(for: cabin), isSelected: Binding(
-                get: { selection == cabin },
-                set: { isOn in if isOn { selection = cabin } }
-            ))
-            .icon(showsGlyphs ? glyph(for: cabin) : nil)
-            if let sizeOverride { chip.size(sizeOverride.chip) } else { chip }
-        }
-    }
-
-    // MARK: .list — RadioGroup rows for sheet contexts
-
-    private var radioList: some View {
-        RadioGroup(
-            options: displayedClasses,
-            selection: Binding<CabinClass?>(
-                get: { selection },
-                set: { newValue in if let newValue { selection = newValue } }
-            ),
-            label: { label(for: $0) }
-        )
-        .accent(accent)
-    }
-
-    // MARK: .cards — 2×2 grid of selectable cards (glyph + label + optional description)
-
-    private var cardGrid: some View {
-        LazyVGrid(
-            columns: Array(repeating: GridItem(.flexible(), spacing: Theme.SpacingKey.sm.value), count: 2),
-            spacing: Theme.SpacingKey.sm.value
-        ) {
-            ForEach(displayedClasses, id: \.self) { cabin in card(cabin) }
-        }
-    }
-
-    private func card(_ cabin: CabinClass) -> some View {
-        let isOn = selection == cabin
-        let tint = accent ?? .primary
-        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
-        return Button { selection = cabin } label: {
-            VStack(spacing: Theme.SpacingKey.xs.value) {
-                Image(systemName: glyph(for: cabin))
-                    .textStyle(.headingXs)
-                    .foregroundStyle(isOn ? tint.base : theme.text(.textSecondary))
-                Text(label(for: cabin))
-                    .textStyle(.labelBase600)
-                    .foregroundStyle(theme.text(.textPrimary))
-                if let description = description(for: cabin) {
-                    Text(description)
-                        .textStyle(.bodySm400)
-                        .foregroundStyle(theme.text(.textSecondary))
-                        .multilineTextAlignment(.center)
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, (sizeOverride ?? .medium).cardPadding)
-            .padding(.horizontal, Theme.SpacingKey.sm.value)
-            .background(isOn ? tint.soft : theme.background(.bgElevatorPrimary), in: shape)
-            .overlay { shape.strokeBorder(isOn ? tint.base : theme.border(.borderPrimary), lineWidth: isOn ? 1.5 : 1) }
-            .contentShape(shape)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel([label(for: cabin), description(for: cabin)].compactMap { $0 }.joined(separator: ", "))
-        .accessibilityAddTraits(isOn ? .isSelected : [])
+        (explicitStyle ?? envStyle).makeBody(configuration: configuration)
+            .allowsHitTesting(!isReadOnly)   // E1 — read-only keeps chrome + VoiceOver value
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(String(themeKitTravel: "Cabin class"))
     }
 }
 
@@ -234,11 +137,24 @@ public extension CabinClassSelector {
     /// E.g. a domestic network: `[.economy, .business]`. An empty list falls
     /// back to all four so the control never renders empty.
     func classes(_ list: [CabinClass]) -> Self { copy { $0.classes = list } }
-    /// Presentation: `.segmented` (default), a `.chips` row, or `.list`
-    /// (RadioGroup-style rows for sheet contexts).
-    func variant(_ v: CabinClassVariant) -> Self { copy { $0.variant = v } }
-    /// Show each cabin's SF Symbol next to its label (`.segmented` / `.chips`;
-    /// the `.list` rows stay text-only, matching `RadioGroup` anatomy).
+    /// Presentation — superseded by the style axis: prefer
+    /// `.cabinClassSelectorStyle(.segmented/.chips/.list/.cards)`, settable once
+    /// per screen via the environment. This modifier keeps working and, when
+    /// called, wins over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .cabinClassSelectorStyle(.segmented/.chips/.list/.cards) instead")
+    func variant(_ v: CabinClassVariant) -> Self {
+        copy {
+            switch v {
+            case .segmented: $0.explicitStyle = AnyCabinClassSelectorStyle(SegmentedCabinClassSelectorStyle())
+            case .chips: $0.explicitStyle = AnyCabinClassSelectorStyle(ChipsCabinClassSelectorStyle())
+            case .list: $0.explicitStyle = AnyCabinClassSelectorStyle(ListCabinClassSelectorStyle())
+            case .cards: $0.explicitStyle = AnyCabinClassSelectorStyle(CardsCabinClassSelectorStyle())
+            }
+        }
+    }
+    /// Show each cabin's SF Symbol next to its label (the `.segmented` /
+    /// `.chips` styles; the `.list` rows stay text-only, matching `RadioGroup`
+    /// anatomy).
     func showsGlyphs(_ on: Bool = true) -> Self { copy { $0.showsGlyphs = on } }
     /// Semantic tint: `.segmented` switches to the tinted selection style,
     /// `.list` tints the radios, `.chips` feeds the subtree accent cascade,
@@ -247,16 +163,16 @@ public extension CabinClassSelector {
     /// Control-size ramp forwarded to the wrapped `SegmentedControl` / `Chip`
     /// (and the `.cards` padding step). Unset keeps each control's stock size.
     func size(_ s: CabinClassSelectorSize) -> Self { copy { $0.sizeOverride = s } }
-    /// Lay `.chips` out as a wrapping ``FlowLayout`` (RTL-aware) instead of a
-    /// horizontal `ScrollView` — every option visible at once.
+    /// Lay the `.chips` style out as a wrapping ``FlowLayout`` (RTL-aware)
+    /// instead of a horizontal `ScrollView` — every option visible at once.
     func chipsWrap(_ on: Bool = true) -> Self { copy { $0.chipsWrap = on } }
     /// Override the display label per cabin (default: the canonical
     /// ``CabinClass/label``), e.g. shortened labels for tight segmented rows.
     func label(_ f: @escaping (CabinClass) -> String) -> Self { copy { $0.labelOverride = f } }
     /// Override the SF Symbol per cabin (default: the canonical ``CabinClass/glyph``).
     func glyph(_ f: @escaping (CabinClass) -> String) -> Self { copy { $0.glyphOverride = f } }
-    /// Per-cabin description line, rendered by the `.cards` variant beneath the
-    /// label (`nil` for no description on that card). Other variants ignore it.
+    /// Per-cabin description line, rendered by the `.cards` style beneath the
+    /// label (`nil` for no description on that card). Other styles ignore it.
     func description(_ f: @escaping (CabinClass) -> String?) -> Self { copy { $0.descriptionProvider = f } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
@@ -280,18 +196,18 @@ public extension CabinClassSelector {
                     Text(verbatim: "Subset + tinted accent")
                     CabinClassSelector(selection: $cabin).classes([.economy, .business]).accent(.success)
                     Text(verbatim: "Chips")
-                    CabinClassSelector(selection: $cabin).variant(.chips).showsGlyphs()
+                    CabinClassSelector(selection: $cabin).showsGlyphs().cabinClassSelectorStyle(.chips)
                     Text(verbatim: "Chips · wrapping + small")
-                    CabinClassSelector(selection: $cabin).variant(.chips).chipsWrap().size(.small)
+                    CabinClassSelector(selection: $cabin).chipsWrap().size(.small).cabinClassSelectorStyle(.chips)
                     Text(verbatim: "List (sheet contexts)")
-                    CabinClassSelector(selection: $cabin).variant(.list).accent(.info)
+                    CabinClassSelector(selection: $cabin).accent(.info).cabinClassSelectorStyle(.list)
                     Text(verbatim: "Cards (glyph + label + description)")
                     CabinClassSelector(selection: $cabin)
-                        .variant(.cards)
                         .description { cabin in
                             cabin == .economy ? String(themeKitTravel: "Best value") : nil
                         }
                         .accent(.success)
+                        .cabinClassSelectorStyle(.cards)
                     Text(verbatim: "Label + glyph overrides · large")
                     CabinClassSelector(selection: $cabin)
                         .showsGlyphs()
@@ -300,7 +216,7 @@ public extension CabinClassSelector {
                         .glyph { $0 == .first ? "star" : $0.glyph }
                     Text(verbatim: "Uncontrolled · read-only · disabled")
                     CabinClassSelector(initiallySelected: .business)
-                    CabinClassSelector(selection: $cabin).variant(.chips).readOnly()
+                    CabinClassSelector(selection: $cabin).readOnly().cabinClassSelectorStyle(.chips)
                     CabinClassSelector(selection: $cabin).disabled(true)
                 }
                 .padding()
@@ -316,9 +232,9 @@ public extension CabinClassSelector {
         var body: some View {
             VStack(alignment: .leading, spacing: 24) {
                 CabinClassSelector(selection: $cabin).showsGlyphs()
-                CabinClassSelector(selection: $cabin).variant(.chips)
-                CabinClassSelector(selection: $cabin).variant(.list).accent(.success)
-                CabinClassSelector(selection: $cabin).variant(.cards)
+                CabinClassSelector(selection: $cabin).cabinClassSelectorStyle(.chips)
+                CabinClassSelector(selection: $cabin).accent(.success).cabinClassSelectorStyle(.list)
+                CabinClassSelector(selection: $cabin).cabinClassSelectorStyle(.cards)
             }
             .padding()
         }

--- a/Sources/ThemeKitTravel/Components/Molecules/CabinClassSelectorStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/CabinClassSelectorStyle.swift
@@ -1,0 +1,403 @@
+//
+//  CabinClassSelectorStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``CabinClassSelector`` — promotes the former
+//  ``CabinClassVariant`` enum (ADR-0004) so the whole presentation is a
+//  swappable style, settable once per screen via the environment. Four
+//  built-ins map 1:1 to the old variant cases, and each keeps *delegating* to
+//  the neutral kit exactly as the component always has — a style arranges, it
+//  never re-implements a control:
+//
+//    .segmented  inline `SegmentedControl` (CabinClass ⇄ index) — default
+//    .chips      `Chip` row — horizontal scroll, or a wrapping `FlowLayout`
+//    .list       `RadioGroup` rows for sheet contexts
+//    .cards      2×2 grid of selectable cards (glyph + label + description)
+//
+//      CabinClassSelector(selection: $draft.cabin)
+//          .classes([.economy, .business])
+//          .cabinClassSelectorStyle(.chips)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the token
+//  theme colors everything. Selection state stays in the component
+//  (`ControllableState`, ADR-F4) — styles read ``CabinClassSelectorConfiguration/selected``
+//  and write through ``CabinClassSelectorConfiguration/select`` (or the derived
+//  binding helpers), never owning state of their own.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``CabinClassSelectorStyle`` lays out. Fields a given
+/// style doesn't use are simply ignored — every built-in degrades gracefully
+/// (no glyphs requested → text-only, no description → two-line cards, no size
+/// override → each wrapped control's stock ramp).
+public struct CabinClassSelectorConfiguration {
+    /// The offered cabins, in display order — already resolved by the component
+    /// (`.classes(_:)`, with the empty-list → all-four fallback applied), so a
+    /// style never renders an empty control.
+    public let classes: [CabinClass]
+    /// The current selection. A value outside ``classes`` displays as the first
+    /// option until the user picks (the ``indexBinding`` rule).
+    public let selected: CabinClass
+    /// Commits a new selection — routes into the component's
+    /// `ControllableState`, so controlled and uncontrolled call sites both work.
+    public let select: (CabinClass) -> Void
+    /// Show each cabin's SF Symbol next to its label (`.showsGlyphs()`).
+    public let showsGlyphs: Bool
+    /// Display label per cabin — the `.label(_:)` override already folded over
+    /// the canonical ``CabinClass/label`` fallback.
+    public let labelProvider: (CabinClass) -> String
+    /// SF Symbol per cabin — the `.glyph(_:)` override already folded over the
+    /// canonical ``CabinClass/glyph`` fallback.
+    public let glyphProvider: (CabinClass) -> String
+    /// Optional per-cabin description line (`.description(_:)`), rendered by
+    /// `.cards` beneath the label; `nil` for no description on that cabin.
+    public let descriptionProvider: (CabinClass) -> String?
+    /// Control-size ramp (`.size(_:)`) forwarded to the wrapped
+    /// `SegmentedControl` / `Chip` (and the `.cards` padding step);
+    /// `nil` keeps each control's stock size.
+    public let size: CabinClassSelectorSize?
+    /// Lay chip-based styles out as a wrapping `FlowLayout` instead of a
+    /// horizontal `ScrollView` (`.chipsWrap()`).
+    public let chipsWrap: Bool
+    /// Semantic tint (`.accent(_:)`); `nil` = the stock hero chroma. `.cards`
+    /// resolves its selected-state tint via ``resolvedAccent``.
+    public let accent: SemanticColor?
+    /// The environment's component density, captured by the component — scale
+    /// chrome gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — use it for any
+    /// formatted values a custom style renders (labels arrive pre-localized
+    /// through ``labelProvider``).
+    public let locale: Locale
+
+    /// Whether `cabin` is the current selection.
+    public func isSelected(_ cabin: CabinClass) -> Bool { selected == cabin }
+
+    /// The `.accent(_:)` override, else `.primary` — the selected-state tint
+    /// the `.cards` built-in hardcoded before the style axis existed.
+    public var resolvedAccent: SemanticColor { accent ?? .primary }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out the selector.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// `CabinClass` ⇄ index bridge for `SegmentedControl`-like styles. A
+    /// selection outside ``classes`` displays as the first option until the
+    /// user picks; writes always land on a real member.
+    public var indexBinding: Binding<Int> {
+        Binding(
+            get: { classes.firstIndex(of: selected) ?? 0 },
+            set: { index in
+                guard classes.indices.contains(index) else { return }
+                select(classes[index])
+            }
+        )
+    }
+
+    /// Per-cabin on/off bridge for `Chip`-like styles — radio semantics:
+    /// selecting turns a cabin on, tapping the selected cabin again keeps it.
+    public func chipBinding(for cabin: CabinClass) -> Binding<Bool> {
+        Binding(
+            get: { selected == cabin },
+            set: { isOn in if isOn { select(cabin) } }
+        )
+    }
+
+    /// Optional-selection bridge for `RadioGroup`-like styles — deselection
+    /// writes (`nil`) are ignored, keeping the control single-select.
+    public var radioBinding: Binding<CabinClass?> {
+        Binding(
+            get: { selected },
+            set: { newValue in if let newValue { select(newValue) } }
+        )
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `CabinClassSelector`'s entire presentation. Implement `makeBody`
+/// to arrange the configuration's cabins. Set one with
+/// `.cabinClassSelectorStyle(_:)`; the default is ``SegmentedCabinClassSelectorStyle``.
+public protocol CabinClassSelectorStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: CabinClassSelectorConfiguration) -> Body
+}
+
+// MARK: - .segmented
+
+/// Today's default look, extracted verbatim: the neutral `SegmentedControl`
+/// wrapped over the cabin list (`CabinClass` ⇄ index), optional glyphs, the
+/// thumbless `.tinted` selection style when an accent is set.
+public struct SegmentedCabinClassSelectorStyle: CabinClassSelectorStyle {
+    public init() {}
+    public func makeBody(configuration: CabinClassSelectorConfiguration) -> some View {
+        SegmentedCabinClassChrome(configuration: configuration)
+    }
+}
+
+private struct SegmentedCabinClassChrome: View {
+    let configuration: CabinClassSelectorConfiguration
+
+    var body: some View {
+        let base = SegmentedControl(
+            configuration.classes.map {
+                SegmentItem(configuration.labelProvider($0),
+                            systemImage: configuration.showsGlyphs ? configuration.glyphProvider($0) : nil)
+            },
+            selection: configuration.indexBinding
+        )
+        let control = configuration.size.map { base.size($0.segmented) } ?? base
+        // Spec mapping: accent → the thumbless `.tinted` selection style; the
+        // stock raised thumb keeps its neutral chroma when no accent is set.
+        if let accent = configuration.accent { control.tinted(accent) } else { control }
+    }
+}
+
+// MARK: - .chips
+
+/// A `Chip` row with radio semantics (tapping the selected chip keeps it) — a
+/// horizontal `ScrollView`, or a wrapping RTL-aware `FlowLayout` when
+/// ``CabinClassSelectorConfiguration/chipsWrap`` is set.
+public struct ChipsCabinClassSelectorStyle: CabinClassSelectorStyle {
+    public init() {}
+    public func makeBody(configuration: CabinClassSelectorConfiguration) -> some View {
+        ChipsCabinClassChrome(configuration: configuration)
+    }
+}
+
+private struct ChipsCabinClassChrome: View {
+    @Environment(\.layoutDirection) private var layoutDirection
+    let configuration: CabinClassSelectorConfiguration
+
+    var body: some View {
+        // Accent flows down the standard ComponentDefaults cascade so
+        // accent-aware `ChipStyle`s resolve it; the built-in tonal/solid
+        // chip chroma stays hero-tinted by design.
+        if configuration.chipsWrap {
+            // Wrapping FlowLayout — RTL-aware via the injected layout direction.
+            FlowLayout(spacing: configuration.spacing(.sm),
+                       lineSpacing: configuration.spacing(.sm),
+                       layoutDirection: layoutDirection) {
+                chipItems
+            }
+            .componentDefaults(accent: configuration.accent)
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: configuration.spacing(.sm)) { chipItems }
+            }
+            .componentDefaults(accent: configuration.accent)
+        }
+    }
+
+    private var chipItems: some View {
+        ForEach(configuration.classes, id: \.self) { cabin in
+            let chip = Chip(configuration.labelProvider(cabin), isSelected: configuration.chipBinding(for: cabin))
+                .icon(configuration.showsGlyphs ? configuration.glyphProvider(cabin) : nil)
+            if let size = configuration.size { chip.size(size.chip) } else { chip }
+        }
+    }
+}
+
+// MARK: - .list
+
+/// `RadioGroup` rows for sheet contexts — the stock radio anatomy, text-only
+/// labels, accent-tinted radios when an accent is set.
+public struct ListCabinClassSelectorStyle: CabinClassSelectorStyle {
+    public init() {}
+    public func makeBody(configuration: CabinClassSelectorConfiguration) -> some View {
+        RadioGroup(
+            options: configuration.classes,
+            selection: configuration.radioBinding,
+            label: { configuration.labelProvider($0) }
+        )
+        .accent(configuration.accent)
+    }
+}
+
+// MARK: - .cards
+
+/// A 2×2 grid of selectable cards — glyph + label + optional description per
+/// cabin, the selected card tinted with ``CabinClassSelectorConfiguration/resolvedAccent``.
+public struct CardsCabinClassSelectorStyle: CabinClassSelectorStyle {
+    public init() {}
+    public func makeBody(configuration: CabinClassSelectorConfiguration) -> some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: configuration.spacing(.sm)), count: 2),
+            spacing: configuration.spacing(.sm)
+        ) {
+            ForEach(configuration.classes, id: \.self) { cabin in
+                CabinClassCard(configuration: configuration, cabin: cabin)
+            }
+        }
+    }
+}
+
+/// One selectable card of the `.cards` grid — glyph, label, optional
+/// description, accent-tinted when selected (extracted verbatim from the
+/// pre-style component body).
+private struct CabinClassCard: View {
+    @Environment(\.theme) private var theme
+    let configuration: CabinClassSelectorConfiguration
+    let cabin: CabinClass
+
+    var body: some View {
+        let isOn = configuration.isSelected(cabin)
+        let tint = configuration.resolvedAccent
+        let description = configuration.descriptionProvider(cabin)
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
+        Button { configuration.select(cabin) } label: {
+            VStack(spacing: configuration.spacing(.xs)) {
+                Image(systemName: configuration.glyphProvider(cabin))
+                    .textStyle(.headingXs)
+                    .foregroundStyle(isOn ? tint.base : theme.text(.textSecondary))
+                Text(configuration.labelProvider(cabin))
+                    .textStyle(.labelBase600)
+                    .foregroundStyle(theme.text(.textPrimary))
+                if let description {
+                    Text(description)
+                        .textStyle(.bodySm400)
+                        .foregroundStyle(theme.text(.textSecondary))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, (configuration.size ?? .medium).cardPadding)
+            .padding(.horizontal, configuration.spacing(.sm))
+            .background(isOn ? tint.soft : theme.background(.bgElevatorPrimary), in: shape)
+            .overlay { shape.strokeBorder(isOn ? tint.base : theme.border(.borderPrimary), lineWidth: isOn ? 1.5 : 1) }
+            .contentShape(shape)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel([configuration.labelProvider(cabin), description].compactMap { $0 }.joined(separator: ", "))
+        .accessibilityAddTraits(isOn ? .isSelected : [])
+    }
+}
+
+// MARK: - Static accessors
+
+public extension CabinClassSelectorStyle where Self == SegmentedCabinClassSelectorStyle {
+    /// Inline `SegmentedControl` over the cabin list. The default.
+    static var segmented: SegmentedCabinClassSelectorStyle { SegmentedCabinClassSelectorStyle() }
+}
+public extension CabinClassSelectorStyle where Self == ChipsCabinClassSelectorStyle {
+    /// A `Chip` row — horizontal scroll, or a wrapping `FlowLayout` with `.chipsWrap()`.
+    static var chips: ChipsCabinClassSelectorStyle { ChipsCabinClassSelectorStyle() }
+}
+public extension CabinClassSelectorStyle where Self == ListCabinClassSelectorStyle {
+    /// `RadioGroup` rows for sheet contexts.
+    static var list: ListCabinClassSelectorStyle { ListCabinClassSelectorStyle() }
+}
+public extension CabinClassSelectorStyle where Self == CardsCabinClassSelectorStyle {
+    /// A 2×2 grid of selectable cards (glyph + label + optional description).
+    static var cards: CardsCabinClassSelectorStyle { CardsCabinClassSelectorStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyCabinClassSelectorStyle: CabinClassSelectorStyle {
+    private let _makeBody: @MainActor (CabinClassSelectorConfiguration) -> AnyView
+    init<S: CabinClassSelectorStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: CabinClassSelectorConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct CabinClassSelectorStyleKey: EnvironmentKey {
+    static let defaultValue = AnyCabinClassSelectorStyle(SegmentedCabinClassSelectorStyle())
+}
+
+extension EnvironmentValues {
+    var cabinClassSelectorStyle: AnyCabinClassSelectorStyle {
+        get { self[CabinClassSelectorStyleKey.self] }
+        set { self[CabinClassSelectorStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``CabinClassSelectorStyle`` for `CabinClassSelector`s in this
+    /// view and its descendants — one screen can mix archetypes per section.
+    func cabinClassSelectorStyle<S: CabinClassSelectorStyle>(_ style: sending S) -> some View {
+        environment(\.cabinClassSelectorStyle, AnyCabinClassSelectorStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// Proves external implementability: a vertical checklist built purely from
+/// the public configuration + theme tokens — what an app target would write.
+private struct ChecklistCabinClassSelectorStyle: CabinClassSelectorStyle {
+    func makeBody(configuration: CabinClassSelectorConfiguration) -> some View {
+        ChecklistChrome(configuration: configuration)
+    }
+
+    private struct ChecklistChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: CabinClassSelectorConfiguration
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: configuration.spacing(.xs)) {
+                ForEach(configuration.classes, id: \.self) { cabin in
+                    let isOn = configuration.isSelected(cabin)
+                    Button { configuration.select(cabin) } label: {
+                        HStack(spacing: configuration.spacing(.sm)) {
+                            Image(systemName: isOn ? "checkmark.circle.fill" : "circle")
+                                .textStyle(.labelBase600)
+                                .foregroundStyle(isOn ? configuration.resolvedAccent.base : theme.text(.textTertiary))
+                            Text(configuration.labelProvider(cabin))
+                                .textStyle(.labelBase600)
+                                .foregroundStyle(theme.text(.textPrimary))
+                            Spacer()
+                        }
+                        .padding(.vertical, configuration.spacing(.xs))
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityAddTraits(isOn ? .isSelected : [])
+                }
+            }
+        }
+    }
+}
+
+#Preview("CabinClassSelectorStyle — presets × light/dark") {
+    PreviewMatrix("CabinClassSelectorStyle") {
+        PreviewCase("Segmented (default)") {
+            CabinClassSelector(initiallySelected: .economy).showsGlyphs()
+        }
+        PreviewCase("Segmented · subset + accent") {
+            CabinClassSelector(initiallySelected: .business)
+                .classes([.economy, .business])
+                .accent(.success)
+        }
+        PreviewCase("Chips") {
+            CabinClassSelector(initiallySelected: .premiumEconomy)
+                .showsGlyphs()
+                .cabinClassSelectorStyle(.chips)
+        }
+        PreviewCase("Chips · wrapping + small") {
+            CabinClassSelector(initiallySelected: .first)
+                .chipsWrap()
+                .size(.small)
+                .cabinClassSelectorStyle(.chips)
+        }
+        PreviewCase("List (sheet contexts)") {
+            CabinClassSelector(initiallySelected: .economy)
+                .accent(.info)
+                .cabinClassSelectorStyle(.list)
+        }
+        PreviewCase("Cards · description + accent") {
+            CabinClassSelector(initiallySelected: .business)
+                .description { $0 == .economy ? String(themeKitTravel: "Best value") : nil }
+                .accent(.success)
+                .cabinClassSelectorStyle(.cards)
+        }
+        PreviewCase("Custom (in-preview checklist)") {
+            CabinClassSelector(initiallySelected: .economy)
+                .cabinClassSelectorStyle(ChecklistCabinClassSelectorStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Molecules/DatePriceStrip.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/DatePriceStrip.swift
@@ -7,6 +7,14 @@
 //  build their own layout (a row, a carousel…). The lowest fare is auto-highlighted.
 //  Token-bound.
 //
+//  The *arrangement* is owned by the active ``DatePriceStripStyle`` from the
+//  environment (ADR-0004): the component gathers its typed data into a
+//  `DatePriceStripConfiguration` and hands it to the style — `.grid(columns: 3)`
+//  (default) is today's grid verbatim, `.strip` is the horizontal pill timeline,
+//  `.chart` is a price-bar histogram, and apps can implement their own. The
+//  deprecated `.layout(_:)` / `.strip()` / `.columns(_:)` modifiers forward to the
+//  matching preset and, when called, win over an ancestor's environment style.
+//
 
 import SwiftUI
 import ThemeKit
@@ -32,7 +40,11 @@ public struct DatePriceItem: Identifiable, Sendable {
 
 /// Layout of a ``DatePriceStrip``: a multi-column ``grid(columns:)`` (the stock
 /// three-column presentation) or the horizontal ``strip`` of scrollable pills.
-/// `.strip()` / `.columns(_:)` remain as forwarding sugar.
+///
+/// Superseded by ``DatePriceStripStyle`` (each case maps 1:1 to a preset —
+/// `.grid(columns:)` / `.strip`); kept for source compatibility until the next
+/// major, together with the deprecated ``DatePriceStrip/layout(_:)`` modifier
+/// and its `.strip()` / `.columns(_:)` sugar.
 public enum DatePriceLayout: Sendable {
     case grid(columns: Int)
     case strip
@@ -51,7 +63,9 @@ public enum DatePricePillSize: Sendable {
     }
 }
 
-/// A single selectable date+price card. Public so it can be reused outside ``DatePriceStrip``.
+/// A single selectable date+price card — the built-in cell the strip's `.grid` and
+/// `.strip` presets compose. Public so it can be reused outside ``DatePriceStrip``
+/// (a row, a carousel, a custom ``DatePriceStripStyle``…).
 /// The shell (surface, hairline, selected frame) is drawn by the active `CardStyle`;
 /// selection flows through `Configuration.isSelected`, so `.cardStyle(_:)` reskins it.
 public struct DatePriceCard: View {
@@ -200,123 +214,74 @@ public extension DatePriceCard {
 
 public struct DatePriceStrip: View {
     @Environment(\.componentDensity) private var density
+    @Environment(\.datePriceStripStyle) private var envStyle
+    @Environment(\.formatDefaults) private var formatDefaults
+    @Environment(\.locale) private var locale
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let items: [DatePriceItem]
     @Binding private var selection: Int
     // Appearance/state — mutated only through the modifiers below (R2).
-    @Environment(\.theme) private var theme
-    @Environment(\.formatDefaults) private var formatDefaults
-    @Environment(\.locale) private var locale
     private var currencyCode: String?
-    private var columns = 3
     private var highlightsCheapest = true
-    private var stripLayout = false
-    private var surface: Theme.BackgroundColorKey = .bgElevatorPrimary
+    /// `nil` → the style's own default surface (the built-ins use `.bgElevatorPrimary`).
+    private var surfaceKey: Theme.BackgroundColorKey?
     private var accent: SemanticColor?
     private var cheapestToneOverride: SemanticColor?
     private var pillSize: DatePricePillSize = .regular
     private var customCell: ((DatePriceItem, Bool) -> AnyView)?
     private var onPrev: (() -> Void)?
     private var onNext: (() -> Void)?
+    /// Bookkeeping for the deprecated `.layout(_:)` / `.strip()` / `.columns(_:)`
+    /// modifiers — an explicitly chosen per-instance layout wins over an
+    /// ancestor's `.datePriceStripStyle(_:)` (source-behavior stability during
+    /// the enum's deprecation window). `nil` everywhere → environment style.
+    private var explicitStrip: Bool?
+    private var explicitColumns: Int?
 
     public init(_ items: [DatePriceItem], selection: Binding<Int>) {   // R1
         self.items = items
         self._selection = selection
     }
 
-    private var cheapestIndex: Int? {
-        guard highlightsCheapest else { return nil }
-        let bookable = items.indices.filter { !items[$0].unavailable }
-        return bookable.min(by: { items[$0].price < items[$1].price })
-    }
-
     /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
-    /// Passed down explicitly so every card renders the strip's one resolved code.
+    /// Resolved here so every style renders the strip's one resolved code.
     private var resolvedCurrency: String {
         currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
+    /// The preset the deprecated layout modifiers mapped to, or `nil` when none
+    /// was called (the normal path — the environment style renders).
+    private var explicitStyle: AnyDatePriceStripStyle? {
+        if explicitStrip == true { return AnyDatePriceStripStyle(StripDatePriceStripStyle()) }
+        if explicitStrip == false || explicitColumns != nil {
+            return AnyDatePriceStripStyle(GridDatePriceStripStyle(columns: explicitColumns ?? 3))
+        }
+        return nil
+    }
+
     public var body: some View {
-        if stripLayout {
-            stripView
-        } else if onPrev != nil || onNext != nil {
-            HStack(spacing: 8) {
-                pageButton("chevron.left", label: String(themeKit: "Previous"), onPrev)
-                gridView.frame(maxWidth: .infinity)
-                pageButton("chevron.right", label: String(themeKit: "Next"), onNext)
-            }
-        } else {
-            gridView
-        }
-    }
-
-    /// The horizontal "Timeline" strip — scrollable pills on a surface, with the
-    /// selected pill auto-centered. The scroll/selection machinery also hosts a
-    /// custom ``cell(_:)`` when one is set.
-    private var stripView: some View {
-        let cheapest = cheapestIndex
-        return ScrollViewReader { proxy in
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.SpacingKey.xs.value) {
-                    ForEach(Array(items.enumerated()), id: \.offset) { i, item in
-                        cell(i, item, cheapest: cheapest, pill: true)
-                            .id(i)
-                    }
-                }
-                .padding(density.scale(Theme.SpacingKey.sm.value))
-            }
-            .background(theme.background(surface))
-            .onChange(of: selection) { _, new in
-                withAnimation { proxy.scrollTo(new, anchor: .center) }
-            }
-        }
-    }
-
-    private var gridView: some View {
-        let cheapest = cheapestIndex
-        return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: max(1, columns)), spacing: 8) {
-            ForEach(Array(items.enumerated()), id: \.offset) { i, item in
-                cell(i, item, cheapest: cheapest, pill: false)
-            }
-        }
-    }
-
-    /// One cell — a fully custom ``cell(_:)`` slot (selection machinery retained)
-    /// or the built-in ``DatePriceCard``, configured with the strip's settings.
-    @ViewBuilder private func cell(_ i: Int, _ item: DatePriceItem, cheapest: Int?, pill: Bool) -> some View {
-        if let customCell {
-            Button { selection = i } label: { customCell(item, i == selection) }
-                .buttonStyle(.plain)
-                .disabled(item.unavailable)
-                .accessibilityAddTraits(i == selection ? .isSelected : [])
-        } else {
-            configuredCard(i, item, cheapest: cheapest, pill: pill)
-        }
-    }
-
-    private func configuredCard(_ i: Int, _ item: DatePriceItem, cheapest: Int?, pill: Bool) -> DatePriceCard {
-        var card = DatePriceCard(item, isSelected: i == selection) { selection = i }
-            .currency(resolvedCurrency)
-            .cheapest(i == cheapest)
-            .surface(surface)
-            .accent(accent)
-        if let cheapestToneOverride { card = card.cheapestTone(cheapestToneOverride) }
-        if pill { card = card.pill().pillSize(pillSize) }
-        return card
-    }
-
-    private func pageButton(_ name: String, label: String, _ action: (() -> Void)?) -> some View {
-        Button { action?() } label: {
-            Image(systemName: name).textStyle(.labelBase600)
-                .foregroundStyle(theme.foreground(.fgHero))
-                .mirrorsInRTL()
-                .frame(width: 30, height: 30)
-                .background(theme.background(.bgSecondaryLight), in: Circle())
-        }
-        .buttonStyle(.plain)
-        .disabled(action == nil)
-        .opacity(action == nil ? 0.4 : 1)
-        .accessibilityLabel(label)
+        // The arrangement is owned by the active `DatePriceStripStyle`; motion
+        // is resolved *here* (MicroMotion ∧ ¬Reduce Motion) so styles never read
+        // the motion environment.
+        let configuration = DatePriceStripConfiguration(
+            items: items,
+            selectedIndex: selection,
+            select: { selection = $0 },
+            currencyCode: resolvedCurrency,
+            accent: accent,
+            cheapestTone: cheapestToneOverride,
+            pillSize: pillSize,
+            highlightsCheapest: highlightsCheapest,
+            surfaceKey: surfaceKey,
+            cellSlot: customCell,
+            onPrev: onPrev,
+            onNext: onNext,
+            isMotionEnabled: micro && !reduceMotion,
+            density: density,
+            locale: locale)
+        (explicitStyle ?? envStyle).makeBody(configuration: configuration)
     }
 }
 
@@ -326,30 +291,40 @@ public extension DatePriceStrip {
     /// Currency code for the prices. Unset, it resolves from `\.formatDefaults`,
     /// then the locale's currency, then "USD".
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }
-    /// Number of columns for the grid layout (default 3). Sugar for
-    /// `.layout(.grid(columns:))`.
-    func columns(_ count: Int) -> Self { copy { $0.columns = max(1, count) } }
-    /// Lay the dates out as a horizontal **strip** of scrollable pills (the
-    /// "Timeline" presentation) instead of the multi-column grid. Sugar for
-    /// `.layout(.strip)`.
-    func strip(_ on: Bool = true) -> Self { copy { $0.stripLayout = on } }
-    /// Layout of the strip: `.grid(columns:)` (default, 3 columns) or the
-    /// horizontal `.strip` of scrollable pills. Consolidates `.strip()` / `.columns(_:)`.
+    /// Number of columns for the grid layout — superseded by the style axis:
+    /// prefer `.datePriceStripStyle(.grid(columns:))`, settable once per screen
+    /// via the environment. This modifier keeps working and, when called, wins
+    /// over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .datePriceStripStyle(.grid(columns:)) instead")
+    func columns(_ count: Int) -> Self { copy { $0.explicitColumns = max(1, count) } }
+    /// Horizontal-strip presentation — superseded by the style axis: prefer
+    /// `.datePriceStripStyle(.strip)`, settable once per screen via the
+    /// environment. This modifier keeps working and, when called, wins over an
+    /// ancestor's environment style.
+    @available(*, deprecated, message: "Use .datePriceStripStyle(.strip) instead")
+    func strip(_ on: Bool = true) -> Self { copy { $0.explicitStrip = on } }
+    /// Layout of the strip — superseded by the style axis: prefer
+    /// `.datePriceStripStyle(.grid(columns:))` / `.datePriceStripStyle(.strip)`,
+    /// settable once per screen via the environment. This modifier keeps working
+    /// and, when called, wins over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .datePriceStripStyle(.grid(columns:)/.strip) instead")
     func layout(_ l: DatePriceLayout) -> Self {
         copy {
             switch l {
             case .grid(let columns):
-                $0.stripLayout = false
-                $0.columns = max(1, columns)
+                $0.explicitStrip = false
+                $0.explicitColumns = max(1, columns)
             case .strip:
-                $0.stripLayout = true
+                $0.explicitStrip = true
             }
         }
     }
     /// Auto-highlight the lowest fare in success green (default on).
     func highlightCheapest(_ on: Bool = true) -> Self { copy { $0.highlightsCheapest = on } }
-    /// Surface token for the strip track and the cards it builds (default `.bgElevatorPrimary`).
-    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surface = key } }
+    /// Surface token for the strip/chart track and the cards the style builds.
+    /// When unset, the active ``DatePriceStripStyle`` picks its own default
+    /// (the built-ins use `.bgElevatorPrimary`).
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
     /// Semantic accent for the selected state, forwarded to every card — pill
     /// fill `soft` + border `base`, card date/price `base`, wash `bg`.
     /// `nil` (default) keeps the stock hero chroma.
@@ -381,7 +356,9 @@ public extension DatePriceStrip {
         DatePriceItem("21 Jul", price: 1_474.99), DatePriceItem("22 Jul", price: 1_483.99),
     ]
     PreviewMatrix("DatePriceStrip") {
-        PreviewCase("Timeline strip (pills)") { DatePriceStrip(items, selection: $sel).strip() }
+        PreviewCase("Timeline strip (pills)") {
+            DatePriceStrip(items, selection: $sel).datePriceStripStyle(.strip)
+        }
         PreviewCase("Grid") { DatePriceStrip(items, selection: $sel) }
         PreviewCase("Paged grid") { DatePriceStrip(items, selection: $sel).onPage(prev: {}, next: {}) }
         PreviewCase("Custom surface") { DatePriceStrip(items, selection: $sel).surface(.bgSecondaryLight) }
@@ -389,7 +366,11 @@ public extension DatePriceStrip {
             DatePriceStrip(items, selection: $sel).accent(.info).cheapestTone(.warning)
         }
         PreviewCase("Strip · large pills · accent") {
-            DatePriceStrip(items, selection: $sel).layout(.strip).pillSize(.large).accent(.success)
+            DatePriceStrip(items, selection: $sel).pillSize(.large).accent(.success)
+                .datePriceStripStyle(.strip)
+        }
+        PreviewCase("Price chart") {
+            DatePriceStrip(items, selection: $sel).datePriceStripStyle(.chart)
         }
         PreviewCase("Weekdays + unavailable · 2 columns") {
             DatePriceStrip(
@@ -401,19 +382,21 @@ public extension DatePriceStrip {
                 ],
                 selection: $sel
             )
-            .layout(.grid(columns: 2))
+            .datePriceStripStyle(.grid(columns: 2))
         }
         PreviewCase("Custom cell slot") {
-            DatePriceStrip(items, selection: $sel).strip().cell { item, isSelected in
-                VStack(spacing: 2) {
-                    Text(item.date).textStyle(isSelected ? .labelSm700 : .bodySm400)
-                    Text(item.price.formatted(.currency(code: "USD").precision(.fractionLength(0))))
-                        .textStyle(.overline500)
+            DatePriceStrip(items, selection: $sel)
+                .cell { item, isSelected in
+                    VStack(spacing: 2) {
+                        Text(item.date).textStyle(isSelected ? .labelSm700 : .bodySm400)
+                        Text(item.price.formatted(.currency(code: "USD").precision(.fractionLength(0))))
+                            .textStyle(.overline500)
+                    }
+                    .padding(Theme.SpacingKey.sm.value)
+                    .background(isSelected ? SemanticColor.accent.soft : .clear,
+                                in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value))
                 }
-                .padding(Theme.SpacingKey.sm.value)
-                .background(isSelected ? SemanticColor.accent.soft : .clear,
-                            in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value))
-            }
+                .datePriceStripStyle(.strip)
         }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Molecules/DatePriceStripStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/DatePriceStripStyle.swift
@@ -1,0 +1,530 @@
+//
+//  DatePriceStripStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``DatePriceStrip`` — a Class A style protocol of ADR-0004
+//  (per-component style protocols): the configuration hands styles the *typed
+//  date/price data* (items, selection, cheapest highlight, paging…), not pre-laid
+//  content, so a style owns the entire arrangement. Three built-ins:
+//
+//    .grid(columns:)  the stock multi-column grid of date/price cards, with
+//                     optional prev/next paging chevrons. `.grid(columns: 3)`
+//                     is the default — today's render verbatim.
+//    .strip           the horizontal "Timeline" strip of scrollable pills; the
+//                     selected pill auto-centers (Reduce-Motion-gated).
+//    .chart           a price-bar histogram — bar height ∝ price, tap a bar to
+//                     select its date (the Google-Flights price-graph pattern).
+//
+//      DatePriceStrip(items, selection: $day)
+//          .datePriceStripStyle(.chart)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the shell
+//  `CardStyle` paints the card cells' chrome (grid/strip cells keep composing
+//  ``DatePriceCard``, which routes through `\.cardStyle`); the token theme colors
+//  everything. The component resolves MicroMotion / Reduce Motion before calling
+//  a style — styles read ``DatePriceStripConfiguration/isMotionEnabled``, never
+//  the motion environment.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``DatePriceStripStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no paging closures → no chevrons, no custom cell →
+/// the built-in ``DatePriceCard``).
+public struct DatePriceStripConfiguration {
+    /// The date/price options, in display order.
+    public let items: [DatePriceItem]
+    /// Index of the selected item in ``items``.
+    public let selectedIndex: Int
+    /// Selects the item at an index — writes the component's `selection` binding.
+    public let select: (Int) -> Void
+    /// Currency code for the prices — already resolved by the component through
+    /// the FormatDefaults chain (explicit → `formatDefaults` → `locale.currency`
+    /// → `"USD"`). Optional for additive safety only.
+    public let currencyCode: String?
+    /// Semantic accent for the selected state (`DatePriceStrip.accent(_:)`);
+    /// `nil` keeps the stock hero chroma — resolve via ``accentForeground(_:)``.
+    public let accent: SemanticColor?
+    /// Semantic tone for the lowest-fare highlight; `nil` keeps the stock
+    /// success token — resolve via ``cheapestForeground(_:)``.
+    public let cheapestTone: SemanticColor?
+    /// Height ramp for pill-shaped cells (the `.strip` presentation).
+    public let pillSize: DatePricePillSize
+    /// Whether the lowest bookable fare is auto-highlighted — when `false`,
+    /// ``cheapestIndex`` is `nil` and styles render no highlight.
+    public let highlightsCheapest: Bool
+    /// Explicit surface fill, or `nil` to let the style choose its default
+    /// (resolve via ``surface(default:)``; the built-ins use `.bgElevatorPrimary`).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Fully custom per-date cell (`DatePriceStrip.cell(_:)`) — `(item,
+    /// isSelected) → view`. Cell-based styles must wrap it in their own
+    /// selection machinery; non-cell styles (`.chart`) may ignore it.
+    public let cellSlot: ((DatePriceItem, Bool) -> AnyView)?
+    /// Pages the visible date window backwards; `nil` hides the chevron pair.
+    public let onPrev: (() -> Void)?
+    /// Pages the visible date window forwards; `nil` hides the chevron pair.
+    public let onNext: (() -> Void)?
+    /// Micro-animations resolved by the component (`MicroMotion` ∧ ¬Reduce
+    /// Motion) — gate scroll/selection animation on this; never read the motion
+    /// environment.
+    public let isMotionEnabled: Bool
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — use it for every
+    /// price string so injected locales (and RTL demos) render correctly.
+    public let locale: Locale
+
+    /// Index of the lowest-priced *bookable* item, or `nil` when highlighting
+    /// is off (or every item is unavailable). Capture once per body pass.
+    public var cheapestIndex: Int? {
+        guard highlightsCheapest else { return nil }
+        let bookable = items.indices.filter { !items[$0].unavailable }
+        return bookable.min(by: { items[$0].price < items[$1].price })
+    }
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so `.componentDensity`
+    /// compacts or airs out the strip.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// The `accent(_:)` override's base, else the theme's hero foreground — the
+    /// selected-state chroma every built-in uses.
+    public func accentForeground(_ theme: Theme) -> Color { accent?.base ?? theme.foreground(.fgHero) }
+
+    /// The `cheapestTone(_:)` override's base, else the stock success token —
+    /// the lowest-fare chroma every built-in uses.
+    public func cheapestForeground(_ theme: Theme) -> Color {
+        cheapestTone?.base ?? theme.foreground(.systemcolorsFgSuccess)
+    }
+
+    /// An item's price, formatted with the strip's resolved currency and the
+    /// captured locale (default whole units, the pill/chart presentation).
+    public func price(_ item: DatePriceItem, fractionDigits: Int = 0) -> String {
+        item.price.formatted(
+            .currency(code: currencyCode ?? "USD").precision(.fractionLength(fractionDigits)).locale(locale))
+    }
+
+    /// VoiceOver summary for the item at an index — "Fri 18 Jul, $1,768,
+    /// lowest fare, unavailable" — shared so all styles speak one language.
+    public func accessibilityLabel(at index: Int) -> String {
+        let item = items[index]
+        let dayDate = [item.weekday, item.date].compactMap { $0 }.joined(separator: " ")
+        var parts = [dayDate, price(item)]
+        if index == cheapestIndex { parts.append(String(themeKit: "lowest fare")) }
+        if item.unavailable { parts.append(String(themeKit: "unavailable")) }
+        return parts.joined(separator: ", ")
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `DatePriceStrip`'s entire presentation. Implement `makeBody` to
+/// lay out the configuration's date/price data. Set one with
+/// `.datePriceStripStyle(_:)`; the default is ``GridDatePriceStripStyle``
+/// with 3 columns.
+public protocol DatePriceStripStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: DatePriceStripConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// One selectable cell, shared by `.grid` and `.strip`: the custom `cell(_:)`
+/// slot wrapped in the selection machinery, or the built-in ``DatePriceCard``
+/// configured from the strip's settings — extracted verbatim from the
+/// pre-style component.
+private struct DatePriceStripCellView: View {
+    let configuration: DatePriceStripConfiguration
+    let index: Int
+    let cheapestIndex: Int?
+    let pill: Bool
+
+    var body: some View {
+        let item = configuration.items[index]
+        let isSelected = index == configuration.selectedIndex
+        if let slot = configuration.cellSlot {
+            Button { configuration.select(index) } label: { slot(item, isSelected) }
+                .buttonStyle(.plain)
+                .disabled(item.unavailable)
+                .accessibilityAddTraits(isSelected ? .isSelected : [])
+        } else {
+            configuredCard(item, isSelected: isSelected)
+        }
+    }
+
+    private func configuredCard(_ item: DatePriceItem, isSelected: Bool) -> DatePriceCard {
+        var card = DatePriceCard(item, isSelected: isSelected) { configuration.select(index) }
+            .currency(configuration.currencyCode ?? "USD")
+            .cheapest(index == cheapestIndex)
+            .surface(configuration.surface(default: .bgElevatorPrimary))
+            .accent(configuration.accent)
+        if let tone = configuration.cheapestTone { card = card.cheapestTone(tone) }
+        if pill { card = card.pill().pillSize(configuration.pillSize) }
+        return card
+    }
+}
+
+/// The prev/next paging chevron shared by `.grid` and `.chart` — extracted
+/// verbatim from the pre-style component (fixed 30 pt circular hit shape).
+private struct DatePriceStripPageButton: View {
+    @Environment(\.theme) private var theme
+    let systemName: String
+    let label: String
+    let action: (() -> Void)?
+
+    var body: some View {
+        Button { action?() } label: {
+            Image(systemName: systemName).textStyle(.labelBase600)
+                .foregroundStyle(theme.foreground(.fgHero))
+                .mirrorsInRTL()
+                .frame(width: 30, height: 30)
+                .background(theme.background(.bgSecondaryLight), in: Circle())
+        }
+        .buttonStyle(.plain)
+        .disabled(action == nil)
+        .opacity(action == nil ? 0.4 : 1)
+        .accessibilityLabel(label)
+    }
+}
+
+// MARK: - .grid(columns:)
+
+/// Today's ``DatePriceStrip`` look, extracted verbatim: a multi-column
+/// `LazyVGrid` of date/price cards, flanked by prev/next chevrons when paging
+/// closures are set. The column count is part of the preset —
+/// `.grid(columns: 3)` is the default.
+public struct GridDatePriceStripStyle: DatePriceStripStyle {
+    /// Number of grid columns (floored at 1).
+    public let columns: Int
+
+    public init(columns: Int = 3) { self.columns = max(1, columns) }
+
+    public func makeBody(configuration: DatePriceStripConfiguration) -> some View {
+        GridDatePriceStripChrome(configuration: configuration, columns: columns)
+    }
+}
+
+private struct GridDatePriceStripChrome: View {
+    let configuration: DatePriceStripConfiguration
+    let columns: Int
+
+    var body: some View {
+        if configuration.onPrev != nil || configuration.onNext != nil {
+            HStack(spacing: 8) {   // pre-style paged-grid gap, kept for pixel parity
+                DatePriceStripPageButton(
+                    systemName: "chevron.left",
+                    label: String(themeKit: "Previous"),
+                    action: configuration.onPrev)
+                grid.frame(maxWidth: .infinity)
+                DatePriceStripPageButton(
+                    systemName: "chevron.right",
+                    label: String(themeKit: "Next"),
+                    action: configuration.onNext)
+            }
+        } else {
+            grid
+        }
+    }
+
+    private var grid: some View {
+        let cheapest = configuration.cheapestIndex
+        return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: columns), spacing: 8) {
+            ForEach(Array(configuration.items.enumerated()), id: \.offset) { i, _ in
+                DatePriceStripCellView(configuration: configuration, index: i, cheapestIndex: cheapest, pill: false)
+            }
+        }
+    }
+}
+
+// MARK: - .strip
+
+/// The horizontal "Timeline" strip, extracted verbatim: scrollable pills on a
+/// surface track, with the selected pill auto-centered (animation gated on the
+/// component-resolved ``DatePriceStripConfiguration/isMotionEnabled``). Paging
+/// chevrons don't apply — the strip scrolls.
+public struct StripDatePriceStripStyle: DatePriceStripStyle {
+    public init() {}
+
+    public func makeBody(configuration: DatePriceStripConfiguration) -> some View {
+        StripDatePriceStripChrome(configuration: configuration)
+    }
+}
+
+private struct StripDatePriceStripChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: DatePriceStripConfiguration
+
+    var body: some View {
+        let cheapest = configuration.cheapestIndex
+        return ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Theme.SpacingKey.xs.value) {
+                    ForEach(Array(configuration.items.enumerated()), id: \.offset) { i, _ in
+                        DatePriceStripCellView(configuration: configuration, index: i, cheapestIndex: cheapest, pill: true)
+                            .id(i)
+                    }
+                }
+                .padding(configuration.spacing(.sm))
+            }
+            .background(theme.background(configuration.surface(default: .bgElevatorPrimary)))
+            .onChange(of: configuration.selectedIndex) { _, new in
+                withAnimation(configuration.isMotionEnabled ? .default : nil) {
+                    proxy.scrollTo(new, anchor: .center)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - .chart
+
+/// A price-bar histogram — the Google-Flights price-graph pattern: one bar per
+/// date, bar height proportional to the fare, price above and date below. Tap a
+/// bar to select its date; the cheapest bar takes the lowest-fare tone, the
+/// selected bar the accent, unavailable dates render muted and disabled. Sits
+/// on the strip's surface track; honors the paging chevrons. The custom
+/// `cell(_:)` slot doesn't apply — the chart draws its own bars.
+public struct ChartDatePriceStripStyle: DatePriceStripStyle {
+    public init() {}
+
+    public func makeBody(configuration: DatePriceStripConfiguration) -> some View {
+        ChartDatePriceStripChrome(configuration: configuration)
+    }
+}
+
+private struct ChartDatePriceStripChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: DatePriceStripConfiguration
+
+    // Genuine dimensions with no semantic token (SKILL): the bar column's fixed
+    // vertical scale — internal to the preset, never exposed as a knob.
+    private let chartHeight: CGFloat = 96
+    private let minBarHeight: CGFloat = 18
+
+    var body: some View {
+        if configuration.onPrev != nil || configuration.onNext != nil {
+            HStack(spacing: 8) {   // matches the paged-grid gap
+                DatePriceStripPageButton(
+                    systemName: "chevron.left",
+                    label: String(themeKit: "Previous"),
+                    action: configuration.onPrev)
+                chart.frame(maxWidth: .infinity)
+                DatePriceStripPageButton(
+                    systemName: "chevron.right",
+                    label: String(themeKit: "Next"),
+                    action: configuration.onNext)
+            }
+        } else {
+            chart
+        }
+    }
+
+    private var chart: some View {
+        let cheapest = configuration.cheapestIndex
+        return HStack(alignment: .bottom, spacing: Theme.SpacingKey.xs.value) {
+            ForEach(Array(configuration.items.enumerated()), id: \.offset) { i, _ in
+                bar(at: i, cheapestIndex: cheapest)
+            }
+        }
+        .padding(configuration.spacing(.sm))
+        .background(
+            theme.background(configuration.surface(default: .bgElevatorPrimary)),
+            in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+    }
+
+    private func bar(at index: Int, cheapestIndex: Int?) -> some View {
+        let item = configuration.items[index]
+        let isSelected = index == configuration.selectedIndex
+        let isCheapest = index == cheapestIndex
+        return Button { configuration.select(index) } label: {
+            VStack(spacing: Theme.SpacingKey.xs.value) {
+                Text(configuration.price(item))
+                    .textStyle(isSelected ? .overline500 : .overline400)
+                    .foregroundStyle(priceColor(item, isSelected: isSelected, isCheapest: isCheapest))
+                    .lineLimit(1)
+                UnevenRoundedRectangle(
+                    topLeadingRadius: Theme.RadiusRole.selector.value,
+                    topTrailingRadius: Theme.RadiusRole.selector.value,
+                    style: .continuous)
+                    .fill(barFill(item, isSelected: isSelected, isCheapest: isCheapest))
+                    .frame(height: barHeight(for: item))
+                Text(item.date)
+                    .textStyle(isSelected ? .labelSm600 : .overline400)
+                    .foregroundStyle(dateColor(item, isSelected: isSelected))
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(item.unavailable)
+        .accessibilityLabel(configuration.accessibilityLabel(at: index))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    /// Bar height ∝ price, normalized across *all* items (unavailable included,
+    /// so the scale stays stable): the cheapest date draws at ``minBarHeight``,
+    /// the priciest at ``chartHeight``. A flat fare curve draws mid-height.
+    private func barHeight(for item: DatePriceItem) -> CGFloat {
+        let prices = configuration.items.map(\.price)
+        guard let lowest = prices.min(), let highest = prices.max(), highest > lowest else {
+            return chartHeight * 0.62
+        }
+        let fraction = CGFloat(truncating: NSDecimalNumber(decimal: (item.price - lowest) / (highest - lowest)))
+        return minBarHeight + fraction * (chartHeight - minBarHeight)
+    }
+
+    private func barFill(_ item: DatePriceItem, isSelected: Bool, isCheapest: Bool) -> Color {
+        if item.unavailable { return theme.background(.bgSecondaryLight) }
+        if isSelected { return configuration.accentForeground(theme) }
+        if isCheapest { return configuration.cheapestForeground(theme) }
+        return (configuration.accent ?? .primary).soft
+    }
+
+    private func priceColor(_ item: DatePriceItem, isSelected: Bool, isCheapest: Bool) -> Color {
+        if item.unavailable { return theme.text(.textDisabled) }
+        if isSelected { return configuration.accentForeground(theme) }
+        if isCheapest { return configuration.cheapestForeground(theme) }
+        return theme.text(.textSecondary)
+    }
+
+    private func dateColor(_ item: DatePriceItem, isSelected: Bool) -> Color {
+        if item.unavailable { return theme.text(.textDisabled) }
+        return isSelected ? theme.text(.textPrimary) : theme.text(.textTertiary)
+    }
+}
+
+// MARK: - Static accessors
+
+public extension DatePriceStripStyle where Self == GridDatePriceStripStyle {
+    /// The stock multi-column grid of date/price cards — today's strip. The
+    /// default is `.grid(columns: 3)`.
+    static func grid(columns: Int = 3) -> GridDatePriceStripStyle { GridDatePriceStripStyle(columns: columns) }
+}
+public extension DatePriceStripStyle where Self == StripDatePriceStripStyle {
+    /// The horizontal "Timeline" strip of scrollable pills.
+    static var strip: StripDatePriceStripStyle { StripDatePriceStripStyle() }
+}
+public extension DatePriceStripStyle where Self == ChartDatePriceStripStyle {
+    /// A price-bar histogram — bar height ∝ price (the Google-Flights pattern).
+    static var chart: ChartDatePriceStripStyle { ChartDatePriceStripStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyDatePriceStripStyle: DatePriceStripStyle {
+    private let _makeBody: @MainActor (DatePriceStripConfiguration) -> AnyView
+    init<S: DatePriceStripStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: DatePriceStripConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct DatePriceStripStyleKey: EnvironmentKey {
+    static let defaultValue = AnyDatePriceStripStyle(GridDatePriceStripStyle(columns: 3))
+}
+
+extension EnvironmentValues {
+    var datePriceStripStyle: AnyDatePriceStripStyle {
+        get { self[DatePriceStripStyleKey.self] }
+        set { self[DatePriceStripStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``DatePriceStripStyle`` for `DatePriceStrip`s in this view and
+    /// its descendants — one screen can mix presentations per section.
+    func datePriceStripStyle<S: DatePriceStripStyle>(_ style: sending S) -> some View {
+        environment(\.datePriceStripStyle, AnyDatePriceStripStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a vertical agenda list, one row per date with the price trailing.
+private struct AgendaDatePriceStripStyle: DatePriceStripStyle {
+    func makeBody(configuration: DatePriceStripConfiguration) -> some View {
+        AgendaChrome(configuration: configuration)
+    }
+
+    private struct AgendaChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: DatePriceStripConfiguration
+
+        var body: some View {
+            let cheapest = configuration.cheapestIndex
+            return VStack(spacing: Theme.SpacingKey.xs.value) {
+                ForEach(Array(configuration.items.enumerated()), id: \.offset) { i, item in
+                    row(i, item, isCheapest: i == cheapest)
+                }
+            }
+        }
+
+        private func row(_ index: Int, _ item: DatePriceItem, isCheapest: Bool) -> some View {
+            let isSelected = index == configuration.selectedIndex
+            return Button { configuration.select(index) } label: {
+                HStack {
+                    Text([item.weekday, item.date].compactMap { $0 }.joined(separator: " "))
+                        .textStyle(isSelected ? .labelSm700 : .bodySm400)
+                        .foregroundStyle(item.unavailable ? theme.text(.textDisabled) : theme.text(.textPrimary))
+                    Spacer()
+                    Text(configuration.price(item))
+                        .textStyle(.labelSm600)
+                        .foregroundStyle(isCheapest
+                            ? configuration.cheapestForeground(theme)
+                            : theme.text(.textSecondary))
+                }
+                .padding(configuration.spacing(.sm))
+                .background(
+                    isSelected ? (configuration.accent ?? .primary).soft : theme.background(.bgWhite),
+                    in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
+            }
+            .buttonStyle(.plain)
+            .disabled(item.unavailable)
+            .accessibilityLabel(configuration.accessibilityLabel(at: index))
+            .accessibilityAddTraits(isSelected ? .isSelected : [])
+        }
+    }
+}
+
+#Preview("DatePriceStripStyle — presets × light/dark") {
+    @Previewable @State var sel = 1
+    let items = [
+        DatePriceItem("17 Jul", price: 1_697.99, weekday: "Fri"),
+        DatePriceItem("18 Jul", price: 1_767.99, weekday: "Sat"),
+        DatePriceItem("19 Jul", price: 1_960.99, weekday: "Sun", unavailable: true),
+        DatePriceItem("20 Jul", price: 1_914.99, weekday: "Mon"),
+        DatePriceItem("21 Jul", price: 1_474.99, weekday: "Tue"),
+        DatePriceItem("22 Jul", price: 1_483.99, weekday: "Wed"),
+    ]
+    PreviewMatrix("DatePriceStripStyle") {
+        PreviewCase("Grid (default, 3 columns)") { DatePriceStrip(items, selection: $sel) }
+        PreviewCase("Grid · 2 columns") {
+            DatePriceStrip(items, selection: $sel).datePriceStripStyle(.grid(columns: 2))
+        }
+        PreviewCase("Grid · paged") {
+            DatePriceStrip(items, selection: $sel).onPage(prev: {}, next: {})
+        }
+        PreviewCase("Strip") { DatePriceStrip(items, selection: $sel).datePriceStripStyle(.strip) }
+        PreviewCase("Chart") { DatePriceStrip(items, selection: $sel).datePriceStripStyle(.chart) }
+        PreviewCase("Chart · accent + cheapest tone + paged") {
+            DatePriceStrip(items, selection: $sel)
+                .accent(.info).cheapestTone(.warning)
+                .onPage(prev: {}, next: {})
+                .datePriceStripStyle(.chart)
+        }
+        PreviewCase("Custom (in-preview)") {
+            DatePriceStrip(items, selection: $sel).datePriceStripStyle(AgendaDatePriceStripStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Molecules/RecentSearchRow.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/RecentSearchRow.swift
@@ -4,11 +4,13 @@
 //
 //  Molecule. A recent / saved search summary — the route (from → to, one-way or
 //  round-trip), a dates + passengers caption, and a trailing chevron or remove
-//  button. Tap to re-run. Token-bound.
+//  button. Tap to re-run. Presentation is style-driven (``RecentSearchRowStyle``,
+//  ADR-0004) — set once per list via `.recentSearchRowStyle(_:)`. Token-bound.
 //
 //  ```swift
 //  RecentSearchRow(from: "IST", to: "AYT") { rerun() }
 //      .roundTrip().dates("18 – 27 Jul").passengers("2 adults · Economy").onRemove { remove() }
+//      .recentSearchRowStyle(.card)      // .plain (default) / .bordered / .pill
 //  ```
 //
 
@@ -17,8 +19,12 @@ import ThemeKit
 
 /// Chrome of a ``RecentSearchRow``: a flush `.plain` list row (default), a
 /// `.bordered` card, or a fully-rounded `.pill` capsule (the mini search bar).
-/// Consolidates the `.bordered()` / `.pill()` boolean pair — the previously
-/// silently-resolved `.bordered().pill()` conflict is unrepresentable.
+///
+/// Superseded by ``RecentSearchRowStyle`` (each case maps 1:1 to a preset —
+/// `.plain`/`.bordered`/`.pill`, joined by the new `.card` tile); kept for
+/// source compatibility until the next major, together with the deprecated
+/// ``RecentSearchRow/variant(_:)`` / ``RecentSearchRow/bordered(_:)`` /
+/// ``RecentSearchRow/pill(_:)`` modifiers.
 public enum RecentSearchVariant: Sendable { case plain, bordered, pill }
 
 /// Size ramp of the leading icon tile (internal 32/12 · 40/16 · 48/20 pt).
@@ -42,8 +48,9 @@ public enum RecentSearchTileSize: Sendable {
 }
 
 public struct RecentSearchRow: View {
-    @Environment(\.theme) private var theme
+    @Environment(\.recentSearchRowStyle) private var envStyle
     @Environment(\.componentDensity) private var density
+    @Environment(\.locale) private var locale
 
     private let from: String
     private let to: String
@@ -57,12 +64,18 @@ public struct RecentSearchRow: View {
     private var onSearch: (() -> Void)?
     private var searchAccent: SemanticColor = .neutral
     private var accent: SemanticColor?
-    private var variant: RecentSearchVariant = .plain
-    private var surfaceKey: Theme.BackgroundColorKey = .bgBase
-    private var radiusRole: Theme.RadiusRole = .field
+    /// `nil` → the style's own default surface (the built-ins use `.bgBase`).
+    private var surfaceKey: Theme.BackgroundColorKey?
+    /// `nil` → the style's own default role (`.bordered` uses `.field`, `.card` `.box`).
+    private var radiusRole: Theme.RadiusRole?
     private var tileSize: RecentSearchTileSize = .md
     private var viaCodes: [String] = []
     private var customLeading: AnyView?
+    /// Set by the deprecated ``variant(_:)`` / ``bordered(_:)`` / ``pill(_:)``
+    /// modifiers — an explicitly chosen per-instance style wins over an
+    /// ancestor's `.recentSearchRowStyle(_:)` (source-behavior stability
+    /// during the enum's deprecation window, ADR-0004 §5).
+    private var explicitStyle: AnyRecentSearchRowStyle?
 
     public init(from: String, to: String, action: @escaping () -> Void = {}) {   // R1
         self.from = from
@@ -70,94 +83,30 @@ public struct RecentSearchRow: View {
         self.action = action
     }
 
-    private var bordered: Bool { variant == .bordered }
-    private var pill: Bool { variant == .pill }
-
-    private var shape: AnyShape {
-        pill
-            ? AnyShape(Capsule(style: .continuous))
-            : AnyShape(RoundedRectangle(cornerRadius: radiusRole.value, style: .continuous))
-    }
-    private var caption: String? {
-        [dates, passengers].compactMap { $0 }.joined(separator: " · ").nilIfEmpty
-    }
-    /// The full route — origin, any `via` codes, destination.
-    private var routeStops: [String] { [from] + viaCodes + [to] }
-
     public var body: some View {
-        Button(action: action) {
-            HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-                if let customLeading {
-                    customLeading
-                } else if let systemImage {
-                    IconTile(systemImage).size(tileSize.tile).iconSize(tileSize.icon).accent(accent)
-                }
-                VStack(alignment: .leading, spacing: 2) {
-                    routeLine
-                    if let caption { Text(caption).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(1) }
-                }
-                Spacer(minLength: 6)
-                trailing
-            }
-            // Uniform tap padding, except the pill "mini search bar" (no leading
-            // tile) insets its content from the left (Figma pl-24 · pr-8 · py-8).
-            .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
-            .padding(.trailing, density.scale(Theme.SpacingKey.sm.value))
-            .padding(.leading, density.scale(pill && systemImage == nil && customLeading == nil
-                                             ? Theme.SpacingKey.base.value
-                                             : Theme.SpacingKey.sm.value))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background((bordered || pill) ? theme.background(surfaceKey) : .clear, in: shape)
-            .overlay { if bordered { shape.stroke(theme.border(.borderPrimary), lineWidth: 1) } }
-            .contentShape(shape)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(
-            String(themeKit: "\(from) to \(to)")
-                + (viaCodes.isEmpty ? "" : ", " + String(themeKit: "via \(viaCodes.joined(separator: ", "))"))
-                + (caption.map { ", " + $0 } ?? "")
-        )
+        // The arrangement is owned by the active `RecentSearchRowStyle`; the
+        // component only gathers its typed summary. No motion to resolve here.
+        let configuration = RecentSearchRowConfiguration(
+            from: from,
+            to: to,
+            roundTrip: roundTrip,
+            viaCodes: viaCodes,
+            dates: dates,
+            passengers: passengers,
+            systemImage: systemImage,
+            leading: customLeading,
+            action: action,
+            onSearch: onSearch,
+            onRemove: onRemove,
+            searchAccent: searchAccent,
+            accent: accent,
+            surfaceKey: surfaceKey,
+            radiusRole: radiusRole,
+            tileSize: tileSize,
+            density: density,
+            locale: locale)
+        (explicitStyle ?? envStyle).makeBody(configuration: configuration)
     }
-
-    /// The route — a from → to pair, or a multi-city chain when ``via(_:)`` is set
-    /// (IST → FRA → JFK). Multi-city always renders one-way arrows.
-    private var routeLine: some View {
-        HStack(spacing: 6) {
-            ForEach(Array(routeStops.enumerated()), id: \.offset) { i, code in
-                if i > 0 { routeArrow }
-                Text(code).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
-            }
-        }
-    }
-
-    private var routeArrow: some View {
-        Image(systemName: roundTrip && viaCodes.isEmpty ? "arrow.left.arrow.right" : "arrow.right")
-            .font(.system(size: 12, weight: .semibold))
-            .foregroundStyle(theme.text(.textTertiary))
-            .mirrorsInRTL()
-    }
-
-    @ViewBuilder private var trailing: some View {
-        if let onSearch {
-            ThemeButton(action: onSearch)
-                .icon(leading: "magnifyingglass")
-                .shape(.circle)
-                .color(searchAccent)
-                .size(.small)
-                .accessibilityLabel(String(themeKit: "Search"))
-        } else if let onRemove {
-            Button { onRemove() } label: {
-                Image(systemName: "xmark").font(.system(size: 12, weight: .semibold)).foregroundStyle(theme.text(.textTertiary))
-                    .frame(width: 44, height: 44).contentShape(Rectangle())
-            }.buttonStyle(.plain).accessibilityLabel(String(themeKit: "Remove"))
-        } else {
-            Image(systemName: "chevron.right").font(.system(size: 12, weight: .semibold)).foregroundStyle(theme.text(.textTertiary)).mirrorsInRTL()
-        }
-    }
-}
-
-private extension String {
-    var nilIfEmpty: String? { isEmpty ? nil : self }
 }
 
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
@@ -179,19 +128,49 @@ public extension RecentSearchRow {
     func searchAccent(_ color: SemanticColor) -> Self { copy { $0.searchAccent = color } }
     /// Brand-tints the leading icon tile (default: neutral tile).
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
-    /// Chrome: a flush `.plain` list row (default), a `.bordered` card, or the
-    /// fully-rounded `.pill` capsule. Consolidates `.bordered()` / `.pill()`.
-    func variant(_ v: RecentSearchVariant) -> Self { copy { $0.variant = v } }
-    /// Wrap in a bordered surface (default off — flush list row). Sugar for
-    /// `.variant(.bordered)`.
-    func bordered(_ on: Bool = true) -> Self { copy { $0.variant = on ? .bordered : .plain } }
+    /// Chrome — superseded by the style axis: prefer
+    /// `.recentSearchRowStyle(.plain/.bordered/.pill)`, settable once per list
+    /// via the environment (and joined by the new `.card` tile). This modifier
+    /// keeps working and, when called, wins over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .recentSearchRowStyle(.plain/.bordered/.pill) instead")
+    func variant(_ v: RecentSearchVariant) -> Self {
+        copy {
+            switch v {
+            case .plain: $0.explicitStyle = AnyRecentSearchRowStyle(PlainRecentSearchRowStyle())
+            case .bordered: $0.explicitStyle = AnyRecentSearchRowStyle(BorderedRecentSearchRowStyle())
+            case .pill: $0.explicitStyle = AnyRecentSearchRowStyle(PillRecentSearchRowStyle())
+            }
+        }
+    }
+    /// Wrap in a bordered surface (default off — flush list row). Superseded by
+    /// `.recentSearchRowStyle(.bordered)`; when called it wins over an
+    /// ancestor's environment style.
+    @available(*, deprecated, message: "Use .recentSearchRowStyle(.bordered) instead")
+    func bordered(_ on: Bool = true) -> Self {
+        copy {
+            $0.explicitStyle = on
+                ? AnyRecentSearchRowStyle(BorderedRecentSearchRowStyle())
+                : AnyRecentSearchRowStyle(PlainRecentSearchRowStyle())
+        }
+    }
     /// Fully-rounded **capsule** surface — a pill that sits on a colored band (the
     /// search-result mini bar). Fills with ``surface(_:)`` and drops the hairline.
-    /// Sugar for `.variant(.pill)`.
-    func pill(_ on: Bool = true) -> Self { copy { $0.variant = on ? .pill : .plain } }
-    /// Surface fill of the bordered / pill variant (background token key, default `.bgBase`).
+    /// Superseded by `.recentSearchRowStyle(.pill)`; when called it wins over an
+    /// ancestor's environment style.
+    @available(*, deprecated, message: "Use .recentSearchRowStyle(.pill) instead")
+    func pill(_ on: Bool = true) -> Self {
+        copy {
+            $0.explicitStyle = on
+                ? AnyRecentSearchRowStyle(PillRecentSearchRowStyle())
+                : AnyRecentSearchRowStyle(PlainRecentSearchRowStyle())
+        }
+    }
+    /// Surface fill of surfaced styles (background token key). When unset, the
+    /// active ``RecentSearchRowStyle`` picks its own default (the built-ins
+    /// use `.bgBase`; `.plain` draws no surface).
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
-    /// Corner radius role of the `.bordered` variant (default `.field`).
+    /// Corner-radius role of surfaced styles. When unset, the active style
+    /// picks its own default (`.bordered` uses `.field`, `.card` uses `.box`).
     func radius(_ role: Theme.RadiusRole) -> Self { copy { $0.radiusRole = role } }
     /// Intermediate stops for a multi-city route — renders IST → FRA → JFK
     /// instead of the fixed from → to pair.
@@ -212,13 +191,23 @@ public extension RecentSearchRow {
 
 #Preview {
     PreviewMatrix("RecentSearchRow") {
-        PreviewCase("Round trip") { RecentSearchRow(from: "IST", to: "AYT") { }.roundTrip().dates("18 – 27 Jul").passengers("2 adults · Economy") }
-        PreviewCase("Removable") { RecentSearchRow(from: "SAW", to: "ESB") { }.dates("2 Aug").passengers("1 adult").onRemove { } }
-        PreviewCase("Bordered") { RecentSearchRow(from: "IST", to: "LHR") { }.dates("5 Sep").passengers("1 adult").bordered() }
+        PreviewCase("Round trip") {
+            RecentSearchRow(from: "IST", to: "AYT") { }
+                .roundTrip().dates("18 – 27 Jul").passengers("2 adults · Economy")
+        }
+        PreviewCase("Removable") {
+            RecentSearchRow(from: "SAW", to: "ESB") { }.dates("2 Aug").passengers("1 adult").onRemove { }
+        }
+        PreviewCase("Bordered") {
+            RecentSearchRow(from: "IST", to: "LHR") { }
+                .dates("5 Sep").passengers("1 adult")
+                .recentSearchRowStyle(.bordered)
+        }
         PreviewCase("Bordered · box radius · large tile") {
             RecentSearchRow(from: "IST", to: "CDG") { }
                 .dates("12 Oct").passengers("2 adults")
-                .variant(.bordered).radius(.box).tileSize(.lg)
+                .radius(.box).tileSize(.lg)
+                .recentSearchRowStyle(.bordered)
         }
         PreviewCase("Multi-city via") {
             RecentSearchRow(from: "IST", to: "JFK") { }
@@ -240,8 +229,9 @@ public extension RecentSearchRow {
     RecentSearchRow(from: "Istanbul", to: "Antalya") { }
         .icon(nil)
         .dates("14 Jan").passengers("7")
-        .pill().surface(.bgWhite)
+        .surface(.bgWhite)
         .onSearch { }
+        .recentSearchRowStyle(.pill)
         .padding()
         .frame(maxWidth: .infinity)
         .background(SemanticColor.primary.solid)

--- a/Sources/ThemeKitTravel/Components/Molecules/RecentSearchRowStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/RecentSearchRowStyle.swift
@@ -1,0 +1,448 @@
+//
+//  RecentSearchRowStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``RecentSearchRow`` (ADR-0004): the configuration hands
+//  styles the *typed search summary* (route, caption strings, trailing actions),
+//  not pre-laid content, so a style owns the entire arrangement. Four built-ins
+//  — the first three map 1:1 to the former ``RecentSearchVariant`` cases:
+//
+//    .plain     flush list row, no surface — today's default, verbatim.
+//    .bordered  the row on a hairline-bordered rounded surface.
+//    .pill      fully-rounded capsule surface (the "mini search bar"), no hairline.
+//    .card      vertical tile for a horizontally scrolling recents carousel.
+//
+//      RecentSearchRow(from: "IST", to: "AYT") { rerun() }
+//          .roundTrip().dates("18 – 27 Jul")
+//          .recentSearchRowStyle(.card)
+//
+//  Component style arranges content; token theme colors everything. There is no
+//  motion in this component, so styles never touch the motion environment.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``RecentSearchRowStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no caption → route only, no trailing action → a
+/// plain chevron, no leading icon → no tile and no reserved space).
+public struct RecentSearchRowConfiguration {
+    /// Departure airport / city ("IST").
+    public let from: String
+    /// Arrival airport / city ("AYT").
+    public let to: String
+    /// Round-trip route — the built-ins draw a ⇄ arrow instead of → (multi-city
+    /// chains always render one-way arrows; see ``routeStops``).
+    public let roundTrip: Bool
+    /// Intermediate stops for a multi-city route (``RecentSearchRow/via(_:)``).
+    public let viaCodes: [String]
+    /// Preformatted dates caption ("18 – 27 Jul"); combine via ``caption``.
+    public let dates: String?
+    /// Preformatted passengers caption ("2 adults · Economy").
+    public let passengers: String?
+    /// Leading icon-tile glyph; `nil` = no tile (e.g. the search pill). Ignored
+    /// when the ``leading`` slot is set.
+    public let systemImage: String?
+    /// Custom replacement for the leading icon tile (an avatar, a flag…).
+    public let leading: AnyView?
+    /// The row's primary tap — re-runs the search. Every built-in wraps its
+    /// whole surface in a button that calls this.
+    public let action: () -> Void
+    /// Trailing filled search button; takes precedence over ``onRemove``.
+    public let onSearch: (() -> Void)?
+    /// Trailing remove (✕) button; `nil` (with no ``onSearch``) = a chevron.
+    public let onRemove: (() -> Void)?
+    /// Fill color of the ``onSearch`` button (default `.neutral` ink).
+    public let searchAccent: SemanticColor
+    /// Brand tint for the leading icon tile; `nil` = the neutral tile.
+    public let accent: SemanticColor?
+    /// Explicit surface fill, or `nil` to let the style choose its default
+    /// (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Explicit corner-radius role, or `nil` for the style's own default
+    /// (resolve via ``radius(default:)`` — `.bordered` uses `.field`,
+    /// `.card` uses `.box`).
+    public let radiusRole: Theme.RadiusRole?
+    /// Size ramp of the leading icon tile.
+    public let tileSize: RecentSearchTileSize
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — the built-ins render
+    /// preformatted strings, but custom styles that format dates/numbers must
+    /// use it so injected locales (and RTL demos) render correctly.
+    public let locale: Locale
+
+    /// The full route — origin, any `via` codes, destination.
+    public var routeStops: [String] { [from] + viaCodes + [to] }
+
+    /// The dates + passengers captions joined with a middot; `nil` when empty.
+    public var caption: String? {
+        let joined = [dates, passengers].compactMap { $0 }.joined(separator: " · ")
+        return joined.isEmpty ? nil : joined
+    }
+
+    /// The row's spoken summary — route, via stops, caption. Built-ins apply it
+    /// to their primary button so custom trailing controls stay reachable.
+    public var accessibilitySummary: String {
+        String(themeKit: "\(from) to \(to)")
+            + (viaCodes.isEmpty ? "" : ", " + String(themeKit: "via \(viaCodes.joined(separator: ", "))"))
+            + (caption.map { ", " + $0 } ?? "")
+    }
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// The explicit `radius(_:)` override, or the style's own default.
+    public func radius(default fallback: Theme.RadiusRole) -> Theme.RadiusRole {
+        radiusRole ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so `.componentDensity`
+    /// compacts or airs out the row.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+}
+
+// MARK: - Protocol
+
+/// Defines a `RecentSearchRow`'s entire presentation. Implement `makeBody` to
+/// lay out the configuration's search summary. Set one with
+/// `.recentSearchRowStyle(_:)`; the default is ``PlainRecentSearchRowStyle``.
+public protocol RecentSearchRowStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: RecentSearchRowConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The leading affordance — the custom ``RecentSearchRowConfiguration/leading``
+/// slot when set, else the ``IconTile`` glyph, else nothing.
+private struct RecentSearchRowLeading: View {
+    let configuration: RecentSearchRowConfiguration
+
+    var body: some View {
+        if let leading = configuration.leading {
+            leading
+        } else if let systemImage = configuration.systemImage {
+            IconTile(systemImage)
+                .size(configuration.tileSize.tile)
+                .iconSize(configuration.tileSize.icon)
+                .accent(configuration.accent)
+        }
+    }
+}
+
+/// The route — a from → to pair, or a multi-city chain when `via(_:)` is set
+/// (IST → FRA → JFK). Multi-city always renders one-way arrows.
+private struct RecentSearchRowRouteLine: View {
+    @Environment(\.theme) private var theme
+    let configuration: RecentSearchRowConfiguration
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(Array(configuration.routeStops.enumerated()), id: \.offset) { i, code in
+                if i > 0 { arrow }
+                Text(code).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
+            }
+        }
+    }
+
+    private var arrow: some View {
+        Image(systemName: configuration.roundTrip && configuration.viaCodes.isEmpty
+                ? "arrow.left.arrow.right"
+                : "arrow.right")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(theme.text(.textTertiary))
+            .mirrorsInRTL()
+    }
+}
+
+/// The trailing control — the filled search button (wins), the remove ✕, or,
+/// in row-shaped styles, a plain chevron.
+private struct RecentSearchRowTrailing: View {
+    @Environment(\.theme) private var theme
+    let configuration: RecentSearchRowConfiguration
+    var showsChevron = true
+
+    var body: some View {
+        if let onSearch = configuration.onSearch {
+            ThemeButton(action: onSearch)
+                .icon(leading: "magnifyingglass")
+                .shape(.circle)
+                .color(configuration.searchAccent)
+                .size(.small)
+                .accessibilityLabel(String(themeKit: "Search"))
+        } else if let onRemove = configuration.onRemove {
+            Button { onRemove() } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(theme.text(.textTertiary))
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(themeKit: "Remove"))
+        } else if showsChevron {
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(theme.text(.textTertiary))
+                .mirrorsInRTL()
+        }
+    }
+}
+
+/// The horizontal row shared by `.plain` / `.bordered` / `.pill` — today's
+/// ``RecentSearchRow`` body extracted verbatim; the chrome case only changes
+/// the surface fill, hairline and leading inset.
+private struct RecentSearchRowListChrome: View {
+    enum Chrome { case plain, bordered, pill }
+
+    @Environment(\.theme) private var theme
+    let configuration: RecentSearchRowConfiguration
+    let chrome: Chrome
+
+    private var shape: AnyShape {
+        chrome == .pill
+            ? AnyShape(Capsule(style: .continuous))
+            : AnyShape(RoundedRectangle(cornerRadius: configuration.radius(default: .field).value, style: .continuous))
+    }
+    private var hasLeading: Bool { configuration.leading != nil || configuration.systemImage != nil }
+
+    var body: some View {
+        Button(action: configuration.action) {
+            HStack(spacing: configuration.spacing(.sm)) {
+                RecentSearchRowLeading(configuration: configuration)
+                VStack(alignment: .leading, spacing: 2) {
+                    RecentSearchRowRouteLine(configuration: configuration)
+                    if let caption = configuration.caption {
+                        Text(caption).textStyle(.bodySm400)
+                            .foregroundStyle(theme.text(.textSecondary))
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 6)
+                RecentSearchRowTrailing(configuration: configuration)
+            }
+            // Uniform tap padding, except the pill "mini search bar" (no leading
+            // tile) insets its content from the left (Figma pl-24 · pr-8 · py-8).
+            .padding(.vertical, configuration.spacing(.sm))
+            .padding(.trailing, configuration.spacing(.sm))
+            .padding(.leading, configuration.spacing(chrome == .pill && !hasLeading ? .base : .sm))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                chrome == .plain ? .clear : theme.background(configuration.surface(default: .bgBase)),
+                in: shape)
+            .overlay { if chrome == .bordered { shape.stroke(theme.border(.borderPrimary), lineWidth: 1) } }
+            .contentShape(shape)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(configuration.accessibilitySummary)
+    }
+}
+
+// MARK: - .plain
+
+/// Today's ``RecentSearchRow`` look, extracted verbatim: a flush list row —
+/// leading tile, route + caption, trailing control — with no surface. Default.
+public struct PlainRecentSearchRowStyle: RecentSearchRowStyle {
+    public init() {}
+    public func makeBody(configuration: RecentSearchRowConfiguration) -> some View {
+        RecentSearchRowListChrome(configuration: configuration, chrome: .plain)
+    }
+}
+
+// MARK: - .bordered
+
+/// The row on a hairline-bordered rounded surface (`surface(_:)` fill, default
+/// `.bgBase`; `radius(_:)` role, default `.field`) — the standalone card form.
+public struct BorderedRecentSearchRowStyle: RecentSearchRowStyle {
+    public init() {}
+    public func makeBody(configuration: RecentSearchRowConfiguration) -> some View {
+        RecentSearchRowListChrome(configuration: configuration, chrome: .bordered)
+    }
+}
+
+// MARK: - .pill
+
+/// A fully-rounded capsule surface that sits on a colored band — the search
+/// summary "mini bar". Fills with `surface(_:)` and drops the hairline; with no
+/// leading tile the content insets further from the leading edge.
+public struct PillRecentSearchRowStyle: RecentSearchRowStyle {
+    public init() {}
+    public func makeBody(configuration: RecentSearchRowConfiguration) -> some View {
+        RecentSearchRowListChrome(configuration: configuration, chrome: .pill)
+    }
+}
+
+// MARK: - .card
+
+/// A vertical tile for a horizontally scrolling recents carousel: leading tile
+/// and trailing control on top, route + caption below, on a hairline-bordered
+/// `.box` surface. Give carousel tiles a width from the outside.
+public struct CardRecentSearchRowStyle: RecentSearchRowStyle {
+    public init() {}
+    public func makeBody(configuration: RecentSearchRowConfiguration) -> some View {
+        CardRecentSearchRowChrome(configuration: configuration)
+    }
+}
+
+private struct CardRecentSearchRowChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: RecentSearchRowConfiguration
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: configuration.radius(default: .box).value, style: .continuous)
+    }
+
+    var body: some View {
+        Button(action: configuration.action) {
+            VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+                HStack(alignment: .top, spacing: configuration.spacing(.sm)) {
+                    RecentSearchRowLeading(configuration: configuration)
+                    Spacer(minLength: 0)
+                    // Search wins over remove (the row presets' precedence); no
+                    // chevron — the whole tile is the tap affordance.
+                    RecentSearchRowTrailing(configuration: configuration, showsChevron: false)
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    RecentSearchRowRouteLine(configuration: configuration)
+                    if let caption = configuration.caption {
+                        Text(caption).textStyle(.bodySm400)
+                            .foregroundStyle(theme.text(.textSecondary))
+                            .lineLimit(2)
+                    }
+                }
+            }
+            .padding(configuration.spacing(.md))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(theme.background(configuration.surface(default: .bgBase)), in: shape)
+            .overlay { shape.stroke(theme.border(.borderPrimary), lineWidth: 1) }
+            .contentShape(shape)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(configuration.accessibilitySummary)
+    }
+}
+
+// MARK: - Static accessors
+
+public extension RecentSearchRowStyle where Self == PlainRecentSearchRowStyle {
+    /// Flush list row, no surface — today's look. The default.
+    static var plain: PlainRecentSearchRowStyle { PlainRecentSearchRowStyle() }
+}
+public extension RecentSearchRowStyle where Self == BorderedRecentSearchRowStyle {
+    /// The row on a hairline-bordered rounded surface.
+    static var bordered: BorderedRecentSearchRowStyle { BorderedRecentSearchRowStyle() }
+}
+public extension RecentSearchRowStyle where Self == PillRecentSearchRowStyle {
+    /// Fully-rounded capsule surface — the "mini search bar", no hairline.
+    static var pill: PillRecentSearchRowStyle { PillRecentSearchRowStyle() }
+}
+public extension RecentSearchRowStyle where Self == CardRecentSearchRowStyle {
+    /// Vertical tile for a recents carousel: tile top, route + caption below.
+    static var card: CardRecentSearchRowStyle { CardRecentSearchRowStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyRecentSearchRowStyle: RecentSearchRowStyle {
+    private let _makeBody: @MainActor (RecentSearchRowConfiguration) -> AnyView
+    init<S: RecentSearchRowStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: RecentSearchRowConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct RecentSearchRowStyleKey: EnvironmentKey {
+    static let defaultValue = AnyRecentSearchRowStyle(PlainRecentSearchRowStyle())
+}
+
+extension EnvironmentValues {
+    var recentSearchRowStyle: AnyRecentSearchRowStyle {
+        get { self[RecentSearchRowStyleKey.self] }
+        set { self[RecentSearchRowStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``RecentSearchRowStyle`` for `RecentSearchRow`s in this view and
+    /// its descendants — a recents list sets it once for every row.
+    func recentSearchRowStyle<S: RecentSearchRowStyle>(_ style: sending S) -> some View {
+        environment(\.recentSearchRowStyle, AnyRecentSearchRowStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a one-line route chip on a soft accent capsule, caption dropped.
+private struct ChipRecentSearchRowStyle: RecentSearchRowStyle {
+    func makeBody(configuration: RecentSearchRowConfiguration) -> some View {
+        ChipChrome(configuration: configuration)
+    }
+
+    private struct ChipChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: RecentSearchRowConfiguration
+
+        var body: some View {
+            Button(action: configuration.action) {
+                HStack(spacing: configuration.spacing(.xs)) {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle((configuration.accent ?? .neutral).base)
+                    RecentSearchRowRouteLine(configuration: configuration)
+                }
+                .padding(.vertical, configuration.spacing(.xs))
+                .padding(.horizontal, configuration.spacing(.sm))
+                .background((configuration.accent ?? .neutral).soft, in: Capsule(style: .continuous))
+                .contentShape(Capsule(style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(configuration.accessibilitySummary)
+        }
+    }
+}
+
+#Preview("RecentSearchRowStyle — presets × light/dark") {
+    PreviewMatrix("RecentSearchRowStyle") {
+        PreviewCase("Plain (default)") {
+            RecentSearchRow(from: "IST", to: "AYT") { }
+                .roundTrip().dates("18 – 27 Jul").passengers("2 adults · Economy").onRemove { }
+        }
+        PreviewCase("Bordered") {
+            RecentSearchRow(from: "IST", to: "LHR") { }
+                .dates("5 Sep").passengers("1 adult")
+                .recentSearchRowStyle(.bordered)
+        }
+        PreviewCase("Pill · mini search bar") {
+            RecentSearchRow(from: "Istanbul", to: "Antalya") { }
+                .icon(nil).dates("14 Jan").passengers("7")
+                .surface(.bgWhite).onSearch { }
+                .padding(Theme.SpacingKey.sm.value)
+                .background(SemanticColor.primary.solid)
+                .recentSearchRowStyle(.pill)
+        }
+        PreviewCase("Card · carousel tile") {
+            HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
+                RecentSearchRow(from: "IST", to: "JFK") { }
+                    .via(["FRA"]).dates("3 Nov").passengers("1 adult · Business").onRemove { }
+                    .frame(width: 220)
+                RecentSearchRow(from: "SAW", to: "AMS") { }
+                    .roundTrip().dates("9 – 16 Dec").accent(.info)
+                    .frame(width: 180)
+            }
+            .recentSearchRowStyle(.card)
+        }
+        PreviewCase("Custom (in-preview)") {
+            RecentSearchRow(from: "IST", to: "AYT") { }
+                .roundTrip().dates("18 – 27 Jul")
+                .recentSearchRowStyle(ChipRecentSearchRowStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Molecules/TripTypeToggle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/TripTypeToggle.swift
@@ -2,13 +2,15 @@
 //  TripTypeToggle.swift
 //  ThemeKit
 //
-//  Molecule. A compact pill-segmented control — the selected option is an
-//  accent-filled pill inside a soft container. Generic (one-way / round-trip /
-//  multi-city, or any options), with optional per-option icons. Token-bound.
+//  Molecule. A compact trip-type selector — generic (one-way / round-trip /
+//  multi-city, or any options), with optional per-option icons. Presentation
+//  is style-driven (``TripTypeToggleStyle``, ADR-0004) — set once per screen
+//  via `.tripTypeToggleStyle(_:)`. Token-bound.
 //
 //  ```swift
 //  TripTypeToggle(["One way", "Round trip", "Multi-city"], selection: $trip)
 //      .icons(["arrow.right", "arrow.left.arrow.right", "point.3.connected.trianglepath.dotted"])
+//      .tripTypeToggleStyle(.underline)   // .pill (default) / .underline / .menu
 //  ```
 //
 
@@ -20,21 +22,24 @@ import ThemeKit
 public enum TripTypeToggleSize: Sendable {
     case compact, regular, large
 
-    var minHeight: CGFloat {
+    /// Minimum option height at this step — styles apply it per option.
+    public var minHeight: CGFloat {
         switch self {
         case .compact: 28
         case .regular: 36
         case .large: 44
         }
     }
-    var textStyle: TextStyle {
+    /// The option label's text style at this step.
+    public var textStyle: TextStyle {
         switch self {
         case .compact: .labelSm600
         case .regular: .labelSm700
         case .large: .labelBase700
         }
     }
-    var iconStyle: TextStyle {
+    /// The option icon's text style at this step.
+    public var iconStyle: TextStyle {
         switch self {
         case .compact: .overline500
         case .regular: .labelSm600
@@ -45,6 +50,11 @@ public enum TripTypeToggleSize: Sendable {
 
 /// Look of a ``TripTypeToggle``: the stock accent-filled `.pill` inside a soft
 /// track, or a borderless `.underline` tab row with an indicator bar.
+///
+/// Superseded by ``TripTypeToggleStyle`` (each case maps 1:1 to a preset —
+/// `.pill`/`.underline`, plus the new `.menu`); kept for source compatibility
+/// until the next major, together with the deprecated
+/// ``TripTypeToggle/variant(_:)`` modifier.
 public enum TripTypeToggleVariant: Sendable { case pill, underline }
 
 /// Corner treatment of the pill variant's track and thumb: a full `.capsule`
@@ -55,8 +65,9 @@ public enum TripTypeToggleShape {
 }
 
 public struct TripTypeToggle: View {
-    @Environment(\.theme) private var theme
+    @Environment(\.tripTypeToggleStyle) private var envStyle
     @Environment(\.componentDensity) private var density
+    @Environment(\.locale) private var locale
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -66,10 +77,13 @@ public struct TripTypeToggle: View {
     private var icons: [String] = []
     private var accent: SemanticColor?
     private var fullWidth = true
-    private var surface: Theme.BackgroundColorKey = .bgBase
+    private var surfaceKey: Theme.BackgroundColorKey?
     private var size: TripTypeToggleSize = .regular
-    private var variant: TripTypeToggleVariant = .pill
     private var shape: TripTypeToggleShape = .capsule
+    /// Set by the deprecated ``variant(_:)`` modifier — an explicitly chosen
+    /// per-instance style wins over an ancestor's `.tripTypeToggleStyle(_:)`
+    /// (source-behavior stability during the enum's deprecation window).
+    private var explicitStyle: AnyTripTypeToggleStyle?
 
     /// Controlled — reads and writes flow through the caller's binding (ADR-4).
     public init(_ options: [String], selection: Binding<Int>) {   // R1
@@ -83,81 +97,24 @@ public struct TripTypeToggle: View {
         self._selection = ControllableState(wrappedValue: initiallySelected)
     }
 
-    private var accentSemantic: SemanticColor { accent ?? .primary }
-    /// Selection slide, gated by `microAnimations` + Reduce Motion.
-    private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
-
-    private var trackShape: AnyShape {
-        switch shape {
-        case .capsule: AnyShape(Capsule(style: .continuous))
-        case .rounded(let role): AnyShape(RoundedRectangle(cornerRadius: role.value, style: .continuous))
-        }
-    }
-
     public var body: some View {
-        switch variant {
-        case .pill:
-            HStack(spacing: 4) {
-                ForEach(Array(options.enumerated()), id: \.offset) { i, option in pill(i, option) }
-            }
-            .padding(4)
-            .background(theme.background(surface), in: trackShape)
-            .frame(maxWidth: fullWidth ? .infinity : nil)
-        case .underline:
-            HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-                ForEach(Array(options.enumerated()), id: \.offset) { i, option in underlineTab(i, option) }
-            }
-            .frame(maxWidth: fullWidth ? .infinity : nil)
-        }
-    }
-
-    private func pill(_ i: Int, _ option: String) -> some View {
-        let isOn = i == selection
-        return Button {
-            withAnimation(motion) { selection = i }
-        } label: {
-            optionLabel(i, option)
-                .foregroundStyle(isOn ? accentSemantic.onSolid : theme.text(.textSecondary))
-                .padding(.horizontal, density.scale(Theme.SpacingKey.sm.value))
-                .frame(maxWidth: fullWidth ? .infinity : nil)
-                .frame(minHeight: size.minHeight)
-                .background(isOn ? accentSemantic.solid : .clear, in: trackShape)
-                .contentShape(trackShape)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(option)
-        .accessibilityAddTraits(isOn ? .isSelected : [])
-    }
-
-    /// Borderless tab look — no track, a 2pt accent indicator bar under the
-    /// selected option.
-    private func underlineTab(_ i: Int, _ option: String) -> some View {
-        let isOn = i == selection
-        return Button {
-            withAnimation(motion) { selection = i }
-        } label: {
-            VStack(spacing: Theme.SpacingKey.xs.value) {
-                optionLabel(i, option)
-                    .foregroundStyle(isOn ? accentSemantic.base : theme.text(.textSecondary))
-                Rectangle()
-                    .fill(isOn ? accentSemantic.base : Color.clear)
-                    .frame(height: 2)
-            }
-            .padding(.horizontal, density.scale(Theme.SpacingKey.xs.value))
-            .frame(maxWidth: fullWidth ? .infinity : nil)
-            .frame(minHeight: size.minHeight)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(option)
-        .accessibilityAddTraits(isOn ? .isSelected : [])
-    }
-
-    private func optionLabel(_ i: Int, _ option: String) -> some View {
-        HStack(spacing: 5) {
-            if i < icons.count { Image(systemName: icons[i]).textStyle(size.iconStyle) }
-            Text(option).textStyle(size.textStyle).lineLimit(1).minimumScaleFactor(0.8)
-        }
+        // Selection slide, gated by `microAnimations` + Reduce Motion and baked
+        // into `select` — styles call it, never read the motion environment.
+        let motion = MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion)
+        let configuration = TripTypeToggleConfiguration(
+            options: options,
+            selectedIndex: selection,
+            select: { index in withAnimation(motion) { selection = index } },
+            icons: icons,
+            size: size,
+            shape: shape,
+            accent: accent,
+            surfaceKey: surfaceKey,
+            fullWidth: fullWidth,
+            density: density,
+            locale: locale
+        )
+        (explicitStyle ?? envStyle).makeBody(configuration: configuration)
     }
 }
 
@@ -173,13 +130,23 @@ public extension TripTypeToggle {
     /// Token-fed track fill behind the pills (default `.bgBase` — a soft,
     /// low-contrast track that reads well on a white card). Pass `.bgWhite` for a
     /// flush track or `.bgSecondary` for the stronger grey.
-    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surface = key } }
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
     /// Size ramp — steps the option height and the icon + label styles
     /// (default `.regular`).
     func size(_ s: TripTypeToggleSize) -> Self { copy { $0.size = s } }
-    /// Look: the stock accent-filled `.pill` (default) or the borderless
-    /// `.underline` tab row with an indicator bar.
-    func variant(_ v: TripTypeToggleVariant) -> Self { copy { $0.variant = v } }
+    /// Look — superseded by the style axis: prefer
+    /// `.tripTypeToggleStyle(.pill/.underline/.menu)`, settable once per screen
+    /// via the environment. This modifier keeps working and, when called,
+    /// wins over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .tripTypeToggleStyle(.pill/.underline) instead")
+    func variant(_ v: TripTypeToggleVariant) -> Self {
+        copy {
+            switch v {
+            case .pill: $0.explicitStyle = AnyTripTypeToggleStyle(PillTripTypeToggleStyle())
+            case .underline: $0.explicitStyle = AnyTripTypeToggleStyle(UnderlineTripTypeToggleStyle())
+            }
+        }
+    }
     /// Corner treatment of the pill track + thumb: `.capsule` (default) or
     /// `.rounded(_:)` at a radius role.
     func shape(_ s: TripTypeToggleShape) -> Self { copy { $0.shape = s } }
@@ -221,8 +188,14 @@ public extension TripTypeToggle {
         }
         PreviewCase("Underline tabs") {
             TripTypeToggle(["One way", "Round trip", "Multi-city"], selection: $sel)
-                .variant(.underline)
                 .accent(.info)
+                .tripTypeToggleStyle(.underline)
+        }
+        PreviewCase("Menu (tap in live preview)") {
+            TripTypeToggle(["One way", "Round trip", "Multi-city"], selection: $sel)
+                .icons(["arrow.right", "arrow.left.arrow.right", "point.3.connected.trianglepath.dotted"])
+                .fullWidth(false)
+                .tripTypeToggleStyle(.menu)
         }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Molecules/TripTypeToggleStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/TripTypeToggleStyle.swift
@@ -1,0 +1,397 @@
+//
+//  TripTypeToggleStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``TripTypeToggle`` — promotes the former
+//  ``TripTypeToggleVariant`` enum (ADR-0004) so the whole selector is a
+//  swappable style, settable once per screen via the environment. Three
+//  built-ins:
+//
+//    .pill       accent-filled pill inside a soft track — today's look. Default.
+//    .underline  borderless tab row with a 2pt accent indicator bar.
+//    .menu       a Dropdown-composed selector for dense headers: the current
+//                option is the trigger, the alternatives open in a floating menu.
+//
+//      TripTypeToggle(["One way", "Round trip", "Multi-city"], selection: $trip)
+//          .tripTypeToggleStyle(.underline)
+//
+//  Component style arranges content; token theme colors everything. Selection
+//  motion is resolved by the component (`MicroMotion` ∧ ¬Reduce Motion) and
+//  baked into ``TripTypeToggleConfiguration/select`` — styles call it, never
+//  read the motion environment.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``TripTypeToggleStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no icons → text-only options, no surface override
+/// → the style's own default track fill).
+public struct TripTypeToggleConfiguration {
+    /// The selectable option titles, in display order.
+    public let options: [String]
+    /// Index of the currently selected option (``ControllableState`` lives in
+    /// the component — styles only read this and call ``select``).
+    public let selectedIndex: Int
+    /// Selects the option at an index. The selection animation is already
+    /// resolved by the component (`MicroMotion` + Reduce Motion), so styles
+    /// call this directly and never wrap it in `withAnimation`.
+    public let select: (Int) -> Void
+    /// Per-option leading SF Symbols, aligned to ``options`` by index; shorter
+    /// arrays leave the remaining options text-only. Prefer ``icon(at:)``.
+    public let icons: [String]
+    /// Size ramp — steps the option height and the icon + label text styles.
+    public let size: TripTypeToggleSize
+    /// Corner treatment of tracks and thumbs (`.capsule` or `.rounded(_:)` at
+    /// a radius role). Resolve via ``trackShape``.
+    public let shape: TripTypeToggleShape
+    /// Semantic accent for the selected option (`.accent(_:)`); `nil` = the
+    /// stock primary. Resolve via ``resolvedAccent``.
+    public let accent: SemanticColor?
+    /// Explicit track fill (`.surface(_:)`), or `nil` to let the style choose
+    /// its own default (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Stretch options to fill the available width (default on); off =
+    /// intrinsic width.
+    public let fullWidth: Bool
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component (ADR-0004 §4). The
+    /// built-ins render caller-supplied titles verbatim; custom styles that
+    /// format dates/numbers around the options must use it.
+    public let locale: Locale
+
+    /// The SF Symbol for the option at `index`, or `nil` past the end of ``icons``.
+    public func icon(at index: Int) -> String? {
+        icons.indices.contains(index) ? icons[index] : nil
+    }
+
+    /// The title of the selected option — empty when ``options`` is empty.
+    public var selectedTitle: String {
+        options.indices.contains(selectedIndex) ? options[selectedIndex] : ""
+    }
+
+    /// The `accent(_:)` override, else the stock primary — the value the
+    /// built-ins hardcoded before the style axis existed.
+    public var resolvedAccent: SemanticColor { accent ?? .primary }
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out the control.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// The ``shape`` resolved to a fillable/clippable shape — the pill track,
+    /// the selected thumb and the menu trigger all draw with it.
+    public var trackShape: AnyShape {
+        switch shape {
+        case .capsule: AnyShape(Capsule(style: .continuous))
+        case .rounded(let role): AnyShape(RoundedRectangle(cornerRadius: role.value, style: .continuous))
+        }
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `TripTypeToggle`'s entire presentation. Implement `makeBody` to
+/// lay out the configuration's options. Set one with `.tripTypeToggleStyle(_:)`;
+/// the default is ``PillTripTypeToggleStyle``.
+public protocol TripTypeToggleStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: TripTypeToggleConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// One option's icon + title pair, shared by `.pill` and `.underline` —
+/// the former `optionLabel(_:_:)`, verbatim.
+private struct TripTypeOptionLabel: View {
+    let configuration: TripTypeToggleConfiguration
+    let index: Int
+    let option: String
+
+    var body: some View {
+        HStack(spacing: 5) {
+            if let symbol = configuration.icon(at: index) {
+                Image(systemName: symbol).textStyle(configuration.size.iconStyle)
+            }
+            Text(option).textStyle(configuration.size.textStyle).lineLimit(1).minimumScaleFactor(0.8)
+        }
+    }
+}
+
+// MARK: - 1. Pill — accent thumb in a soft track (default)
+
+/// The stock look, extracted verbatim: the selected option is an accent-filled
+/// pill inside a soft track (`.bgBase` unless overridden by `.surface(_:)`).
+public struct PillTripTypeToggleStyle: TripTypeToggleStyle {
+    public init() {}
+    public func makeBody(configuration: TripTypeToggleConfiguration) -> some View {
+        PillTripTypeToggleChrome(configuration: configuration)
+    }
+}
+
+private struct PillTripTypeToggleChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: TripTypeToggleConfiguration
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(Array(configuration.options.enumerated()), id: \.offset) { index, option in
+                pill(index, option)
+            }
+        }
+        .padding(4)
+        .background(theme.background(configuration.surface(default: .bgBase)), in: configuration.trackShape)
+        .frame(maxWidth: configuration.fullWidth ? .infinity : nil)
+    }
+
+    private func pill(_ index: Int, _ option: String) -> some View {
+        let isOn = index == configuration.selectedIndex
+        return Button {
+            configuration.select(index)
+        } label: {
+            TripTypeOptionLabel(configuration: configuration, index: index, option: option)
+                .foregroundStyle(isOn ? configuration.resolvedAccent.onSolid : theme.text(.textSecondary))
+                .padding(.horizontal, configuration.spacing(.sm))
+                .frame(maxWidth: configuration.fullWidth ? .infinity : nil)
+                .frame(minHeight: configuration.size.minHeight)
+                .background(isOn ? configuration.resolvedAccent.solid : .clear, in: configuration.trackShape)
+                .contentShape(configuration.trackShape)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(option)
+        .accessibilityAddTraits(isOn ? .isSelected : [])
+    }
+}
+
+// MARK: - 2. Underline — borderless tab indicator bar
+
+/// Borderless tab look, extracted verbatim — no track, a 2pt accent indicator
+/// bar under the selected option.
+public struct UnderlineTripTypeToggleStyle: TripTypeToggleStyle {
+    public init() {}
+    public func makeBody(configuration: TripTypeToggleConfiguration) -> some View {
+        UnderlineTripTypeToggleChrome(configuration: configuration)
+    }
+}
+
+private struct UnderlineTripTypeToggleChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: TripTypeToggleConfiguration
+
+    var body: some View {
+        HStack(spacing: configuration.spacing(.sm)) {
+            ForEach(Array(configuration.options.enumerated()), id: \.offset) { index, option in
+                tab(index, option)
+            }
+        }
+        .frame(maxWidth: configuration.fullWidth ? .infinity : nil)
+    }
+
+    private func tab(_ index: Int, _ option: String) -> some View {
+        let isOn = index == configuration.selectedIndex
+        return Button {
+            configuration.select(index)
+        } label: {
+            VStack(spacing: Theme.SpacingKey.xs.value) {
+                TripTypeOptionLabel(configuration: configuration, index: index, option: option)
+                    .foregroundStyle(isOn ? configuration.resolvedAccent.base : theme.text(.textSecondary))
+                Rectangle()
+                    .fill(isOn ? configuration.resolvedAccent.base : Color.clear)
+                    .frame(height: 2)
+            }
+            .padding(.horizontal, configuration.spacing(.xs))
+            .frame(maxWidth: configuration.fullWidth ? .infinity : nil)
+            .frame(minHeight: configuration.size.minHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(option)
+        .accessibilityAddTraits(isOn ? .isSelected : [])
+    }
+}
+
+// MARK: - 3. Menu — Dropdown-composed for dense headers
+
+/// The current option as a compact trigger; the alternatives open in a
+/// floating ``Dropdown`` menu with a checkmark on the selected row. For
+/// headers and toolbars too dense for a segmented track.
+public struct MenuTripTypeToggleStyle: TripTypeToggleStyle {
+    public init() {}
+    public func makeBody(configuration: TripTypeToggleConfiguration) -> some View {
+        MenuTripTypeToggleChrome(configuration: configuration)
+    }
+}
+
+private struct MenuTripTypeToggleChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: TripTypeToggleConfiguration
+
+    var body: some View {
+        Dropdown(items: items) { trigger }
+            .indicator(.checkmark)
+            .accent(configuration.resolvedAccent)
+    }
+
+    private var items: [DropdownItem] {
+        configuration.options.enumerated().map { index, option in
+            DropdownItem(option,
+                         systemImage: configuration.icon(at: index),
+                         isSelected: index == configuration.selectedIndex) {
+                configuration.select(index)
+            }
+        }
+    }
+
+    private var trigger: some View {
+        HStack(spacing: configuration.spacing(.xs)) {
+            if let symbol = configuration.icon(at: configuration.selectedIndex) {
+                Image(systemName: symbol)
+                    .textStyle(configuration.size.iconStyle)
+                    .foregroundStyle(configuration.resolvedAccent.base)
+            }
+            Text(configuration.selectedTitle)
+                .textStyle(configuration.size.textStyle)
+                .foregroundStyle(theme.text(.textPrimary))
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            Icon(systemName: "chevron.down").size(.xs).color(theme.text(.textTertiary))
+        }
+        .padding(.horizontal, configuration.spacing(.sm))
+        .frame(maxWidth: configuration.fullWidth ? .infinity : nil)
+        .frame(minHeight: configuration.size.minHeight)
+        .background(theme.background(configuration.surface(default: .bgSecondaryLight)),
+                    in: configuration.trackShape)
+        .contentShape(configuration.trackShape)
+        .accessibilityLabel(configuration.selectedTitle)
+    }
+}
+
+// MARK: - Static accessors
+
+public extension TripTypeToggleStyle where Self == PillTripTypeToggleStyle {
+    /// Accent-filled pill inside a soft track — today's look. The default.
+    static var pill: PillTripTypeToggleStyle { PillTripTypeToggleStyle() }
+}
+public extension TripTypeToggleStyle where Self == UnderlineTripTypeToggleStyle {
+    /// Borderless tab row with a 2pt accent indicator bar.
+    static var underline: UnderlineTripTypeToggleStyle { UnderlineTripTypeToggleStyle() }
+}
+public extension TripTypeToggleStyle where Self == MenuTripTypeToggleStyle {
+    /// Dropdown-composed selector for dense headers — the current option is
+    /// the trigger, the alternatives open in a floating menu.
+    static var menu: MenuTripTypeToggleStyle { MenuTripTypeToggleStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyTripTypeToggleStyle: TripTypeToggleStyle {
+    private let _makeBody: @MainActor (TripTypeToggleConfiguration) -> AnyView
+    init<S: TripTypeToggleStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: TripTypeToggleConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct TripTypeToggleStyleKey: EnvironmentKey {
+    static let defaultValue = AnyTripTypeToggleStyle(PillTripTypeToggleStyle())
+}
+
+extension EnvironmentValues {
+    var tripTypeToggleStyle: AnyTripTypeToggleStyle {
+        get { self[TripTypeToggleStyleKey.self] }
+        set { self[TripTypeToggleStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``TripTypeToggleStyle`` for `TripTypeToggle`s in this view and
+    /// its descendants — one search header can restyle every toggle at once.
+    func tripTypeToggleStyle<S: TripTypeToggleStyle>(_ style: sending S) -> some View {
+        environment(\.tripTypeToggleStyle, AnyTripTypeToggleStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// Proves external implementability: a vertical radio list built purely from
+/// the public configuration + theme tokens — what an app target would write.
+private struct RadioListTripTypeToggleStyle: TripTypeToggleStyle {
+    func makeBody(configuration: TripTypeToggleConfiguration) -> some View {
+        RadioListChrome(configuration: configuration)
+    }
+
+    private struct RadioListChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: TripTypeToggleConfiguration
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: configuration.spacing(.xs)) {
+                ForEach(Array(configuration.options.enumerated()), id: \.offset) { index, option in
+                    row(index, option)
+                }
+            }
+        }
+
+        private func row(_ index: Int, _ option: String) -> some View {
+            let isOn = index == configuration.selectedIndex
+            return Button {
+                configuration.select(index)
+            } label: {
+                HStack(spacing: configuration.spacing(.sm)) {
+                    Image(systemName: isOn ? "largecircle.fill.circle" : "circle")
+                        .textStyle(configuration.size.iconStyle)
+                        .foregroundStyle(isOn ? configuration.resolvedAccent.base : theme.text(.textTertiary))
+                    Text(option)
+                        .textStyle(configuration.size.textStyle)
+                        .foregroundStyle(isOn ? theme.text(.textPrimary) : theme.text(.textSecondary))
+                    Spacer(minLength: 0)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(option)
+            .accessibilityAddTraits(isOn ? .isSelected : [])
+        }
+    }
+}
+
+#Preview("TripTypeToggleStyle — presets × light/dark") {
+    @Previewable @State var sel = 1
+    let options = ["One way", "Round trip", "Multi-city"]
+    let icons = ["arrow.right", "arrow.left.arrow.right", "point.3.connected.trianglepath.dotted"]
+    PreviewMatrix("TripTypeToggleStyle") {
+        PreviewCase("Pill (default)") {
+            TripTypeToggle(options, selection: $sel).icons(icons)
+        }
+        PreviewCase("Underline") {
+            TripTypeToggle(options, selection: $sel)
+                .icons(icons)
+                .accent(.info)
+                .tripTypeToggleStyle(.underline)
+        }
+        PreviewCase("Menu (tap in live preview)") {
+            TripTypeToggle(options, selection: $sel)
+                .icons(icons)
+                .tripTypeToggleStyle(.menu)
+        }
+        PreviewCase("Menu · intrinsic width · rounded") {
+            TripTypeToggle(options, selection: $sel)
+                .fullWidth(false)
+                .shape(.rounded(.field))
+                .tripTypeToggleStyle(.menu)
+        }
+        PreviewCase("Custom (in-preview radio list)") {
+            TripTypeToggle(options, selection: $sel)
+                .tripTypeToggleStyle(RadioListTripTypeToggleStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/AirportPicker.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/AirportPicker.swift
@@ -18,8 +18,15 @@
 //  `.sheet` renders a `FieldButton` trigger that opens the same search UI in
 //  the shared `BottomSheet` (`.bottomSheet(isPresented:detents:)`).
 //
-//  Rows are fixed anatomy (bold IATA code chip + city/airport text) — no Style
-//  protocol until real archetypes exist (promotion rule).
+//  The *arrangement* is owned by the active ``AirportPickerStyle`` from the
+//  environment (ADR-0004, Class B): the component wires the live search field,
+//  the built sections, rows and chips into an `AirportPickerConfiguration` and
+//  hands those pre-wired units to the style — `.list` (default) is today's
+//  sectioned rows verbatim, `.compact` densifies (the promoted
+//  `AirportPickerDensity.compact` knob), `.codeGrid` renders the browse
+//  sections as an IATA chip grid. `AirportPickerPresentation` stays orthogonal
+//  (presentation ≠ style): the trigger + sheet/popover/cover machinery live
+//  here, never in a style.
 //
 
 import SwiftUI
@@ -34,6 +41,8 @@ public enum AirportPickerPresentation: Sendable { case inline, sheet, popover, f
 
 /// Vertical density of the suggestion rows: `.regular` (default) or
 /// `.compact` (tighter row padding and section gaps for dense pickers).
+/// Promoted to ``AirportPickerStyle`` presets by ADR-0004 — prefer
+/// `.airportPickerStyle(.compact)`.
 public enum AirportPickerDensity: Sendable { case compact, regular }
 
 /// Airport search & select. Controlled selection + caller-owned suggestions;
@@ -51,6 +60,10 @@ public struct AirportPicker: View {
     @Environment(\.isEnabled) private var isEnabled     // R3 — set natively by `.disabled(_:)`
     /// Read-only subtree axis (set with `.readOnly(_:)`) — normal chrome, no editing/selection.
     @Environment(\.isReadOnly) private var isReadOnly
+    /// The active arrangement (ADR-0004) — set once per subtree with `.airportPickerStyle(_:)`.
+    @Environment(\.airportPickerStyle) private var envStyle
+    @Environment(\.componentDensity) private var componentDensity
+    @Environment(\.locale) private var locale
 
     @Binding private var selection: Airport?
     private let suggestions: [Airport]
@@ -84,7 +97,11 @@ public struct AirportPicker: View {
     private var chipVariantValue: FillVariant = .soft
     private var sheetDetents: [BottomSheetDetent] = [.large]
     private var triggerIconName = "airplane"
-    private var densityValue: AirportPickerDensity = .regular
+    /// The deprecated `.density(_:)` knob — `nil` (unset) defers to the
+    /// environment ``AirportPickerStyle``; explicit wins over it (ADR-0004 §5).
+    private var densityOverride: AirportPickerDensity?
+    /// Optional surface fill behind the search UI; `nil` = transparent (today's default).
+    private var surfaceKey: Theme.BackgroundColorKey?
 
     /// Query is internal UI state (§9.4); selection is the controlled outcome.
     @State private var query = ""
@@ -93,6 +110,7 @@ public struct AirportPicker: View {
     /// Genuine dimensions with no semantic token — fixed row-anatomy constants.
     private enum Metrics {
         static let chipMinWidth: CGFloat = 44          // aligns the code column
+        static let chipTapTarget: CGFloat = 44         // HIG minimum for the grid chip unit
         static let skeletonRowCount = 4
         static let skeletonChipHeight: CGFloat = 24
         static let skeletonTitle = CGSize(width: 120, height: 12)
@@ -116,29 +134,94 @@ public struct AirportPicker: View {
         }
     }
 
-    /// Row/section paddings resolved from the density axis (token-fed).
-    private var rowVPad: CGFloat {
-        densityValue == .compact ? Theme.SpacingKey.xs.value : Theme.SpacingKey.sm.value
-    }
-    private var sectionGap: CGFloat {
-        densityValue == .compact ? Theme.SpacingKey.sm.value : Theme.SpacingKey.md.value
+    /// The embedded form — the active style arranges the search field and
+    /// sections directly in the screen (no internal scrolling).
+    private var inlineBody: some View {
+        styledSearch(isPresented: false)
     }
 
-    private var inlineBody: some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
-            searchField
-            listContent
+    // MARK: - Style dispatch (ADR-0004)
+
+    /// Hands the pre-wired units + typed signals to the resolved style. The
+    /// component keeps search/debounce/selection wiring and the presentation
+    /// machinery; the style only arranges.
+    private func styledSearch(isPresented: Bool) -> some View {
+        resolvedStyle.makeBody(configuration: configuration(isPresented: isPresented))
+    }
+
+    /// ADR-0004 §5 precedence: an explicitly-set deprecated `.density(_:)`
+    /// wins over the environment style (source-behaviour stability during
+    /// migration) — `.compact` maps to ``CompactAirportPickerStyle``,
+    /// `.regular` to the default ``ListAirportPickerStyle``.
+    private var resolvedStyle: AnyAirportPickerStyle {
+        guard let densityOverride else { return envStyle }
+        return densityOverride == .compact
+            ? AnyAirportPickerStyle(CompactAirportPickerStyle())
+            : AnyAirportPickerStyle(ListAirportPickerStyle())
+    }
+
+    /// Gathers the pre-wired units (Class B) and typed signals for the style.
+    private func configuration(isPresented: Bool) -> AirportPickerConfiguration {
+        AirportPickerConfiguration(
+            searchField: AnyView(searchField),
+            loadingView: AnyView(loadingContentView),
+            emptyView: AnyView(emptyState),
+            sections: builtSections,
+            sectionView: { AnyView(self.sectionView($0)) },
+            sectionHeader: { AnyView(self.sectionHeaderView($0)) },
+            row: { AnyView(self.row($0)) },
+            selectableRow: { airport, label in AnyView(self.selectableRow(airport, label: label)) },
+            codeChip: { AnyView(self.codeChip($0.code)) },
+            selectableChip: { AnyView(self.selectableChip($0)) },
+            customRowLabel: rowContentSlot.map { slot in
+                { (airport: Airport) -> AnyView in slot(airport, self.isSelected(airport)) }
+            },
+            query: query,
+            isLoading: isLoading,
+            showsEmptyState: !isLoading && !query.isEmpty && suggestions.isEmpty,
+            isPresented: isPresented,
+            selection: selection,
+            select: { self.select($0) },
+            chipVariant: chipVariantValue,
+            accent: accentColor,
+            surfaceKey: surfaceKey,
+            density: componentDensity,
+            locale: locale)
+    }
+
+    /// The sections the active style arranges — pre-filtered (never empty),
+    /// with resolved titles: the browse lists before typing, or the single
+    /// results section while a query has suggestions.
+    private var builtSections: [AirportPickerSection] {
+        if query.isEmpty {
+            var sections: [AirportPickerSection] = []
+            if !nearbyAirports.isEmpty {
+                sections.append(AirportPickerSection(
+                    kind: .nearby, title: nearbyTitle ?? String(themeKitTravel: "Nearby"),
+                    airports: nearbyAirports, onClear: nil))
+            }
+            if !recentAirports.isEmpty {
+                sections.append(AirportPickerSection(
+                    kind: .recent, title: recentTitle ?? String(themeKitTravel: "Recent"),
+                    airports: recentAirports, onClear: onClearRecent))
+            }
+            if !popularAirports.isEmpty {
+                sections.append(AirportPickerSection(
+                    kind: .popular, title: popularTitle ?? String(themeKitTravel: "Popular"),
+                    airports: popularAirports, onClear: nil))
+            }
+            return sections
         }
+        guard !suggestions.isEmpty else { return [] }
+        return [AirportPickerSection(kind: .results, title: nil, airports: suggestions, onClear: nil)]
     }
 
     // MARK: - Presented forms (sheet / popover / full-screen cover)
 
-    /// The shared search UI hosted by every presented form.
+    /// The shared search UI hosted by every presented form — the style pins
+    /// the search field and scrolls the sections (`isPresented` signal).
     private var presentedSearch: some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
-            searchField
-            ScrollView { listContent }
-        }
+        styledSearch(isPresented: true)
     }
 
     /// The field-shaped trigger shared by the presented forms. FieldButton
@@ -217,49 +300,37 @@ public struct AirportPicker: View {
         return String(themeKitTravel: "\(suggestions.count) results")
     }
 
-    // MARK: - Sections
+    // MARK: - Section units (handed to the style)
 
+    /// The full stock section unit: header + rows + hairline dividers, plus
+    /// the results accessibility identifier — `.list` places these verbatim.
     @ViewBuilder
-    private var listContent: some View {
-        if isLoading {
-            if let loadingSlot { loadingSlot } else { loadingRows }
-        } else if query.isEmpty {
-            preTypingSections
-        } else if suggestions.isEmpty {
-            emptyState
-        } else {
-            section(nil, airports: suggestions)
+    private func sectionView(_ section: AirportPickerSection) -> some View {
+        if section.kind == .results {
+            sectionStack(section)
                 .travelA11y("results", in: accessibilityID)
+        } else {
+            sectionStack(section)
         }
     }
 
-    /// Shown before/alongside typing — each section only when it has airports.
-    @ViewBuilder
-    private var preTypingSections: some View {
-        VStack(alignment: .leading, spacing: sectionGap) {
-            if !nearbyAirports.isEmpty {
-                section(nearbyTitle ?? String(themeKitTravel: "Nearby"), airports: nearbyAirports)
-            }
-            if !recentAirports.isEmpty {
-                section(recentTitle ?? String(themeKitTravel: "Recent"),
-                        airports: recentAirports, onClear: onClearRecent)
-            }
-            if !popularAirports.isEmpty {
-                section(popularTitle ?? String(themeKitTravel: "Popular"), airports: popularAirports)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func section(_ title: String?, airports: [Airport], onClear: (() -> Void)? = nil) -> some View {
+    private func sectionStack(_ section: AirportPickerSection) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let title { sectionHeader(title, onClear: onClear) }
-            ForEach(airports) { airport in
+            sectionHeaderView(section)
+            ForEach(section.airports) { airport in
                 row(airport)
-                if airport.id != airports.last?.id {
+                if airport.id != section.airports.last?.id {
                     DividerView().size(.small).padding(.leading, Theme.SpacingKey.md.value)
                 }
             }
+        }
+    }
+
+    /// The header-only unit (title + Clear); nothing when the section is untitled.
+    @ViewBuilder
+    private func sectionHeaderView(_ section: AirportPickerSection) -> some View {
+        if let title = section.title {
+            sectionHeader(title, onClear: section.onClear)
         }
     }
 
@@ -286,29 +357,65 @@ public struct AirportPicker: View {
         .padding(.vertical, Theme.SpacingKey.xs.value)
     }
 
-    // MARK: - Row (fixed anatomy: bold IATA code chip + city/airport text)
+    // MARK: - Row & chip units (bold IATA code chip + city/airport text)
 
+    private func isSelected(_ airport: Airport) -> Bool { selection?.id == airport.id }
+
+    /// The stock wired row: label (or the `.rowContent` slot) at regular
+    /// padding, wrapped in the shared selection wiring.
     private func row(_ airport: Airport) -> some View {
-        let isSelected = selection?.id == airport.id
-        return Button { select(airport) } label: {
-            Group {
-                if let rowContentSlot {
-                    rowContentSlot(airport, isSelected)
-                } else {
-                    builtInRowLabel(airport, isSelected: isSelected)
-                }
-            }
-            .padding(.horizontal, Theme.SpacingKey.md.value)
-            .padding(.vertical, rowVPad)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
+        selectableRow(airport, label: AnyView(
+            rowLabel(airport)
+                .padding(.horizontal, Theme.SpacingKey.md.value)
+                .padding(.vertical, Theme.SpacingKey.sm.value)))
+    }
+
+    @ViewBuilder
+    private func rowLabel(_ airport: Airport) -> some View {
+        if let rowContentSlot {
+            rowContentSlot(airport, isSelected(airport))
+        } else {
+            builtInRowLabel(airport, isSelected: isSelected(airport))
+        }
+    }
+
+    /// The single source of row interaction — tap → select, read-only gating,
+    /// VoiceOver label/traits — reused by every style through the
+    /// configuration's `selectableRow` unit.
+    private func selectableRow(_ airport: Airport, label: AnyView) -> some View {
+        Button { select(airport) } label: {
+            label
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .allowsHitTesting(!isReadOnly)
         // Buttons carry `.isButton`; reads "IST, Istanbul Airport, Istanbul".
         .accessibilityLabel("\(airport.code), \(airport.name), \(airport.city)")
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityAddTraits(isSelected(airport) ? .isSelected : [])
         .travelA11y("row.\(airport.code)", in: accessibilityID)
+    }
+
+    /// The wired chip unit for grid/cloud styles: the stock code chip, an
+    /// accent ring when selected, a 44pt hit target and the row's VoiceOver
+    /// treatment.
+    private func selectableChip(_ airport: Airport) -> some View {
+        Button { select(airport) } label: {
+            codeChip(airport.code)
+                .overlay {
+                    if isSelected(airport) {
+                        RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
+                            .strokeBorder(accentColor?.accent ?? theme.foreground(.fgHero), lineWidth: 1)
+                    }
+                }
+                .frame(minWidth: Metrics.chipMinWidth, minHeight: Metrics.chipTapTarget)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .allowsHitTesting(!isReadOnly)
+        .accessibilityLabel("\(airport.code), \(airport.name), \(airport.city)")
+        .accessibilityAddTraits(isSelected(airport) ? .isSelected : [])
+        .travelA11y("chip.\(airport.code)", in: accessibilityID)
     }
 
     /// The stock row anatomy — IATA chip + city/airport + selection checkmark.
@@ -368,6 +475,13 @@ public struct AirportPicker: View {
     }
 
     // MARK: - Loading (Skeleton rows) & empty states
+
+    /// The loading unit handed to the style — the caller's `.loadingContent`
+    /// slot when set, else the built-in Skeleton rows.
+    @ViewBuilder
+    private var loadingContentView: some View {
+        if let loadingSlot { loadingSlot } else { loadingRows }
+    }
 
     private var loadingRows: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -500,9 +614,18 @@ public extension AirportPicker {
     /// SF Symbol on the field-shaped trigger (default `"airplane"`).
     func triggerIcon(_ systemName: String) -> Self { copy { $0.triggerIconName = systemName } }
 
-    /// Row density: `.regular` (default) or `.compact` — tighter row padding
-    /// and section gaps, resolved from spacing tokens.
-    func density(_ d: AirportPickerDensity) -> Self { copy { $0.densityValue = d } }
+    /// Row density: `.regular` (default) or `.compact`. Deprecate-forward
+    /// (ADR-0004): `.compact` maps to the ``CompactAirportPickerStyle`` preset,
+    /// `.regular` to ``ListAirportPickerStyle``; when explicitly set it wins
+    /// over an ancestor `.airportPickerStyle(_:)` for source-behaviour
+    /// stability during migration.
+    @available(*, deprecated, message: "Use .airportPickerStyle(.compact)")
+    func density(_ d: AirportPickerDensity) -> Self { copy { $0.densityOverride = d } }
+
+    /// Surface fill behind the search field and sections (background token
+    /// key); unset keeps the transparent default — the picker rides its
+    /// screen's background.
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
 
     /// Replaces the built-in "No airports found" state (T2 slot). Shown when a
     /// typed query has no suggestions and no lookup is in flight.
@@ -640,14 +763,15 @@ private let previewAirports: [Airport] = [
                                 Spacer()
                             }
                         }
-                    // Solid chip variant + custom section titles + compact density.
+                    // Solid chip variant + custom section titles + the compact style
+                    // (the promoted `.density(.compact)` knob, ADR-0004).
                     AirportPicker(selection: .constant(nil), suggestions: [])
                         .chipVariant(.solid)
                         .accent(.info)
-                        .density(.compact)
                         .sectionTitles(recent: "Your searches", popular: "Trending routes")
                         .recent([previewAirports[2], previewAirports[4]])
                         .popular([previewAirports[0], previewAirports[5]])
+                        .airportPickerStyle(.compact)
                     // Outline chips.
                     AirportPicker(selection: .constant(nil), suggestions: [])
                         .chipVariant(.outline)

--- a/Sources/ThemeKitTravel/Components/Organisms/AirportPickerStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/AirportPickerStyle.swift
@@ -1,0 +1,486 @@
+//
+//  AirportPickerStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``AirportPicker`` — a Class B configuration of ADR-0004
+//  (per-component style protocols): the component owns the *live interaction*
+//  (search field with debounced `onQueryChange`, selection wiring, read-only
+//  gating, presentation sheets), and hands styles **pre-wired units** plus typed
+//  signals. Styles arrange; they never re-wire. Three built-ins:
+//
+//    .list      the sectioned suggestion list — search field over nearby /
+//               recent / popular / results rows (IATA chip + city/airport).
+//               Today's picker, verbatim. Default.
+//    .compact   dense rows — tight padding, subtitle hidden (the promotion of
+//               the deprecated `AirportPickerDensity.compact` knob).
+//    .codeGrid  the browse sections (nearby/recent/popular) as a tappable
+//               IATA-code chip grid; typed results keep the full rows.
+//
+//      AirportPicker(selection: $origin, suggestions: results)
+//          .popular(curated.popular)
+//          .airportPickerStyle(.codeGrid)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the token
+//  theme colors everything. ``AirportPickerPresentation`` stays orthogonal —
+//  presentation ≠ style: the trigger, bottom sheet, popover and full-screen
+//  cover machinery live in the component; styles only read the
+//  ``AirportPickerConfiguration/isPresented`` signal to pin the search field
+//  and scroll the sections inside a presented container.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Section model
+
+/// One suggestion section the component built for the active style — typed,
+/// pre-filtered (empty sections are never handed to a style), with the resolved
+/// title (custom override or the localized stock string) and, for `.recent`,
+/// the caller's clear action.
+public struct AirportPickerSection: Identifiable {
+    /// Which list this section carries; `.results` is the typed-query list.
+    public enum Kind: Hashable, Sendable { case nearby, recent, popular, results }
+
+    public let kind: Kind
+    /// The resolved header title; `nil` for `.results` (no header today).
+    public let title: String?
+    public let airports: [Airport]
+    /// The Clear action for `.recent`; `nil` elsewhere.
+    public let onClear: (() -> Void)?
+
+    public var id: Kind { kind }
+}
+
+// MARK: - Configuration
+
+/// What an ``AirportPickerStyle`` arranges. Class B (ADR-0004 §2.2): the
+/// interactive units arrive **pre-wired** — the search field already debounces
+/// the caller's `onQueryChange`, rows/chips already select on tap with
+/// read-only gating and VoiceOver labels — so a style composes them at any
+/// granularity (whole ``sectionView``, or ``sectionHeader`` + ``row`` /
+/// ``selectableChip``, or a fully custom label through ``selectableRow``)
+/// without ever duplicating interaction logic.
+public struct AirportPickerConfiguration {
+    // MARK: Pre-wired units — fully interactive; styles arrange, never re-wire.
+
+    /// The live search unit (the composed `SearchBar`): binding, placeholder,
+    /// debounced `onQueryChange`, result-count announcement and read-only
+    /// gating are wired by the component.
+    public let searchField: AnyView
+    /// What to show while the caller's lookup is in flight — the built-in
+    /// Skeleton rows, or the caller's `.loadingContent { }` slot.
+    public let loadingView: AnyView
+    /// The typed-query-with-no-matches state — built-in, or `.emptyContent { }`.
+    public let emptyView: AnyView
+
+    // MARK: Arrangeable typed data.
+
+    /// The sections to arrange, already resolved for the current query: the
+    /// non-empty *nearby / recent / popular* lists before typing, or the single
+    /// `.results` section while a query has suggestions. Never contains empty
+    /// sections.
+    public let sections: [AirportPickerSection]
+
+    // MARK: Per-section / per-airport unit builders (wiring stays in the component).
+
+    /// The full stock section — header (with Clear for `.recent`), rows,
+    /// dividers and the results accessibility identifier. `.list` places these
+    /// verbatim.
+    public let sectionView: (AirportPickerSection) -> AnyView
+    /// The section header alone (title + Clear button, header a11y trait);
+    /// renders nothing when ``AirportPickerSection/title`` is `nil`.
+    public let sectionHeader: (AirportPickerSection) -> AnyView
+    /// The stock wired row: IATA chip + city/airport + selection checkmark
+    /// (or the caller's `.rowContent` slot), tap-to-select, read-only gating
+    /// and VoiceOver label/traits included.
+    public let row: (Airport) -> AnyView
+    /// Wraps a style-built label in the component's row wiring (tap → select,
+    /// read-only gating, VoiceOver label + selected trait, row a11y id) — for
+    /// styles that draw their own row anatomy, like `.compact`.
+    public let selectableRow: (Airport, AnyView) -> AnyView
+    /// The bold IATA code chip as a plain *visual* (chip variant + accent
+    /// applied, no tap wiring) — compose it inside custom labels.
+    public let codeChip: (Airport) -> AnyView
+    /// The IATA code chip as a *wired* tappable unit (tap → select, selected
+    /// accent ring, 44pt hit target, VoiceOver label/traits) — the `.codeGrid`
+    /// cell, reusable by any chip-cloud style.
+    public let selectableChip: (Airport) -> AnyView
+    /// The caller's `.rowContent` slot bound to `(airport, isSelected)`;
+    /// `nil` = not set. Styles that build their own labels should prefer this
+    /// when present so the caller's replacement survives a style switch.
+    public let customRowLabel: ((Airport) -> AnyView)?
+
+    // MARK: Typed signals.
+
+    /// The live query text (internal UI state owned by the component).
+    public let query: String
+    /// `true` while the caller's lookup is in flight — show ``loadingView``.
+    public let isLoading: Bool
+    /// `true` when a typed query produced no suggestions (and no lookup is in
+    /// flight) — show ``emptyView``.
+    public let showsEmptyState: Bool
+    /// `true` when the search UI is hosted by a presented container (`.sheet`,
+    /// `.popover`, `.fullScreenCover`) rather than embedded inline — built-ins
+    /// pin the search field and scroll the sections in that case (the
+    /// component's classic behaviour); inline pickers let the screen scroll.
+    public let isPresented: Bool
+    /// The controlled selection, if any.
+    public let selection: Airport?
+    /// Selects an airport: updates the binding, echoes the choice into the
+    /// query and dismisses a presented container. Guards `.disabled` /
+    /// `.readOnly` internally — safe to call from any custom item view.
+    public let select: (Airport) -> Void
+    /// The `.chipVariant(_:)` axis (`.soft` default) — already applied by
+    /// ``codeChip``/``selectableChip``; exposed for styles drawing their own.
+    public let chipVariant: FillVariant
+    /// The `.accent(_:)` override; `nil` keeps the hero/neutral tokens —
+    /// resolve via ``accentForeground(_:)``.
+    public let accent: SemanticColor?
+    /// The `.surface(_:)` override; `nil` (default) keeps the picker
+    /// transparent so it rides its screen's background.
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component.
+    public let locale: Locale
+
+    // MARK: Helpers.
+
+    /// Whether this airport is the current selection.
+    public func isSelected(_ airport: Airport) -> Bool { selection?.id == airport.id }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out the picker.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// The `accent(_:)` override's tint, else the theme's hero foreground —
+    /// the value the stock checkmark and Clear button use.
+    public func accentForeground(_ theme: Theme) -> Color { accent?.accent ?? theme.foreground(.fgHero) }
+}
+
+// MARK: - Protocol
+
+/// Defines an `AirportPicker`'s search-UI arrangement. Implement `makeBody` to
+/// arrange the configuration's pre-wired units (search field, sections, rows,
+/// chips). Set one with `.airportPickerStyle(_:)`; the default is
+/// ``ListAirportPickerStyle``. Presentation is *not* part of a style — the
+/// trigger + sheet/popover/cover machinery stay in the component.
+public protocol AirportPickerStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: AirportPickerConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The scaffold every built-in shares: search field on top, the arranged list
+/// below — scrolling under a pinned field inside presented containers (today's
+/// behaviour), inline otherwise — over the optional `.surface(_:)` fill.
+private struct AirportPickerScaffold<List: View>: View {
+    @Environment(\.theme) private var theme
+    let configuration: AirportPickerConfiguration
+    @ViewBuilder let list: () -> List
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            configuration.searchField
+            if configuration.isPresented {
+                ScrollView { list() }
+            } else {
+                list()
+            }
+        }
+        .background {
+            if let key = configuration.surfaceKey { theme.background(key) }
+        }
+    }
+}
+
+// MARK: - .list
+
+/// Today's ``AirportPicker`` look, verbatim: the search field over sectioned
+/// suggestion rows — bold IATA code chip + city/airport text, hairline
+/// dividers, *Nearby / Recent / Popular* headers before typing, the caller's
+/// results while typing, Skeleton rows while loading.
+public struct ListAirportPickerStyle: AirportPickerStyle {
+    public init() {}
+    public func makeBody(configuration: AirportPickerConfiguration) -> some View {
+        AirportPickerScaffold(configuration: configuration) {
+            ListAirportPickerSections(configuration: configuration)
+        }
+    }
+}
+
+private struct ListAirportPickerSections: View {
+    let configuration: AirportPickerConfiguration
+
+    var body: some View {
+        if configuration.isLoading {
+            configuration.loadingView
+        } else if configuration.showsEmptyState {
+            configuration.emptyView
+        } else {
+            VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
+                ForEach(configuration.sections) { configuration.sectionView($0) }
+            }
+        }
+    }
+}
+
+// MARK: - .compact
+
+/// Dense rows for tight pickers — the promotion of the deprecated
+/// `AirportPickerDensity.compact` knob: tighter row padding and section gaps,
+/// and the airport-name subtitle hidden (IATA chip + city only). A caller's
+/// `.rowContent` slot still replaces the row label.
+public struct CompactAirportPickerStyle: AirportPickerStyle {
+    public init() {}
+    public func makeBody(configuration: AirportPickerConfiguration) -> some View {
+        AirportPickerScaffold(configuration: configuration) {
+            CompactAirportPickerSections(configuration: configuration)
+        }
+    }
+}
+
+private struct CompactAirportPickerSections: View {
+    @Environment(\.theme) private var theme
+    let configuration: AirportPickerConfiguration
+
+    var body: some View {
+        if configuration.isLoading {
+            configuration.loadingView
+        } else if configuration.showsEmptyState {
+            configuration.emptyView
+        } else {
+            VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+                ForEach(configuration.sections) { compactSection($0) }
+            }
+        }
+    }
+
+    private func compactSection(_ section: AirportPickerSection) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            configuration.sectionHeader(section)
+            ForEach(section.airports) { airport in
+                compactRow(airport)
+                if airport.id != section.airports.last?.id {
+                    DividerView().size(.small).padding(.leading, configuration.spacing(.md))
+                }
+            }
+        }
+    }
+
+    /// A style-built dense label handed back through the component's row
+    /// wiring — tap, read-only gating and VoiceOver stay single-sourced.
+    private func compactRow(_ airport: Airport) -> some View {
+        configuration.selectableRow(airport, AnyView(
+            compactLabel(airport)
+                .padding(.horizontal, configuration.spacing(.md))
+                .padding(.vertical, configuration.spacing(.xs))))
+    }
+
+    @ViewBuilder
+    private func compactLabel(_ airport: Airport) -> some View {
+        if let customRowLabel = configuration.customRowLabel {
+            customRowLabel(airport)
+        } else {
+            HStack(spacing: configuration.spacing(.sm)) {
+                configuration.codeChip(airport)
+                Text(airport.city)
+                    .textStyle(.bodyBase400)
+                    .foregroundStyle(theme.text(.textPrimary))
+                    .lineLimit(1)
+                Spacer(minLength: configuration.spacing(.xs))
+                if configuration.isSelected(airport) {
+                    Icon(systemName: "checkmark")
+                        .size(.sm)
+                        .color(configuration.accentForeground(theme))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - .codeGrid
+
+/// The browse sections (*nearby / recent / popular*) as an adaptive grid of
+/// tappable IATA-code chips — a compact departure-board browse for screens
+/// where codes carry the meaning. Typed results keep the full stock rows
+/// (name + city matter while searching), as do loading and empty states.
+public struct CodeGridAirportPickerStyle: AirportPickerStyle {
+    public init() {}
+    public func makeBody(configuration: AirportPickerConfiguration) -> some View {
+        AirportPickerScaffold(configuration: configuration) {
+            CodeGridAirportPickerSections(configuration: configuration)
+        }
+    }
+}
+
+private struct CodeGridAirportPickerSections: View {
+    let configuration: AirportPickerConfiguration
+
+    /// Genuine dimension with no semantic token — the adaptive grid cell's
+    /// minimum width (fits a 3-letter IATA chip with breathing room).
+    private static let chipCellMinWidth: CGFloat = 56
+
+    var body: some View {
+        if configuration.isLoading {
+            configuration.loadingView
+        } else if configuration.showsEmptyState {
+            configuration.emptyView
+        } else {
+            VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
+                ForEach(configuration.sections) { section in
+                    if section.kind == .results {
+                        configuration.sectionView(section)
+                    } else {
+                        gridSection(section)
+                    }
+                }
+            }
+        }
+    }
+
+    private func gridSection(_ section: AirportPickerSection) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            configuration.sectionHeader(section)
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: Self.chipCellMinWidth),
+                                   spacing: configuration.spacing(.xs))],
+                alignment: .leading,
+                spacing: configuration.spacing(.xs)
+            ) {
+                ForEach(section.airports) { configuration.selectableChip($0) }
+            }
+            .padding(.horizontal, configuration.spacing(.md))
+            .padding(.vertical, configuration.spacing(.xs))
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension AirportPickerStyle where Self == ListAirportPickerStyle {
+    /// The sectioned suggestion list — IATA chip + city/airport rows. The default.
+    static var list: ListAirportPickerStyle { ListAirportPickerStyle() }
+}
+public extension AirportPickerStyle where Self == CompactAirportPickerStyle {
+    /// Dense rows: tight padding, airport-name subtitle hidden.
+    static var compact: CompactAirportPickerStyle { CompactAirportPickerStyle() }
+}
+public extension AirportPickerStyle where Self == CodeGridAirportPickerStyle {
+    /// Browse sections as a tappable IATA-code chip grid; results keep rows.
+    static var codeGrid: CodeGridAirportPickerStyle { CodeGridAirportPickerStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyAirportPickerStyle: AirportPickerStyle {
+    private let _makeBody: @MainActor (AirportPickerConfiguration) -> AnyView
+    init<S: AirportPickerStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: AirportPickerConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct AirportPickerStyleKey: EnvironmentKey {
+    static let defaultValue = AnyAirportPickerStyle(ListAirportPickerStyle())
+}
+
+extension EnvironmentValues {
+    var airportPickerStyle: AnyAirportPickerStyle {
+        get { self[AirportPickerStyleKey.self] }
+        set { self[AirportPickerStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``AirportPickerStyle`` for `AirportPicker`s in this view and its
+    /// descendants — origin and destination pickers restyle together. The
+    /// deprecated `.density(_:)` modifier, when explicitly set, wins over this
+    /// environment style (ADR-0004 §5 source-behaviour stability).
+    func airportPickerStyle<S: AirportPickerStyle>(_ style: sending S) -> some View {
+        environment(\.airportPickerStyle, AnyAirportPickerStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: sections first with a departure glyph per row, the search field
+/// pinned *below* the list. Proves the pre-wired units arrange freely.
+private struct SearchLastAirportPickerStyle: AirportPickerStyle {
+    func makeBody(configuration: AirportPickerConfiguration) -> some View {
+        SearchLastChrome(configuration: configuration)
+    }
+
+    private struct SearchLastChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: AirportPickerConfiguration
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+                if configuration.isLoading {
+                    configuration.loadingView
+                } else if configuration.showsEmptyState {
+                    configuration.emptyView
+                } else {
+                    ForEach(configuration.sections) { section in
+                        configuration.sectionHeader(section)
+                        ForEach(section.airports) { airport in
+                            configuration.selectableRow(airport, AnyView(label(airport)))
+                        }
+                    }
+                }
+                configuration.searchField
+            }
+        }
+
+        private func label(_ airport: Airport) -> some View {
+            HStack(spacing: configuration.spacing(.sm)) {
+                Icon(systemName: "airplane.departure")
+                    .size(.sm)
+                    .color(configuration.accentForeground(theme))
+                Text("\(airport.city) · \(airport.code)")
+                    .textStyle(.labelBase600)
+                    .foregroundStyle(theme.text(.textPrimary))
+                Spacer()
+                if configuration.isSelected(airport) {
+                    Icon(systemName: "checkmark").size(.sm).color(configuration.accentForeground(theme))
+                }
+            }
+            .padding(.horizontal, configuration.spacing(.md))
+            .padding(.vertical, configuration.spacing(.xs))
+        }
+    }
+}
+
+private let styleAirports: [Airport] = [
+    Airport(code: "IST", name: "Istanbul Airport", city: "Istanbul", countryCode: "TR"),
+    Airport(code: "LHR", name: "Heathrow Airport", city: "London", countryCode: "GB"),
+    Airport(code: "LGW", name: "Gatwick Airport", city: "London", countryCode: "GB"),
+    Airport(code: "JFK", name: "John F. Kennedy Airport", city: "New York", countryCode: "US"),
+    Airport(code: "CDG", name: "Charles de Gaulle Airport", city: "Paris", countryCode: "FR"),
+    Airport(code: "AMS", name: "Schiphol Airport", city: "Amsterdam", countryCode: "NL"),
+]
+
+#Preview("AirportPickerStyle — presets × light/dark") {
+    let browse = AirportPicker(selection: .constant(styleAirports[0]), suggestions: [])
+        .nearby([styleAirports[5]])
+        .recent([styleAirports[1], styleAirports[3]], onClear: { })
+        .popular([styleAirports[0], styleAirports[4]])
+    let results = AirportPicker(selection: .constant(styleAirports[1]),
+                                suggestions: [styleAirports[1], styleAirports[2]])
+        .seedQuery("Lon")
+    return PreviewMatrix("AirportPickerStyle", rtl: true) {
+        PreviewCase("List (default)") { browse }
+        PreviewCase("List · results") { results }
+        PreviewCase("Compact") { browse.airportPickerStyle(.compact) }
+        PreviewCase("Compact · results") { results.airportPickerStyle(.compact) }
+        PreviewCase("Code grid") { browse.airportPickerStyle(.codeGrid) }
+        PreviewCase("Code grid · accent + solid chips") {
+            browse.chipVariant(.solid).accent(.info).airportPickerStyle(.codeGrid)
+        }
+        PreviewCase("Custom (in-preview)") { browse.airportPickerStyle(SearchLastAirportPickerStyle()) }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift
@@ -11,10 +11,16 @@
 //    → FieldButton + GuestSelector (bottom sheet) → CabinClassSelector
 //    → PrimaryButton CTA → optional `.promo { }` slot.
 //
-//  The shell is drawn by the active **CardStyle**: the organism wraps its
-//  content in the neutral `Card`, which routes `surface` / `elevation` through
-//  `CardStyleConfiguration` — so `.cardStyle(_:)` set on the subtree re-chromes
-//  this card exactly like every other card-shaped organism.
+//  The *arrangement* is owned by the active ``TripSearchCardStyle`` from the
+//  environment (ADR-0004, Class B): the component builds fully-wired field
+//  units (bindings, sheets, swap spin, debounced lookups) plus typed signals
+//  into a ``TripSearchCardConfiguration`` and hands it to the style — `.card`
+//  (default) is today's stacked editor verbatim; `.hero`, `.compact`,
+//  `.inlineBar` and `.pill` swap the whole layout, and apps can implement
+//  their own. Card-shaped styles keep composing the neutral `Card`, which
+//  routes `surface` / `elevation` through `CardStyleConfiguration` — so
+//  `.cardStyle(_:)` set on the subtree still re-chromes this card exactly
+//  like every other card-shaped organism.
 //
 //  Multi-city (decided in-PR, per the §9.6 "only if cheap" note): `.multiCity`
 //  is accepted in the model and selectable in the toggle, but v1 renders the
@@ -31,13 +37,12 @@
 import SwiftUI
 import ThemeKit
 
-// MARK: - Variant
+// MARK: - Variant (deprecated toward TripSearchCardStyle)
 
-/// How ``TripSearchCard`` presents: the standard `.card`, a larger `.hero`
-/// treatment for landing headers, a `.compact` collapsed summary row that
-/// expands into the full editor on tap, or an `.inlineBar` — a single-row
-/// horizontal bar for wide/iPad headers (narrow widths fall back to the
-/// stacked editor via `ViewThatFits`).
+/// How ``TripSearchCard`` presents. Superseded by ``TripSearchCardStyle``
+/// (ADR-0004) — every case maps 1:1 to a preset (`.card` →
+/// `.tripSearchCardStyle(.card)` and so on, plus the new `.pill`); the enum
+/// remains for source compatibility and is removed at the next major.
 public enum TripSearchVariant: Sendable { case card, hero, compact, inlineBar }
 
 /// Vertical density of the editor: `.regular` (default) or `.compact` —
@@ -56,7 +61,7 @@ public enum TripSearchDensity: Sendable { case compact, regular }
 /// TripSearchCard(draft: $draft) { search($0) }
 ///     .airports(suggestions: results, recent: store.recents, popular: curated)
 ///     .onAirportQuery { lookup($0) }
-///     .variant(.hero)
+///     .tripSearchCardStyle(.hero)
 ///     .promo { PromoBanner("Summer sale") }
 /// ```
 ///
@@ -72,6 +77,8 @@ public struct TripSearchCard: View {
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.locale) private var locale
+    @Environment(\.componentDensity) private var envDensity
+    @Environment(\.tripSearchCardStyle) private var envStyle
 
     @Binding private var draft: TripSearchDraft
     private let onSearch: (TripSearchDraft) -> Void
@@ -88,9 +95,13 @@ public struct TripSearchCard: View {
     /// Render-time default — re-resolves through the localization chain on
     /// every body pass, so a live language switch is never frozen at init.
     private var ctaTitle: String { ctaTitleOverride ?? String(themeKitTravel: "Search flights") }
-    private var variant: TripSearchVariant = .card
-    private var surfaceKey: Theme.BackgroundColorKey = .bgWhite
-    /// Explicit `.elevation(_:)` wins; otherwise `.hero` lifts to `.elevated`.
+    /// Style set by the deprecated `.variant(_:)`; wins over the environment
+    /// style (ADR-0004 §5 — source-behavior stability during migration).
+    private var explicitStyle: AnyTripSearchCardStyle?
+    /// `nil` → the style's own default surface (the built-ins use `.bgWhite`).
+    private var surfaceKey: Theme.BackgroundColorKey?
+    /// Explicit `.elevation(_:)` wins; otherwise the style picks (`.card`/
+    /// `.compact`/`.inlineBar` → `.soft`, `.hero`/`.pill` → `.elevated`).
     private var explicitElevation: CardElevation?
     private var accentColor: SemanticColor?
     /// Promo slot under the CTA. Local erasure (ThemeKit's `SlotContent` is
@@ -112,6 +123,8 @@ public struct TripSearchCard: View {
     private var passengerDetents: [BottomSheetDetent] = [.medium]
 
     /// UI-only state (house rule 1): sheet + compact-expansion + swap spin.
+    /// Class B contract: this never leaves the component — styles see only
+    /// `isExpanded` and the motion-gated `toggleExpand`.
     @State private var isPassengerSheetPresented = false
     @State private var isExpanded = false
     @State private var swapAngle: Double = 0
@@ -126,10 +139,6 @@ public struct TripSearchCard: View {
 
     private var motion: Animation? {
         MicroMotion.animation(enabled: micro, reduceMotion: reduceMotion)
-    }
-
-    private var effectiveElevation: CardElevation {
-        explicitElevation ?? (variant == .hero ? .elevated : .soft)
     }
 
     /// Past dates are excluded by default (§9.6); an explicit `.dateRange(_:)` wins.
@@ -156,76 +165,40 @@ public struct TripSearchCard: View {
     // MARK: - Body
 
     public var body: some View {
-        Card { cardBody }
-            .contentPadding(variant == .hero ? .lg : .md)
-            .elevation(effectiveElevation)
-            .surface(surfaceKey)
+        // The arrangement is owned by the active `TripSearchCardStyle` (ADR-0004
+        // Class B): the units below are pre-wired and fully interactive; the
+        // style arranges them, never re-wires them. Motion is resolved *here*
+        // (`toggleExpand` is animation-gated, and the expansion/trip-type
+        // animations ride on the component) — styles never read the motion env.
+        let configuration = TripSearchCardConfiguration(
+            tripType: showsTripType ? AnyView(tripTypeToggle) : nil,
+            routeFields: AnyView(routeFields),
+            dateFields: AnyView(dateFields),
+            passengersField: AnyView(passengersTrigger),
+            cabinField: showsCabinPicker ? AnyView(cabinSection) : nil,
+            cta: AnyView(ctaUnit(fullWidth: true, prominent: false)),
+            heroCta: AnyView(ctaUnit(fullWidth: true, prominent: true)),
+            inlineCta: AnyView(ctaUnit(fullWidth: false, prominent: false)),
+            header: headerContent,
+            promo: promoContent,
+            footer: footerContent,
+            draft: draft,
+            isDraftComplete: isDraftComplete,
+            isExpanded: isExpanded,
+            toggleExpand: { withAnimation(motion) { isExpanded.toggle() } },
+            accent: accentColor,
+            surfaceKey: surfaceKey,
+            elevation: explicitElevation,
+            editorDensity: densityValue,
+            density: envDensity,
+            locale: locale)
+        let style = explicitStyle ?? envStyle   // explicit (deprecated .variant) wins — ADR-0004 §5
+        return style.makeBody(configuration: configuration)
             .animation(motion, value: isExpanded)
-            .accessibilityElement(children: .contain)
-            .accessibilityLabel(String(themeKitTravel: "Flight search"))
-    }
-
-    @ViewBuilder
-    private var cardBody: some View {
-        if variant == .compact && !isExpanded {
-            summaryRow
-        } else {
-            VStack(alignment: .leading, spacing: stackSpacing) {
-                if variant == .compact { collapseHeader }
-                if let headerContent { headerContent }
-                if variant == .inlineBar { inlineRun } else { editorStack }
-                if let promoContent { promoContent }
-                if let footerContent { footerContent }
-            }
             // `.oneWay` hides the return field; gated by `microAnimations` + Reduce Motion.
             .animation(motion, value: draft.tripType)
-        }
-    }
-
-    /// Stack gap from the density axis (token-fed).
-    private var stackSpacing: CGFloat {
-        densityValue == .compact ? Theme.SpacingKey.sm.value : Theme.SpacingKey.md.value
-    }
-
-    // MARK: - Form (the full stacked editor)
-
-    private var editorStack: some View {
-        VStack(alignment: .leading, spacing: stackSpacing) {
-            if showsTripType { tripTypeToggle }
-            routeFields
-            dateFields
-            passengersTrigger
-            if showsCabinPicker { cabinSection }
-            cta(fullWidth: true)
-        }
-    }
-
-    // MARK: - Inline bar (single-row editor for wide/iPad headers)
-
-    /// One horizontal run of the core fields; when the row can't fit (narrow
-    /// widths, accessibility type sizes) `ViewThatFits` falls back to the
-    /// stacked editor — nothing is ever clipped. Trip type and cabin stay
-    /// draft-driven (no room in one row); toggle them with the modifiers on
-    /// a wrapping toolbar if needed.
-    private var inlineRun: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
-                originPicker
-                if showsSwapValue { swapControl("arrow.left.arrow.right") }
-                destinationPicker
-                DateField(String(themeKitTravel: "Departure"), date: $draft.departureDate)
-                    .range(effectiveDateRange)
-                    .icon(departureIconName ?? "calendar")
-                if showsReturnDate {
-                    DateField(String(themeKitTravel: "Return"), date: $draft.returnDate)
-                        .range(returnDateRange)
-                        .icon(departureIconName ?? "calendar")
-                }
-                passengersTrigger
-                cta(fullWidth: false)
-            }
-            editorStack
-        }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(String(themeKitTravel: "Flight search"))
     }
 
     // MARK: Trip type (TripTypeToggle wrap — TripType ⇄ index)
@@ -253,7 +226,8 @@ public struct TripSearchCard: View {
 
     /// Horizontal at regular sizes; falls to a stacked layout with a floating
     /// swap at accessibility Dynamic Type sizes (§9.6). Both arrangements are
-    /// `HStack`/`VStack`-composed, so they mirror under RTL for free.
+    /// `HStack`/`VStack`-composed, so they mirror under RTL for free. Handed
+    /// to styles welded (ADR-0004 §9.2) — the fallback travels with the unit.
     private var routeFields: some View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: Theme.SpacingKey.sm.value) {
@@ -407,18 +381,19 @@ public struct TripSearchCard: View {
             // (phone width, a sidebar column), where four equal segments can't fit
             // "Premium Economy" without wrapping the labels character-by-character.
             CabinClassSelector(selection: $draft.cabin)
-                .variant(.chips)
                 .accent(accentColor)
+                .cabinClassSelectorStyle(.chips)
         }
     }
 
     // MARK: CTA
 
-    /// The submit control. A `.ctaLabel { }` slot replaces the button's look
-    /// (caller-styled label inside a plain button) while the submit guard and
-    /// completeness-driven `.disabled` wiring stay intact.
+    /// The submit control, built in the three shapes styles arrange
+    /// (`cta`/`heroCta`/`inlineCta`). A `.ctaLabel { }` slot replaces the
+    /// button's look (caller-styled label inside a plain button) while the
+    /// submit guard and completeness-driven `.disabled` wiring stay intact.
     @ViewBuilder
-    private func cta(fullWidth: Bool) -> some View {
+    private func ctaUnit(fullWidth: Bool, prominent: Bool) -> some View {
         if let ctaLabelContent {
             Button {
                 guard !isReadOnly else { return }   // E1 — read-only never submits
@@ -437,91 +412,11 @@ public struct TripSearchCard: View {
                 guard !isReadOnly else { return }   // E1 — read-only never submits
                 onSearch(draft)
             }
-            .size(variant == .hero ? .large : .medium)
+            .size(prominent ? .large : .medium)
             .fullWidth(fullWidth)
             .disabled(!isDraftComplete)
             .allowsHitTesting(!isReadOnly)
         }
-    }
-
-    // MARK: Compact (collapsed summary row → expands to the full editor)
-
-    private var summaryRow: some View {
-        Button {
-            withAnimation(motion) { isExpanded = true }
-        } label: {
-            HStack(spacing: Theme.SpacingKey.sm.value) {
-                Icon(systemName: "magnifyingglass")
-                    .size(.sm)
-                    .color(theme.text(.textTertiary))
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(routeSummary)
-                        .textStyle(.labelBase600)
-                        .foregroundStyle(draft.origin == nil ? theme.text(.textTertiary) : theme.text(.textPrimary))
-                    if !detailSummary.isEmpty {
-                        Text(detailSummary)
-                            .textStyle(.bodySm400)
-                            .foregroundStyle(theme.text(.textSecondary))
-                    }
-                }
-                .lineLimit(1)
-                Spacer(minLength: Theme.SpacingKey.xs.value)
-                Icon(systemName: "chevron.down")
-                    .size(.sm)
-                    .color(theme.text(.textTertiary))
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(String(themeKitTravel: "Edit search"))
-        .accessibilityValue("\(routeSummary), \(detailSummary)")
-        .accessibilityAddTraits(.isButton)
-    }
-
-    private var collapseHeader: some View {
-        HStack {
-            Spacer()
-            Button {
-                withAnimation(motion) { isExpanded = false }
-            } label: {
-                Icon(systemName: "chevron.up")
-                    .size(.sm)
-                    .color(theme.text(.textTertiary))
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(String(themeKitTravel: "Collapse search"))
-        }
-    }
-
-    /// "Istanbul (IST) – London (LHR)" — an en dash, not an arrow, so the
-    /// string stays direction-neutral under RTL.
-    private var routeSummary: String {
-        guard let origin = draft.origin, let destination = draft.destination else {
-            return String(themeKitTravel: "Where to?")
-        }
-        return "\(AirportPicker.displayText(origin)) – \(AirportPicker.displayText(destination))"
-    }
-
-    /// "Jan 5 – Jan 12 · 2 travelers · Economy" — captured-locale formatting.
-    private var detailSummary: String {
-        var parts: [String] = []
-        if let departure = draft.departureDate {
-            var dates = format(departure)
-            if showsReturnDate, let ret = draft.returnDate {
-                dates += " – " + format(ret)
-            }
-            parts.append(dates)
-        }
-        let travelers = draft.passengers.total
-        parts.append(travelers == 1
-            ? String(themeKitTravel: "1 traveler")
-            : String(themeKitTravel: "\(travelers) travelers"))
-        parts.append(draft.cabin.label)
-        return parts.joined(separator: " · ")
-    }
-
-    private func format(_ date: Date) -> String {
-        date.formatted(Date.FormatStyle(date: .abbreviated, time: .omitted).locale(locale))
     }
 }
 
@@ -560,21 +455,34 @@ public extension TripSearchCard {
     /// CTA title (default "Search flights").
     func ctaTitle(_ text: String) -> Self { copy { $0.ctaTitleOverride = text } }
 
-    /// `.card` (default) · `.hero` (larger treatment for landing headers) ·
-    /// `.compact` (collapsed summary row that expands on tap).
-    func variant(_ v: TripSearchVariant) -> Self { copy { $0.variant = v } }
+    /// Maps 1:1 onto the ``TripSearchCardStyle`` presets and, when called,
+    /// wins over the environment style (source-behavior stability during
+    /// migration — ADR-0004 §5).
+    @available(*, deprecated, message: "Use .tripSearchCardStyle(_:) — e.g. .tripSearchCardStyle(.hero)")
+    func variant(_ v: TripSearchVariant) -> Self {
+        copy {
+            switch v {
+            case .card: $0.explicitStyle = AnyTripSearchCardStyle(CardTripSearchCardStyle())
+            case .hero: $0.explicitStyle = AnyTripSearchCardStyle(HeroTripSearchCardStyle())
+            case .compact: $0.explicitStyle = AnyTripSearchCardStyle(CompactTripSearchCardStyle())
+            case .inlineBar: $0.explicitStyle = AnyTripSearchCardStyle(InlineBarTripSearchCardStyle())
+            }
+        }
+    }
 
     /// Surface fill by background token, threaded into the active ``CardStyle``'s
-    /// configuration (e.g. `.bgHero` under a hero header).
+    /// configuration (e.g. `.bgHero` under a hero header). When unset, the
+    /// active ``TripSearchCardStyle`` picks its default (built-ins: `.bgWhite`).
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
 
-    /// Card elevation. Default `.soft` (`.elevated` for the `.hero` variant);
-    /// an explicit call always wins.
+    /// Card elevation. When unset, the active ``TripSearchCardStyle`` picks
+    /// (`.card`/`.compact`/`.inlineBar` → `.soft`, `.hero` and the expanded
+    /// `.pill` → `.elevated`); an explicit call always wins.
     func elevation(_ e: CardElevation) -> Self { copy { $0.explicitElevation = e } }
 
     /// Semantic tint threaded through the composed pieces (trip-type pill,
-    /// airport-picker chips, cabin selector). `nil` (default) keeps the stock
-    /// hero chroma.
+    /// airport-picker chips, cabin selector, the `.pill` search disc). `nil`
+    /// (default) keeps the stock hero chroma.
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accentColor = color } }
 
     /// Promo slot rendered under the CTA (campaign strip, fare notice…).
@@ -627,7 +535,7 @@ public extension TripSearchCard {
         copy { $0.passengerDetents = detents.isEmpty ? [.medium] : detents }
     }
 
-    /// Seeds the compact variant expanded (previews/snapshots only).
+    /// Seeds the collapsing styles expanded (previews/snapshots only).
     internal func seedExpanded(_ on: Bool = true) -> Self {
         copy { $0._isExpanded = State(initialValue: on) }
     }
@@ -683,11 +591,12 @@ private func previewDraft(roundTrip: Bool = true) -> TripSearchDraft {
     return Demo()
 }
 
-#Preview("One-way · hero · compact · accent") {
+#Preview("One-way · hero · compact · pill · accent") {
     struct Demo: View {
         @State private var oneWay = previewDraft(roundTrip: false)
         @State private var hero = previewDraft()
         @State private var compact = previewDraft()
+        @State private var pill = previewDraft()
         @State private var empty = TripSearchDraft()
         var body: some View {
             ScrollView {
@@ -696,11 +605,14 @@ private func previewDraft(roundTrip: Bool = true) -> TripSearchDraft {
                     TripSearchCard(draft: $oneWay) { _ in }
                     // Hero: larger padding + CTA, elevated by default.
                     TripSearchCard(draft: $hero) { _ in }
-                        .variant(.hero)
                         .accent(.success)
+                        .tripSearchCardStyle(.hero)
                     // Compact: collapsed summary row.
                     TripSearchCard(draft: $compact) { _ in }
-                        .variant(.compact)
+                        .tripSearchCardStyle(.compact)
+                    // Pill: floating capsule that expands into the editor.
+                    TripSearchCard(draft: $pill) { _ in }
+                        .tripSearchCardStyle(.pill)
                     // Empty draft: placeholders + disabled CTA; trimmed axes.
                     TripSearchCard(draft: $empty) { _ in }
                         .showsTripType(false)
@@ -727,11 +639,11 @@ private func previewDraft(roundTrip: Bool = true) -> TripSearchDraft {
                 VStack(spacing: 24) {
                     // Single-row bar for wide hosts (stacks when it can't fit).
                     TripSearchCard(draft: $bar) { _ in }
-                        .variant(.inlineBar)
                         .showsSwap(false)
                         .header {
                             Text("Find your next flight").textStyle(.headingSm)
                         }
+                        .tripSearchCardStyle(.inlineBar)
 
                     // Compact density + custom field icons + custom CTA label
                     // + footer + tall passenger sheet.

--- a/Sources/ThemeKitTravel/Components/Organisms/TripSearchCardStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/TripSearchCardStyle.swift
@@ -1,0 +1,581 @@
+//
+//  TripSearchCardStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``TripSearchCard`` — the Class B exemplar of ADR-0004
+//  (per-component style protocols). Unlike Class A (typed data the style lays
+//  out itself), this component owns *live interactive controls* — the draft
+//  binding, the airport-picker and passenger sheets, the swap spin, the
+//  compact expansion — so the configuration hands styles **pre-wired,
+//  type-erased field units** plus typed read-only signals. Styles ARRANGE the
+//  units; they never re-wire them. Five built-ins:
+//
+//    .card       the stacked editor — today's card. Default.
+//    .hero       larger treatment for landing headers: `.lg` padding, elevated
+//                shell, large CTA.
+//    .compact    a collapsed summary row that expands into the editor on tap.
+//    .inlineBar  one horizontal run for wide/iPad headers; narrow widths fall
+//                back to the stacked editor via `ViewThatFits`.
+//    .pill       a floating capsule showing the route summary that expands
+//                into the editor (Airbnb/Skyscanner home header).
+//
+//      TripSearchCard(draft: $draft) { search($0) }
+//          .airports(suggestions: results)
+//          .tripSearchCardStyle(.pill)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the shell
+//  `CardStyle` paints *chrome* (card-shaped presets keep composing the neutral
+//  `Card`, so `.cardStyle(_:)` still re-chromes them); the token theme colors
+//  everything. Motion is resolved in the component (`MicroMotion` ∧ ¬Reduce
+//  Motion): ``TripSearchCardConfiguration/toggleExpand`` is already animation-
+//  gated, and the expansion/trip-type animations ride on the component's own
+//  `.animation(_:value:)` — styles never read the motion environment.
+//
+//  Unit granularity (ADR-0004 §9.2): the route unit ships *welded*
+//  (origin + swap + destination, accessibility-size fallback inside). Note for
+//  custom one-row styles: nesting the welded unit's own `ViewThatFits` inside
+//  another `ViewThatFits` row can settle on the stacked route arrangement
+//  instead of rejecting the row — a graceful degradation, audited under
+//  ADR-0004 §9.4. Splitting the unit later is additive.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The pre-wired inputs a ``TripSearchCardStyle`` arranges. The `AnyView`
+/// fields are fully interactive units built by the component (bindings,
+/// sheets and callbacks included) — place them, never rebuild them. The typed
+/// fields are read-only signals for arrangement decisions; the component's
+/// `@State` (expansion, sheets, swap spin) never leaves the component.
+public struct TripSearchCardConfiguration {
+    // Pre-wired field units — fully interactive; styles arrange, never re-wire.
+    /// The ``TripTypeToggle`` bound to the draft; `nil` when the caller hid it
+    /// with `showsTripType(false)`.
+    public let tripType: AnyView?
+    /// Origin + swap + destination — the accessibility-size fallback (stacked
+    /// fields with a floating swap) lives *inside* the unit.
+    public let routeFields: AnyView
+    /// Departure date (+ the animated return date for round trips).
+    public let dateFields: AnyView
+    /// The passengers `FieldButton` and its `GuestSelector` bottom sheet.
+    public let passengersField: AnyView
+    /// The labeled ``CabinClassSelector`` section; `nil` when the caller hid
+    /// it with `showsCabinPicker(false)`.
+    public let cabinField: AnyView?
+    /// The completeness-disabled submit control — full width, standard size
+    /// (the stacked editor's CTA). Custom `.ctaLabel { }` content is already
+    /// wired in.
+    public let cta: AnyView
+    /// The submit control at large size, full width — hero treatments.
+    public let heroCta: AnyView
+    /// The submit control hugging its content — single-row runs.
+    public let inlineCta: AnyView
+    /// Header slot above the editor (`.header { }`); `nil` = none.
+    public let header: AnyView?
+    /// Promo slot under the CTA (`.promo { }`); `nil` = none.
+    public let promo: AnyView?
+    /// Footer slot below the editor and promo (`.footer { }`); `nil` = none.
+    public let footer: AnyView?
+
+    // Typed signals for arrangement decisions.
+    /// A read-only snapshot of the bound draft — for summaries and emphasis
+    /// only; mutate it exclusively through the pre-wired units.
+    public let draft: TripSearchDraft
+    /// `true` when the draft can be submitted (route + dates chosen). The CTA
+    /// units already disable themselves — this is for layout decisions.
+    public let isDraftComplete: Bool
+    /// Collapsed styles (`.compact`, `.pill`) read this…
+    public let isExpanded: Bool
+    /// …and flip it. Already `MicroMotion`-gated in the component — call it
+    /// directly, never wrap it in `withAnimation`.
+    public let toggleExpand: () -> Void
+    /// Semantic tint (`accent(_:)`), or `nil` for the theme's hero chroma —
+    /// resolve via ``accentFill(_:)`` / ``accentOnFill(_:)``.
+    public let accent: SemanticColor?
+    /// Explicit surface fill (`surface(_:)`), or `nil` to let the style choose
+    /// its default (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Explicit shell elevation (`elevation(_:)`), or `nil` to let the style
+    /// choose (`.card` uses `.soft`, `.hero`/`.pill` lift to `.elevated`).
+    public let elevation: CardElevation?
+    /// The editor-density axis (`density(_:)`) — resolve gaps via ``stackSpacing``.
+    public let editorDensity: TripSearchDensity
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — use it for every
+    /// date/number string so injected locales (and RTL demos) render correctly.
+    public let locale: Locale
+
+    /// The vertical gap between editor rows, resolved from the editor-density
+    /// axis (token-fed: `.compact` → `sm`, `.regular` → `md`).
+    public var stackSpacing: CGFloat {
+        editorDensity == .compact ? Theme.SpacingKey.sm.value : Theme.SpacingKey.md.value
+    }
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out the card.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    // Accent resolution — the `accent(_:)` override, else the theme's hero
+    // tokens (mirrors the FlightListItemConfiguration convention).
+    /// Emphasized fill (the pill's search glyph disc).
+    public func accentFill(_ theme: Theme) -> Color { accent?.solid ?? theme.background(.bgHero) }
+    /// Content color on top of ``accentFill(_:)``.
+    public func accentOnFill(_ theme: Theme) -> Color { accent?.onSolid ?? theme.foreground(.fgSecondary) }
+
+    // Shared summaries, so collapsed styles speak one language.
+    /// "Istanbul (IST) – London (LHR)" — an en dash, not an arrow, so the
+    /// string stays direction-neutral under RTL. Falls back to "Where to?"
+    /// while the route is incomplete.
+    public func routeSummary() -> String {
+        guard let origin = draft.origin, let destination = draft.destination else {
+            return String(themeKitTravel: "Where to?")
+        }
+        return "\(AirportPicker.displayText(origin)) – \(AirportPicker.displayText(destination))"
+    }
+
+    /// "Jan 5 – Jan 12 · 2 travelers · Economy" — captured-locale formatting.
+    public func detailSummary() -> String {
+        var parts: [String] = []
+        if let departure = draft.departureDate {
+            var dates = shortDate(departure)
+            if draft.tripType == .roundTrip, let ret = draft.returnDate {
+                dates += " – " + shortDate(ret)
+            }
+            parts.append(dates)
+        }
+        let travelers = draft.passengers.total
+        parts.append(travelers == 1
+            ? String(themeKitTravel: "1 traveler")
+            : String(themeKitTravel: "\(travelers) travelers"))
+        parts.append(draft.cabin.label)
+        return parts.joined(separator: " · ")
+    }
+
+    /// An abbreviated captured-locale date ("Jan 5").
+    public func shortDate(_ date: Date) -> String {
+        date.formatted(Date.FormatStyle(date: .abbreviated, time: .omitted).locale(locale))
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `TripSearchCard`'s entire presentation. Implement `makeBody` to
+/// arrange the configuration's pre-wired field units. Set one with
+/// `.tripSearchCardStyle(_:)`; the default is ``CardTripSearchCardStyle``.
+public protocol TripSearchCardStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: TripSearchCardConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The stacked editor column every card-shaped built-in shares — today's
+/// `editorStack`, arranged from the pre-wired units verbatim.
+private struct TripSearchEditorStack: View {
+    let configuration: TripSearchCardConfiguration
+    /// `true` swaps the standard CTA for the large hero CTA.
+    var isProminent = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.stackSpacing) {
+            if let tripType = configuration.tripType { tripType }
+            configuration.routeFields
+            configuration.dateFields
+            configuration.passengersField
+            if let cabinField = configuration.cabinField { cabinField }
+            if isProminent { configuration.heroCta } else { configuration.cta }
+        }
+    }
+}
+
+/// Header → editor → promo → footer — today's expanded `cardBody`, verbatim.
+private struct TripSearchEditorBody: View {
+    let configuration: TripSearchCardConfiguration
+    var isProminent = false
+    /// Collapsing styles pin a trailing chevron-up above the editor.
+    var showsCollapseHeader = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.stackSpacing) {
+            if showsCollapseHeader { TripSearchCollapseHeader(configuration: configuration) }
+            if let header = configuration.header { header }
+            TripSearchEditorStack(configuration: configuration, isProminent: isProminent)
+            if let promo = configuration.promo { promo }
+            if let footer = configuration.footer { footer }
+        }
+    }
+}
+
+/// The collapsed one-line summary (`.compact`, and `.pill` with capsule
+/// chrome): magnifier, route + detail summaries, an expand affordance. The tap
+/// calls the component-gated ``TripSearchCardConfiguration/toggleExpand``.
+private struct TripSearchSummaryRow: View {
+    @Environment(\.theme) private var theme
+    let configuration: TripSearchCardConfiguration
+    /// `.pill` swaps the trailing chevron for an accent search disc and draws
+    /// its own capsule chrome around the row.
+    var isPill = false
+
+    var body: some View {
+        Button(action: configuration.toggleExpand) {
+            if isPill {
+                row
+                    .padding(.vertical, Theme.SpacingKey.sm.value)
+                    .padding(.horizontal, Theme.SpacingKey.md.value)
+                    .background(theme.background(configuration.surface(default: .bgWhite)),
+                                in: Capsule(style: .continuous))
+                    .overlay(Capsule(style: .continuous).strokeBorder(theme.border(.borderPrimary), lineWidth: 1))
+                    .contentShape(Capsule(style: .continuous))
+            } else {
+                row.contentShape(Rectangle())
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(themeKitTravel: "Edit search"))
+        .accessibilityValue("\(configuration.routeSummary()), \(configuration.detailSummary())")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var row: some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            Icon(systemName: "magnifyingglass")
+                .size(.sm)
+                .color(theme.text(.textTertiary))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(configuration.routeSummary())
+                    .textStyle(.labelBase600)
+                    .foregroundStyle(configuration.draft.origin == nil
+                        ? theme.text(.textTertiary)
+                        : theme.text(.textPrimary))
+                let detail = configuration.detailSummary()
+                if !detail.isEmpty {
+                    Text(detail)
+                        .textStyle(.bodySm400)
+                        .foregroundStyle(theme.text(.textSecondary))
+                }
+            }
+            .lineLimit(1)
+            Spacer(minLength: Theme.SpacingKey.xs.value)
+            if isPill {
+                Icon(systemName: "magnifyingglass")
+                    .size(.sm)
+                    .color(configuration.accentOnFill(theme))
+                    .padding(Theme.SpacingKey.xs.value)
+                    .background(configuration.accentFill(theme), in: Circle())
+            } else {
+                Icon(systemName: "chevron.down")
+                    .size(.sm)
+                    .color(theme.text(.textTertiary))
+            }
+        }
+    }
+}
+
+/// The trailing chevron-up that collapses an expanded editor back to its
+/// summary (`.compact` expanded, `.pill` expanded).
+private struct TripSearchCollapseHeader: View {
+    @Environment(\.theme) private var theme
+    let configuration: TripSearchCardConfiguration
+
+    var body: some View {
+        HStack {
+            Spacer()
+            Button(action: configuration.toggleExpand) {
+                Icon(systemName: "chevron.up")
+                    .size(.sm)
+                    .color(theme.text(.textTertiary))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(themeKitTravel: "Collapse search"))
+        }
+    }
+}
+
+// MARK: - .card (default)
+
+/// Today's stacked editor, extracted verbatim: trip type, route, dates,
+/// passengers, cabin and a full-width CTA inside the neutral `Card`
+/// (`.md` padding, `.soft` elevation unless overridden).
+public struct CardTripSearchCardStyle: TripSearchCardStyle {
+    public init() {}
+    public func makeBody(configuration: TripSearchCardConfiguration) -> some View {
+        Card { TripSearchEditorBody(configuration: configuration) }
+            .contentPadding(.md)
+            .elevation(configuration.elevation ?? .soft)
+            .surface(configuration.surface(default: .bgWhite))
+    }
+}
+
+// MARK: - .hero
+
+/// The landing-header treatment: the same stacked editor with `.lg` padding,
+/// an `.elevated` shell (unless overridden) and the large CTA.
+public struct HeroTripSearchCardStyle: TripSearchCardStyle {
+    public init() {}
+    public func makeBody(configuration: TripSearchCardConfiguration) -> some View {
+        Card { TripSearchEditorBody(configuration: configuration, isProminent: true) }
+            .contentPadding(.lg)
+            .elevation(configuration.elevation ?? .elevated)
+            .surface(configuration.surface(default: .bgWhite))
+    }
+}
+
+// MARK: - .compact
+
+/// A collapsed summary row ("IST – LHR · dates · travelers") that expands into
+/// the full editor on tap — `isExpanded`/`toggleExpand` drive the flip; the
+/// expansion animation is the component's (`MicroMotion`-gated).
+public struct CompactTripSearchCardStyle: TripSearchCardStyle {
+    public init() {}
+    public func makeBody(configuration: TripSearchCardConfiguration) -> some View {
+        Card {
+            if configuration.isExpanded {
+                TripSearchEditorBody(configuration: configuration, showsCollapseHeader: true)
+            } else {
+                TripSearchSummaryRow(configuration: configuration)
+            }
+        }
+        .contentPadding(.md)
+        .elevation(configuration.elevation ?? .soft)
+        .surface(configuration.surface(default: .bgWhite))
+    }
+}
+
+// MARK: - .inlineBar
+
+/// One horizontal run of the core units — route, dates, passengers, CTA — for
+/// wide/iPad headers. When the row can't fit (narrow widths, accessibility
+/// type sizes) `ViewThatFits` falls back to the stacked editor — nothing is
+/// ever clipped. Trip type and cabin stay draft-driven (no room in one row).
+public struct InlineBarTripSearchCardStyle: TripSearchCardStyle {
+    public init() {}
+    public func makeBody(configuration: TripSearchCardConfiguration) -> some View {
+        Card {
+            VStack(alignment: .leading, spacing: configuration.stackSpacing) {
+                if let header = configuration.header { header }
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
+                        configuration.routeFields
+                        configuration.dateFields
+                        configuration.passengersField
+                        configuration.inlineCta
+                    }
+                    TripSearchEditorStack(configuration: configuration)
+                }
+                if let promo = configuration.promo { promo }
+                if let footer = configuration.footer { footer }
+            }
+        }
+        .contentPadding(.md)
+        .elevation(configuration.elevation ?? .soft)
+        .surface(configuration.surface(default: .bgWhite))
+    }
+}
+
+// MARK: - .pill
+
+/// The floating home-header capsule (Airbnb/Skyscanner): a route-summary pill
+/// with an accent search disc that expands into the full editor on an
+/// elevated card. Collapse it back with the chevron; both flips ride
+/// `isExpanded`/`toggleExpand` (component-gated motion).
+public struct PillTripSearchCardStyle: TripSearchCardStyle {
+    public init() {}
+    public func makeBody(configuration: TripSearchCardConfiguration) -> some View {
+        PillTripSearchChrome(configuration: configuration)
+    }
+}
+
+private struct PillTripSearchChrome: View {
+    let configuration: TripSearchCardConfiguration
+
+    var body: some View {
+        if configuration.isExpanded {
+            Card { TripSearchEditorBody(configuration: configuration, showsCollapseHeader: true) }
+                .contentPadding(.md)
+                .elevation(configuration.elevation ?? .elevated)
+                .surface(configuration.surface(default: .bgWhite))
+        } else {
+            TripSearchSummaryRow(configuration: configuration, isPill: true)
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension TripSearchCardStyle where Self == CardTripSearchCardStyle {
+    /// The stacked editor — today's card. The default.
+    static var card: CardTripSearchCardStyle { CardTripSearchCardStyle() }
+}
+public extension TripSearchCardStyle where Self == HeroTripSearchCardStyle {
+    /// Landing-header treatment: `.lg` padding, elevated shell, large CTA.
+    static var hero: HeroTripSearchCardStyle { HeroTripSearchCardStyle() }
+}
+public extension TripSearchCardStyle where Self == CompactTripSearchCardStyle {
+    /// Collapsed summary row that expands into the editor on tap.
+    static var compact: CompactTripSearchCardStyle { CompactTripSearchCardStyle() }
+}
+public extension TripSearchCardStyle where Self == InlineBarTripSearchCardStyle {
+    /// One-row run for wide/iPad headers; stacks when it can't fit.
+    static var inlineBar: InlineBarTripSearchCardStyle { InlineBarTripSearchCardStyle() }
+}
+public extension TripSearchCardStyle where Self == PillTripSearchCardStyle {
+    /// Floating route-summary capsule that expands into the editor
+    /// (Airbnb/Skyscanner home header).
+    static var pill: PillTripSearchCardStyle { PillTripSearchCardStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyTripSearchCardStyle: TripSearchCardStyle {
+    private let _makeBody: @MainActor (TripSearchCardConfiguration) -> AnyView
+    init<S: TripSearchCardStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: TripSearchCardConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct TripSearchCardStyleKey: EnvironmentKey {
+    static let defaultValue = AnyTripSearchCardStyle(CardTripSearchCardStyle())
+}
+
+extension EnvironmentValues {
+    var tripSearchCardStyle: AnyTripSearchCardStyle {
+        get { self[TripSearchCardStyleKey.self] }
+        set { self[TripSearchCardStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``TripSearchCardStyle`` for `TripSearchCard`s in this view and
+    /// its descendants — a home screen can run the `.pill` header while a
+    /// results screen keeps the `.compact` editor.
+    func tripSearchCardStyle<S: TripSearchCardStyle>(_ style: sending S) -> some View {
+        environment(\.tripSearchCardStyle, AnyTripSearchCardStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a soft banner panel arranging only the route, dates and CTA, with
+/// the route summary as its headline. Proves external implementability.
+private struct BannerTripSearchCardStyle: TripSearchCardStyle {
+    func makeBody(configuration: TripSearchCardConfiguration) -> some View {
+        BannerChrome(configuration: configuration)
+    }
+
+    private struct BannerChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: TripSearchCardConfiguration
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: configuration.stackSpacing) {
+                Text(configuration.routeSummary())
+                    .textStyle(.headingSm)
+                    .foregroundStyle(theme.text(.textPrimary))
+                configuration.routeFields
+                configuration.dateFields
+                configuration.cta
+            }
+            .padding(configuration.spacing(.md))
+            .background(theme.background(.bgSecondaryLight),
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+        }
+    }
+}
+
+/// Preview-only harness: owns the `@State` draft each interactive case binds to.
+private struct TripSearchStyleHarness<Content: View>: View {
+    @State private var draft: TripSearchDraft
+    private let content: (Binding<TripSearchDraft>) -> Content
+
+    init(_ draft: TripSearchDraft, @ViewBuilder content: @escaping (Binding<TripSearchDraft>) -> Content) {
+        self._draft = State(initialValue: draft)
+        self.content = content
+    }
+
+    var body: some View { content($draft) }
+}
+
+private func styleDraft(roundTrip: Bool = true) -> TripSearchDraft {
+    var draft = TripSearchDraft()
+    draft.tripType = roundTrip ? .roundTrip : .oneWay
+    draft.origin = Airport(code: "IST", name: "Istanbul Airport", city: "Istanbul", countryCode: "TR")
+    draft.destination = Airport(code: "LHR", name: "Heathrow Airport", city: "London", countryCode: "GB")
+    draft.departureDate = Calendar.current.date(byAdding: .day, value: 7, to: .now)
+    draft.returnDate = Calendar.current.date(byAdding: .day, value: 14, to: .now)
+    draft.passengers = PassengerCount(adults: 2)
+    return draft
+}
+
+#Preview("TripSearchCardStyle — presets × light/dark") {
+    PreviewMatrix("TripSearchCardStyle") {
+        PreviewCase(".card (default)") {
+            TripSearchStyleHarness(styleDraft()) { TripSearchCard(draft: $0) { _ in } }
+        }
+        PreviewCase(".hero") {
+            TripSearchStyleHarness(styleDraft()) {
+                TripSearchCard(draft: $0) { _ in }.tripSearchCardStyle(.hero)
+            }
+        }
+        PreviewCase(".compact — collapsed") {
+            TripSearchStyleHarness(styleDraft()) {
+                TripSearchCard(draft: $0) { _ in }.tripSearchCardStyle(.compact)
+            }
+        }
+        PreviewCase(".compact — expanded") {
+            TripSearchStyleHarness(styleDraft(roundTrip: false)) {
+                TripSearchCard(draft: $0) { _ in }.seedExpanded().tripSearchCardStyle(.compact)
+            }
+        }
+        PreviewCase(".inlineBar (stacks when narrow)") {
+            TripSearchStyleHarness(styleDraft()) {
+                TripSearchCard(draft: $0) { _ in }.tripSearchCardStyle(.inlineBar)
+            }
+        }
+        PreviewCase(".pill — collapsed") {
+            TripSearchStyleHarness(styleDraft()) {
+                TripSearchCard(draft: $0) { _ in }.tripSearchCardStyle(.pill)
+            }
+        }
+        PreviewCase(".pill — collapsed · accent · empty draft") {
+            TripSearchStyleHarness(TripSearchDraft()) {
+                TripSearchCard(draft: $0) { _ in }.accent(.success).tripSearchCardStyle(.pill)
+            }
+        }
+        PreviewCase(".pill — expanded") {
+            TripSearchStyleHarness(styleDraft()) {
+                TripSearchCard(draft: $0) { _ in }.seedExpanded().tripSearchCardStyle(.pill)
+            }
+        }
+        PreviewCase("Custom (in-preview)") {
+            TripSearchStyleHarness(styleDraft()) {
+                TripSearchCard(draft: $0) { _ in }.tripSearchCardStyle(BannerTripSearchCardStyle())
+            }
+        }
+    }
+}
+
+#Preview("Collapsing presets — XL type / RTL") {
+    PreviewMatrix("TripSearchCard — .compact & .pill", schemes: [.light], dynamicType: true, rtl: true) {
+        PreviewCase(".compact") {
+            TripSearchStyleHarness(styleDraft()) {
+                TripSearchCard(draft: $0) { _ in }.tripSearchCardStyle(.compact)
+            }
+        }
+        PreviewCase(".pill") {
+            TripSearchStyleHarness(styleDraft()) {
+                TripSearchCard(draft: $0) { _ in }.tripSearchCardStyle(.pill)
+            }
+        }
+    }
+}

--- a/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
+++ b/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
@@ -31,7 +31,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) adults",
             "%@ adults", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift:385")
+            site: "Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift:359")
         assertKey(
             "\(d) card ending \(d)",
             "%@ card ending %@", 2,
@@ -39,7 +39,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) children",
             "%@ children", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift:389")
+            site: "Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift:363")
         assertKey(
             "\(d) from \(d) to \(d)",
             "%@ from %@ to %@", 3,
@@ -47,7 +47,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) infants",
             "%@ infants", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift:394")
+            site: "Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift:368")
         assertKey(
             "\(d) installments",
             "%@ installments", 1,
@@ -111,7 +111,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) travelers",
             "%@ travelers", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/TripSearchCard.swift:518")
+            site: "Sources/ThemeKitTravel/Components/Organisms/TripSearchCardStyle.swift:158")
         assertKey(
             "\(d)% off",
             "%@%% off", 1,
@@ -313,6 +313,6 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "via \(d)",
             "via %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Molecules/RecentSearchRow.swift:117")
+            site: "Sources/ThemeKitTravel/Components/Molecules/RecentSearchRowStyle.swift:92")
     }
 }


### PR DESCRIPTION
Second wave of **ADR-0004** (per-component Style protocols). Six Search-cluster components each gain their own full Style protocol, and the **Class-B field-unit shape** lands with `TripSearchCardStyle` (the exemplar for components that own live interactive controls). Every default preset reproduces today's render pixel-for-pixel; additive.

| Component | Protocol → modifier | Presets | Class |
|---|---|---|---|
| TripSearchCard *(Class-B exemplar)* | `.tripSearchCardStyle(_:)` | `.card` · `.hero` · `.compact` · `.inlineBar` · `.pill` | B |
| AirportPicker | `.airportPickerStyle(_:)` | `.list` · `.compact` · `.codeGrid` | B |
| RecentSearchRow | `.recentSearchRowStyle(_:)` | `.plain` · `.bordered` · `.pill` · `.card` | A |
| TripTypeToggle | `.tripTypeToggleStyle(_:)` | `.pill` · `.underline` · `.menu` | A |
| CabinClassSelector | `.cabinClassSelectorStyle(_:)` | `.segmented` · `.chips` · `.list` · `.cards` | A |
| DatePriceStrip | `.datePriceStripStyle(_:)` | `.grid(columns:)` · `.strip` · `.chart` | A |

**22 presets** across 6 protocols.

## Notes
- **Class B (field-unit config):** TripSearchCard/AirportPicker hand styles **pre-wired, type-erased interactive units** + typed signals — styles *arrange*, the component keeps all `@State`/sheets/debounce/selection wiring (ADR §2.2). AirportPicker's **presentation** (inline/sheet/popover) stays **orthogonal** — presentation ≠ style.
- **Parameterized preset:** `DatePriceStripStyle.grid(columns:)` — a preset struct with a stored `columns` (ADR §9 OQ-3).
- **Deprecate-forward:** every existing `.variant(_:)`/`.layout(_:)`/`.strip()`/`.columns()`/`.density(_:)` is `@available(*, deprecated)` and forwards to the style accessors; an explicit deprecated modifier **wins over the environment style**. Enums stay public, removed at next major.
- **l10n** catalogs regenerated (drift gate green).
- **Known follow-up:** 24 deprecation *warnings* at un-migrated call sites in Demo/Tests — harmless (deprecate-forward renders identically); to be swept before the enums are removed.

## Verification
`swift build` **0 errors** · **312 tests pass** (incl. l10n gate) · **Demo BUILD SUCCEEDED** (iOS Simulator; 24 non-fatal deprecation warnings).

Wave 2 lands the Class-B template. Part of the ADR-0004 6-wave plan (Waves 3–5 to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)