### PR TITLE
feat(travel): Style-protocol Wave 3 — Booking & payment cluster (ADR-0004)

### DIFF
--- a/Sources/ThemeKitCore/Resources/Localizable.xcstrings
+++ b/Sources/ThemeKitCore/Resources/Localizable.xcstrings
@@ -10,6 +10,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "%@ items": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "%@ left": {
       "comment": "Text shown in the trailing corner of a text input, indicating how many characters are left to be entered. The argument is the number of remaining characters.",
       "extractionState": "manual",
@@ -345,6 +349,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Collapse fare details": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Collapsed": {
       "comment": "Accessibility value of a closed dropdown trigger.",
       "extractionState": "manual",
@@ -509,6 +517,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Expand fare details": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Expanded": {
       "comment": "Accessibility value of an open dropdown trigger.",
       "extractionState": "manual",
@@ -564,6 +576,10 @@
       "generatesSymbol": false
     },
     "Hex color": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Hide breakdown": {
       "extractionState": "manual",
       "generatesSymbol": false
     },
@@ -1026,6 +1042,10 @@
       "generatesSymbol": false
     },
     "Show %@ more": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Show breakdown": {
       "extractionState": "manual",
       "generatesSymbol": false
     },

--- a/Sources/ThemeKitTravel/Components/Organisms/AncillaryCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/AncillaryCard.swift
@@ -11,19 +11,25 @@
 //      .price(450).quantity($bags, range: 0...4)
 //  ```
 //
-//  The outer shell (surface fill, corner clipping, border, elevation shadow) is drawn
-//  by the active `CardStyle` from the environment — `.surface()/.cornerRadius()` and
-//  the added/quantity "active" state (as `isSelected`) feed the
-//  `CardStyleConfiguration`, so `.cardStyle(_:)` can swap in a different shell.
+//  The *arrangement* is owned by the active ``AncillaryCardStyle`` from the
+//  environment (ADR-0004): the component gathers its typed data — plus the
+//  quantity/added control as pre-wired state + closures — into an
+//  ``AncillaryCardConfiguration`` and hands it to the style. `.row` (default) is
+//  today's card verbatim; `.tile` and `.banner` swap the whole layout, and apps
+//  can implement their own. Every built-in is card-shaped, so it keeps drawing
+//  the outer shell (surface fill, corner clipping, border, elevation shadow)
+//  through the active `CardStyle` — `.surface()/.cornerRadius()` and the
+//  added/quantity "active" state (as `isSelected`) feed the
+//  `CardStyleConfiguration`, so `.cardStyle(_:)` still swaps the chrome
+//  independently of `.ancillaryCardStyle(_:)`.
 //
 
 import SwiftUI
 import ThemeKit
 
 public struct AncillaryCard: View {
-    @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
-    @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.ancillaryCardStyle) private var style
     @Environment(\.formatDefaults) private var formatDefaults
     @Environment(\.locale) private var locale
 
@@ -54,8 +60,10 @@ public struct AncillaryCard: View {
     /// every body pass, so a live language switch is never frozen at init.
     private var addedTitle: String { addedTitleOverride ?? String(themeKit: "Added") }
     private var accent: SemanticColor?
-    private var surfaceKey: Theme.BackgroundColorKey = .bgBase
-    private var controlSurfaceKey: Theme.BackgroundColorKey = .bgSecondary
+    /// `nil` → the active ``AncillaryCardStyle``'s own default (`.row` uses `.bgBase`).
+    private var surfaceKey: Theme.BackgroundColorKey?
+    /// `nil` → the active style's own default (`.row`/`.tile` use `.bgSecondary`).
+    private var controlSurfaceKey: Theme.BackgroundColorKey?
     private var radiusRole: Theme.RadiusRole = .box
     private var elevation: CardElevation = .none
     private var leadingSlot: AnyView?
@@ -63,125 +71,45 @@ public struct AncillaryCard: View {
 
     public init(_ title: String) { self.title = title }   // R1
 
-    @Environment(\.componentDefaults) private var defaults
-    @Environment(\.isReadOnly) private var isReadOnly   // E1 — set by `.readOnly(_:)`
-    private var accentSemantic: SemanticColor { accent ?? defaults.accent ?? .primary }
     private var resolvedCurrency: String {
         currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
-    private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: radiusRole.value, style: .continuous) }
-    @MainActor
-    private var isActive: Bool { (showsAdded && addedState) || (showsQuantity && quantityState > 0) }
 
     public var body: some View {
-        // The shell (fill, corner clipping, border, shadow) is drawn by the active
-        // `CardStyle` — built-ins and custom styles go through the same gate. The
-        // added/quantity "active" state feeds `isSelected`, so the selected border is
-        // the style's to draw (the default style uses the hero border token). `.none`
-        // elevation reproduces today's flat look: a 1pt hairline border, no shadow.
-        cardStyle.makeBody(configuration: CardStyleConfiguration(
-            content: AnyView(cardContent),
-            elevation: elevation,
-            isSelected: isActive,
-            isPressed: false,
+        // The arrangement is owned by the active `AncillaryCardStyle`; the
+        // quantity/added `@ControllableState` storage stays *here* (ADR-F4) —
+        // styles only see the current value + a typed step/toggle closure, so
+        // the interaction logic (clamping, toggling) is never re-implemented
+        // per style.
+        let configuration = AncillaryCardConfiguration(
+            title: title,
+            systemImage: systemImage,
+            imageURL: imageURL,
+            subtitle: subtitle,
+            priceAmount: price,
+            currencyCode: resolvedCurrency,
+            priceSuffix: priceSuffix,
+            badgeText: badgeText,
+            badgeStyle: badgeStyle,
+            showsQuantity: showsQuantity,
+            quantity: quantityState,
+            quantityRange: quantityRange,
+            setQuantity: showsQuantity ? { quantityState = $0 } : nil,
+            showsAdded: showsAdded,
+            isAdded: addedState,
+            toggleAdded: showsAdded ? { addedState.toggle() } : nil,
+            addTitle: addTitle,
+            addedTitle: addedTitle,
+            leading: leadingSlot,
+            trailing: trailingSlot,
+            accent: accent,
             surfaceKey: surfaceKey,
-            radius: radiusRole))
-            .contentShape(shape)
-    }
-
-    /// The card's inner layout — everything inside the shell.
-    @MainActor
-    private var cardContent: some View {
-        HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            leading
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
-                    Text(title).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
-                    if let badgeText { Badge(badgeText).badgeStyle(badgeStyle).variant(.soft).size(.small).fixedSize() }
-                }
-                if let subtitle { Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(1) }
-                if let price { priceLine(price) }
-            }
-            Spacer(minLength: 6)
-            control
-        }
-        .padding(density.scale(Theme.SpacingKey.md.value))
-    }
-
-    @ViewBuilder private var leading: some View {
-        if let leadingSlot {
-            leadingSlot
-        } else if let imageURL {
-            RemoteImage(imageURL).contentMode(.fill).frame(width: 46, height: 46)
-                .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
-        } else {
-            IconTile(systemImage).accent(accentSemantic)
-        }
-    }
-
-    private func priceLine(_ amount: Decimal) -> some View {
-        HStack(spacing: 2) {
-            Text(amount.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0))))
-                .textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
-            if let priceSuffix { Text(priceSuffix).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary)) }
-        }
-    }
-
-    @MainActor
-    @ViewBuilder private var control: some View {
-        if let trailingSlot {
-            trailingSlot
-        } else if showsQuantity {
-            stepper($quantityState)
-        } else if showsAdded {
-            addButton($addedState)
-        }
-    }
-
-    private func stepper(_ qty: Binding<Int>) -> some View {
-        HStack(spacing: 0) {
-            stepButton("minus", label: String(themeKit: "Decrease"), value: qty.wrappedValue, enabled: qty.wrappedValue > quantityRange.lowerBound) {
-                qty.wrappedValue = max(quantityRange.lowerBound, qty.wrappedValue - 1)
-            }
-            Text("\(qty.wrappedValue)").textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
-                .frame(minWidth: 28).monospacedDigit()
-            stepButton("plus", label: String(themeKit: "Increase"), value: qty.wrappedValue, enabled: qty.wrappedValue < quantityRange.upperBound) {
-                qty.wrappedValue = min(quantityRange.upperBound, qty.wrappedValue + 1)
-            }
-        }
-        .padding(.horizontal, 4)
-        .background(theme.background(controlSurfaceKey), in: Capsule())
-        .disabled(isReadOnly)   // E1 — read-only surfaces render but don't mutate
-    }
-
-    private func stepButton(_ icon: String, label: String, value: Int, enabled: Bool, _ action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Image(systemName: icon).font(.system(size: 13, weight: .bold))
-                .foregroundStyle(enabled ? accentSemantic.base : theme.text(.textDisabled))
-                .frame(width: 32, height: 32)
-        }
-        .buttonStyle(.plain)
-        .disabled(!enabled)
-        .accessibilityLabel(label)
-        .accessibilityValue("\(value)")
-    }
-
-    private func addButton(_ added: Binding<Bool>) -> some View {
-        let on = added.wrappedValue
-        return Button { added.wrappedValue.toggle() } label: {
-            HStack(spacing: 4) {
-                Image(systemName: on ? "checkmark" : "plus").font(.system(size: 12, weight: .bold))
-                Text(on ? addedTitle : addTitle).textStyle(.labelSm700)
-            }
-            .foregroundStyle(on ? accentSemantic.onSolid : accentSemantic.base)
-            .padding(.horizontal, density.scale(Theme.SpacingKey.md.value))
-            .frame(height: 36)
-            .background(on ? accentSemantic.solid : accentSemantic.bg, in: Capsule())
-        }
-        .buttonStyle(.plain)
-        .disabled(isReadOnly)   // E1 — read-only surfaces render but don't mutate
-        .accessibilityLabel(title)
-        .accessibilityAddTraits(on ? .isSelected : [])
+            controlSurfaceKey: controlSurfaceKey,
+            radiusRole: radiusRole,
+            elevation: elevation,
+            density: density,
+            locale: locale)
+        style.makeBody(configuration: configuration)
     }
 }
 
@@ -261,8 +189,10 @@ public extension AncillaryCard {
         @State private var insurance = false
         var body: some View {
             VStack(spacing: 10) {
-                AncillaryCard("Checked baggage").icon("suitcase.fill").subtitle("20 kg").price(450, suffix: "/ bag").quantity($bags, range: 0...4)
-                AncillaryCard("Travel insurance").icon("cross.case.fill").subtitle("Full coverage").price(120).badge("Popular").added($insurance)
+                AncillaryCard("Checked baggage").icon("suitcase.fill").subtitle("20 kg")
+                    .price(450, suffix: "/ bag").quantity($bags, range: 0...4)
+                AncillaryCard("Travel insurance").icon("cross.case.fill").subtitle("Full coverage")
+                    .price(120).badge("Popular").added($insurance)
                 AncillaryCard("Extra legroom").icon("figure.seated.side").subtitle("Row 12").price(75).quantity($bags, range: 0...4)
                     .surface(.bgSecondaryLight)
                     .controlSurface(.bgWhite)

--- a/Sources/ThemeKitTravel/Components/Organisms/AncillaryCardStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/AncillaryCardStyle.swift
@@ -1,0 +1,557 @@
+//
+//  AncillaryCardStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``AncillaryCard`` (ADR-0004, Wave 3, Class A): the
+//  configuration hands styles the *typed* add-on data (title, thumbnail, price,
+//  badge…) plus the quantity/added control as pre-wired **state + closures** —
+//  not a laid-out `AnyView` unit — so a style arranges the control itself and
+//  never re-implements the stepper/toggle interaction. Three built-ins:
+//
+//    .row     icon/title/price + stepper or toggle, trailing edge — today's card. Default.
+//    .tile    vertical grid tile: leading/badge row, title/subtitle, price, control at the bottom.
+//    .banner  thumbnail-led full-width upsell strip — bigger art, softer surface.
+//
+//      AncillaryCard("Checked baggage").icon("suitcase.fill").subtitle("20 kg")
+//          .price(450).quantity($bags, range: 0...4)
+//          .ancillaryCardStyle(.tile)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the shell
+//  `CardStyle` paints *chrome* (every built-in here is card-shaped, so it keeps
+//  routing surface, elevation, selection and radius through `\.cardStyle`); the
+//  token theme colors everything. Quantity/added state is a `@ControllableState`
+//  owned by the component (ADR-F4) — the configuration exposes the current value
+//  plus a `setQuantity`/`toggleAdded` closure, and a shared private
+//  `AncillaryCardControl` (analogous to `FlightCardFavoriteHeart`) renders it
+//  identically across all three presets, so the interaction logic is written once.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs an ``AncillaryCardStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no price → no price line, no badge → no chip).
+public struct AncillaryCardConfiguration {
+    /// The add-on's name, e.g. "Checked baggage".
+    public let title: String
+    /// SF Symbol used when there is no ``imageURL``/``leading`` slot.
+    public let systemImage: String
+    /// A remote thumbnail; wins over ``systemImage`` when set (and there's no
+    /// ``leading`` slot). Styles size it.
+    public let imageURL: URL?
+    /// A one-line detail under the title, e.g. "20 kg".
+    public let subtitle: String?
+    /// The fare; `nil` hides the price line.
+    public let priceAmount: Decimal?
+    /// Currency code for ``priceAmount``, already resolved by the component
+    /// through the FormatDefaults chain (explicit → `formatDefaults` →
+    /// `locale.currency` → `"USD"`). Optional for additive safety only.
+    public let currencyCode: String?
+    /// A per-unit suffix after the price, e.g. `"/ bag"`.
+    public let priceSuffix: String?
+    /// Title badge text, e.g. "Popular"; `nil` hides the badge.
+    public let badgeText: String?
+    /// The title badge's style (`.info` unless overridden).
+    public let badgeStyle: BadgeStyle
+
+    /// `true` when ``AncillaryCard/quantity(_:range:)`` / ``AncillaryCard/quantity(range:)``
+    /// was called — the interactive control is a stepper.
+    public let showsQuantity: Bool
+    /// The stepper's current value.
+    public let quantity: Int
+    /// The stepper's clamped range.
+    public let quantityRange: ClosedRange<Int>
+    /// Pre-wired step closure: styles read ``quantity`` and call this to change
+    /// it. The `@ControllableState` storage stays in the component (ADR-F4) —
+    /// styles never own a `Binding`, only this typed setter.
+    public let setQuantity: ((Int) -> Void)?
+
+    /// `true` when ``AncillaryCard/added(_:title:addedTitle:)`` /
+    /// ``AncillaryCard/added(title:addedTitle:)`` was called — the interactive
+    /// control is an add/remove toggle.
+    public let showsAdded: Bool
+    /// The toggle's current value.
+    public let isAdded: Bool
+    /// Pre-wired toggle closure — flips ``isAdded``. Same ADR-F4 split as
+    /// ``setQuantity``.
+    public let toggleAdded: (() -> Void)?
+    /// Render-time-resolved "Add" title (already localized; re-resolves on
+    /// every body pass, so a live language switch is never frozen).
+    public let addTitle: String
+    /// Render-time-resolved "Added" title.
+    public let addedTitle: String
+
+    /// Replacement for the built-in icon tile / thumbnail (`.leading { }`); `nil` = built-in.
+    public let leading: AnyView?
+    /// Replacement for the built-in stepper / add-button control area (`.trailing { }`).
+    public let trailing: AnyView?
+
+    /// Brand-chrome accent override (`AncillaryCard.accent(_:)`); `nil` defers
+    /// to the subtree `ComponentDefaults.accent`, else `.primary` — resolve via
+    /// ``resolvedAccent(_:)``.
+    public let accent: SemanticColor?
+    /// Explicit card-shell surface fill, or `nil` to let the style choose its
+    /// own default (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Explicit stepper-track surface fill, or `nil` for the style's own
+    /// default (resolve via ``controlSurface(default:)``).
+    public let controlSurfaceKey: Theme.BackgroundColorKey?
+    /// Shell corner radius role, fed to the active `CardStyle` by every
+    /// (card-shaped) built-in.
+    public let radiusRole: Theme.RadiusRole
+    /// Shell elevation, fed to the active `CardStyle`.
+    public let elevation: CardElevation
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component.
+    public let locale: Locale
+
+    /// Added, or a positive quantity — card-shaped styles feed this to the
+    /// `CardStyle` shell's `isSelected` (the default style draws a hero border).
+    public var isActive: Bool { (showsAdded && isAdded) || (showsQuantity && quantity > 0) }
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+    /// The explicit `controlSurface(_:)` override, or the style's own default.
+    public func controlSurface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        controlSurfaceKey ?? fallback
+    }
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out the card.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+    /// The `accent(_:)` override, else the subtree `ComponentDefaults.accent`,
+    /// else `.primary` — the resolution every built-in tints its icon/control
+    /// with (the value the pre-style component computed as `accentSemantic`).
+    public func resolvedAccent(_ defaults: ComponentDefaults) -> SemanticColor {
+        accent ?? defaults.accent ?? .primary
+    }
+    /// Shared price formatting, so every style speaks one language. Matches the
+    /// pre-style rendering exactly (no explicit `.locale()` — the amount is
+    /// already currency-coded via ``currencyCode``).
+    public func formattedPrice(_ amount: Decimal) -> String {
+        amount.formatted(.currency(code: currencyCode ?? "USD").precision(.fractionLength(0)))
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines an `AncillaryCard`'s entire presentation. Implement `makeBody` to lay
+/// out the configuration's add-on data. Set one with `.ancillaryCardStyle(_:)`;
+/// the default is ``RowAncillaryCardStyle``.
+public protocol AncillaryCardStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: AncillaryCardConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The leading affordance — a custom slot, a remote thumbnail, or the icon
+/// tile — shared by every preset. `size`/`iconSize` are fixed per-preset
+/// constants (not public knobs); the defaults reproduce `IconTile`'s own
+/// defaults exactly, so `.row` renders byte-for-byte identical to the
+/// pre-style component.
+private struct AncillaryCardLeadingTile: View {
+    @Environment(\.componentDefaults) private var defaults
+    let configuration: AncillaryCardConfiguration
+    var size: CGFloat = 46
+    var iconSize: CGFloat = 18
+
+    var body: some View {
+        if let leading = configuration.leading {
+            leading
+        } else if let imageURL = configuration.imageURL {
+            RemoteImage(imageURL).contentMode(.fill).frame(width: size, height: size)
+                .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
+        } else {
+            IconTile(configuration.systemImage)
+                .accent(configuration.resolvedAccent(defaults))
+                .size(size)
+                .iconSize(iconSize)
+        }
+    }
+}
+
+/// The formatted price (+ optional unit suffix) — shared by every preset.
+private struct AncillaryCardPriceLine: View {
+    @Environment(\.theme) private var theme
+    let configuration: AncillaryCardConfiguration
+    let amount: Decimal
+    var textStyle: TextStyle = .labelBase700
+
+    var body: some View {
+        HStack(spacing: 2) {
+            Text(configuration.formattedPrice(amount))
+                .textStyle(textStyle).foregroundStyle(theme.text(.textPrimary))
+            if let priceSuffix = configuration.priceSuffix {
+                Text(priceSuffix).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
+            }
+        }
+    }
+}
+
+/// The interactive control area — a custom slot, the quantity stepper, or the
+/// add/remove toggle. Every built-in preset places this one view; the
+/// interaction logic (clamping, toggling, read-only gating, a11y) is written
+/// once here instead of once per preset.
+private struct AncillaryCardControl: View {
+    let configuration: AncillaryCardConfiguration
+
+    var body: some View {
+        if let trailing = configuration.trailing {
+            trailing
+        } else if configuration.showsQuantity {
+            AncillaryCardStepper(configuration: configuration)
+        } else if configuration.showsAdded {
+            AncillaryCardAddButton(configuration: configuration)
+        }
+    }
+}
+
+private struct AncillaryCardStepper: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.componentDefaults) private var defaults
+    @Environment(\.isReadOnly) private var isReadOnly   // E1 — read-only surfaces render but don't mutate
+    let configuration: AncillaryCardConfiguration
+
+    private var accentSemantic: SemanticColor { configuration.resolvedAccent(defaults) }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            stepButton("minus", label: String(themeKit: "Decrease"),
+                       enabled: configuration.quantity > configuration.quantityRange.lowerBound) {
+                configuration.setQuantity?(max(configuration.quantityRange.lowerBound, configuration.quantity - 1))
+            }
+            Text("\(configuration.quantity)").textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+                .frame(minWidth: 28).monospacedDigit()
+            stepButton("plus", label: String(themeKit: "Increase"),
+                       enabled: configuration.quantity < configuration.quantityRange.upperBound) {
+                configuration.setQuantity?(min(configuration.quantityRange.upperBound, configuration.quantity + 1))
+            }
+        }
+        .padding(.horizontal, 4)
+        .background(theme.background(configuration.controlSurface(default: .bgSecondary)), in: Capsule())
+        .disabled(isReadOnly)
+    }
+
+    private func stepButton(_ icon: String, label: String, enabled: Bool, _ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: icon).font(.system(size: 13, weight: .bold))
+                .foregroundStyle(enabled ? accentSemantic.base : theme.text(.textDisabled))
+                .frame(width: 32, height: 32)
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .accessibilityLabel(label)
+        .accessibilityValue("\(configuration.quantity)")
+    }
+}
+
+private struct AncillaryCardAddButton: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.componentDefaults) private var defaults
+    @Environment(\.isReadOnly) private var isReadOnly   // E1 — read-only surfaces render but don't mutate
+    let configuration: AncillaryCardConfiguration
+
+    private var accentSemantic: SemanticColor { configuration.resolvedAccent(defaults) }
+
+    var body: some View {
+        let on = configuration.isAdded
+        Button { configuration.toggleAdded?() } label: {
+            HStack(spacing: 4) {
+                Image(systemName: on ? "checkmark" : "plus").font(.system(size: 12, weight: .bold))
+                Text(on ? configuration.addedTitle : configuration.addTitle).textStyle(.labelSm700)
+            }
+            .foregroundStyle(on ? accentSemantic.onSolid : accentSemantic.base)
+            .padding(.horizontal, configuration.spacing(.md))
+            .frame(height: 36)
+            .background(on ? accentSemantic.solid : accentSemantic.bg, in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(isReadOnly)
+        .accessibilityLabel(configuration.title)
+        .accessibilityAddTraits(on ? .isSelected : [])
+    }
+}
+
+// MARK: - .row
+
+/// Today's ``AncillaryCard`` look, extracted verbatim: leading tile, title +
+/// badge, subtitle, price, and the stepper/toggle control at the trailing edge
+/// — all inside the active `CardStyle` shell.
+public struct RowAncillaryCardStyle: AncillaryCardStyle {
+    public init() {}
+    public func makeBody(configuration: AncillaryCardConfiguration) -> some View {
+        RowAncillaryCardChrome(configuration: configuration)
+    }
+}
+
+private struct RowAncillaryCardChrome: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.cardStyle) private var cardStyle
+    let configuration: AncillaryCardConfiguration
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: configuration.radiusRole.value, style: .continuous)
+    }
+
+    var body: some View {
+        // The shell (fill, corner clipping, border, shadow) is drawn by the
+        // active `CardStyle` — built-ins and custom styles go through the same
+        // gate. `.none` elevation reproduces the classic flat look: a 1pt
+        // hairline border, no shadow.
+        cardStyle.makeBody(configuration: CardStyleConfiguration(
+            content: AnyView(cardContent),
+            elevation: configuration.elevation,
+            isSelected: configuration.isActive,
+            isPressed: false,
+            surfaceKey: configuration.surface(default: .bgBase),
+            radius: configuration.radiusRole))
+            .contentShape(shape)
+    }
+
+    private var cardContent: some View {
+        HStack(spacing: configuration.spacing(.sm)) {
+            AncillaryCardLeadingTile(configuration: configuration)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(configuration.title).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
+                    if let badgeText = configuration.badgeText {
+                        Badge(badgeText).badgeStyle(configuration.badgeStyle).variant(.soft).size(.small).fixedSize()
+                    }
+                }
+                if let subtitle = configuration.subtitle {
+                    Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(1)
+                }
+                if let price = configuration.priceAmount {
+                    AncillaryCardPriceLine(configuration: configuration, amount: price)
+                }
+            }
+            Spacer(minLength: 6)
+            AncillaryCardControl(configuration: configuration)
+        }
+        .padding(configuration.spacing(.md))
+    }
+}
+
+// MARK: - .tile
+
+/// A vertical grid tile: leading tile + badge on top, title/subtitle below,
+/// then the price and — at the bottom — the stepper/toggle control. Destination
+/// / add-on carousels and grid pickers.
+public struct TileAncillaryCardStyle: AncillaryCardStyle {
+    public init() {}
+    public func makeBody(configuration: AncillaryCardConfiguration) -> some View {
+        TileAncillaryCardChrome(configuration: configuration)
+    }
+}
+
+private struct TileAncillaryCardChrome: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.cardStyle) private var cardStyle
+    let configuration: AncillaryCardConfiguration
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: configuration.radiusRole.value, style: .continuous)
+    }
+
+    var body: some View {
+        cardStyle.makeBody(configuration: CardStyleConfiguration(
+            content: AnyView(tileContent),
+            elevation: configuration.elevation,
+            isSelected: configuration.isActive,
+            isPressed: false,
+            surfaceKey: configuration.surface(default: .bgBase),
+            radius: configuration.radiusRole))
+            .contentShape(shape)
+    }
+
+    private var tileContent: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            HStack(alignment: .top, spacing: configuration.spacing(.sm)) {
+                AncillaryCardLeadingTile(configuration: configuration, size: 40, iconSize: 16)
+                Spacer(minLength: 0)
+                if let badgeText = configuration.badgeText {
+                    Badge(badgeText).badgeStyle(configuration.badgeStyle).variant(.soft).size(.small).fixedSize()
+                }
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(configuration.title).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(2)
+                if let subtitle = configuration.subtitle {
+                    Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(1)
+                }
+            }
+            if let price = configuration.priceAmount {
+                AncillaryCardPriceLine(configuration: configuration, amount: price)
+            }
+            // The control anchors the tile's bottom edge (VStack's leading
+            // alignment keeps it left-aligned, matching a grid-tile CTA).
+            AncillaryCardControl(configuration: configuration)
+        }
+        .padding(configuration.spacing(.md))
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - .banner
+
+/// A thumbnail-led, full-width upsell strip: a larger leading image/icon, a
+/// bigger title, subtitle and price in the middle, the control on the trailing
+/// edge — and a softer default surface so it reads as a promo, not a list row.
+public struct BannerAncillaryCardStyle: AncillaryCardStyle {
+    public init() {}
+    public func makeBody(configuration: AncillaryCardConfiguration) -> some View {
+        BannerAncillaryCardChrome(configuration: configuration)
+    }
+}
+
+private struct BannerAncillaryCardChrome: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.cardStyle) private var cardStyle
+    let configuration: AncillaryCardConfiguration
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: configuration.radiusRole.value, style: .continuous)
+    }
+
+    var body: some View {
+        cardStyle.makeBody(configuration: CardStyleConfiguration(
+            content: AnyView(bannerContent),
+            elevation: configuration.elevation,
+            isSelected: configuration.isActive,
+            isPressed: false,
+            surfaceKey: configuration.surface(default: .bgSecondaryLight),
+            radius: configuration.radiusRole))
+            .contentShape(shape)
+    }
+
+    private var bannerContent: some View {
+        HStack(alignment: .center, spacing: configuration.spacing(.md)) {
+            AncillaryCardLeadingTile(configuration: configuration, size: 64, iconSize: 26)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(configuration.title).textStyle(.labelLg700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
+                    if let badgeText = configuration.badgeText {
+                        Badge(badgeText).badgeStyle(configuration.badgeStyle).variant(.soft).size(.small).fixedSize()
+                    }
+                }
+                if let subtitle = configuration.subtitle {
+                    Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(2)
+                }
+                if let price = configuration.priceAmount {
+                    AncillaryCardPriceLine(configuration: configuration, amount: price)
+                }
+            }
+            Spacer(minLength: configuration.spacing(.sm))
+            AncillaryCardControl(configuration: configuration)
+        }
+        .padding(configuration.spacing(.md))
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Static accessors
+
+public extension AncillaryCardStyle where Self == RowAncillaryCardStyle {
+    /// Icon/title/price + stepper or toggle, trailing edge — today's card. The default.
+    static var row: RowAncillaryCardStyle { RowAncillaryCardStyle() }
+}
+public extension AncillaryCardStyle where Self == TileAncillaryCardStyle {
+    /// Vertical grid tile: leading/badge row, title/subtitle, price, control at the bottom.
+    static var tile: TileAncillaryCardStyle { TileAncillaryCardStyle() }
+}
+public extension AncillaryCardStyle where Self == BannerAncillaryCardStyle {
+    /// Thumbnail-led full-width upsell strip.
+    static var banner: BannerAncillaryCardStyle { BannerAncillaryCardStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyAncillaryCardStyle: AncillaryCardStyle {
+    private let _makeBody: @MainActor (AncillaryCardConfiguration) -> AnyView
+    init<S: AncillaryCardStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: AncillaryCardConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct AncillaryCardStyleKey: EnvironmentKey {
+    static let defaultValue = AnyAncillaryCardStyle(RowAncillaryCardStyle())
+}
+
+extension EnvironmentValues {
+    var ancillaryCardStyle: AnyAncillaryCardStyle {
+        get { self[AncillaryCardStyleKey.self] }
+        set { self[AncillaryCardStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``AncillaryCardStyle`` for `AncillaryCard`s in this view and its
+    /// descendants — one screen can mix archetypes per section.
+    func ancillaryCardStyle<S: AncillaryCardStyle>(_ style: sending S) -> some View {
+        environment(\.ancillaryCardStyle, AnyAncillaryCardStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a flat accent-tinted strip, no card shell, control still pre-wired.
+private struct AccentFlatAncillaryCardStyle: AncillaryCardStyle {
+    func makeBody(configuration: AncillaryCardConfiguration) -> some View {
+        AccentFlatChrome(configuration: configuration)
+    }
+
+    private struct AccentFlatChrome: View {
+        @Environment(\.theme) private var theme
+        @Environment(\.componentDefaults) private var defaults
+        let configuration: AncillaryCardConfiguration
+
+        var body: some View {
+            HStack(spacing: configuration.spacing(.sm)) {
+                Icon(systemName: configuration.systemImage).size(.lg)
+                    .accent(configuration.resolvedAccent(defaults))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(configuration.title).textStyle(.labelMd700).foregroundStyle(theme.text(.textPrimary))
+                    if let price = configuration.priceAmount {
+                        Text(configuration.formattedPrice(price))
+                            .textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                    }
+                }
+                Spacer()
+                AncillaryCardControl(configuration: configuration)
+            }
+            .padding(configuration.spacing(.sm))
+            .background(theme.background(.bgSecondaryLight), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
+        }
+    }
+}
+
+#Preview("AncillaryCardStyle — presets × light/dark") {
+    struct Demo: View {
+        @State private var bags = 1
+        @State private var insurance = false
+        var body: some View {
+            let row = AncillaryCard("Checked baggage").icon("suitcase.fill").subtitle("20 kg")
+                .price(450, suffix: "/ bag").quantity($bags, range: 0...4)
+            let toggle = AncillaryCard("Travel insurance").icon("cross.case.fill").subtitle("Full coverage")
+                .price(120).badge("Popular").added($insurance)
+            return PreviewMatrix("AncillaryCardStyle") {
+                PreviewCase("Row · stepper (default)") { row }
+                PreviewCase("Row · toggle") { toggle }
+                PreviewCase("Tile · stepper") { row.ancillaryCardStyle(.tile).frame(width: 180) }
+                PreviewCase("Tile · toggle") { toggle.ancillaryCardStyle(.tile).frame(width: 180) }
+                PreviewCase("Banner · stepper") { row.ancillaryCardStyle(.banner) }
+                PreviewCase("Banner · toggle") { toggle.ancillaryCardStyle(.banner) }
+                PreviewCase("Custom (in-preview)") { row.ancillaryCardStyle(AccentFlatAncillaryCardStyle()) }
+            }
+        }
+    }
+    return Demo()
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/FareFamilyCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FareFamilyCard.swift
@@ -7,10 +7,18 @@
 //  price + radio row (selectable set). Token-bound; the accent colour brands the
 //  tier. Composes the FareFeatureRow atom, PriceTag, RadioButton and ThemeButton.
 //
+//  Presentation is style-driven (``FareFamilyCardStyle``, ADR-0004) — set once
+//  per screen via `.fareFamilyCardStyle(_:)`. `.stacked` (default) is today's
+//  card verbatim; `.column`/`.row`/`.accordion` swap the whole layout, and apps
+//  can implement their own. Selection stays here in the component (ADR-F4):
+//  every preset only ever *reads* `isSelected`/`showsSelector` and calls
+//  `select()` — the `.selection(_:)` binding and the uncontrolled fallback both
+//  live in this file.
+//
 //  The outer shell (surface fill, hairline, selected hero frame) is drawn by the
-//  active `CardStyle` from the environment: `.surface()` and the selection state
-//  (`.selected()` / `.selection()`) feed the `CardStyleConfiguration`, so
-//  `.cardStyle(_:)` can reskin the shell and restyle the selected frame in one
+//  active `CardStyle` from the environment — card-shaped presets keep routing
+//  their surface, elevation and selection state through `CardStyleConfiguration`,
+//  so `.cardStyle(_:)` can reskin the shell and restyle the selected frame in one
 //  place. The card is flat (no shadow), so it reports `.none` elevation and the
 //  default style draws the classic 1pt hairline.
 //
@@ -19,6 +27,10 @@ import SwiftUI
 import ThemeKit
 
 /// Layout archetype for ``FareFamilyCard``.
+///
+/// Superseded by ``FareFamilyCardStyle`` (each case maps 1:1 to a preset —
+/// `.stacked`/`.column`); kept for source compatibility until the next major,
+/// together with the deprecated ``FareFamilyCard/layout(_:)`` modifier.
 public enum FareFamilyLayout: String, CaseIterable, Sendable {
     /// The classic full-width card — leading chip, feature list, price footer.
     case stacked
@@ -35,18 +47,22 @@ public enum FareFamilyLayout: String, CaseIterable, Sendable {
 ///     .features([FareFeature("Cabin bag", systemImage: "handbag", detail: "55×40×23"),
 ///                FareFeature("Non-refundable", systemImage: "nosign", status: .excluded)])
 ///     .onSelect { book() }
+///     .fareFamilyCardStyle(.row)      // .stacked (default) / .column / .accordion
 /// ```
 public struct FareFamilyCard: View {
     @Environment(\.componentDensity) private var density
-    @Environment(\.cardStyle) private var cardStyle
+    @Environment(\.fareFamilyCardStyle) private var envStyle
     @Environment(\.formatDefaults) private var formatDefaults
     @Environment(\.locale) private var locale
+    @Environment(\.microAnimations) private var micro
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Required content (R1).
     private let name: String
     private let price: Decimal
     // Appearance/state — mutated only through the modifiers below (R2).
-    private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    /// `nil` → the active style's own default (every built-in uses `.bgBase`).
+    private var surfaceKey: Theme.BackgroundColorKey?
     private var currencyCode: String?
     private var accent: SemanticColor = .success
     private var features: [FareFeature] = []
@@ -58,165 +74,72 @@ public struct FareFamilyCard: View {
     private var ctaTitleOverride: String?
     private var chipVariant: FillVariant = .solid
     private var elevation: CardElevation = .none
-    private var layout: FareFamilyLayout = .stacked
+    /// Expansion state for `.accordion` — ignored by every other preset.
+    /// Uncontrolled by default; `.expanded(_:)` swaps in the caller's binding
+    /// (ADR-F4 via `ControllableState`, mirroring `FlightListItem`).
+    @ControllableState private var expandedState = false
+    /// Set by the deprecated ``layout(_:)`` modifier — an explicitly chosen
+    /// per-instance style wins over an ancestor's `.fareFamilyCardStyle(_:)`
+    /// (source-behavior stability during the enum's deprecation window).
+    private var explicitStyle: AnyFareFamilyCardStyle?
 
     public init(_ name: String, price: Decimal) {   // R1
         self.name = name
         self.price = price
     }
 
-    private var active: Bool { selection?.wrappedValue ?? isSelected }
-
     /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
     private var resolvedCurrency: String {
         currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
-    public var body: some View {
-        // The shell (fill, hairline, selected hero frame) is drawn by the active
-        // `CardStyle`; selection flows through `Configuration.isSelected`, so a
-        // custom style restyles the selected frame too. Flat card → `.none`
-        // elevation keeps the classic hairline (no shadow), as in HotelResultCard.
-        cardStyle.makeBody(configuration: CardStyleConfiguration(
-            content: AnyView(cardContent),
-            elevation: elevation,
-            isSelected: active,
-            isPressed: false,
-            surfaceKey: surfaceKey,
-            radius: .box))
-            .contentShape(Rectangle())
-            .onTapGesture { if selection != nil { select() } }
-            .accessibilityElement(children: .contain)
-            .accessibilityAddTraits(active ? .isSelected : [])
-    }
-
-    /// The card's inner layout — everything inside the shell.
-    @ViewBuilder private var cardContent: some View {
-        switch layout {
-        case .stacked: stackedContent
-        case .column: columnContent
-        }
-    }
-
-    private var stackedContent: some View {
-        VStack(alignment: .leading, spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            if let headerSlot { headerSlot } else { tierChip }
-
-            if !features.isEmpty {
-                VStack(alignment: .leading, spacing: 8) {
-                    ForEach(features) { FareFeatureRow($0) }
-                }
-            }
-
-            if let footerSlot {
-                footerSlot
-            } else {
-                footer
-            }
-        }
-        .padding(density.scale(Theme.SpacingKey.md.value))
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    /// The narrow comparison-matrix column: centered chip, condensed features,
-    /// price at the bottom. Designed to sit side by side in an `HStack`.
-    private var columnContent: some View {
-        VStack(alignment: .leading, spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            Group {
-                if let headerSlot { headerSlot } else { tierChip }
-            }
-            .frame(maxWidth: .infinity, alignment: .center)
-
-            if !features.isEmpty {
-                VStack(alignment: .leading, spacing: 6) {
-                    ForEach(features) { FareFeatureRow($0) }
-                }
-            }
-
-            Spacer(minLength: 0)
-
-            if let footerSlot {
-                footerSlot
-            } else {
-                columnFooter
-            }
-        }
-        .padding(density.scale(Theme.SpacingKey.sm.value))
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    /// The tier name chip, rendered per ``FillVariant`` on the accent's ladder.
-    private var tierChip: some View {
-        Text(name.uppercased())
-            .textStyle(.labelSm700)
-            .foregroundStyle(chipForeground)
-            .padding(.horizontal, 10).padding(.vertical, 4)
-            .background(chipBackground,
-                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
-            .overlay {
-                if chipVariant == .outline {
-                    RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
-                        .strokeBorder(accent.border, lineWidth: 1)
-                }
-            }
-    }
-
-    private var chipForeground: Color {
-        switch chipVariant {
-        case .solid: return accent.onSolid
-        case .soft, .outline, .ghost: return accent.accent
-        }
-    }
-    private var chipBackground: Color {
-        switch chipVariant {
-        case .solid: return accent.solid
-        case .soft: return accent.soft
-        case .outline, .ghost: return .clear
-        }
-    }
-
-    @ViewBuilder private var footer: some View {
-        if let selection {
-            HStack {
-                PriceTag(price, currencyCode: resolvedCurrency).emphasis(.hero)
-                Spacer()
-                RadioButton(isSelected: selection)
-            }
-            .padding(.top, 2)
-        } else {
-            ThemeButton(ctaText) { select() }
-                .color(accent).shape(.rounded).fullWidth()
-                .padding(.top, 4)
-        }
-    }
-
-    /// Column-mode footer — price and control stacked, centered, pinned at the bottom.
-    @ViewBuilder private var columnFooter: some View {
-        if let selection {
-            VStack(spacing: Theme.SpacingKey.xs.value) {
-                PriceTag(price, currencyCode: resolvedCurrency).emphasis(.hero)
-                RadioButton(isSelected: selection)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.top, 2)
-        } else {
-            ThemeButton(ctaText) { select() }
-                .color(accent).shape(.rounded).size(.small).fullWidth()
-                .padding(.top, 4)
-        }
-    }
-
-    private var ctaText: String { ctaTitleOverride ?? priceText }
     private var priceText: String {
         price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(2)))
     }
-    private func select() { selection?.wrappedValue = true; onSelect?() }
+
+    /// Sets the `.selection(_:)` binding (when bound) and fires `.onSelect(_:)`
+    /// (when set) — the one action every preset's selector/CTA calls.
+    private func select() {
+        selection?.wrappedValue = true
+        onSelect?()
+    }
+
+    public var body: some View {
+        // The arrangement is owned by the active `FareFamilyCardStyle`; motion
+        // is resolved *here* (MicroMotion ∧ ¬Reduce Motion) so styles never
+        // read the motion environment. `showsSelector` mirrors the pre-style
+        // `selection != nil` check that used to pick the footer's look.
+        let expandMotion: Animation? = (micro && !reduceMotion) ? Motion.base.spring : nil
+        let configuration = FareFamilyCardConfiguration(
+            name: name,
+            priceAmount: price,
+            currencyCode: resolvedCurrency,
+            features: features,
+            isSelected: selection?.wrappedValue ?? isSelected,
+            showsSelector: selection != nil,
+            select: { select() },
+            ctaTitle: ctaTitleOverride ?? priceText,
+            badgeVariant: chipVariant,
+            header: headerSlot,
+            footer: footerSlot,
+            elevation: elevation,
+            accent: accent,
+            surfaceKey: surfaceKey,
+            isExpanded: expandedState,
+            toggleExpand: { withAnimation(expandMotion) { expandedState.toggle() } },
+            isMotionEnabled: micro && !reduceMotion,
+            density: density,
+            locale: locale)
+        (explicitStyle ?? envStyle).makeBody(configuration: configuration)
+    }
 }
 
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension FareFamilyCard {
-    /// Surface fill (background token key, default `.bgBase`).
+    /// Surface fill (background token key). When unset, the active
+    /// ``FareFamilyCardStyle`` picks its own default (every built-in uses
+    /// `.bgBase`); card-shaped presets feed it through to the `CardStyle` shell.
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
     /// Currency code for the price. Unset, it resolves from `\.formatDefaults`,
     /// then the locale's currency, then "USD".
@@ -227,7 +150,7 @@ public extension FareFamilyCard {
     func features(_ list: [FareFeature]) -> Self { copy { $0.features = list } }
     /// Selected state (for a CTA card without a binding).
     func selected(_ on: Bool = true) -> Self { copy { $0.isSelected = on } }
-    /// Bind selection — renders a price + radio row instead of a CTA button.
+    /// Bind selection — presets render a price + radio row instead of a CTA button.
     func selection(_ binding: Binding<Bool>) -> Self { copy { $0.selection = binding } }
     /// Called when the card's CTA is tapped.
     func onSelect(_ action: (() -> Void)?) -> Self { copy { $0.onSelect = action } }
@@ -243,8 +166,24 @@ public extension FareFamilyCard {
     /// Shell elevation, fed to the active `CardStyle` (default `.none` — today's
     /// flat, hairline-only chrome).
     func elevation(_ e: CardElevation) -> Self { copy { $0.elevation = e } }
-    /// Layout archetype: `.stacked` (default) or a narrow comparison `.column`.
-    func layout(_ v: FareFamilyLayout) -> Self { copy { $0.layout = v } }
+    /// Drives `.accordion`'s expansion from outside — e.g. a fare-compare list
+    /// where only one tier stays open at a time. Without it the card self-manages.
+    func expanded(_ binding: Binding<Bool>) -> Self {
+        copy { $0._expandedState = ControllableState(wrappedValue: false, external: binding) }
+    }
+    /// Layout archetype — superseded by the style axis: prefer
+    /// `.fareFamilyCardStyle(.stacked/.column/.row/.accordion)`, settable once
+    /// per screen via the environment. This modifier keeps working and, when
+    /// called, wins over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .fareFamilyCardStyle(.stacked) or .fareFamilyCardStyle(.column) instead")
+    func layout(_ v: FareFamilyLayout) -> Self {
+        copy {
+            switch v {
+            case .stacked: $0.explicitStyle = AnyFareFamilyCardStyle(StandardFareFamilyCardStyle())
+            case .column: $0.explicitStyle = AnyFareFamilyCardStyle(ColumnFareFamilyCardStyle())
+            }
+        }
+    }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -283,25 +222,49 @@ public extension FareFamilyCard {
 
 #Preview("Comparison columns") {
     HStack(alignment: .top, spacing: 10) {
-        FareFamilyCard("Eco", price: 1_871.99).accent(.success).layout(.column)
+        FareFamilyCard("Eco", price: 1_871.99).accent(.success)
             .features([
                 FareFeature("Cabin bag", systemImage: "handbag", status: .included),
                 FareFeature("Checked", systemImage: "suitcase.fill", status: .excluded),
             ])
             .selection(.constant(false))
-        FareFamilyCard("Flex", price: 3_116.99).accent(.purple).layout(.column)
+            .fareFamilyCardStyle(.column)
+        FareFamilyCard("Flex", price: 3_116.99).accent(.purple)
             .features([
                 FareFeature("Cabin bag", systemImage: "handbag", status: .included),
                 FareFeature("Checked", systemImage: "suitcase.fill", status: .included),
             ])
             .selection(.constant(true))
-        FareFamilyCard("Biz", price: 6_420).accent(.info).layout(.column)
+            .fareFamilyCardStyle(.column)
+        FareFamilyCard("Biz", price: 6_420).accent(.info)
             .badgeVariant(.soft).ctaTitle("Choose")
             .features([FareFeature("Lounge", systemImage: "sofa.fill", status: .included)])
             .onSelect { }
+            .fareFamilyCardStyle(.column)
     }
     .frame(height: 260)
     .padding()
+}
+
+#Preview("Row + accordion presets") {
+    ScrollView {
+        VStack(spacing: 12) {
+            FareFamilyCard("Super Eco", price: 1_871.99).accent(.success)
+                .features([
+                    FareFeature("Cabin bag", systemImage: "handbag", status: .included),
+                    FareFeature("Non-refundable", systemImage: "nosign", status: .excluded),
+                ])
+                .onSelect { }
+                .fareFamilyCardStyle(.row)
+            FareFamilyCard("Comfort Flex", price: 3_116.99).accent(.purple)
+                .features([
+                    FareFeature("Partial refund", systemImage: "arrow.uturn.backward", status: .included),
+                    FareFeature("Snack", systemImage: "takeoutbag.and.cup.and.straw.fill", status: .included),
+                ])
+                .onSelect { }
+                .fareFamilyCardStyle(.accordion)
+        }.padding()
+    }
 }
 
 #Preview("Selected + outlined style") {

--- a/Sources/ThemeKitTravel/Components/Organisms/FareFamilyCardStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FareFamilyCardStyle.swift
@@ -1,0 +1,544 @@
+//
+//  FareFamilyCardStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``FareFamilyCard`` (ADR-0004, Wave 3 — Class A). The
+//  configuration hands styles the tier's *typed data* (name, price, features,
+//  selection), not pre-laid content, so a style owns the entire arrangement.
+//  Four built-ins:
+//
+//    .stacked    leading chip, feature list, price footer — today's card. Default.
+//    .column     a narrow comparison-matrix column — several sit side by side.
+//    .row        horizontal strip: chip+features leading, price+selector trailing.
+//    .accordion  a collapsed tier whose feature list expands in place; the
+//                price/selector row stays visible whether collapsed or open.
+//
+//      FareFamilyCard("Super Eco", price: 1_871.99)
+//          .accent(.success)
+//          .features([FareFeature("Cabin bag", systemImage: "handbag", detail: "55×40×23")])
+//          .onSelect { book() }
+//          .fareFamilyCardStyle(.row)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the shell
+//  `CardStyle` paints *chrome* (every built-in here is card-shaped and keeps
+//  routing its surface, elevation, selection and radius through `\.cardStyle`);
+//  the token theme colors everything. The component resolves MicroMotion /
+//  Reduce Motion before calling a style — styles read
+//  ``FareFamilyCardConfiguration/isMotionEnabled`` and
+//  ``FareFamilyCardConfiguration/isExpanded``, never the motion/expansion state
+//  themselves.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``FareFamilyCardStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no features → no feature list, a custom `footer`
+/// slot → the built-in price/selector row never renders).
+public struct FareFamilyCardConfiguration {
+    /// The fare-family tier name, e.g. "Super Eco" — the built-in chip's label.
+    public let name: String
+    /// The fare amount; presets format it with ``currencyCode`` (via `PriceTag`
+    /// or ``ctaTitle``'s pre-resolved text).
+    public let priceAmount: Decimal
+    /// Currency code for ``priceAmount`` — already resolved by the component
+    /// through the FormatDefaults chain (explicit `.currency(_:)` →
+    /// `formatDefaults` → `locale.currency` → `"USD"`).
+    public let currencyCode: String
+    /// The feature & rule lines (baggage, refund policy, amenities…).
+    public let features: [FareFeature]
+    /// Selected state — combines the caller's `.selected(_:)` flag with a live
+    /// `.selection(_:)` binding's `wrappedValue` (component-resolved). Card-
+    /// shaped presets feed it to the `CardStyle` shell and any radio control.
+    public let isSelected: Bool
+    /// `true` when the card was bound with `.selection(_:)` — presets render a
+    /// price + radio row driven by ``isSelected``/``select``. `false` (the
+    /// default) renders a price/CTA button titled with ``ctaTitle``.
+    public let showsSelector: Bool
+    /// Selects the tier — sets the `.selection(_:)` binding (when bound) and
+    /// fires `.onSelect(_:)` (when set). Call from a radio control or a CTA.
+    public let select: () -> Void
+    /// The footer CTA's title — already merged (`.ctaTitle(_:)` override, else
+    /// the formatted price) and re-resolved every body pass, so a live locale/
+    /// currency switch is never frozen.
+    public let ctaTitle: String
+    /// Fill treatment of the tier name chip (`.solid`, `.soft`, `.outline`, `.ghost`).
+    public let badgeVariant: FillVariant
+    /// Replacement for the built-in tier chip (`.header { }`); `nil` = built-in.
+    public let header: AnyView?
+    /// Replacement for the built-in price/selector footer (`.footer { }`); `nil` = built-in.
+    public let footer: AnyView?
+    /// Shell elevation, fed to the active `CardStyle` (default `.none` — the
+    /// classic flat, hairline-only chrome).
+    public let elevation: CardElevation
+    /// The tier accent — brands the chip, icons and CTA. Non-optional: a fare
+    /// family always carries a brand tint (`.success` unless overridden).
+    public let accent: SemanticColor
+    /// Explicit surface fill, or `nil` to let the preset choose its own default
+    /// (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Expansion state for `.accordion` — ignored by every other preset.
+    /// Uncontrolled by default; `.expanded(_:)` swaps in the caller's binding.
+    public let isExpanded: Bool
+    /// Flips ``isExpanded`` (MicroMotion-gated by the component). `.accordion`'s
+    /// disclosure control calls this.
+    public let toggleExpand: () -> Void
+    /// Micro-animations resolved by the component (`MicroMotion` ∧ ¬Reduce
+    /// Motion) — gate symbol effects/rotations on this; never read the motion
+    /// environment directly.
+    public let isMotionEnabled: Bool
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — pass to any
+    /// locale-sensitive formatting so injected locales/RTL demos render right.
+    public let locale: Locale
+
+    /// The explicit `surface(_:)` override, or the preset's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so `.componentDensity`
+    /// compacts or airs out the card.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+}
+
+/// A synthesized `Binding` for `RadioButton` — reads the resolved selection,
+/// and any tap calls ``FareFamilyCardConfiguration/select()``. Radio selection
+/// here is one-way (there's no "deselect" gesture on the control), mirroring
+/// `SavedCardsList.isSelectedBinding(_:)`.
+private extension FareFamilyCardConfiguration {
+    var selectorBinding: Binding<Bool> {
+        Binding(get: { isSelected }, set: { _ in select() })
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `FareFamilyCard`'s entire presentation. Implement `makeBody` to
+/// lay out the configuration's tier data. Set one with `.fareFamilyCardStyle(_:)`;
+/// the default is ``StandardFareFamilyCardStyle``.
+public protocol FareFamilyCardStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: FareFamilyCardConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The tier name chip, rendered per ``FillVariant`` on the accent's ladder —
+/// shared by every built-in preset (`.header { }` replaces it).
+private struct FareFamilyTierChip: View {
+    let configuration: FareFamilyCardConfiguration
+
+    var body: some View {
+        Text(configuration.name.uppercased())
+            .textStyle(.labelSm700)
+            .foregroundStyle(foreground)
+            .padding(.horizontal, 10).padding(.vertical, 4)
+            .background(background,
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
+            .overlay {
+                if configuration.badgeVariant == .outline {
+                    RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
+                        .strokeBorder(configuration.accent.border, lineWidth: 1)
+                }
+            }
+    }
+
+    private var foreground: Color {
+        switch configuration.badgeVariant {
+        case .solid: return configuration.accent.onSolid
+        case .soft, .outline, .ghost: return configuration.accent.accent
+        }
+    }
+    private var background: Color {
+        switch configuration.badgeVariant {
+        case .solid: return configuration.accent.solid
+        case .soft: return configuration.accent.soft
+        case .outline, .ghost: return .clear
+        }
+    }
+}
+
+/// The feature & rule lines, one ``FareFeatureRow`` per line — shared by every
+/// built-in preset.
+private struct FareFamilyFeatureList: View {
+    let features: [FareFeature]
+    var spacing: CGFloat = 8
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: spacing) {
+            ForEach(features) { FareFeatureRow($0) }
+        }
+    }
+}
+
+/// The default horizontal price/selector footer — a price + radio row when the
+/// card carries a `.selection(_:)` binding (``showsSelector``), else a
+/// full-width CTA button titled with ``ctaTitle``. Shared by `.stacked` and
+/// `.accordion`.
+private struct FareFamilyFooterRow: View {
+    let configuration: FareFamilyCardConfiguration
+
+    var body: some View {
+        if configuration.showsSelector {
+            HStack {
+                PriceTag(configuration.priceAmount, currencyCode: configuration.currencyCode).emphasis(.hero)
+                Spacer()
+                RadioButton(isSelected: configuration.selectorBinding)
+            }
+            .padding(.top, 2)
+        } else {
+            ThemeButton(configuration.ctaTitle) { configuration.select() }
+                .color(configuration.accent).shape(.rounded).fullWidth()
+                .padding(.top, 4)
+        }
+    }
+}
+
+/// The narrow comparison-column footer — price above the control, centered,
+/// pinned at the bottom. Used by `.column`.
+private struct FareFamilyColumnFooter: View {
+    let configuration: FareFamilyCardConfiguration
+
+    var body: some View {
+        if configuration.showsSelector {
+            VStack(spacing: Theme.SpacingKey.xs.value) {
+                PriceTag(configuration.priceAmount, currencyCode: configuration.currencyCode).emphasis(.hero)
+                RadioButton(isSelected: configuration.selectorBinding)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 2)
+        } else {
+            ThemeButton(configuration.ctaTitle) { configuration.select() }
+                .color(configuration.accent).shape(.rounded).size(.small).fullWidth()
+                .padding(.top, 4)
+        }
+    }
+}
+
+// MARK: - .stacked
+
+/// Today's ``FareFamilyCard`` look, extracted verbatim: leading tier chip, the
+/// feature list, and a price/CTA footer inside the active `CardStyle` shell.
+public struct StandardFareFamilyCardStyle: FareFamilyCardStyle {
+    public init() {}
+    public func makeBody(configuration: FareFamilyCardConfiguration) -> some View {
+        StandardFareFamilyCardChrome(configuration: configuration)
+    }
+}
+
+private struct StandardFareFamilyCardChrome: View {
+    @Environment(\.cardStyle) private var cardStyle
+    let configuration: FareFamilyCardConfiguration
+
+    var body: some View {
+        cardStyle.makeBody(configuration: CardStyleConfiguration(
+            content: AnyView(cardContent),
+            elevation: configuration.elevation,
+            isSelected: configuration.isSelected,
+            isPressed: false,
+            surfaceKey: configuration.surface(default: .bgBase),
+            radius: .box))
+            .contentShape(Rectangle())
+            .onTapGesture { if configuration.showsSelector { configuration.select() } }
+            .accessibilityElement(children: .contain)
+            .accessibilityAddTraits(configuration.isSelected ? .isSelected : [])
+    }
+
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            if let header = configuration.header { header } else { FareFamilyTierChip(configuration: configuration) }
+
+            if !configuration.features.isEmpty {
+                FareFamilyFeatureList(features: configuration.features, spacing: 8)
+            }
+
+            if let footer = configuration.footer { footer } else { FareFamilyFooterRow(configuration: configuration) }
+        }
+        .padding(configuration.spacing(.md))
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - .column
+
+/// A narrow comparison-matrix column: centered chip, condensed features, price
+/// pinned at the bottom. Place several side by side in an `HStack`.
+public struct ColumnFareFamilyCardStyle: FareFamilyCardStyle {
+    public init() {}
+    public func makeBody(configuration: FareFamilyCardConfiguration) -> some View {
+        ColumnFareFamilyCardChrome(configuration: configuration)
+    }
+}
+
+private struct ColumnFareFamilyCardChrome: View {
+    @Environment(\.cardStyle) private var cardStyle
+    let configuration: FareFamilyCardConfiguration
+
+    var body: some View {
+        cardStyle.makeBody(configuration: CardStyleConfiguration(
+            content: AnyView(cardContent),
+            elevation: configuration.elevation,
+            isSelected: configuration.isSelected,
+            isPressed: false,
+            surfaceKey: configuration.surface(default: .bgBase),
+            radius: .box))
+            .contentShape(Rectangle())
+            .onTapGesture { if configuration.showsSelector { configuration.select() } }
+            .accessibilityElement(children: .contain)
+            .accessibilityAddTraits(configuration.isSelected ? .isSelected : [])
+    }
+
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            Group {
+                if let header = configuration.header { header } else { FareFamilyTierChip(configuration: configuration) }
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+
+            if !configuration.features.isEmpty {
+                FareFamilyFeatureList(features: configuration.features, spacing: 6)
+            }
+
+            Spacer(minLength: 0)
+
+            if let footer = configuration.footer { footer } else { FareFamilyColumnFooter(configuration: configuration) }
+        }
+        .padding(configuration.spacing(.sm))
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - .row
+
+/// A horizontal comparison strip: chip + features leading, price + selector
+/// trailing. For dense fare-picker lists where each tier is one row instead of
+/// a stacked card (Google Flights / Kayak fare-compare rows).
+public struct RowFareFamilyCardStyle: FareFamilyCardStyle {
+    public init() {}
+    public func makeBody(configuration: FareFamilyCardConfiguration) -> some View {
+        RowFareFamilyCardChrome(configuration: configuration)
+    }
+}
+
+private struct RowFareFamilyCardChrome: View {
+    @Environment(\.cardStyle) private var cardStyle
+    let configuration: FareFamilyCardConfiguration
+
+    var body: some View {
+        cardStyle.makeBody(configuration: CardStyleConfiguration(
+            content: AnyView(rowContent),
+            elevation: configuration.elevation,
+            isSelected: configuration.isSelected,
+            isPressed: false,
+            surfaceKey: configuration.surface(default: .bgBase),
+            radius: .box))
+            .contentShape(Rectangle())
+            .onTapGesture { if configuration.showsSelector { configuration.select() } }
+            .accessibilityElement(children: .contain)
+            .accessibilityAddTraits(configuration.isSelected ? .isSelected : [])
+    }
+
+    private var rowContent: some View {
+        HStack(alignment: .center, spacing: configuration.spacing(.md)) {
+            VStack(alignment: .leading, spacing: configuration.spacing(.xs)) {
+                if let header = configuration.header { header } else { FareFamilyTierChip(configuration: configuration) }
+                if !configuration.features.isEmpty {
+                    FareFamilyFeatureList(features: configuration.features, spacing: 4)
+                }
+            }
+            Spacer(minLength: configuration.spacing(.sm))
+            if let footer = configuration.footer { footer } else { trailingBlock }
+        }
+        .padding(configuration.spacing(.md))
+    }
+
+    private var trailingBlock: some View {
+        VStack(alignment: .trailing, spacing: Theme.SpacingKey.xs.value) {
+            PriceTag(configuration.priceAmount, currencyCode: configuration.currencyCode).emphasis(.hero).size(.medium)
+            if configuration.showsSelector {
+                RadioButton(isSelected: configuration.selectorBinding).accent(configuration.accent)
+            } else {
+                ThemeButton(configuration.ctaTitle) { configuration.select() }
+                    .color(configuration.accent).shape(.rounded).size(.small)
+            }
+        }
+    }
+}
+
+// MARK: - .accordion
+
+/// A collapsed tier whose feature list expands in place — the price/selector
+/// row stays visible whether collapsed or open, so a traveler can compare
+/// prices at a glance and only expand the tier they're weighing. The whole
+/// card is deliberately NOT a tap target (unlike `.stacked`/`.column`/`.row`):
+/// the disclosure chevron and the selector each own one unambiguous gesture.
+public struct AccordionFareFamilyCardStyle: FareFamilyCardStyle {
+    public init() {}
+    public func makeBody(configuration: FareFamilyCardConfiguration) -> some View {
+        AccordionFareFamilyCardChrome(configuration: configuration)
+    }
+}
+
+private struct AccordionFareFamilyCardChrome: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.cardStyle) private var cardStyle
+    let configuration: FareFamilyCardConfiguration
+
+    var body: some View {
+        cardStyle.makeBody(configuration: CardStyleConfiguration(
+            content: AnyView(accordionContent),
+            elevation: configuration.elevation,
+            isSelected: configuration.isSelected,
+            isPressed: false,
+            surfaceKey: configuration.surface(default: .bgBase),
+            radius: .box))
+            .accessibilityElement(children: .contain)
+            .accessibilityAddTraits(configuration.isSelected ? .isSelected : [])
+    }
+
+    private var accordionContent: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            disclosureHeader
+
+            if configuration.isExpanded, !configuration.features.isEmpty {
+                FareFamilyFeatureList(features: configuration.features, spacing: 8)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+
+            if let footer = configuration.footer { footer } else { FareFamilyFooterRow(configuration: configuration) }
+        }
+        .padding(configuration.spacing(.md))
+    }
+
+    private var disclosureHeader: some View {
+        HStack(spacing: configuration.spacing(.sm)) {
+            if let header = configuration.header { header } else { FareFamilyTierChip(configuration: configuration) }
+            Spacer(minLength: configuration.spacing(.xs))
+            Button(action: configuration.toggleExpand) {
+                Icon(systemName: "chevron.down")
+                    .size(.xs)
+                    .color(theme.text(.textTertiary))
+                    .rotationEffect(.degrees(configuration.isExpanded ? 180 : 0))
+                    .frame(minWidth: 44, minHeight: 44)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(configuration.isExpanded
+                ? String(themeKit: "Collapse fare details")
+                : String(themeKit: "Expand fare details"))
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension FareFamilyCardStyle where Self == StandardFareFamilyCardStyle {
+    /// Leading tier chip + feature list + price/CTA footer — today's card. The default.
+    static var stacked: StandardFareFamilyCardStyle { StandardFareFamilyCardStyle() }
+}
+public extension FareFamilyCardStyle where Self == ColumnFareFamilyCardStyle {
+    /// A narrow comparison-matrix column — several sit side by side in an `HStack`.
+    static var column: ColumnFareFamilyCardStyle { ColumnFareFamilyCardStyle() }
+}
+public extension FareFamilyCardStyle where Self == RowFareFamilyCardStyle {
+    /// A horizontal strip: chip + features leading, price + selector trailing.
+    static var row: RowFareFamilyCardStyle { RowFareFamilyCardStyle() }
+}
+public extension FareFamilyCardStyle where Self == AccordionFareFamilyCardStyle {
+    /// A collapsed tier that expands its feature list; the price/selector row
+    /// stays visible whether collapsed or open.
+    static var accordion: AccordionFareFamilyCardStyle { AccordionFareFamilyCardStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyFareFamilyCardStyle: FareFamilyCardStyle {
+    private let _makeBody: @MainActor (FareFamilyCardConfiguration) -> AnyView
+    init<S: FareFamilyCardStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: FareFamilyCardConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct FareFamilyCardStyleKey: EnvironmentKey {
+    static let defaultValue = AnyFareFamilyCardStyle(StandardFareFamilyCardStyle())
+}
+
+extension EnvironmentValues {
+    var fareFamilyCardStyle: AnyFareFamilyCardStyle {
+        get { self[FareFamilyCardStyleKey.self] }
+        set { self[FareFamilyCardStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``FareFamilyCardStyle`` for `FareFamilyCard`s in this view and
+    /// its descendants — a fare-compare screen can mix archetypes per section.
+    func fareFamilyCardStyle<S: FareFamilyCardStyle>(_ style: sending S) -> some View {
+        environment(\.fareFamilyCardStyle, AnyFareFamilyCardStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// Proves external implementability: a borderless pill — no `CardStyle` shell
+/// at all, just the name, price and a selector, built purely from the public
+/// configuration + theme tokens.
+private struct PillFareFamilyCardStyle: FareFamilyCardStyle {
+    func makeBody(configuration: FareFamilyCardConfiguration) -> some View {
+        PillChrome(configuration: configuration)
+    }
+
+    private struct PillChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: FareFamilyCardConfiguration
+
+        var body: some View {
+            HStack(spacing: configuration.spacing(.sm)) {
+                Circle().fill(configuration.accent.base).frame(width: 8, height: 8)
+                Text(configuration.name).textStyle(.labelMd700).foregroundStyle(theme.text(.textPrimary))
+                Spacer()
+                PriceTag(configuration.priceAmount, currencyCode: configuration.currencyCode).size(.small)
+                if configuration.showsSelector {
+                    RadioButton(isSelected: configuration.selectorBinding).accent(configuration.accent)
+                } else {
+                    ThemeButton(configuration.ctaTitle) { configuration.select() }
+                        .color(configuration.accent).shape(.pill).size(.small)
+                }
+            }
+            .padding(configuration.spacing(.sm))
+            .background(theme.background(.bgSecondaryLight), in: Capsule())
+        }
+    }
+}
+
+#Preview("FareFamilyCardStyle — presets × light/dark") {
+    @Previewable @State var picked = true
+    let features: [FareFeature] = [
+        FareFeature("Cabin bag", systemImage: "handbag", detail: "40×30×15 cm"),
+        FareFeature("Carry-on", systemImage: "suitcase.rolling", detail: "55×40×23 cm"),
+        FareFeature("Non-refundable", systemImage: "nosign", status: .excluded),
+    ]
+    let radioCard = FareFamilyCard("Super Eco", price: 1_871.99)
+        .accent(.success).features(features).selection($picked)
+    let ctaCard = FareFamilyCard("Comfort Flex", price: 3_116.99)
+        .accent(.purple).features(features).onSelect { }
+    PreviewMatrix("FareFamilyCardStyle") {
+        PreviewCase("Stacked (default) · radio") { radioCard }
+        PreviewCase("Stacked · CTA") { ctaCard }
+        PreviewCase("Column · radio") { radioCard.fareFamilyCardStyle(.column).frame(width: 170) }
+        PreviewCase("Column · CTA") { ctaCard.fareFamilyCardStyle(.column).frame(width: 170) }
+        PreviewCase("Row · radio") { radioCard.fareFamilyCardStyle(.row) }
+        PreviewCase("Row · CTA") { ctaCard.fareFamilyCardStyle(.row) }
+        PreviewCase("Accordion · collapsed") { radioCard.fareFamilyCardStyle(.accordion) }
+        PreviewCase("Accordion · expanded") {
+            ctaCard.expanded(.constant(true)).fareFamilyCardStyle(.accordion)
+        }
+        PreviewCase("Custom (in-preview)") { ctaCard.fareFamilyCardStyle(PillFareFamilyCardStyle()) }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/FareSummary.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FareSummary.swift
@@ -3,7 +3,10 @@
 //  ThemeKit
 //
 //  An itemised price breakdown — base fare, taxes/fees, discounts, and an emphasised
-//  total. Token-bound; discounts read green, the total is a hero PriceTag.
+//  total. Token-bound; discounts read green, the total is a hero PriceTag. The entire
+//  layout is a swappable ``FareSummaryStyle`` (ADR-0004) — the component owns the
+//  fare *data*, the style owns the *arrangement*; see FareSummaryStyle.swift for the
+//  three built-ins (`.list` default, `.receipt`, `.collapsed`).
 //
 //  Flexible: per-line info buttons (.onInfo), a footer slot (a note or CTA), an
 //  animated total, and density-aware spacing. Honours `.redacted(.placeholder)`.
@@ -23,12 +26,12 @@ import ThemeKit
 /// ]).onInfo { line in showSheet(line.info) } footer: { TermsLink() }
 /// ```
 public struct FareSummary: View {
-    @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.formatDefaults) private var formatDefaults
     @Environment(\.locale) private var locale
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.fareSummaryStyle) private var style
 
     private let lines: [FareLine]
     private var currencyCode: String?
@@ -60,93 +63,26 @@ public struct FareSummary: View {
         currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
-    public var body: some View {
-        VStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            if let headerSlot { headerSlot }
-            // Position-keyed: robust to duplicate labels (two "Fee" lines) which would
-            // collide on the content-derived `id`. Fare lists are fixed-order, so index is stable.
-            ForEach(Array(visibleLines.enumerated()), id: \.offset) { _, line in
-                switch line.kind {
-                case .item:
-                    itemRow(line, value: formatted(line.amount),
-                            color: theme.text(.textSecondary), valueColor: theme.text(.textPrimary))
-                case .discount:
-                    itemRow(line, value: "-\(formatted(line.amount))",
-                            color: theme.foreground(.systemcolorsFgSuccess),
-                            valueColor: theme.foreground(.systemcolorsFgSuccess))
-                case .total:
-                    totalRow(line)
-                }
-            }
-            if let footerSlot { footerSlot }
-        }
-    }
-
-    /// Collapsed (`.expandable…`, chevron up) shows only the total row(s);
-    /// expanded — and the non-expandable default — shows every line in order.
-    @MainActor private var visibleLines: [FareLine] {
-        (isExpandable && !expandedState) ? lines.filter { $0.kind == .total } : lines
-    }
-
+    /// Reduce-Motion-gated toggle animation, resolved here (never by a style) and
+    /// handed to ``FareSummaryConfiguration/toggleExpand`` as a plain closure.
     private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
 
-    private func itemRow(_ line: FareLine, value: String, color: Color, valueColor: Color) -> some View {
-        HStack(spacing: Theme.SpacingKey.xs.value) {
-            Text(line.label).textStyle(.bodyBase400).foregroundStyle(color)
-            if line.info != nil, let onInfoHandler {
-                Button { onInfoHandler(line) } label: {
-                    Image(systemName: "info.circle").font(.caption).foregroundStyle(theme.text(.textTertiary))
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(themeKit: "More about \(line.label)"))
-            }
-            Spacer()
-            Text(value).textStyle(.bodyBase500).foregroundStyle(valueColor)
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(line.label) \(value)")
-    }
-
-    @MainActor
-    @ViewBuilder private func totalRow(_ line: FareLine) -> some View {
-        VStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            if showsDividerFlag { Divider().overlay(theme.border(.borderPrimary)) }
-            if isExpandable {
-                Button {
-                    withAnimation(motion) { expandedState.toggle() }
-                } label: {
-                    totalContent(line)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(expandedState
-                    ? String(themeKit: "Hide fare breakdown")
-                    : String(themeKit: "Show fare breakdown"))
-            } else {
-                totalContent(line)
-            }
-        }
-    }
-
-    @MainActor
-    private func totalContent(_ line: FareLine) -> some View {
-        HStack {
-            Text(line.label).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
-            if isExpandable {
-                Image(systemName: "chevron.down")
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(theme.text(.textTertiary))
-                    .rotationEffect(.degrees(expandedState ? 180 : 0))
-                    .accessibilityHidden(true)   // the row's a11y label announces the state
-            }
-            Spacer()
-            PriceTag(line.amount, currencyCode: resolvedCurrency)
-                .size(totalSize).emphasis(totalEmphasis).animatesValue()
-        }
-        .contentShape(Rectangle())
-    }
-
-    private func formatted(_ value: Decimal) -> String {
-        value.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0)).locale(locale))
+    public var body: some View {
+        style.makeBody(configuration: FareSummaryConfiguration(
+            lines: lines,
+            total: lines.last(where: { $0.kind == .total }),
+            currencyCode: resolvedCurrency,
+            onInfo: onInfoHandler,
+            header: headerSlot,
+            footer: footerSlot,
+            totalSize: totalSize,
+            totalEmphasis: totalEmphasis,
+            showsDivider: showsDividerFlag,
+            isExpandable: isExpandable,
+            isExpanded: expandedState,
+            toggleExpand: { withAnimation(motion) { expandedState.toggle() } },
+            density: density,
+            locale: locale))
     }
 }
 

--- a/Sources/ThemeKitTravel/Components/Organisms/FareSummaryStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FareSummaryStyle.swift
@@ -1,0 +1,539 @@
+//
+//  FareSummaryStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``FareSummary`` (ADR-0004, Wave 3): the configuration
+//  hands styles the *typed fare lines* (item / discount / total, already
+//  currency-resolved), not pre-laid content, so a style owns the entire
+//  arrangement. Three built-ins:
+//
+//    .list       labeled lines + a hero total under a divider — today's
+//                breakdown, verbatim. Default.
+//    .receipt    printed-receipt look: overline labels joined to their value
+//                by a dotted leader, closed by a dashed rule + total.
+//    .collapsed  total-first row that discloses the itemised lines on tap.
+//
+//      FareSummary([.item("Base fare", 1_100), .total("Total", 1_199)])
+//          .fareSummaryStyle(.receipt)
+//
+//  Money colours stay semantic-fixed everywhere: discounts always read
+//  success/green, the total is always the hero `PriceTag` emphasis the caller
+//  picked with `.totalEmphasis(_:)` — there is no `accent(_:)` axis on this
+//  configuration, on purpose (a fare breakdown is not brand chrome to retint).
+//  Expansion state (`ControllableState`) and its Reduce-Motion-gated animation
+//  both stay in the component — styles only ever read
+//  ``FareSummaryConfiguration/isExpanded`` and call
+//  ``FareSummaryConfiguration/toggleExpand``.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``FareSummaryStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no ``total`` line → no total row; `onInfo == nil`
+/// → no info affordance, even on lines carrying `info` text).
+public struct FareSummaryConfiguration {
+    /// Every line, in the order the caller supplied — items, discounts, and
+    /// (usually) one total, unfiltered. Styles decide for themselves what to
+    /// show while collapsed via ``isExpanded``.
+    public let lines: [FareLine]
+    /// The breakdown's total — the last `.total`-kind entry in ``lines``,
+    /// hoisted for styles that render it apart from the itemised body (e.g.
+    /// ``CollapsedFareSummaryStyle``'s total-first row). `nil` when no line
+    /// was built with `.total(...)`.
+    public let total: FareLine?
+    /// Currency code — already resolved by the component through the
+    /// FormatDefaults chain (explicit `.currency(_:)` → `formatDefaults` →
+    /// `locale.currency` → `"USD"`).
+    public let currencyCode: String
+    /// Called when a line's info button is tapped; `nil` hides every info
+    /// affordance (only lines created with `info:` show one, and only when
+    /// this is set — mirrors `FareSummary.onInfo(_:)`).
+    public let onInfo: ((FareLine) -> Void)?
+    /// Replacement for the built-in header slot (`.header { }`); `nil` = none.
+    public let header: AnyView?
+    /// Replacement for the built-in footer slot (`.footer { }`); `nil` = none.
+    public let footer: AnyView?
+    /// Size of the total `PriceTag` (`.totalSize(_:)`, default `.large`).
+    public let totalSize: PriceSize
+    /// Colour emphasis of the total `PriceTag` (`.totalEmphasis(_:)`, default `.hero`).
+    public let totalEmphasis: PriceEmphasis
+    /// Draws the divider/rule above the total row (`.showsDivider(_:)`, default on).
+    public let showsDivider: Bool
+    /// `true` once `.expandable()` / `.expandable(_:)` was called — gates
+    /// whether the disclosure affordance shows at all. Styles built around
+    /// *always* disclosing (``CollapsedFareSummaryStyle``) read ``isExpanded``
+    /// / ``toggleExpand`` directly and ignore this flag.
+    public let isExpandable: Bool
+    /// Expanded/collapsed read state (`ControllableState`, ADR-F4) — the
+    /// component owns the storage; styles only read it.
+    public let isExpanded: Bool
+    /// Flips ``isExpanded`` (Reduce-Motion aware; resolved by the component,
+    /// never by a style). Styles with a disclosure affordance call this.
+    public let toggleExpand: () -> Void
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — use it for every
+    /// currency string so injected locales (and RTL demos) render correctly.
+    public let locale: Locale
+
+    /// Every non-total line, in order — the itemised body most styles render
+    /// separately from ``total``.
+    public var itemLines: [FareLine] { lines.filter { $0.kind != .total } }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so `.componentDensity`
+    /// compacts or airs out the breakdown.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// Locale + currency-formatted amount, matching the component's own formatting.
+    public func formatted(_ amount: Decimal) -> String {
+        amount.formatted(.currency(code: currencyCode).precision(.fractionLength(0)).locale(locale))
+    }
+
+    /// A line's displayed value — discounts render with a leading minus,
+    /// everything else renders the plain formatted amount.
+    public func displayAmount(for line: FareLine) -> String {
+        line.kind == .discount ? "-\(formatted(line.amount))" : formatted(line.amount)
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `FareSummary`'s entire presentation. Implement `makeBody` to lay
+/// out the configuration's fare lines. Set one with `.fareSummaryStyle(_:)`;
+/// the default is ``ListFareSummaryStyle``.
+public protocol FareSummaryStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: FareSummaryConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// A horizontal 1pt line path (dash-friendly) — mirrors the private `Line`
+/// shape declared per-file across the suite (`FlightListItemStyle`,
+/// `LayoverRow`); redeclared here rather than shared, per house convention.
+private struct Line: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        p.move(to: CGPoint(x: rect.minX, y: rect.midY))
+        p.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+        return p
+    }
+}
+
+/// The `.receipt` leader — a tight dotted rule that fills the space between a
+/// label and its value, like a printed price list. Flipped under RTL so the
+/// dash phase stays anchored consistently with the row's mirrored order.
+private struct DottedLeader: View {
+    let color: Color
+    var body: some View {
+        Line()
+            .stroke(color, style: StrokeStyle(lineWidth: 1, lineCap: .round, dash: [1, 4]))
+            .frame(height: 6)
+            .frame(maxWidth: .infinity)
+            .flipsForRightToLeftLayoutDirection(true)
+    }
+}
+
+/// The `.receipt` / `.collapsed` info affordance — `.list` keeps its
+/// byte-identical original rendering (a raw `Image`, sized to match its
+/// existing body text), so it doesn't route through this helper.
+private struct FareInfoButton: View {
+    let line: FareLine
+    let onInfo: (FareLine) -> Void
+
+    var body: some View {
+        Button { onInfo(line) } label: {
+            Icon(systemName: "info.circle").size(.xs).accent(.neutral)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(themeKit: "More about \(line.label)"))
+    }
+}
+
+/// The `.receipt` / `.collapsed` disclosure chevron.
+private struct FareDisclosureChevron: View {
+    let isExpanded: Bool
+    var body: some View {
+        Icon(systemName: "chevron.down").size(.xs).accent(.neutral)
+            .rotationEffect(.degrees(isExpanded ? 180 : 0))
+            .accessibilityHidden(true)   // the row's own a11y label announces the state
+    }
+}
+
+// MARK: - .list
+
+/// Today's ``FareSummary`` look, extracted verbatim: labeled item/discount
+/// lines, an optional per-line info button, and a divider-topped hero total —
+/// collapsible behind the total row once `.expandable()` is set.
+public struct ListFareSummaryStyle: FareSummaryStyle {
+    public init() {}
+    public func makeBody(configuration: FareSummaryConfiguration) -> some View {
+        ListFareSummaryChrome(configuration: configuration)
+    }
+}
+
+private struct ListFareSummaryChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: FareSummaryConfiguration
+
+    var body: some View {
+        VStack(spacing: configuration.spacing(.sm)) {
+            if let header = configuration.header { header }
+            // Position-keyed: robust to duplicate labels (two "Fee" lines) which would
+            // collide on the content-derived `id`. Fare lists are fixed-order, so index is stable.
+            ForEach(Array(visibleLines.enumerated()), id: \.offset) { _, line in
+                switch line.kind {
+                case .item:
+                    itemRow(line, value: configuration.formatted(line.amount),
+                            color: theme.text(.textSecondary), valueColor: theme.text(.textPrimary))
+                case .discount:
+                    itemRow(line, value: configuration.displayAmount(for: line),
+                            color: theme.foreground(.systemcolorsFgSuccess),
+                            valueColor: theme.foreground(.systemcolorsFgSuccess))
+                case .total:
+                    totalRow(line)
+                }
+            }
+            if let footer = configuration.footer { footer }
+        }
+    }
+
+    /// Collapsed (`.expandable…`, chevron up) shows only the total row(s);
+    /// expanded — and the non-expandable default — shows every line in order.
+    private var visibleLines: [FareLine] {
+        (configuration.isExpandable && !configuration.isExpanded)
+            ? configuration.lines.filter { $0.kind == .total }
+            : configuration.lines
+    }
+
+    private func itemRow(_ line: FareLine, value: String, color: Color, valueColor: Color) -> some View {
+        HStack(spacing: Theme.SpacingKey.xs.value) {
+            Text(line.label).textStyle(.bodyBase400).foregroundStyle(color)
+            if line.info != nil, let onInfo = configuration.onInfo {
+                Button { onInfo(line) } label: {
+                    Image(systemName: "info.circle").font(.caption).foregroundStyle(theme.text(.textTertiary))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(themeKit: "More about \(line.label)"))
+            }
+            Spacer()
+            Text(value).textStyle(.bodyBase500).foregroundStyle(valueColor)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(line.label) \(value)")
+    }
+
+    @ViewBuilder private func totalRow(_ line: FareLine) -> some View {
+        VStack(spacing: configuration.spacing(.sm)) {
+            if configuration.showsDivider { Divider().overlay(theme.border(.borderPrimary)) }
+            if configuration.isExpandable {
+                Button(action: configuration.toggleExpand) {
+                    totalContent(line)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(configuration.isExpanded
+                    ? String(themeKit: "Hide fare breakdown")
+                    : String(themeKit: "Show fare breakdown"))
+            } else {
+                totalContent(line)
+            }
+        }
+    }
+
+    private func totalContent(_ line: FareLine) -> some View {
+        HStack {
+            Text(line.label).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+            if configuration.isExpandable {
+                Image(systemName: "chevron.down")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(theme.text(.textTertiary))
+                    .rotationEffect(.degrees(configuration.isExpanded ? 180 : 0))
+                    .accessibilityHidden(true)   // the row's a11y label announces the state
+            }
+            Spacer()
+            PriceTag(line.amount, currencyCode: configuration.currencyCode)
+                .size(configuration.totalSize).emphasis(configuration.totalEmphasis).animatesValue()
+        }
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - .receipt
+
+/// A printed-receipt look: every item/discount line is an overline label
+/// joined to its value by a dotted leader, closed by a dashed rule and the
+/// total. Honours ``FareSummaryConfiguration/isExpandable``/`isExpanded`
+/// exactly like `.list` — the leader/rule treatment is purely visual.
+public struct ReceiptFareSummaryStyle: FareSummaryStyle {
+    public init() {}
+    public func makeBody(configuration: FareSummaryConfiguration) -> some View {
+        ReceiptFareSummaryChrome(configuration: configuration)
+    }
+}
+
+private struct ReceiptFareSummaryChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: FareSummaryConfiguration
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            if let header = configuration.header { header }
+            ForEach(Array(visibleItemLines.enumerated()), id: \.offset) { _, line in
+                leaderRow(line)
+            }
+            if let total = configuration.total {
+                if configuration.showsDivider { DividerView().dashed() }
+                totalRow(total)
+            }
+            if let footer = configuration.footer { footer }
+        }
+    }
+
+    /// Item/discount lines — hidden while collapsed, same gate as `.list`.
+    private var visibleItemLines: [FareLine] {
+        (configuration.isExpandable && !configuration.isExpanded) ? [] : configuration.itemLines
+    }
+
+    private func leaderRow(_ line: FareLine) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.xs.value) {
+            Text(line.label.uppercased())
+                .textStyle(.overline400)
+                .foregroundStyle(line.kind == .discount
+                    ? theme.foreground(.systemcolorsFgSuccess) : theme.text(.textSecondary))
+                .lineLimit(1)
+            DottedLeader(color: theme.border(.borderPrimary))
+            if line.info != nil, let onInfo = configuration.onInfo {
+                FareInfoButton(line: line, onInfo: onInfo)
+            }
+            Text(configuration.displayAmount(for: line))
+                .textStyle(.labelSm600)
+                .foregroundStyle(line.kind == .discount
+                    ? theme.foreground(.systemcolorsFgSuccess) : theme.text(.textPrimary))
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(line.label) \(configuration.displayAmount(for: line))")
+    }
+
+    @ViewBuilder private func totalRow(_ line: FareLine) -> some View {
+        if configuration.isExpandable {
+            Button(action: configuration.toggleExpand) { totalContent(line) }
+                .buttonStyle(.plain)
+                .accessibilityLabel(configuration.isExpanded
+                    ? String(themeKit: "Hide fare breakdown")
+                    : String(themeKit: "Show fare breakdown"))
+        } else {
+            totalContent(line)
+        }
+    }
+
+    private func totalContent(_ line: FareLine) -> some View {
+        HStack {
+            Text(line.label.uppercased()).textStyle(.overline500).foregroundStyle(theme.text(.textSecondary))
+            if configuration.isExpandable { FareDisclosureChevron(isExpanded: configuration.isExpanded) }
+            Spacer()
+            PriceTag(line.amount, currencyCode: configuration.currencyCode)
+                .size(configuration.totalSize).emphasis(configuration.totalEmphasis).animatesValue()
+        }
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - .collapsed
+
+/// A total-first row that always discloses the itemised lines on tap —
+/// unlike `.list`/`.receipt`, this style reads ``FareSummaryConfiguration/isExpanded``
+/// directly (it *is* the disclosure affordance, so `isExpandable` is
+/// irrelevant to it); pair with `.expandable()`/`.expandable(_:)` only when
+/// the caller needs to observe or drive the flag from outside.
+public struct CollapsedFareSummaryStyle: FareSummaryStyle {
+    public init() {}
+    public func makeBody(configuration: FareSummaryConfiguration) -> some View {
+        CollapsedFareSummaryChrome(configuration: configuration)
+    }
+}
+
+private struct CollapsedFareSummaryChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: FareSummaryConfiguration
+
+    var body: some View {
+        VStack(spacing: configuration.spacing(.sm)) {
+            if let header = configuration.header { header }
+            totalRow
+            if configuration.isExpanded {
+                VStack(spacing: configuration.spacing(.xs)) {
+                    if configuration.showsDivider { Divider().overlay(theme.border(.borderPrimary)) }
+                    ForEach(Array(configuration.itemLines.enumerated()), id: \.offset) { _, line in
+                        itemRow(line)
+                    }
+                }
+            }
+            if let footer = configuration.footer { footer }
+        }
+    }
+
+    private var totalRow: some View {
+        Button(action: configuration.toggleExpand) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(configuration.total?.label ?? String(themeKit: "Total"))
+                        .textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+                    Text(configuration.isExpanded
+                        ? String(themeKit: "Hide breakdown")
+                        : String(themeKit: "Show breakdown"))
+                        .textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+                }
+                Spacer()
+                if let total = configuration.total {
+                    PriceTag(total.amount, currencyCode: configuration.currencyCode)
+                        .size(configuration.totalSize).emphasis(configuration.totalEmphasis).animatesValue()
+                }
+                FareDisclosureChevron(isExpanded: configuration.isExpanded)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(configuration.isExpanded
+            ? String(themeKit: "Hide fare breakdown")
+            : String(themeKit: "Show fare breakdown"))
+    }
+
+    private func itemRow(_ line: FareLine) -> some View {
+        HStack(spacing: Theme.SpacingKey.xs.value) {
+            Text(line.label).textStyle(.bodySm400).foregroundStyle(line.kind == .discount
+                ? theme.foreground(.systemcolorsFgSuccess) : theme.text(.textSecondary))
+            if line.info != nil, let onInfo = configuration.onInfo {
+                FareInfoButton(line: line, onInfo: onInfo)
+            }
+            Spacer()
+            Text(configuration.displayAmount(for: line))
+                .textStyle(.bodySm500)
+                .foregroundStyle(line.kind == .discount
+                    ? theme.foreground(.systemcolorsFgSuccess) : theme.text(.textPrimary))
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(line.label) \(configuration.displayAmount(for: line))")
+    }
+}
+
+// MARK: - Static accessors
+
+public extension FareSummaryStyle where Self == ListFareSummaryStyle {
+    /// Labeled item/discount lines + a divider-topped hero total. The default.
+    static var list: ListFareSummaryStyle { ListFareSummaryStyle() }
+}
+public extension FareSummaryStyle where Self == ReceiptFareSummaryStyle {
+    /// Printed-receipt look: overline labels joined to their value by a
+    /// dotted leader, closed by a dashed rule + total.
+    static var receipt: ReceiptFareSummaryStyle { ReceiptFareSummaryStyle() }
+}
+public extension FareSummaryStyle where Self == CollapsedFareSummaryStyle {
+    /// Total-first row that discloses the itemised lines on tap.
+    static var collapsed: CollapsedFareSummaryStyle { CollapsedFareSummaryStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyFareSummaryStyle: FareSummaryStyle {
+    private let _makeBody: @MainActor (FareSummaryConfiguration) -> AnyView
+    init<S: FareSummaryStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: FareSummaryConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct FareSummaryStyleKey: EnvironmentKey {
+    static let defaultValue = AnyFareSummaryStyle(ListFareSummaryStyle())
+}
+
+extension EnvironmentValues {
+    var fareSummaryStyle: AnyFareSummaryStyle {
+        get { self[FareSummaryStyleKey.self] }
+        set { self[FareSummaryStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``FareSummaryStyle`` for `FareSummary`s in this view and its
+    /// descendants — one screen can mix archetypes per section.
+    func fareSummaryStyle<S: FareSummaryStyle>(_ style: sending S) -> some View {
+        environment(\.fareSummaryStyle, AnyFareSummaryStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a compact single-line "N items · Total" summary that expands to the
+/// full breakdown, no divider chrome at all.
+private struct OneLineFareSummaryStyle: FareSummaryStyle {
+    func makeBody(configuration: FareSummaryConfiguration) -> some View {
+        OneLineChrome(configuration: configuration)
+    }
+
+    private struct OneLineChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: FareSummaryConfiguration
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: configuration.spacing(.xs)) {
+                Button(action: configuration.toggleExpand) {
+                    HStack {
+                        Text(String(themeKit: "\(configuration.itemLines.count) items"))
+                            .textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                        Spacer()
+                        if let total = configuration.total {
+                            PriceTag(total.amount, currencyCode: configuration.currencyCode)
+                                .size(.medium).emphasis(.hero)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                if configuration.isExpanded {
+                    ForEach(Array(configuration.itemLines.enumerated()), id: \.offset) { _, line in
+                        HStack {
+                            Text(line.label).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
+                            Spacer()
+                            Text(configuration.displayAmount(for: line))
+                                .textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview("FareSummaryStyle — presets × light/dark") {
+    @Previewable @State var collapsedOpen = true
+    let lines: [FareLine] = [
+        .item("Base fare", 1_100),
+        .item("Taxes & fees", 199, info: "Airport tax + carrier surcharge"),
+        .discount("Member discount", 100),
+        .total("Total", 1_199),
+    ]
+    return PreviewMatrix("FareSummaryStyle") {
+        PreviewCase("List (default)") { FareSummary(lines).onInfo { _ in } }
+        PreviewCase("List · expandable") { FareSummary(lines).onInfo { _ in }.expandable() }
+        PreviewCase("Receipt") { FareSummary(lines).onInfo { _ in }.fareSummaryStyle(.receipt) }
+        PreviewCase("Receipt · expandable") {
+            FareSummary(lines).onInfo { _ in }.expandable().fareSummaryStyle(.receipt)
+        }
+        // `.collapsed` reads isExpanded/toggleExpand directly; pair with `.expandable()`
+        // to start closed (its own uncontrolled default is otherwise `true` — the same
+        // idle value `.list`/`.receipt` carry when expansion was never requested).
+        PreviewCase("Collapsed") { FareSummary(lines).onInfo { _ in }.expandable().fareSummaryStyle(.collapsed) }
+        PreviewCase("Collapsed · open") {
+            FareSummary(lines).onInfo { _ in }.expandable($collapsedOpen).fareSummaryStyle(.collapsed)
+        }
+        PreviewCase("Custom (in-preview)") {
+            FareSummary(lines).expandable().fareSummaryStyle(OneLineFareSummaryStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelector.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelector.swift
@@ -8,6 +8,12 @@
 //  ThemeKit's neutral `ListRow` anatomy, `RadioButton`, `Badge` and
 //  `InstallmentPicker` — nothing is re-implemented here.
 //
+//  The entire layout is a swappable ``PaymentMethodSelectorStyle`` (ADR-0004):
+//  this component owns the *data* (options, selection, instalments, badges)
+//  and the active style owns the *arrangement*. See
+//  `PaymentMethodSelectorStyle.swift` for the five built-ins
+//  (`.list` `.grid` `.carousel` `.compactList` `.sectioned`).
+//
 //  State follows ADR-F4: controlled-first (`selection: Binding<String?>`) plus
 //  an uncontrolled preview convenience (`initiallySelected:`), both funneled
 //  through `ControllableState`. Currency for the installment amounts is NOT a
@@ -18,6 +24,7 @@
 //  PaymentMethodSelector(options, selection: $method)
 //      .installments([1, 3, 6, 9], selection: $months, total: fareTotal)
 //      .badge("No fee", for: "transfer")
+//      .paymentMethodSelectorStyle(.grid)
 //  ```
 //
 
@@ -27,6 +34,11 @@ import ThemeKit
 /// Layout archetype of a ``PaymentMethodSelector``: radio rows (`.list`),
 /// tiles (`.grid`), horizontally-snapping tiles (`.carousel`), or dense
 /// single-line rows (`.compactList`).
+///
+/// Superseded by ``PaymentMethodSelectorStyle`` (each case maps 1:1 to a
+/// preset, which also adds `.sectioned`); kept for source compatibility until
+/// the next major, together with the deprecated
+/// ``PaymentMethodSelector/variant(_:)`` modifier.
 public enum PaymentMethodVariant: Sendable { case list, grid, carousel, compactList }
 
 /// The per-option selected glyph: a leading `RadioButton` (`.radio`, the list
@@ -42,18 +54,18 @@ public enum TileEmphasis: Sendable { case subtle, strong }
 /// ``PaymentMethodOption`` values, with an optional inline instalment picker
 /// under the selected card option.
 public struct PaymentMethodSelector: View {
-    @Environment(\.theme) private var theme
     @Environment(\.isReadOnly) private var isReadOnly
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.componentDensity) private var density
+    @Environment(\.locale) private var locale
+    @Environment(\.paymentMethodSelectorStyle) private var envStyle
 
     private let options: [PaymentMethodOption]
     /// Selected option id — controlled or uncontrolled per init (ADR-F4).
     @ControllableState private var selection: String?
 
     // Config — mutated only through the modifiers below (R2).
-    private var variantValue: PaymentMethodVariant = .list
     private var installmentMonths: [Int]?
     private var installmentSelection: Binding<Int>?
     private var installmentTotal: Decimal?
@@ -62,9 +74,9 @@ public struct PaymentMethodSelector: View {
     private var accent: SemanticColor?
     private var footerSlot: AnyView?
     private var headerSlot: AnyView?
-    private var surfaceKey: Theme.BackgroundColorKey = .bgBase
-    /// Selected glyph — `nil` = the variant's default (`.radio` for the row
-    /// variants, `.checkmark` for the tile variants).
+    private var surfaceKey: Theme.BackgroundColorKey?
+    /// Selected glyph — `nil` = the active style's own default (`.radio` for
+    /// row-shaped presets, `.checkmark` for tile-shaped ones).
     private var indicatorOverride: SelectionIndicator?
     private var columnsValue = 2
     /// Per-option replacement (`(option, isSelected)`); nil = built-in anatomy.
@@ -72,6 +84,10 @@ public struct PaymentMethodSelector: View {
     private var badgeStyleValue: BadgeStyle = .info
     private var tileRadiusRole: Theme.RadiusRole = .field
     private var emphasisValue: TileEmphasis = .subtle
+    /// Set by the deprecated ``variant(_:)`` modifier — an explicitly chosen
+    /// per-instance style wins over an ancestor's ``paymentMethodSelectorStyle(_:)``
+    /// (source-behavior stability during the enum's deprecation window).
+    private var explicitStyle: AnyPaymentMethodSelectorStyle?
 
     /// R1 — options + controlled selection (option id). The binding is the
     /// change channel; observe with `.onChange(of:)` at the call site.
@@ -90,287 +106,20 @@ public struct PaymentMethodSelector: View {
     private var motion: Animation? {
         MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion)
     }
-    private var accentBase: Color { (accent ?? .primary).base }
 
-    /// The variant's effective indicator: the explicit override, or `.radio`
-    /// for row variants / `.checkmark` for tile variants.
-    private var effectiveIndicator: SelectionIndicator {
-        if let indicatorOverride { return indicatorOverride }
-        switch variantValue {
-        case .list, .compactList: return .radio
-        case .grid, .carousel: return .checkmark
-        }
-    }
-
-    public var body: some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
-            if let headerSlot { headerSlot }
-            switch variantValue {
-            case .list: listBody
-            case .grid: gridBody
-            case .carousel: carouselBody
-            case .compactList: compactListBody
-            }
-            if let footerSlot { footerSlot }
-        }
-        .animation(motion, value: selection)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(String(themeKitTravel: "Payment method, \(options.count) options"))
-    }
-
-    // MARK: List variant — ListRow anatomy with radio semantics
-
-    @MainActor
-    private var listBody: some View {
-        VStack(spacing: 0) {
-            ForEach(Array(options.enumerated()), id: \.element.id) { index, option in
-                row(option)
-                if showsInstallments(under: option) {
-                    inlineInstallments
-                        .padding(.bottom, Theme.SpacingKey.sm.value)
-                }
-                if index < options.count - 1 {
-                    DividerView().size(.small)
-                }
-            }
-        }
-    }
-
-    @MainActor
-    @ViewBuilder
-    private func row(_ option: PaymentMethodOption) -> some View {
-        let isOn = selection == option.id
-        if let optionSlot {
-            slotButton(option, isOn: isOn) { optionSlot(option, isOn) }
-        } else {
-            builtInRow(option, isOn: isOn)
-        }
-    }
-
-    @MainActor
-    private func builtInRow(_ option: PaymentMethodOption, isOn: Bool) -> some View {
-        var listRow = ListRow(option.title) { select(option.id) }
-            .subtitle(option.subtitle)
-            .leading {
-                HStack(spacing: Theme.SpacingKey.sm.value) {
-                    if effectiveIndicator == .radio {
-                        RadioButton(isSelected: isSelectedBinding(option.id)).accent(accent)
-                    }
-                    Icon(systemName: option.systemImage)
-                        .size(.sm)
-                        .color(isOn ? accentBase : theme.text(.textSecondary))
-                }
-            }
-            .badge(badges[option.id])
-            .selected(isOn)
-        if effectiveIndicator == .checkmark, isOn {
-            listRow = listRow.trailing {
-                Icon(systemName: "checkmark").size(.sm).color(accentBase)
-            }
-        } else {
-            listRow = listRow.trailing(ListRowTrailing.none)
-        }
-        return listRow
-            .disabled(disabledIDs.contains(option.id))
-            .accessibilityElement(children: .combine)
-            .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
-    }
-
-    /// Wraps `.optionContent` slot output in the selection button, preserving
-    /// tap handling, disabling and VoiceOver traits around caller content.
-    @MainActor
-    private func slotButton<Content: View>(
-        _ option: PaymentMethodOption, isOn: Bool, @ViewBuilder content: () -> Content
-    ) -> some View {
-        Button { select(option.id) } label: {
-            content().contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(disabledIDs.contains(option.id))
-        .allowsHitTesting(!isReadOnly)
-        .accessibilityElement(children: .combine)
-        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
-    }
-
-    // MARK: Compact-list variant — dense single-line rows
-
-    @MainActor
-    private var compactListBody: some View {
-        VStack(spacing: 0) {
-            ForEach(Array(options.enumerated()), id: \.element.id) { index, option in
-                compactRow(option)
-                if showsInstallments(under: option) {
-                    inlineInstallments
-                        .padding(.bottom, Theme.SpacingKey.sm.value)
-                }
-                if index < options.count - 1 {
-                    DividerView().size(.small)
-                }
-            }
-        }
-    }
-
-    @MainActor
-    @ViewBuilder
-    private func compactRow(_ option: PaymentMethodOption) -> some View {
-        let isOn = selection == option.id
-        let isDisabled = disabledIDs.contains(option.id)
-        slotButton(option, isOn: isOn) {
-            if let optionSlot {
-                optionSlot(option, isOn)
-            } else {
-                HStack(spacing: Theme.SpacingKey.sm.value) {
-                    if effectiveIndicator == .radio {
-                        RadioButton(isSelected: isSelectedBinding(option.id)).accent(accent)
-                    }
-                    Icon(systemName: option.systemImage)
-                        .size(.sm)
-                        .color(isDisabled ? theme.text(.textDisabled) : (isOn ? accentBase : theme.text(.textSecondary)))
-                    Text(option.title)
-                        .textStyle(.labelBase600)
-                        .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
-                        .lineLimit(1)
-                    Spacer(minLength: Theme.SpacingKey.xs.value)
-                    if let badgeText = badges[option.id] {
-                        Badge(badgeText).badgeStyle(badgeStyleValue).variant(.soft).size(.small)
-                    }
-                    if effectiveIndicator == .checkmark, isOn {
-                        Icon(systemName: "checkmark").size(.sm).color(accentBase)
-                    }
-                }
-                .padding(.vertical, Theme.SpacingKey.xs.value)
-            }
-        }
-    }
-
-    // MARK: Carousel variant — horizontal snap tiles
-
-    @MainActor
-    @ViewBuilder
-    private var carouselBody: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: Theme.SpacingKey.sm.value) {
-                ForEach(options) { option in
-                    tile(option)
-                        .frame(width: Metrics.carouselTileWidth)
-                }
-            }
-            .scrollTargetLayout()
-        }
-        .scrollTargetBehavior(.viewAligned)
-        .scrollClipDisabled()
-        if options.contains(where: { showsInstallments(under: $0) }) {
-            inlineInstallments
-        }
-    }
-
-    /// Genuine dimensions with no semantic token — fixed tile constants.
-    private enum Metrics {
-        static let carouselTileWidth: CGFloat = 148
-        static let tileMinHeight: CGFloat = 88
-    }
-
-    // MARK: Grid variant — selection tiles (vertical fallback at a11y sizes)
-
-    @MainActor
-    @ViewBuilder
-    private var gridBody: some View {
-        let gap = Theme.SpacingKey.sm.value
-        if dynamicTypeSize.isAccessibilitySize {
-            VStack(spacing: gap) { ForEach(options) { tile($0) } }
-        } else {
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.flexible(), spacing: gap), count: columnsValue),
-                spacing: gap
-            ) {
-                ForEach(options) { tile($0) }
-            }
-        }
-        if options.contains(where: { showsInstallments(under: $0) }) {
-            inlineInstallments
-        }
-    }
-
-    /// Selected-stroke color/width from the emphasis axis — named semantic
-    /// steps only (`base` / `strong`).
-    private var selectedStroke: (color: Color, width: CGFloat) {
-        switch emphasisValue {
-        case .subtle: return (accentBase, 1.5)
-        case .strong: return ((accent ?? .primary).strong, 2)
-        }
-    }
-
-    @MainActor
-    @ViewBuilder
-    private func tile(_ option: PaymentMethodOption) -> some View {
-        let isOn = selection == option.id
-        let isDisabled = disabledIDs.contains(option.id)
-        let shape = RoundedRectangle(cornerRadius: tileRadiusRole.value, style: .continuous)
-        slotButton(option, isOn: isOn) {
-            Group {
-                if let optionSlot {
-                    optionSlot(option, isOn)
-                } else {
-                    builtInTileLabel(option, isOn: isOn, isDisabled: isDisabled)
-                }
-            }
-            .frame(maxWidth: .infinity, minHeight: Metrics.tileMinHeight)
-            .padding(Theme.SpacingKey.md.value)
-            .background(isOn ? (accent ?? .primary).bg : theme.background(surfaceKey), in: shape)
-            .overlay(shape.stroke(isOn ? selectedStroke.color : theme.border(.borderPrimary),
-                                  lineWidth: isOn ? selectedStroke.width : 1))
-            .overlay(alignment: .topTrailing) {
-                if let badgeText = badges[option.id] {
-                    Badge(badgeText).badgeStyle(badgeStyleValue).variant(.soft).size(.small)
-                        .padding(Theme.SpacingKey.xs.value)
-                }
-            }
-            .contentShape(shape)
-        }
-    }
-
-    @MainActor
-    private func builtInTileLabel(_ option: PaymentMethodOption, isOn: Bool, isDisabled: Bool) -> some View {
-        VStack(spacing: Theme.SpacingKey.xs.value) {
-            Icon(systemName: option.systemImage)
-                .size(.md)
-                .color(isDisabled ? theme.text(.textDisabled) : (isOn ? accentBase : theme.text(.textSecondary)))
-            Text(option.title)
-                .textStyle(.labelSm600)
-                .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
-                .multilineTextAlignment(.center)
-            if let subtitle = option.subtitle {
-                Text(subtitle)
-                    .textStyle(.bodySm400)
-                    .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textSecondary))
-                    .multilineTextAlignment(.center)
-            }
-            if effectiveIndicator == .checkmark, isOn {
-                Icon(systemName: "checkmark.circle.fill").size(.sm).color(accentBase)
-            }
-        }
-    }
-
-    // MARK: Installments (composes the existing InstallmentPicker)
-
-    /// Whether the inline instalment picker belongs under this option: the
-    /// modifier is configured, the option is the current selection, and it is
-    /// a `.card` method.
-    @MainActor
-    private func showsInstallments(under option: PaymentMethodOption) -> Bool {
-        installmentMonths?.isEmpty == false
-            && installmentSelection != nil
-            && installmentTotal != nil
-            && option.kind == .card
-            && option.id == selection
-    }
-
-    @MainActor
-    @ViewBuilder
-    private var inlineInstallments: some View {
-        if let months = installmentMonths, let picked = installmentSelection, let total = installmentTotal {
-            // Currency deliberately not set: InstallmentPicker resolves it via
-            // the §10 chain (`\.formatDefaults` > locale currency > "USD").
+    /// The pre-built, accent-styled inline instalment picker for the current
+    /// selection, or `nil` when instalments aren't configured, nothing is
+    /// selected, or the selection isn't a `.card` method (composes the
+    /// neutral `InstallmentPicker`; currency deliberately unset — it resolves
+    /// via the §10 chain inside `InstallmentPicker` itself).
+    private var installmentsSlot: AnyView? {
+        guard let months = installmentMonths, !months.isEmpty,
+              let picked = installmentSelection,
+              let total = installmentTotal,
+              let selectedOption = options.first(where: { $0.id == selection }),
+              selectedOption.kind == .card
+        else { return nil }
+        return AnyView(
             InstallmentPicker(months.map { count in
                 InstallmentOption(
                     count: count,
@@ -378,10 +127,42 @@ public struct PaymentMethodSelector: View {
                     monthly: count > 1 ? total / Decimal(count) : nil
                 )
             }, selection: picked)
-            .accent(accent)
-            .padding(.leading, Theme.SpacingKey.lg.value)
-            .transition(.opacity)
-        }
+                .accent(accent)
+                .padding(.leading, density.scale(Theme.SpacingKey.lg.value))
+                .transition(.opacity)
+        )
+    }
+
+    /// The typed configuration handed to the active ``PaymentMethodSelectorStyle``.
+    private var configuration: PaymentMethodSelectorConfiguration {
+        PaymentMethodSelectorConfiguration(
+            options: options,
+            selectedID: selection,
+            select: { select($0) },
+            installmentsSlot: installmentsSlot,
+            badges: badges,
+            disabledMethods: disabledIDs,
+            indicatorOverride: indicatorOverride,
+            columns: columnsValue,
+            optionContent: optionSlot,
+            badgeStyle: badgeStyleValue,
+            header: headerSlot,
+            footer: footerSlot,
+            radiusRole: tileRadiusRole,
+            emphasis: emphasisValue,
+            accent: accent,
+            surfaceKey: surfaceKey,
+            isReadOnly: isReadOnly,
+            density: density,
+            locale: locale
+        )
+    }
+
+    public var body: some View {
+        (explicitStyle ?? envStyle).makeBody(configuration: configuration)
+            .animation(motion, value: selection)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(String(themeKitTravel: "Payment method, \(options.count) options"))
     }
 
     // MARK: Selection plumbing
@@ -391,28 +172,30 @@ public struct PaymentMethodSelector: View {
         guard !isReadOnly else { return }   // E1 — read-only blocks mutation, not focus
         selection = id
     }
-
-    /// Radio-style binding for one option: setting `true` selects it; a
-    /// payment method can't be deselected by tapping its own radio.
-    @MainActor
-    private func isSelectedBinding(_ id: String) -> Binding<Bool> {
-        Binding(
-            get: { selection == id },
-            set: { if $0 { select(id) } }
-        )
-    }
 }
 
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension PaymentMethodSelector {
-    /// Layout archetype: `.list` radio rows (default), `.grid` tiles,
-    /// `.carousel` horizontal snap tiles, or `.compactList` single-line rows.
-    func variant(_ v: PaymentMethodVariant) -> Self { copy { $0.variantValue = v } }
+    /// Layout archetype — superseded by the style axis: prefer
+    /// `.paymentMethodSelectorStyle(.list/.grid/.carousel/.compactList)`,
+    /// settable once per screen via the environment. This modifier keeps
+    /// working and, when called, wins over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .paymentMethodSelectorStyle(.grid)")
+    func variant(_ v: PaymentMethodVariant) -> Self {
+        copy {
+            switch v {
+            case .list: $0.explicitStyle = AnyPaymentMethodSelectorStyle(ListPaymentMethodSelectorStyle())
+            case .grid: $0.explicitStyle = AnyPaymentMethodSelectorStyle(GridPaymentMethodSelectorStyle())
+            case .carousel: $0.explicitStyle = AnyPaymentMethodSelectorStyle(CarouselPaymentMethodSelectorStyle())
+            case .compactList: $0.explicitStyle = AnyPaymentMethodSelectorStyle(CompactListPaymentMethodSelectorStyle())
+            }
+        }
+    }
 
-    /// Selected glyph: `.radio` (row variants' default), `.checkmark`
-    /// (tile variants' default), or `.none` — the selected chrome alone
-    /// signals the choice. Tile variants ignore `.radio` (no glyph).
+    /// Selected glyph: `.radio` (row-shaped presets' default), `.checkmark`
+    /// (tile-shaped presets' default), or `.none` — the selected chrome alone
+    /// signals the choice. Tile-shaped presets ignore `.radio` (no glyph).
     func indicator(_ i: SelectionIndicator) -> Self { copy { $0.indicatorOverride = i } }
 
     /// Grid column count, clamped 1…4 (default 2). The accessibility-size
@@ -420,19 +203,20 @@ public extension PaymentMethodSelector {
     func columns(_ n: Int) -> Self { copy { $0.columnsValue = min(4, max(1, n)) } }
 
     /// Replaces the built-in row/tile anatomy with caller content, built per
-    /// `(option, isSelected)` in every variant. Selection tap handling,
-    /// disabling and VoiceOver traits are preserved around the slot; the tile
-    /// variants keep their selected chrome (fill/stroke/badge) around it.
+    /// `(option, isSelected)` in every style. Selection tap handling,
+    /// disabling and VoiceOver traits are preserved around the slot; the
+    /// tile-shaped presets keep their selected chrome (fill/stroke/badge)
+    /// around it.
     func optionContent(@ViewBuilder _ content: @escaping (PaymentMethodOption, Bool) -> some View) -> Self {
         copy { $0.optionSlot = { AnyView(content($0, $1)) } }
     }
 
     /// Style of the per-option badges (default `.info`) — applies wherever
-    /// this component draws the `Badge` itself (tiles, carousel, compact
-    /// rows); the `.list` variant's badge is drawn by `ListRow`.
+    /// the active style draws the `Badge` itself (tiles, carousel, compact
+    /// rows); the `.list`/`.sectioned` row's badge is drawn by `ListRow`.
     func badgeStyle(_ s: BadgeStyle) -> Self { copy { $0.badgeStyleValue = s } }
 
-    /// Corner role for the tile variants (default `.field`).
+    /// Corner role for tile-shaped presets (default `.field`).
     func radius(_ role: Theme.RadiusRole) -> Self { copy { $0.tileRadiusRole = role } }
 
     /// Selected-tile stroke strength: `.subtle` (default, base step) or
@@ -470,8 +254,8 @@ public extension PaymentMethodSelector {
     /// `nil` (default) uses the primary triad.
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
 
-    /// Surface token for the *unselected* `.grid` tile fill (default `.bgBase`);
-    /// the selected tile keeps the accent tint and stroke.
+    /// Surface token for the *unselected* tile-shaped presets' fill (default
+    /// `.bgBase`); the selected tile keeps the accent tint and stroke.
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
 
     /// Bottom-aligned accessory area (canonical `.footer { }` slot), e.g. a
@@ -537,7 +321,6 @@ public extension PaymentMethodSelector {
                         .init(id: "transfer", kind: .transfer, title: "Transfer"),
                         .init(id: "card2", kind: .card, title: "Corporate"),
                     ], selection: $method)
-                        .variant(.carousel)
                         .emphasis(.strong)
                         .radius(.box)
                         .badge("New", for: "wallet")
@@ -545,6 +328,7 @@ public extension PaymentMethodSelector {
                         .header {
                             Text("How would you like to pay?").textStyle(.headingSm)
                         }
+                        .paymentMethodSelectorStyle(.carousel)
 
                     ListSectionHeader("Compact list · checkmark indicator")
                     PaymentMethodSelector([
@@ -552,8 +336,8 @@ public extension PaymentMethodSelector {
                         .init(id: "wallet", kind: .wallet, title: "Digital wallet"),
                         .init(id: "transfer", kind: .transfer, title: "Bank transfer"),
                     ], selection: $method)
-                        .variant(.compactList)
                         .indicator(.checkmark)
+                        .paymentMethodSelectorStyle(.compactList)
 
                     ListSectionHeader("Grid · 3 columns · custom option slot")
                     PaymentMethodSelector([
@@ -561,7 +345,6 @@ public extension PaymentMethodSelector {
                         .init(id: "wallet", kind: .wallet, title: "Wallet"),
                         .init(id: "transfer", kind: .transfer, title: "Transfer"),
                     ], selection: $method)
-                        .variant(.grid)
                         .columns(3)
                         .indicator(.none)
                         .optionContent { option, isSelected in
@@ -570,6 +353,7 @@ public extension PaymentMethodSelector {
                                 Text(option.title).textStyle(isSelected ? .labelSm700 : .labelSm600)
                             }
                         }
+                        .paymentMethodSelectorStyle(.grid)
                 }
                 .padding()
             }
@@ -578,29 +362,30 @@ public extension PaymentMethodSelector {
     return Demo()
 }
 
-#Preview("Grid · dark") {
+#Preview("Sectioned · grid · dark") {
     struct Demo: View {
         @State private var method: String? = "wallet"
         var body: some View {
             let dark = Theme()
             dark.loadTheme(named: Theme.defaultThemeName, dark: true)
             return VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
+                ListSectionHeader("Sectioned — cards / wallets / other")
                 PaymentMethodSelector([
-                    .init(id: "card", kind: .card, title: "Card"),
-                    .init(id: "wallet", kind: .wallet, title: "Wallet", subtitle: "One tap"),
-                    .init(id: "transfer", kind: .transfer, title: "Transfer"),
+                    .init(id: "card", kind: .card, title: "Visa •••• 4242"),
                     .init(id: "card2", kind: .card, title: "Corporate card"),
+                    .init(id: "wallet", kind: .wallet, title: "Wallet", subtitle: "One tap"),
+                    .init(id: "transfer", kind: .transfer, title: "Bank transfer"),
                 ], selection: $method)
-                    .variant(.grid)
                     .badge("New", for: "wallet")
+                    .paymentMethodSelectorStyle(.sectioned)
 
                 ListSectionHeader("Grid · surface(.bgWhite)")
                 PaymentMethodSelector([
                     .init(id: "card", kind: .card, title: "Card"),
                     .init(id: "wallet", kind: .wallet, title: "Wallet"),
                 ], initiallySelected: "card")
-                    .variant(.grid)
                     .surface(.bgWhite)
+                    .paymentMethodSelectorStyle(.grid)
             }
             .padding()
             .background(dark.background(.bgBase))

--- a/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelectorStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelectorStyle.swift
@@ -1,0 +1,671 @@
+//
+//  PaymentMethodSelectorStyle.swift
+//  ThemeKitTravel
+//
+//  The styling hook for ``PaymentMethodSelector`` (ADR-0004, Class A — the
+//  component owns the *data*: options, selection, instalments, badges; the
+//  style owns the entire arrangement). Five built-ins:
+//
+//    .list         radio rows via the neutral `ListRow` anatomy — default.
+//    .grid         selection tiles (vertical fallback at a11y sizes).
+//    .carousel     horizontally-snapping tiles.
+//    .compactList  dense single-line rows.
+//    .sectioned    grouped rows — cards / wallets / other, with section headers.
+//
+//      PaymentMethodSelector(options, selection: $method)
+//          .installments([1, 3, 6, 9], selection: $months, total: fareTotal)
+//          .paymentMethodSelectorStyle(.grid)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the token
+//  theme colors everything (this component has no shell `CardStyle` chrome to
+//  delegate to — its surfaces are drawn directly, gated by ``surface(default:)``).
+//  The component resolves MicroMotion / Reduce Motion and read-only state
+//  before calling a style — styles read ``PaymentMethodSelectorConfiguration``
+//  fields only, never the motion/read-only environment themselves.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``PaymentMethodSelectorStyle`` lays out. Fields a given
+/// style doesn't use are simply ignored — every built-in degrades gracefully
+/// when optional data is absent (no instalments configured → no inline picker,
+/// no badge for an option → no chip).
+public struct PaymentMethodSelectorConfiguration {
+    /// The payment methods to choose among, in caller order.
+    public let options: [PaymentMethodOption]
+    /// The selected option id, or `nil` when nothing is chosen yet.
+    public let selectedID: String?
+    /// Selects an option by id. Already gated on read-only by the component —
+    /// styles call this from taps/rows without re-checking `isReadOnly`.
+    public let select: (String) -> Void
+    /// The pre-built, accent-styled inline instalment picker for the selected
+    /// `.card` option (composes the neutral `InstallmentPicker`), or `nil` when
+    /// instalments aren't configured, nothing is selected, or the selection
+    /// isn't a card. Row-shaped styles place it directly under the matching
+    /// row; tile-shaped styles place it once, below the whole tile layout.
+    public let installmentsSlot: AnyView?
+    /// Per-option badge text (`PaymentMethodSelector.badge(_:for:)`), keyed by
+    /// option id.
+    public let badges: [String: String]
+    /// Option ids rendered disabled and excluded from selection.
+    public let disabledMethods: Set<String>
+    /// The explicit `.indicator(_:)` override, or `nil` to let the style pick
+    /// its own natural default — resolve via ``indicator(default:)``.
+    public let indicatorOverride: SelectionIndicator?
+    /// Grid column count, clamped 1…4 (default 2); the a11y-size vertical
+    /// fallback ignores it.
+    public let columns: Int
+    /// Replacement for the built-in row/tile anatomy, built per
+    /// `(option, isSelected)`; `nil` = built-in. Selection tap handling,
+    /// disabling and VoiceOver traits stay owned by the style around this slot.
+    public let optionContent: ((PaymentMethodOption, Bool) -> AnyView)?
+    /// Style of the per-option badges (default `.info`).
+    public let badgeStyle: BadgeStyle
+    /// Top-aligned accessory area (`.header { }`); `nil` = none.
+    public let header: AnyView?
+    /// Bottom-aligned accessory area (`.footer { }`); `nil` = none.
+    public let footer: AnyView?
+    /// Corner-radius role for tile-shaped styles (default `.field`).
+    public let radiusRole: Theme.RadiusRole
+    /// Selected-tile stroke strength for tile-shaped styles.
+    public let emphasis: TileEmphasis
+    /// Semantic tint for the radio / selected chrome / instalment rows;
+    /// `nil` uses the primary triad.
+    public let accent: SemanticColor?
+    /// Explicit surface fill, or `nil` to let the style choose its own default
+    /// (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Read-only state, captured by the component (`\.isReadOnly`) — styles
+    /// that build their own tap surface (not through ``select``/`ListRow`)
+    /// should gate hit-testing on it, mirroring the built-ins.
+    public let isReadOnly: Bool
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component, for any future
+    /// locale-formatted content a custom style may add.
+    public let locale: Locale
+
+    /// The `accent(_:)` override's base color — the value the built-ins use
+    /// for the radio, selected icon tint and selected tile stroke.
+    public var accentBase: Color { (accent ?? .primary).base }
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out the selector.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// The explicit `indicator(_:)` override, or a style's natural default
+    /// (`.radio` for row-shaped styles, `.checkmark` for tile-shaped ones).
+    public func indicator(default fallback: SelectionIndicator) -> SelectionIndicator {
+        indicatorOverride ?? fallback
+    }
+
+    /// Radio-style binding for one option: setting `true` selects it via
+    /// ``select``; a payment method can't be deselected by tapping its own
+    /// radio (mirrors native radio-group semantics).
+    public func isSelectedBinding(_ id: String) -> Binding<Bool> {
+        Binding(
+            get: { selectedID == id },
+            set: { if $0 { select(id) } }
+        )
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `PaymentMethodSelector`'s entire presentation. Implement
+/// `makeBody` to lay out the configuration's options. Set one with
+/// `.paymentMethodSelectorStyle(_:)`; the default is ``ListPaymentMethodSelectorStyle``.
+public protocol PaymentMethodSelectorStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: PaymentMethodSelectorConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The header/content/footer frame every preset shares — matches the
+/// pre-style component's outer `VStack` verbatim (header slot above, footer
+/// slot below, `.sm`-spaced).
+private extension View {
+    @ViewBuilder
+    func selectorFrame(_ configuration: PaymentMethodSelectorConfiguration) -> some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            if let header = configuration.header { header }
+            self
+            if let footer = configuration.footer { footer }
+        }
+    }
+}
+
+/// Wraps a per-option slot in the selection button, preserving tap handling,
+/// disabling and VoiceOver traits — shared by every built-in that draws its
+/// own row/tile chrome (the `.list`/`.sectioned` `ListRow` anatomy handles its
+/// own tap surface and doesn't use this wrapper).
+private struct PaymentOptionButton<Content: View>: View {
+    let configuration: PaymentMethodSelectorConfiguration
+    let option: PaymentMethodOption
+    let content: () -> Content
+
+    init(configuration: PaymentMethodSelectorConfiguration, option: PaymentMethodOption,
+         @ViewBuilder content: @escaping () -> Content) {
+        self.configuration = configuration
+        self.option = option
+        self.content = content
+    }
+
+    private var isOn: Bool { configuration.selectedID == option.id }
+    private var isDisabled: Bool { configuration.disabledMethods.contains(option.id) }
+
+    var body: some View {
+        Button { configuration.select(option.id) } label: {
+            content().contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .allowsHitTesting(!configuration.isReadOnly)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+}
+
+/// Genuine dimensions with no semantic token — fixed tile constants, shared
+/// by the `.grid` and `.carousel` tile builders.
+private enum Metrics {
+    static let carouselTileWidth: CGFloat = 148
+    static let tileMinHeight: CGFloat = 88
+}
+
+/// The shared row anatomy for `.list` and `.sectioned` — a `ListRow`-based
+/// radio row with the built-in leading indicator + icon, the per-option
+/// badge, an optional selected checkmark, and the inline instalment picker
+/// directly beneath the row when this option is the selected `.card` method.
+private struct PaymentOptionRow: View {
+    @Environment(\.theme) private var theme
+    let configuration: PaymentMethodSelectorConfiguration
+    let option: PaymentMethodOption
+
+    private var isOn: Bool { configuration.selectedID == option.id }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            content
+            if isOn, let installmentsSlot = configuration.installmentsSlot {
+                installmentsSlot.padding(.bottom, configuration.spacing(.sm))
+            }
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        if let optionContent = configuration.optionContent {
+            PaymentOptionButton(configuration: configuration, option: option) {
+                optionContent(option, isOn)
+            }
+        } else {
+            builtInRow
+        }
+    }
+
+    private var builtInRow: some View {
+        var listRow = ListRow(option.title) { configuration.select(option.id) }
+            .subtitle(option.subtitle)
+            .leading {
+                HStack(spacing: configuration.spacing(.sm)) {
+                    if configuration.indicator(default: .radio) == .radio {
+                        RadioButton(isSelected: configuration.isSelectedBinding(option.id))
+                            .accent(configuration.accent)
+                    }
+                    Icon(systemName: option.systemImage)
+                        .size(.sm)
+                        .color(isOn ? configuration.accentBase : theme.text(.textSecondary))
+                }
+            }
+            .badge(configuration.badges[option.id])
+            .selected(isOn)
+        if configuration.indicator(default: .radio) == .checkmark, isOn {
+            listRow = listRow.trailing {
+                Icon(systemName: "checkmark").size(.sm).color(configuration.accentBase)
+            }
+        } else {
+            listRow = listRow.trailing(ListRowTrailing.none)
+        }
+        return listRow
+            .disabled(configuration.disabledMethods.contains(option.id))
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+}
+
+/// The dense single-line row used by `.compactList` — icon, title, badge and
+/// an optional trailing checkmark on one line, plus the inline instalment
+/// picker beneath it when this option is the selected `.card` method.
+private struct PaymentOptionCompactRow: View {
+    @Environment(\.theme) private var theme
+    let configuration: PaymentMethodSelectorConfiguration
+    let option: PaymentMethodOption
+
+    private var isOn: Bool { configuration.selectedID == option.id }
+    private var isDisabled: Bool { configuration.disabledMethods.contains(option.id) }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            PaymentOptionButton(configuration: configuration, option: option) {
+                if let optionContent = configuration.optionContent {
+                    optionContent(option, isOn)
+                } else {
+                    builtInRow
+                }
+            }
+            if isOn, let installmentsSlot = configuration.installmentsSlot {
+                installmentsSlot.padding(.bottom, configuration.spacing(.sm))
+            }
+        }
+    }
+
+    private var builtInRow: some View {
+        HStack(spacing: configuration.spacing(.sm)) {
+            if configuration.indicator(default: .radio) == .radio {
+                RadioButton(isSelected: configuration.isSelectedBinding(option.id))
+                    .accent(configuration.accent)
+            }
+            Icon(systemName: option.systemImage)
+                .size(.sm)
+                .color(isDisabled ? theme.text(.textDisabled)
+                       : (isOn ? configuration.accentBase : theme.text(.textSecondary)))
+            Text(option.title)
+                .textStyle(.labelBase600)
+                .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
+                .lineLimit(1)
+            Spacer(minLength: configuration.spacing(.xs))
+            if let badgeText = configuration.badges[option.id] {
+                Badge(badgeText).badgeStyle(configuration.badgeStyle).variant(.soft).size(.small)
+            }
+            if configuration.indicator(default: .radio) == .checkmark, isOn {
+                Icon(systemName: "checkmark").size(.sm).color(configuration.accentBase)
+            }
+        }
+        .padding(.vertical, configuration.spacing(.xs))
+    }
+}
+
+/// The shared tile anatomy for `.grid` and `.carousel` — icon, title,
+/// optional subtitle and an optional selected checkmark, on a token-filled,
+/// selection-stroked surface with a top-trailing badge overlay.
+private struct PaymentOptionTile: View {
+    @Environment(\.theme) private var theme
+    let configuration: PaymentMethodSelectorConfiguration
+    let option: PaymentMethodOption
+
+    private var isOn: Bool { configuration.selectedID == option.id }
+    private var isDisabled: Bool { configuration.disabledMethods.contains(option.id) }
+
+    /// Selected-stroke color/width from the emphasis axis — named semantic
+    /// steps only (`base` / `strong`).
+    private var selectedStroke: (color: Color, width: CGFloat) {
+        switch configuration.emphasis {
+        case .subtle: return (configuration.accentBase, 1.5)
+        case .strong: return ((configuration.accent ?? .primary).strong, 2)
+        }
+    }
+
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: configuration.radiusRole.value, style: .continuous)
+        PaymentOptionButton(configuration: configuration, option: option) {
+            Group {
+                if let optionContent = configuration.optionContent {
+                    optionContent(option, isOn)
+                } else {
+                    builtInLabel
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: Metrics.tileMinHeight)
+            .padding(configuration.spacing(.md))
+            .background(isOn ? (configuration.accent ?? .primary).bg
+                        : theme.background(configuration.surface(default: .bgBase)), in: shape)
+            .overlay(shape.stroke(isOn ? selectedStroke.color : theme.border(.borderPrimary),
+                                  lineWidth: isOn ? selectedStroke.width : 1))
+            .overlay(alignment: .topTrailing) {
+                if let badgeText = configuration.badges[option.id] {
+                    Badge(badgeText).badgeStyle(configuration.badgeStyle).variant(.soft).size(.small)
+                        .padding(configuration.spacing(.xs))
+                }
+            }
+            .contentShape(shape)
+        }
+    }
+
+    private var builtInLabel: some View {
+        VStack(spacing: configuration.spacing(.xs)) {
+            Icon(systemName: option.systemImage)
+                .size(.md)
+                .color(isDisabled ? theme.text(.textDisabled)
+                       : (isOn ? configuration.accentBase : theme.text(.textSecondary)))
+            Text(option.title)
+                .textStyle(.labelSm600)
+                .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
+                .multilineTextAlignment(.center)
+            if let subtitle = option.subtitle {
+                Text(subtitle)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textSecondary))
+                    .multilineTextAlignment(.center)
+            }
+            if configuration.indicator(default: .checkmark) == .checkmark, isOn {
+                Icon(systemName: "checkmark.circle.fill").size(.sm).color(configuration.accentBase)
+            }
+        }
+    }
+}
+
+// MARK: - .list
+
+/// Today's ``PaymentMethodSelector`` look, extracted verbatim: radio rows via
+/// the neutral `ListRow` anatomy, a hairline divider between options, and the
+/// inline instalment picker directly under the selected `.card` row.
+public struct ListPaymentMethodSelectorStyle: PaymentMethodSelectorStyle {
+    public init() {}
+    public func makeBody(configuration: PaymentMethodSelectorConfiguration) -> some View {
+        ListPaymentMethodSelectorChrome(configuration: configuration)
+    }
+}
+
+private struct ListPaymentMethodSelectorChrome: View {
+    let configuration: PaymentMethodSelectorConfiguration
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(configuration.options.enumerated()), id: \.element.id) { index, option in
+                PaymentOptionRow(configuration: configuration, option: option)
+                if index < configuration.options.count - 1 {
+                    DividerView().size(.small)
+                }
+            }
+        }
+        .selectorFrame(configuration)
+    }
+}
+
+// MARK: - .compactList
+
+/// Dense single-line rows — a compact alternative to `.list` for tight
+/// checkout summaries.
+public struct CompactListPaymentMethodSelectorStyle: PaymentMethodSelectorStyle {
+    public init() {}
+    public func makeBody(configuration: PaymentMethodSelectorConfiguration) -> some View {
+        CompactListPaymentMethodSelectorChrome(configuration: configuration)
+    }
+}
+
+private struct CompactListPaymentMethodSelectorChrome: View {
+    let configuration: PaymentMethodSelectorConfiguration
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(configuration.options.enumerated()), id: \.element.id) { index, option in
+                PaymentOptionCompactRow(configuration: configuration, option: option)
+                if index < configuration.options.count - 1 {
+                    DividerView().size(.small)
+                }
+            }
+        }
+        .selectorFrame(configuration)
+    }
+}
+
+// MARK: - .grid
+
+/// Selection tiles in a fixed-column grid (default 2 columns via
+/// `.columns(_:)`), with a vertical fallback at accessibility Dynamic Type
+/// sizes. The instalment picker, when applicable, renders once below the grid.
+public struct GridPaymentMethodSelectorStyle: PaymentMethodSelectorStyle {
+    public init() {}
+    public func makeBody(configuration: PaymentMethodSelectorConfiguration) -> some View {
+        GridPaymentMethodSelectorChrome(configuration: configuration)
+    }
+}
+
+private struct GridPaymentMethodSelectorChrome: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    let configuration: PaymentMethodSelectorConfiguration
+
+    var body: some View { content.selectorFrame(configuration) }
+
+    @ViewBuilder private var content: some View {
+        let gap = configuration.spacing(.sm)
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(spacing: gap) {
+                ForEach(configuration.options) { PaymentOptionTile(configuration: configuration, option: $0) }
+            }
+        } else {
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: gap), count: configuration.columns),
+                spacing: gap
+            ) {
+                ForEach(configuration.options) { PaymentOptionTile(configuration: configuration, option: $0) }
+            }
+        }
+        if let installmentsSlot = configuration.installmentsSlot { installmentsSlot }
+    }
+}
+
+// MARK: - .carousel
+
+/// Horizontally-snapping selection tiles — a browsable strip for a wide
+/// method list. The instalment picker, when applicable, renders once below
+/// the strip.
+public struct CarouselPaymentMethodSelectorStyle: PaymentMethodSelectorStyle {
+    public init() {}
+    public func makeBody(configuration: PaymentMethodSelectorConfiguration) -> some View {
+        CarouselPaymentMethodSelectorChrome(configuration: configuration)
+    }
+}
+
+private struct CarouselPaymentMethodSelectorChrome: View {
+    let configuration: PaymentMethodSelectorConfiguration
+
+    var body: some View { content.selectorFrame(configuration) }
+
+    @ViewBuilder private var content: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: configuration.spacing(.sm)) {
+                ForEach(configuration.options) { option in
+                    PaymentOptionTile(configuration: configuration, option: option)
+                        .frame(width: Metrics.carouselTileWidth)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.viewAligned)
+        .scrollClipDisabled()
+        if let installmentsSlot = configuration.installmentsSlot { installmentsSlot }
+    }
+}
+
+// MARK: - .sectioned
+
+/// Grouped rows under section headers — cards, wallets, then everything else
+/// (Apple Pay/wallet sheets, checkout flows with a large method catalogue).
+/// Reuses the `.list` row anatomy inside each section; empty sections collapse.
+public struct SectionedPaymentMethodSelectorStyle: PaymentMethodSelectorStyle {
+    public init() {}
+    public func makeBody(configuration: PaymentMethodSelectorConfiguration) -> some View {
+        SectionedPaymentMethodSelectorChrome(configuration: configuration)
+    }
+}
+
+private struct SectionedPaymentMethodSelectorChrome: View {
+    let configuration: PaymentMethodSelectorConfiguration
+
+    /// Cards, then wallets, then everything else — empty groups are dropped.
+    private var sections: [(title: String, options: [PaymentMethodOption])] {
+        let cards = configuration.options.filter { $0.kind == .card }
+        let wallets = configuration.options.filter { $0.kind == .wallet }
+        let other = configuration.options.filter { $0.kind != .card && $0.kind != .wallet }
+        return [
+            (String(themeKitTravel: "Cards"), cards),
+            (String(themeKitTravel: "Wallets"), wallets),
+            (String(themeKitTravel: "Other"), other),
+        ].filter { !$0.options.isEmpty }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
+            ForEach(Array(sections.enumerated()), id: \.offset) { _, section in
+                VStack(alignment: .leading, spacing: 0) {
+                    ListSectionHeader(section.title)
+                    ForEach(Array(section.options.enumerated()), id: \.element.id) { index, option in
+                        PaymentOptionRow(configuration: configuration, option: option)
+                        if index < section.options.count - 1 {
+                            DividerView().size(.small)
+                        }
+                    }
+                }
+            }
+        }
+        .selectorFrame(configuration)
+    }
+}
+
+// MARK: - Static accessors
+
+public extension PaymentMethodSelectorStyle where Self == ListPaymentMethodSelectorStyle {
+    /// Radio rows via the neutral `ListRow` anatomy. The default.
+    static var list: ListPaymentMethodSelectorStyle { ListPaymentMethodSelectorStyle() }
+}
+public extension PaymentMethodSelectorStyle where Self == GridPaymentMethodSelectorStyle {
+    /// Selection tiles (vertical fallback at accessibility Dynamic Type sizes).
+    static var grid: GridPaymentMethodSelectorStyle { GridPaymentMethodSelectorStyle() }
+}
+public extension PaymentMethodSelectorStyle where Self == CarouselPaymentMethodSelectorStyle {
+    /// Horizontally-snapping selection tiles.
+    static var carousel: CarouselPaymentMethodSelectorStyle { CarouselPaymentMethodSelectorStyle() }
+}
+public extension PaymentMethodSelectorStyle where Self == CompactListPaymentMethodSelectorStyle {
+    /// Dense single-line rows.
+    static var compactList: CompactListPaymentMethodSelectorStyle { CompactListPaymentMethodSelectorStyle() }
+}
+public extension PaymentMethodSelectorStyle where Self == SectionedPaymentMethodSelectorStyle {
+    /// Grouped rows — cards / wallets / other — each under a section header.
+    static var sectioned: SectionedPaymentMethodSelectorStyle { SectionedPaymentMethodSelectorStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyPaymentMethodSelectorStyle: PaymentMethodSelectorStyle {
+    private let _makeBody: @MainActor (PaymentMethodSelectorConfiguration) -> AnyView
+    init<S: PaymentMethodSelectorStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: PaymentMethodSelectorConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct PaymentMethodSelectorStyleKey: EnvironmentKey {
+    static let defaultValue = AnyPaymentMethodSelectorStyle(ListPaymentMethodSelectorStyle())
+}
+
+extension EnvironmentValues {
+    var paymentMethodSelectorStyle: AnyPaymentMethodSelectorStyle {
+        get { self[PaymentMethodSelectorStyleKey.self] }
+        set { self[PaymentMethodSelectorStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``PaymentMethodSelectorStyle`` for `PaymentMethodSelector`s in
+    /// this view and its descendants — one checkout screen can mix archetypes
+    /// per section.
+    func paymentMethodSelectorStyle<S: PaymentMethodSelectorStyle>(_ style: sending S) -> some View {
+        environment(\.paymentMethodSelectorStyle, AnyPaymentMethodSelectorStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a single accent-tinted card wrapping plain option rows, no radio at
+/// all (the card fill alone signals the choice).
+private struct AccentCardPaymentMethodSelectorStyle: PaymentMethodSelectorStyle {
+    func makeBody(configuration: PaymentMethodSelectorConfiguration) -> some View {
+        AccentCardChrome(configuration: configuration)
+    }
+
+    private struct AccentCardChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: PaymentMethodSelectorConfiguration
+
+        var body: some View {
+            VStack(spacing: configuration.spacing(.sm)) {
+                ForEach(configuration.options) { option in
+                    let isOn = configuration.selectedID == option.id
+                    Button { configuration.select(option.id) } label: {
+                        HStack(spacing: configuration.spacing(.sm)) {
+                            Icon(systemName: option.systemImage).size(.sm).color(configuration.accentBase)
+                            Text(option.title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+                            Spacer()
+                            if isOn {
+                                Icon(systemName: "checkmark.circle.fill").size(.sm).color(configuration.accentBase)
+                            }
+                        }
+                        .padding(configuration.spacing(.md))
+                        .background(isOn ? (configuration.accent ?? .primary).bg : theme.background(.bgBase),
+                                    in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .selectorFrame(configuration)
+        }
+    }
+}
+
+#Preview("PaymentMethodSelectorStyle — presets × light/dark") {
+    let options: [PaymentMethodOption] = [
+        .init(id: "card", kind: .card, title: "Credit / debit card"),
+        .init(id: "wallet", kind: .wallet, title: "Digital wallet", subtitle: "Pay in one tap"),
+        .init(id: "transfer", kind: .transfer, title: "Bank transfer"),
+    ]
+    PreviewMatrix("PaymentMethodSelectorStyle") {
+        PreviewCase("List (default)") {
+            PaymentMethodSelector(options, initiallySelected: "card").badge("No fee", for: "transfer")
+        }
+        PreviewCase("List · instalments") {
+            PaymentMethodSelector(options, initiallySelected: "card")
+                .installments([1, 3, 6], selection: .constant(3), total: 1_240)
+        }
+        PreviewCase("Grid") {
+            PaymentMethodSelector(options, initiallySelected: "wallet").paymentMethodSelectorStyle(.grid)
+        }
+        PreviewCase("Carousel") {
+            PaymentMethodSelector(options, initiallySelected: "card")
+                .paymentMethodSelectorStyle(.carousel).frame(width: 320)
+        }
+        PreviewCase("Compact list") {
+            PaymentMethodSelector(options, initiallySelected: "transfer").paymentMethodSelectorStyle(.compactList)
+        }
+        PreviewCase("Sectioned") {
+            PaymentMethodSelector([
+                .init(id: "card", kind: .card, title: "Visa •••• 4242"),
+                .init(id: "card2", kind: .card, title: "Corporate card"),
+                .init(id: "wallet", kind: .wallet, title: "Digital wallet"),
+                .init(id: "transfer", kind: .transfer, title: "Bank transfer"),
+            ], initiallySelected: "card")
+                .header { Text("How would you like to pay?").textStyle(.headingSm) }
+                .paymentMethodSelectorStyle(.sectioned)
+        }
+        PreviewCase("Custom (in-preview)") {
+            PaymentMethodSelector([
+                .init(id: "card", kind: .card, title: "Card"),
+                .init(id: "wallet", kind: .wallet, title: "Wallet"),
+            ], initiallySelected: "card")
+                .accent(.success)
+                .paymentMethodSelectorStyle(AccentCardPaymentMethodSelectorStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/SavedCardsList.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SavedCardsList.swift
@@ -6,7 +6,10 @@
 //  •••• last4, holder, expiry and an expired flag — with radio-semantic
 //  single-select plus delete / add-new affordances. Composes ThemeKit's
 //  neutral `ListRow` anatomy, `RadioButton`, `Badge`, `Icon`, `DividerView`
-//  and `EmptyState` — nothing is re-implemented here.
+//  and `EmptyState` — nothing is re-implemented here. Presentation is
+//  style-driven (``SavedCardsListStyle``, ADR-0004) — set once per screen via
+//  `.savedCardsListStyle(_:)`: `.list` (default, radio rows) / `.wallet`
+//  (card-face carousel) / `.stack` (Apple-Wallet fan) / `.grid` (tile grid).
 //
 //  State follows ADR-F4: controlled-first (`selection: Binding<String?>`) plus
 //  an uncontrolled preview convenience (`initiallySelected:`), both funneled
@@ -18,6 +21,7 @@
 //  SavedCardsList(cards, selection: $cardID)
 //      .onDelete { wallet.remove($0) }
 //      .onAddNew { showAddCardSheet = true }
+//      .savedCardsListStyle(.stack)
 //  ```
 //
 
@@ -26,6 +30,11 @@ import ThemeKit
 
 /// Layout archetype of a ``SavedCardsList``: radio rows (`.list`, default) or
 /// a horizontal carousel of card-face tiles (`.wallet`).
+///
+/// Superseded by ``SavedCardsListStyle`` (each case maps 1:1 to a preset,
+/// which also adds `.stack` and `.grid`); kept for source compatibility until
+/// the next major, together with the deprecated ``SavedCardsList/variant(_:)``
+/// modifier.
 public enum SavedCardsVariant: Sendable { case list, wallet }
 
 /// How the delete affordance surfaces: a trailing button (`.button`), a
@@ -36,12 +45,13 @@ public enum DeleteAffordance: Sendable { case button, contextMenu, both }
 /// optional delete and add-new affordances. Pairs with `PaymentMethodSelector`:
 /// apps typically render it when the `card` method is chosen.
 public struct SavedCardsList: View {
-    @Environment(\.theme) private var theme
     @Environment(\.locale) private var locale
     @Environment(\.calendar) private var calendar
+    @Environment(\.componentDensity) private var density
     @Environment(\.isReadOnly) private var isReadOnly
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.savedCardsListStyle) private var envStyle
 
     private let cards: [SavedCard]
     /// Selected card id — controlled or uncontrolled per init (ADR-F4).
@@ -54,7 +64,10 @@ public struct SavedCardsList: View {
     private var flagsExpiredValue = true
     private var accent: SemanticColor?
     private var emptyContentSlot: AnyView?
-    private var variantValue: SavedCardsVariant = .list
+    /// Set by the deprecated ``variant(_:)`` modifier — an explicitly chosen
+    /// per-instance style wins over an ancestor's ``savedCardsListStyle(_:)``
+    /// (source-behavior stability during the enum's deprecation window).
+    private var explicitStyle: AnySavedCardsListStyle?
     /// Per-brand glyph replacement; nil = the stock `CardBrand.icon` symbol.
     private var brandLogoSlot: ((CardBrand) -> AnyView)?
     /// `false` once the caller passed an explicit `nil` text — badge hidden,
@@ -85,14 +98,32 @@ public struct SavedCardsList: View {
     private var motion: Animation? {
         MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion)
     }
-    private var accentBase: Color { (accent ?? .primary).base }
 
-    /// The delete affordances that actually render, per `deleteStyle(_:)`.
-    private var showsDeleteButton: Bool {
-        onDeleteAction != nil && (deleteStyleValue == .button || deleteStyleValue == .both)
-    }
-    private var showsDeleteMenu: Bool {
-        onDeleteAction != nil && (deleteStyleValue == .contextMenu || deleteStyleValue == .both)
+    /// The typed configuration handed to the active ``SavedCardsListStyle``.
+    @MainActor
+    private var configuration: SavedCardsListConfiguration {
+        SavedCardsListConfiguration(
+            cards: cards,
+            selectedID: selection,
+            onSelect: { select($0) },
+            onDelete: onDeleteAction == nil ? nil : { delete($0) },
+            onAddNew: onAddNewAction,
+            addNewTitle: addNewTitle ?? String(themeKitTravel: "Add new card"),
+            flagsExpired: flagsExpiredValue,
+            brandLogo: brandLogoSlot,
+            showsExpiredBadge: showsExpiredBadge,
+            expiredBadgeText: expiredBadgeText,
+            expiredBadgeStyle: expiredBadgeStyle,
+            showsDividers: showsDividersValue,
+            deleteStyle: deleteStyleValue,
+            rowContent: rowContentSlot,
+            accent: accent,
+            surfaceKey: surfaceKeyOverride,
+            density: density,
+            locale: locale,
+            calendar: calendar,
+            isMotionEnabled: micro && !reduceMotion
+        )
     }
 
     public var body: some View {
@@ -100,247 +131,12 @@ public struct SavedCardsList: View {
             if cards.isEmpty {
                 emptyBody
             } else {
-                switch variantValue {
-                case .list: listBody
-                case .wallet: walletBody
-                }
+                (explicitStyle ?? envStyle).makeBody(configuration: configuration)
             }
         }
         .animation(motion, value: selection)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(String(themeKitTravel: "Saved cards, \(cards.count) cards"))
-    }
-
-    // MARK: List — ListRow anatomy with radio semantics
-
-    @MainActor
-    @ViewBuilder
-    private var listBody: some View {
-        let stack = VStack(spacing: 0) {
-            ForEach(cards) { card in
-                row(card)
-                if showsDividersValue, card.id != cards.last?.id || showsAddNewRow {
-                    DividerView().size(.small)
-                }
-            }
-            if showsAddNewRow { addNewRow }
-        }
-        if let surfaceKeyOverride {
-            stack.background(theme.background(surfaceKeyOverride))
-        } else {
-            stack
-        }
-    }
-
-    @MainActor
-    @ViewBuilder
-    private func row(_ card: SavedCard) -> some View {
-        let isOn = selection == card.id
-        let isExpiredRow = flagsExpiredValue && card.isExpired(calendar: calendar)
-        Group {
-            if let rowContentSlot {
-                // `.rowContent` slot: caller anatomy inside the selection
-                // button; auto-disable, context menu and VoiceOver preserved.
-                Button { select(card.id) } label: {
-                    rowContentSlot(card, isOn).contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .allowsHitTesting(!isReadOnly)
-            } else {
-                builtInRow(card, isOn: isOn, isExpiredRow: isExpiredRow)
-            }
-        }
-        .disabled(isExpiredRow)
-        .contextMenu { deleteMenu(for: card) }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel(for: card, isExpired: isExpiredRow))
-        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
-    }
-
-    @MainActor
-    private func builtInRow(_ card: SavedCard, isOn: Bool, isExpiredRow: Bool) -> some View {
-        var listRow = ListRow(maskedTitle(for: card)) { select(card.id) }
-            .subtitle(subtitle(for: card))
-            .leading {
-                HStack(spacing: Theme.SpacingKey.sm.value) {
-                    RadioButton(isSelected: isSelectedBinding(card.id)).accent(accent)
-                    brandGlyph(card.brand, isOn: isOn)
-                }
-            }
-            .selected(isOn)
-            .trailing(ListRowTrailing.none)
-        if (isExpiredRow && showsExpiredBadge) || showsDeleteButton {
-            listRow = listRow.trailing { trailingAccessories(for: card, isExpired: isExpiredRow) }
-        }
-        return listRow
-    }
-
-    /// The brand mark: the caller's `.brandLogo` slot or the stock symbol.
-    @MainActor
-    @ViewBuilder
-    private func brandGlyph(_ brand: CardBrand, isOn: Bool) -> some View {
-        if let brandLogoSlot {
-            brandLogoSlot(brand)
-        } else {
-            Icon(systemName: brand.icon)
-                .size(.sm)
-                .color(isOn ? accentBase : theme.text(.textSecondary))
-        }
-    }
-
-    /// Expired badge and/or the explicit delete affordance, trailing-aligned.
-    @MainActor
-    @ViewBuilder
-    private func trailingAccessories(for card: SavedCard, isExpired: Bool) -> some View {
-        HStack(spacing: Theme.SpacingKey.sm.value) {
-            if isExpired, showsExpiredBadge {
-                Badge(expiredBadgeText ?? String(themeKitTravel: "Expired"))
-                    .badgeStyle(expiredBadgeStyle).variant(.soft).size(.small)
-            }
-            if showsDeleteButton {
-                Button { delete(card) } label: {
-                    Icon(systemName: "trash")
-                        .size(.sm)
-                        .color(theme.foreground(.systemcolorsFgError))
-                        .frame(width: 44, height: 44)   // a11y hit target (heart precedent)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(themeKitTravel: "Remove card ending \(spacedDigits(card.last4))"))
-            }
-        }
-    }
-
-    /// Destructive context-menu entry mirroring the trailing delete button.
-    @MainActor
-    @ViewBuilder
-    private func deleteMenu(for card: SavedCard) -> some View {
-        if showsDeleteMenu, !isReadOnly {
-            Button(role: .destructive) { delete(card) } label: {
-                Label(String(themeKitTravel: "Remove card"), systemImage: "trash")
-            }
-        }
-    }
-
-    // MARK: Wallet — horizontal carousel of card-face tiles
-
-    /// Genuine dimensions with no semantic token — fixed card-face constants
-    /// (the ~1.586 bank-card aspect, sized for a phone-width carousel).
-    private enum WalletMetrics {
-        static let tileWidth: CGFloat = 200
-        static let tileHeight: CGFloat = 126
-    }
-
-    @MainActor
-    private var walletBody: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: Theme.SpacingKey.sm.value) {
-                ForEach(cards) { walletTile($0) }
-                if let onAddNewAction { addNewTile(onAddNewAction) }
-            }
-            .padding(.vertical, Theme.SpacingKey.xs.value)   // room for the lift shadow
-            .scrollTargetLayout()
-        }
-        .scrollTargetBehavior(.viewAligned)
-        .scrollClipDisabled()
-    }
-
-    @MainActor
-    private func walletTile(_ card: SavedCard) -> some View {
-        let isOn = selection == card.id
-        let isExpiredRow = flagsExpiredValue && card.isExpired(calendar: calendar)
-        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
-        return Button { select(card.id) } label: {
-            Group {
-                if let rowContentSlot {
-                    rowContentSlot(card, isOn)
-                } else {
-                    walletFace(card, isOn: isOn, isExpired: isExpiredRow)
-                }
-            }
-            .frame(width: WalletMetrics.tileWidth, height: WalletMetrics.tileHeight)
-            .background(theme.background(surfaceKeyOverride ?? .bgWhite), in: shape)
-            // Selection = lift + accent stroke (the checklist's wallet look).
-            .overlay(shape.strokeBorder(isOn ? accentBase : theme.border(.borderPrimary),
-                                        lineWidth: isOn ? 2 : 1))
-            .themeShadow(isOn ? .elevated : .soft)
-            .contentShape(shape)
-        }
-        .buttonStyle(.plain)
-        .disabled(isExpiredRow)
-        .allowsHitTesting(!isReadOnly)
-        .contextMenu { deleteMenu(for: card) }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel(for: card, isExpired: isExpiredRow))
-        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
-    }
-
-    @MainActor
-    private func walletFace(_ card: SavedCard, isOn: Bool, isExpired: Bool) -> some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
-            HStack {
-                brandGlyph(card.brand, isOn: isOn)
-                Spacer(minLength: Theme.SpacingKey.xs.value)
-                if isExpired, showsExpiredBadge {
-                    Badge(expiredBadgeText ?? String(themeKitTravel: "Expired"))
-                        .badgeStyle(expiredBadgeStyle).variant(.soft).size(.small)
-                }
-            }
-            Spacer(minLength: 0)
-            Text("•••• \(card.last4)")
-                .textStyle(.labelLg600)
-                .foregroundStyle(isExpired ? theme.text(.textDisabled) : theme.text(.textPrimary))
-            if let line = subtitle(for: card) {
-                Text(line)
-                    .textStyle(.bodySm400)
-                    .foregroundStyle(theme.text(.textTertiary))
-                    .lineLimit(1)
-            }
-        }
-        .padding(Theme.SpacingKey.md.value)
-    }
-
-    @MainActor
-    private func addNewTile(_ action: @escaping () -> Void) -> some View {
-        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
-        return Button {
-            guard !isReadOnly else { return }
-            action()
-        } label: {
-            VStack(spacing: Theme.SpacingKey.xs.value) {
-                Icon(systemName: "plus.circle.fill").size(.md).color(accentBase)
-                Text(addNewTitle ?? String(themeKitTravel: "Add new card"))
-                    .textStyle(.labelSm600)
-                    .foregroundStyle(theme.text(.textSecondary))
-            }
-            .frame(width: WalletMetrics.tileWidth, height: WalletMetrics.tileHeight)
-            .background(theme.background(surfaceKeyOverride ?? .bgWhite), in: shape)
-            .overlay(shape.strokeBorder(theme.border(.borderPrimary),
-                                        style: StrokeStyle(lineWidth: 1, dash: [5, 4])))
-            .contentShape(shape)
-        }
-        .buttonStyle(.plain)
-        .accessibilityAddTraits(.isButton)
-    }
-
-    // MARK: Add-new affordance
-
-    private var showsAddNewRow: Bool { onAddNewAction != nil }
-
-    @MainActor
-    @ViewBuilder
-    private var addNewRow: some View {
-        if let onAddNewAction {
-            ListRow(addNewTitle ?? String(themeKitTravel: "Add new card")) {
-                guard !isReadOnly else { return }
-                onAddNewAction()
-            }
-            .leading {
-                Icon(systemName: "plus.circle.fill").size(.sm).color(accentBase)
-            }
-            .trailing(ListRowTrailing.chevron)
-            .accessibilityAddTraits(.isButton)
-        }
     }
 
     // MARK: Empty (T2 slot; default EmptyState)
@@ -371,54 +167,6 @@ public struct SavedCardsList: View {
         return empty
     }
 
-    // MARK: Row text (formatted with the env locale)
-
-    /// "Visa •••• 4242"; brand-less cards render just the masked digits.
-    private func maskedTitle(for card: SavedCard) -> String {
-        let masked = "•••• \(card.last4)"
-        let brand = card.brand.label
-        return brand.isEmpty ? masked : "\(brand) \(masked)"
-    }
-
-    /// "Alex Morgan · Expires 08/28" — either part optional.
-    private func subtitle(for card: SavedCard) -> String? {
-        var parts: [String] = []
-        if let holder = card.holder, !holder.isEmpty { parts.append(holder) }
-        if let expiry = expiryText(for: card) { parts.append(expiry) }
-        return parts.isEmpty ? nil : parts.joined(separator: " · ")
-    }
-
-    private func expiryText(for card: SavedCard) -> String? {
-        guard let month = card.expiryMonth, let year = card.expiryYear else { return nil }
-        var components = DateComponents()
-        components.year = year < 100 ? year + 2000 : year
-        components.month = month
-        components.day = 1
-        guard let date = calendar.date(from: components) else { return nil }
-        let formatted = date.formatted(
-            Date.FormatStyle(calendar: calendar).month(.twoDigits).year(.twoDigits).locale(locale)
-        )
-        return String(themeKitTravel: "Expires \(formatted)")
-    }
-
-    /// "Visa card ending 4 2 4 2, Alex Morgan, Expires 08/28[, Expired]".
-    private func accessibilityLabel(for card: SavedCard, isExpired: Bool) -> String {
-        var parts: [String] = [
-            card.brand.label.isEmpty
-                ? String(themeKitTravel: "Card ending \(spacedDigits(card.last4))")
-                : String(themeKitTravel: "\(card.brand.label) card ending \(spacedDigits(card.last4))"),
-        ]
-        if let holder = card.holder, !holder.isEmpty { parts.append(holder) }
-        if let expiry = expiryText(for: card) { parts.append(expiry) }
-        if isExpired { parts.append(String(themeKitTravel: "Expired")) }
-        return parts.joined(separator: ", ")
-    }
-
-    /// Digits read out one by one: "4242" → "4 2 4 2".
-    private func spacedDigits(_ digits: String) -> String {
-        digits.map(String.init).joined(separator: " ")
-    }
-
     // MARK: Selection plumbing
 
     @MainActor
@@ -431,16 +179,6 @@ public struct SavedCardsList: View {
     private func delete(_ card: SavedCard) {
         guard !isReadOnly else { return }
         onDeleteAction?(card)
-    }
-
-    /// Radio-style binding for one card: setting `true` selects it; a card
-    /// can't be deselected by tapping its own radio.
-    @MainActor
-    private func isSelectedBinding(_ id: String) -> Binding<Bool> {
-        Binding(
-            get: { selection == id },
-            set: { if $0 { select(id) } }
-        )
     }
 }
 
@@ -478,12 +216,22 @@ public extension SavedCardsList {
         copy { $0.emptyContentSlot = AnyView(content()) }
     }
 
-    /// Layout archetype: `.list` radio rows (default) or `.wallet` — a
-    /// horizontal carousel of card-face tiles with lift + stroke selection.
-    func variant(_ v: SavedCardsVariant) -> Self { copy { $0.variantValue = v } }
+    /// Layout archetype — superseded by the style axis: prefer
+    /// `.savedCardsListStyle(.list/.wallet/.stack/.grid)`, settable once per
+    /// screen via the environment. This modifier keeps working and, when
+    /// called, wins over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .savedCardsListStyle(.list) or .savedCardsListStyle(.wallet) instead")
+    func variant(_ v: SavedCardsVariant) -> Self {
+        copy {
+            switch v {
+            case .list: $0.explicitStyle = AnySavedCardsListStyle(ListSavedCardsListStyle())
+            case .wallet: $0.explicitStyle = AnySavedCardsListStyle(WalletSavedCardsListStyle())
+            }
+        }
+    }
 
     /// Replaces the stock brand symbol with caller content, built per
-    /// ``CardBrand`` — e.g. real brand artwork. Applies to both variants.
+    /// ``CardBrand`` — e.g. real brand artwork. Applies to every style.
     func brandLogo(@ViewBuilder _ content: @escaping (CardBrand) -> some View) -> Self {
         copy { $0.brandLogoSlot = { AnyView(content($0)) } }
     }
@@ -499,16 +247,18 @@ public extension SavedCardsList {
         }
     }
 
-    /// Show the hairline dividers between list rows (default on).
+    /// Show the hairline dividers between list rows (default on). Applies to
+    /// the `.list` style only.
     func showsDividers(_ on: Bool = true) -> Self { copy { $0.showsDividersValue = on } }
 
-    /// Surface token: the list's backing fill, or the wallet tiles' card-face
-    /// fill (wallet default `.bgWhite`).
+    /// Surface token: the `.list` style's backing fill, or the tile-shaped
+    /// styles' card-face fill (default `.bgWhite` there).
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKeyOverride = key } }
 
     /// Which delete affordances render once ``onDelete(_:)`` is wired:
-    /// `.button` (trailing trash), `.contextMenu`, or `.both` (default).
-    /// The wallet variant is context-menu only — `.button` there shows none.
+    /// `.button` (trailing trash), `.contextMenu`, or `.both` (default). The
+    /// tile-shaped styles (`.wallet`/`.stack`/`.grid`) are context-menu only —
+    /// `.button` there shows none (their whole tile is already one `Button`).
     func deleteStyle(_ s: DeleteAffordance) -> Self { copy { $0.deleteStyleValue = s } }
 
     /// Replaces the built-in row/tile anatomy with caller content, built per
@@ -582,9 +332,9 @@ public extension SavedCardsList {
                         SavedCard(id: "old", brand: .amex, last4: "0005",
                                   expiryMonth: 3, expiryYear: 2020),
                     ], selection: $cardID)
-                        .variant(.wallet)
                         .onDelete { _ in }
                         .onAddNew { }
+                        .savedCardsListStyle(.wallet)
 
                     ListSectionHeader("Brand-logo slot · custom expired badge · no dividers")
                     SavedCardsList([

--- a/Sources/ThemeKitTravel/Components/Organisms/SavedCardsListStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SavedCardsListStyle.swift
@@ -1,0 +1,850 @@
+//
+//  SavedCardsListStyle.swift
+//  ThemeKitTravel
+//
+//  The styling hook for ``SavedCardsList`` (ADR-0004, Wave 3, Class A) — the
+//  configuration hands styles the *typed* card data (cards, selection, delete /
+//  add-new actions, expiry + brand chrome), not pre-laid content, so a style
+//  owns the whole arrangement. Four built-ins:
+//
+//    .list    radio rows over `ListRow` — today's default look.
+//    .wallet  a horizontal carousel of bank-card-face tiles (today's `.wallet`
+//             variant, verbatim).
+//    .stack   an overlapping pass-book fan that spreads into a vertical list on
+//             tap — the Apple Wallet card-stack pattern.
+//    .grid    a non-scrolling grid of card-face tiles (2 columns, with a
+//             vertical fallback at accessibility Dynamic Type sizes).
+//
+//      SavedCardsList(cards, selection: $cardID)
+//          .onDelete { wallet.remove($0) }
+//          .savedCardsListStyle(.stack)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the token
+//  theme colors everything. There is no `CardStyle` shell delegation here —
+//  unlike the card-shaped Class A styles, ``SavedCardsList`` never routed
+//  through `\.cardStyle`; the tile-shaped presets (`.wallet`/`.stack`/`.grid`)
+//  draw their own bank-card silhouette so a caller can theme it without also
+//  opting into the neutral `Card` chrome. The component resolves MicroMotion /
+//  Reduce Motion before calling a style — styles read
+//  ``SavedCardsListConfiguration/isMotionEnabled``, never the motion environment.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``SavedCardsListStyle`` lays out. Fields a given preset
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no `onDelete` → no delete affordance anywhere, no
+/// `onAddNew` → no add-new row/tile).
+public struct SavedCardsListConfiguration {
+    /// The stored cards to render, in caller order. Never empty — the
+    /// component renders its own `EmptyState` before reaching a style.
+    public let cards: [SavedCard]
+    /// The id of the currently selected card, or `nil` when none is selected.
+    public let selectedID: String?
+    /// Selects a card by id. Already read-only gated by the component — styles
+    /// call it directly, no `@Environment(\.isReadOnly)` check needed.
+    public let onSelect: (String) -> Void
+    /// Removes a card; `nil` hides every delete affordance. Already read-only
+    /// gated by the component.
+    public let onDelete: ((SavedCard) -> Void)?
+    /// The add-new-card action; `nil` hides the affordance. NOT pre-gated —
+    /// presets guard it with `@Environment(\.isReadOnly)` themselves, matching
+    /// the component's own empty-state primary action.
+    public let onAddNew: (() -> Void)?
+    /// Localized label for the add-new affordance — already resolved with the
+    /// caller's override or the default "Add new card".
+    public let addNewTitle: String
+    /// Whether expired cards (`SavedCard.isExpired`) auto-disable and carry the
+    /// expired badge. Set by ``SavedCardsList/flagsExpired(_:)``.
+    public let flagsExpired: Bool
+    /// Replacement for the stock brand symbol, built per ``CardBrand``; `nil`
+    /// uses the built-in `Icon`.
+    public let brandLogo: ((CardBrand) -> AnyView)?
+    /// Whether the expired badge renders at all (`false` when the caller passed
+    /// an explicit `nil` text to ``SavedCardsList/expiredBadge(_:style:)``).
+    public let showsExpiredBadge: Bool
+    /// Custom expired-badge text; `nil` uses the localized "Expired" — resolve
+    /// with ``expiredBadgeLabel()``.
+    public let expiredBadgeText: String?
+    /// The expired badge's semantic style (default `.error`).
+    public let expiredBadgeStyle: BadgeStyle
+    /// Whether row-shaped presets draw hairline dividers between cards.
+    public let showsDividers: Bool
+    /// Which delete affordances render once ``onDelete`` is set.
+    public let deleteStyle: DeleteAffordance
+    /// Replacement for the built-in row/tile anatomy, built per
+    /// `(card, isSelected)`; `nil` uses the preset's own anatomy.
+    public let rowContent: ((SavedCard, Bool) -> AnyView)?
+    /// Semantic tint for the radio / brand glyph / add-new chrome; `nil` uses
+    /// the theme's primary triad.
+    public let accent: SemanticColor?
+    /// Explicit surface fill, or `nil` to let the preset choose its own default
+    /// (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — every date/number
+    /// string (expiry, spoken digits) honors it.
+    public let locale: Locale
+    /// The environment calendar, captured by the component — used for the
+    /// expiry math and the formatted expiry string.
+    public let calendar: Calendar
+    /// Micro-animations resolved by the component (`microAnimations` ∧ ¬Reduce
+    /// Motion) — gate fan/expand transitions on this; never read the motion
+    /// environment directly.
+    public let isMotionEnabled: Bool
+
+    /// Whether `card` is the current selection.
+    public func isSelected(_ card: SavedCard) -> Bool { selectedID == card.id }
+    /// Whether `card` reads as expired for this configuration
+    /// (``flagsExpired`` ∧ `SavedCard.isExpired`, using the captured calendar).
+    public func isExpired(_ card: SavedCard) -> Bool {
+        flagsExpired && card.isExpired(calendar: calendar)
+    }
+    /// The explicit `surface(_:)` override, or the preset's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out a preset.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+    /// The `accent(_:)` override's base, else the theme's primary triad — the
+    /// value the built-ins hardcoded before the accent axis existed.
+    public func accentBase(_ theme: Theme) -> Color { (accent ?? .primary).base }
+    /// The expired badge's resolved text.
+    public func expiredBadgeLabel() -> String { expiredBadgeText ?? String(themeKitTravel: "Expired") }
+
+    /// Whether a trailing delete button renders. Row-shaped presets only —
+    /// tile-shaped presets are a single whole-tile `Button`, so a nested
+    /// trailing button would fight the tap gesture; they stay context-menu-only.
+    public var showsDeleteButton: Bool {
+        onDelete != nil && (deleteStyle == .button || deleteStyle == .both)
+    }
+    /// Whether the destructive context-menu entry renders.
+    public var showsDeleteMenu: Bool {
+        onDelete != nil && (deleteStyle == .contextMenu || deleteStyle == .both)
+    }
+
+    /// Radio-style binding for one card: setting `true` selects it through
+    /// ``onSelect``; a card can't be deselected by tapping its own radio.
+    public func selectionBinding(for card: SavedCard) -> Binding<Bool> {
+        Binding(get: { isSelected(card) }, set: { if $0 { onSelect(card.id) } })
+    }
+
+    // Shared formatting, so every preset speaks one language.
+
+    /// "Visa •••• 4242"; brand-less cards render just the masked digits.
+    public func title(for card: SavedCard) -> String {
+        let masked = "•••• \(card.last4)"
+        let brand = card.brand.label
+        return brand.isEmpty ? masked : "\(brand) \(masked)"
+    }
+    /// "Alex Morgan · Expires 08/28" — either part optional.
+    public func subtitle(for card: SavedCard) -> String? {
+        var parts: [String] = []
+        if let holder = card.holder, !holder.isEmpty { parts.append(holder) }
+        if let expiry = expiryText(for: card) { parts.append(expiry) }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+    /// "Expires 08/28", formatted with the captured locale + calendar.
+    public func expiryText(for card: SavedCard) -> String? {
+        guard let month = card.expiryMonth, let year = card.expiryYear else { return nil }
+        var components = DateComponents()
+        components.year = year < 100 ? year + 2000 : year
+        components.month = month
+        components.day = 1
+        guard let date = calendar.date(from: components) else { return nil }
+        let formatted = date.formatted(
+            Date.FormatStyle(calendar: calendar).month(.twoDigits).year(.twoDigits).locale(locale)
+        )
+        return String(themeKitTravel: "Expires \(formatted)")
+    }
+    /// "Visa card ending 4 2 4 2, Alex Morgan, Expires 08/28[, Expired]".
+    public func accessibilityLabel(for card: SavedCard) -> String {
+        var parts: [String] = [
+            card.brand.label.isEmpty
+                ? String(themeKitTravel: "Card ending \(spacedDigits(card.last4))")
+                : String(themeKitTravel: "\(card.brand.label) card ending \(spacedDigits(card.last4))"),
+        ]
+        if let holder = card.holder, !holder.isEmpty { parts.append(holder) }
+        if let expiry = expiryText(for: card) { parts.append(expiry) }
+        if isExpired(card) { parts.append(String(themeKitTravel: "Expired")) }
+        return parts.joined(separator: ", ")
+    }
+    /// Digits read out one by one: "4242" → "4 2 4 2".
+    public func spacedDigits(_ digits: String) -> String {
+        digits.map(String.init).joined(separator: " ")
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `SavedCardsList`'s entire presentation. Implement `makeBody` to
+/// lay out the configuration's card data. Set one with `.savedCardsListStyle(_:)`;
+/// the default is ``ListSavedCardsListStyle``.
+public protocol SavedCardsListStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: SavedCardsListConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The brand mark: the caller's `.brandLogo` slot or the stock symbol. Shared
+/// by every preset.
+private struct SavedCardBrandGlyph: View {
+    @Environment(\.theme) private var theme
+    let configuration: SavedCardsListConfiguration
+    let card: SavedCard
+    let isOn: Bool
+
+    var body: some View {
+        if let brandLogo = configuration.brandLogo {
+            brandLogo(card.brand)
+        } else {
+            Icon(systemName: card.brand.icon)
+                .size(.sm)
+                .color(isOn ? configuration.accentBase(theme) : theme.text(.textSecondary))
+        }
+    }
+}
+
+/// The "Expired" badge, shared by every preset.
+private struct SavedCardExpiredBadge: View {
+    let configuration: SavedCardsListConfiguration
+    let card: SavedCard
+
+    var body: some View {
+        if configuration.isExpired(card), configuration.showsExpiredBadge {
+            Badge(configuration.expiredBadgeLabel())
+                .badgeStyle(configuration.expiredBadgeStyle).variant(.soft).size(.small)
+        }
+    }
+}
+
+/// The trailing trash button — row-shaped presets only. See
+/// ``SavedCardsListConfiguration/showsDeleteButton``.
+private struct SavedCardDeleteButton: View {
+    @Environment(\.theme) private var theme
+    let configuration: SavedCardsListConfiguration
+    let card: SavedCard
+
+    var body: some View {
+        Button {
+            configuration.onDelete?(card)
+        } label: {
+            Icon(systemName: "trash")
+                .size(.sm)
+                .color(theme.foreground(.systemcolorsFgError))
+                .frame(width: 44, height: 44)   // a11y hit target
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(themeKitTravel: "Remove card ending \(configuration.spacedDigits(card.last4))"))
+    }
+}
+
+/// Destructive context-menu entry, shared by every preset. Hidden (not merely
+/// disabled) while read-only, matching the component's pre-style behavior.
+private struct SavedCardDeleteMenu: View {
+    @Environment(\.isReadOnly) private var isReadOnly
+    let configuration: SavedCardsListConfiguration
+    let card: SavedCard
+
+    var body: some View {
+        if configuration.showsDeleteMenu, !isReadOnly {
+            Button(role: .destructive) { configuration.onDelete?(card) } label: {
+                Label(String(themeKitTravel: "Remove card"), systemImage: "trash")
+            }
+        }
+    }
+}
+
+/// The "card face" tile anatomy shared by every tile-shaped preset — a bank
+/// card silhouette: brand glyph + expired badge up top, masked digits mid,
+/// holder/expiry line at the bottom.
+private struct SavedCardFaceTile: View {
+    @Environment(\.theme) private var theme
+    let configuration: SavedCardsListConfiguration
+    let card: SavedCard
+    let isOn: Bool
+
+    var body: some View {
+        let isExpiredCard = configuration.isExpired(card)
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
+            HStack {
+                SavedCardBrandGlyph(configuration: configuration, card: card, isOn: isOn)
+                Spacer(minLength: Theme.SpacingKey.xs.value)
+                SavedCardExpiredBadge(configuration: configuration, card: card)
+            }
+            Spacer(minLength: 0)
+            Text("•••• \(card.last4)")
+                .textStyle(.labelLg600)
+                .foregroundStyle(isExpiredCard ? theme.text(.textDisabled) : theme.text(.textPrimary))
+            if let line = configuration.subtitle(for: card) {
+                Text(line)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(theme.text(.textTertiary))
+                    .lineLimit(1)
+            }
+        }
+        .padding(Theme.SpacingKey.md.value)
+    }
+}
+
+/// Fixed frame when `width` is given (the wallet carousel); otherwise fills the
+/// parent's width at a fixed height (grid cells / the expanded stack).
+private extension View {
+    @ViewBuilder
+    func tileFrame(width: CGFloat?, height: CGFloat) -> some View {
+        if let width {
+            frame(width: width, height: height)
+        } else {
+            frame(maxWidth: .infinity, minHeight: height, maxHeight: height)
+        }
+    }
+
+    /// Shared tile chrome: surface fill, selection stroke, lift shadow — every
+    /// tile-shaped preset draws the same bank-card shell.
+    func savedCardTileChrome(_ configuration: SavedCardsListConfiguration, isOn: Bool) -> some View {
+        modifier(SavedCardTileChromeModifier(configuration: configuration, isOn: isOn))
+    }
+}
+
+private struct SavedCardTileChromeModifier: ViewModifier {
+    @Environment(\.theme) private var theme
+    let configuration: SavedCardsListConfiguration
+    let isOn: Bool
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+        content
+            .background(theme.background(configuration.surface(default: .bgWhite)), in: shape)
+            .overlay(shape.strokeBorder(isOn ? configuration.accentBase(theme) : theme.border(.borderPrimary),
+                                        lineWidth: isOn ? 2 : 1))
+            .themeShadow(isOn ? .elevated : .soft)
+            .contentShape(shape)
+    }
+}
+
+/// One selectable card-face tile — the whole tile is a `Button`, so its delete
+/// affordance is context-menu-only (see
+/// ``SavedCardsListConfiguration/showsDeleteButton``'s doc). Shared by
+/// `.wallet`, `.grid` and `.stack`'s expanded spread.
+private struct SavedCardTile: View {
+    @Environment(\.isReadOnly) private var isReadOnly
+    let configuration: SavedCardsListConfiguration
+    let card: SavedCard
+    var width: CGFloat?
+    var height: CGFloat
+
+    var body: some View {
+        let isOn = configuration.isSelected(card)
+        let isExpiredRow = configuration.isExpired(card)
+        Button { configuration.onSelect(card.id) } label: {
+            Group {
+                if let rowContent = configuration.rowContent {
+                    rowContent(card, isOn)
+                } else {
+                    SavedCardFaceTile(configuration: configuration, card: card, isOn: isOn)
+                }
+            }
+            .tileFrame(width: width, height: height)
+            .savedCardTileChrome(configuration, isOn: isOn)
+        }
+        .buttonStyle(.plain)
+        .disabled(isExpiredRow)
+        .allowsHitTesting(!isReadOnly)
+        .contextMenu { SavedCardDeleteMenu(configuration: configuration, card: card) }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(configuration.accessibilityLabel(for: card))
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+}
+
+/// The dashed "Add new card" tile — shared by `.wallet`, `.grid` and `.stack`.
+private struct SavedCardAddNewTile: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.isReadOnly) private var isReadOnly
+    let configuration: SavedCardsListConfiguration
+    var width: CGFloat?
+    var height: CGFloat
+    let action: () -> Void
+
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+        Button {
+            guard !isReadOnly else { return }
+            action()
+        } label: {
+            VStack(spacing: Theme.SpacingKey.xs.value) {
+                Icon(systemName: "plus.circle.fill").size(.md).color(configuration.accentBase(theme))
+                Text(configuration.addNewTitle)
+                    .textStyle(.labelSm600)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+            .tileFrame(width: width, height: height)
+            .background(theme.background(configuration.surface(default: .bgWhite)), in: shape)
+            .overlay(shape.strokeBorder(theme.border(.borderPrimary),
+                                        style: StrokeStyle(lineWidth: 1, dash: [5, 4])))
+            .contentShape(shape)
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+/// The trailing "Add new card" `ListRow` — row-shaped presets.
+private struct SavedCardAddNewRow: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.isReadOnly) private var isReadOnly
+    let configuration: SavedCardsListConfiguration
+
+    var body: some View {
+        ListRow(configuration.addNewTitle) {
+            guard !isReadOnly else { return }
+            configuration.onAddNew?()
+        }
+        .leading {
+            Icon(systemName: "plus.circle.fill").size(.sm).color(configuration.accentBase(theme))
+        }
+        .trailing(ListRowTrailing.chevron)
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+// MARK: - .list
+
+/// Today's ``SavedCardsList`` look, extracted verbatim: `ListRow` radio rows —
+/// leading `RadioButton` + brand glyph, masked title + holder/expiry subtitle,
+/// trailing expired badge and/or delete button, hairline dividers, an optional
+/// "Add new card" row. Default.
+public struct ListSavedCardsListStyle: SavedCardsListStyle {
+    public init() {}
+    public func makeBody(configuration: SavedCardsListConfiguration) -> some View {
+        ListSavedCardsListChrome(configuration: configuration)
+    }
+}
+
+private struct ListSavedCardsListChrome: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.isReadOnly) private var isReadOnly
+    let configuration: SavedCardsListConfiguration
+
+    private var showsAddNewRow: Bool { configuration.onAddNew != nil }
+
+    var body: some View {
+        let stack = VStack(spacing: 0) {
+            ForEach(configuration.cards) { card in
+                row(card)
+                if configuration.showsDividers, card.id != configuration.cards.last?.id || showsAddNewRow {
+                    DividerView().size(.small)
+                }
+            }
+            if showsAddNewRow {
+                SavedCardAddNewRow(configuration: configuration)
+            }
+        }
+        if let surfaceKey = configuration.surfaceKey {
+            stack.background(theme.background(surfaceKey))
+        } else {
+            stack
+        }
+    }
+
+    @MainActor
+    @ViewBuilder
+    private func row(_ card: SavedCard) -> some View {
+        let isOn = configuration.isSelected(card)
+        let isExpiredRow = configuration.isExpired(card)
+        Group {
+            if let rowContent = configuration.rowContent {
+                // `.rowContent` slot: caller anatomy inside the selection
+                // button; auto-disable, context menu and VoiceOver preserved.
+                Button { configuration.onSelect(card.id) } label: {
+                    rowContent(card, isOn).contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .allowsHitTesting(!isReadOnly)
+            } else {
+                builtInRow(card, isOn: isOn, isExpiredRow: isExpiredRow)
+            }
+        }
+        .disabled(isExpiredRow)
+        .contextMenu { SavedCardDeleteMenu(configuration: configuration, card: card) }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(configuration.accessibilityLabel(for: card))
+        .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
+    }
+
+    @MainActor
+    private func builtInRow(_ card: SavedCard, isOn: Bool, isExpiredRow: Bool) -> some View {
+        var listRow = ListRow(configuration.title(for: card)) { configuration.onSelect(card.id) }
+            .subtitle(configuration.subtitle(for: card))
+            .leading {
+                HStack(spacing: Theme.SpacingKey.sm.value) {
+                    RadioButton(isSelected: configuration.selectionBinding(for: card)).accent(configuration.accent)
+                    SavedCardBrandGlyph(configuration: configuration, card: card, isOn: isOn)
+                }
+            }
+            .selected(isOn)
+            .trailing(ListRowTrailing.none)
+        if (isExpiredRow && configuration.showsExpiredBadge) || configuration.showsDeleteButton {
+            listRow = listRow.trailing { trailingAccessories(for: card) }
+        }
+        return listRow
+    }
+
+    /// Expired badge and/or the explicit delete affordance, trailing-aligned.
+    @MainActor
+    @ViewBuilder
+    private func trailingAccessories(for card: SavedCard) -> some View {
+        HStack(spacing: Theme.SpacingKey.sm.value) {
+            SavedCardExpiredBadge(configuration: configuration, card: card)
+            if configuration.showsDeleteButton {
+                SavedCardDeleteButton(configuration: configuration, card: card)
+            }
+        }
+    }
+}
+
+// MARK: - .wallet
+
+/// Today's `.wallet` variant, extracted verbatim: a horizontal
+/// `ScrollView` of bank-card-face tiles — lift shadow + accent stroke on
+/// selection, an optional dashed "Add new card" tile trailing the carousel.
+/// Delete is context-menu-only (the whole tile is one `Button`).
+public struct WalletSavedCardsListStyle: SavedCardsListStyle {
+    public init() {}
+    public func makeBody(configuration: SavedCardsListConfiguration) -> some View {
+        WalletSavedCardsListChrome(configuration: configuration)
+    }
+}
+
+private enum TileMetrics {
+    // Genuine dimensions with no semantic token — the ~1.586 bank-card aspect,
+    // sized for a phone-width carousel / grid cell.
+    static let width: CGFloat = 200
+    static let height: CGFloat = 126
+}
+
+private struct WalletSavedCardsListChrome: View {
+    let configuration: SavedCardsListConfiguration
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                ForEach(configuration.cards) { card in
+                    SavedCardTile(configuration: configuration, card: card,
+                                  width: TileMetrics.width, height: TileMetrics.height)
+                }
+                if let onAddNew = configuration.onAddNew {
+                    SavedCardAddNewTile(configuration: configuration,
+                                        width: TileMetrics.width, height: TileMetrics.height, action: onAddNew)
+                }
+            }
+            .padding(.vertical, Theme.SpacingKey.xs.value)   // room for the lift shadow
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.viewAligned)
+        .scrollClipDisabled()
+    }
+}
+
+// MARK: - .stack (new)
+
+/// An overlapping pass-book fan — the Apple Wallet card-stack pattern. Tap the
+/// collapsed fan to spread every card into a vertical list; tap a card there to
+/// select it, or collapse back with the chevron. A single card behaves like a
+/// plain tile (tap selects it directly — nothing to spread into).
+public struct StackSavedCardsListStyle: SavedCardsListStyle {
+    public init() {}
+    public func makeBody(configuration: SavedCardsListConfiguration) -> some View {
+        StackSavedCardsListChrome(configuration: configuration)
+    }
+}
+
+private enum StackMetrics {
+    // Genuine dimensions with no semantic token — the pass-book fan geometry.
+    static let width: CGFloat = 280
+    static let height: CGFloat = 168
+    static let peekOffset: CGFloat = 30
+    static let maxPeek = 3           // cards drawn behind the front card while collapsed
+    static let depthScaleStep: CGFloat = 0.04
+}
+
+private struct StackSavedCardsListChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: SavedCardsListConfiguration
+    @State private var isExpanded = false
+
+    private var motionAnimation: Animation? {
+        configuration.isMotionEnabled ? Motion.base.spring : nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            if isExpanded {
+                expandedStack
+            } else {
+                collapsedStack
+            }
+        }
+        .animation(motionAnimation, value: isExpanded)
+    }
+
+    // MARK: Collapsed — overlapping peek fan, tap to spread
+
+    private var collapsedStack: some View {
+        let peekCount = min(configuration.cards.count - 1, StackMetrics.maxPeek)
+        let height = StackMetrics.height + CGFloat(peekCount) * StackMetrics.peekOffset
+        return Button {
+            if configuration.cards.count > 1 {
+                isExpanded = true
+            } else if let only = configuration.cards.first {
+                configuration.onSelect(only.id)
+            }
+        } label: {
+            ZStack(alignment: .top) {
+                ForEach(Array(configuration.cards.prefix(peekCount + 1).enumerated()).reversed(),
+                        id: \.element.id) { depth, card in
+                    peekFace(card, depth: depth)
+                        .offset(y: CGFloat(depth) * StackMetrics.peekOffset)
+                }
+            }
+            .frame(width: StackMetrics.width, height: height, alignment: .top)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(collapsedAccessibilityLabel)
+        .accessibilityHint(configuration.cards.count > 1
+            ? String(themeKitTravel: "Shows every card in the stack") : "")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var collapsedAccessibilityLabel: String {
+        if configuration.cards.count == 1, let only = configuration.cards.first {
+            return configuration.accessibilityLabel(for: only)
+        }
+        return String(themeKitTravel: "Saved cards, \(configuration.cards.count) cards, collapsed")
+    }
+
+    private func peekFace(_ card: SavedCard, depth: Int) -> some View {
+        let scale = 1 - CGFloat(depth) * StackMetrics.depthScaleStep
+        let isOn = configuration.isSelected(card)
+        return Group {
+            if let rowContent = configuration.rowContent {
+                rowContent(card, isOn)
+            } else {
+                SavedCardFaceTile(configuration: configuration, card: card, isOn: isOn)
+            }
+        }
+        .frame(width: StackMetrics.width, height: StackMetrics.height)
+        .savedCardTileChrome(configuration, isOn: isOn)
+        .scaleEffect(scale, anchor: .top)
+        .accessibilityHidden(true)   // the collapsed button carries one summary label
+    }
+
+    // MARK: Expanded — vertical spread; tap a card to select it
+
+    private var expandedStack: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            collapseButton
+            ForEach(configuration.cards) { card in
+                SavedCardTile(configuration: configuration, card: card, width: nil, height: StackMetrics.height)
+            }
+            if let onAddNew = configuration.onAddNew {
+                SavedCardAddNewTile(configuration: configuration, width: nil, height: StackMetrics.height,
+                                    action: onAddNew)
+            }
+        }
+    }
+
+    private var collapseButton: some View {
+        Button {
+            isExpanded = false
+        } label: {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                Icon(systemName: "chevron.up").size(.xs).color(theme.text(.textSecondary))
+                Text(String(themeKitTravel: "Collapse"))
+                    .textStyle(.labelSm600)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(themeKitTravel: "Collapse saved cards stack"))
+    }
+}
+
+// MARK: - .grid (new)
+
+/// A non-scrolling grid of bank-card-face tiles (2 columns), with a vertical
+/// single-column fallback at accessibility Dynamic Type sizes — mirrors
+/// `PaymentMethodSelector`'s `.grid` a11y behavior. Delete is context-menu-only
+/// (the whole tile is one `Button`).
+public struct GridSavedCardsListStyle: SavedCardsListStyle {
+    public init() {}
+    public func makeBody(configuration: SavedCardsListConfiguration) -> some View {
+        GridSavedCardsListChrome(configuration: configuration)
+    }
+}
+
+private struct GridSavedCardsListChrome: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    let configuration: SavedCardsListConfiguration
+
+    private static let columnCount = 2
+
+    var body: some View {
+        let gap = configuration.spacing(.sm)
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(spacing: gap) { tiles }
+        } else {
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: gap), count: Self.columnCount),
+                spacing: gap
+            ) { tiles }
+        }
+    }
+
+    @ViewBuilder
+    private var tiles: some View {
+        ForEach(configuration.cards) { card in
+            SavedCardTile(configuration: configuration, card: card, width: nil, height: TileMetrics.height)
+        }
+        if let onAddNew = configuration.onAddNew {
+            SavedCardAddNewTile(configuration: configuration, width: nil, height: TileMetrics.height,
+                                action: onAddNew)
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension SavedCardsListStyle where Self == ListSavedCardsListStyle {
+    /// `ListRow` radio rows — today's card list. The default.
+    static var list: ListSavedCardsListStyle { ListSavedCardsListStyle() }
+}
+public extension SavedCardsListStyle where Self == WalletSavedCardsListStyle {
+    /// A horizontal carousel of bank-card-face tiles.
+    static var wallet: WalletSavedCardsListStyle { WalletSavedCardsListStyle() }
+}
+public extension SavedCardsListStyle where Self == StackSavedCardsListStyle {
+    /// An overlapping pass-book fan that spreads into a vertical list on tap.
+    static var stack: StackSavedCardsListStyle { StackSavedCardsListStyle() }
+}
+public extension SavedCardsListStyle where Self == GridSavedCardsListStyle {
+    /// A non-scrolling 2-column grid of bank-card-face tiles.
+    static var grid: GridSavedCardsListStyle { GridSavedCardsListStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnySavedCardsListStyle: SavedCardsListStyle {
+    private let _makeBody: @MainActor (SavedCardsListConfiguration) -> AnyView
+    init<S: SavedCardsListStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: SavedCardsListConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct SavedCardsListStyleKey: EnvironmentKey {
+    static let defaultValue = AnySavedCardsListStyle(ListSavedCardsListStyle())
+}
+
+extension EnvironmentValues {
+    var savedCardsListStyle: AnySavedCardsListStyle {
+        get { self[SavedCardsListStyleKey.self] }
+        set { self[SavedCardsListStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``SavedCardsListStyle`` for `SavedCardsList`s in this view and
+    /// its descendants — one screen can mix archetypes per section.
+    func savedCardsListStyle<S: SavedCardsListStyle>(_ style: sending S) -> some View {
+        environment(\.savedCardsListStyle, AnySavedCardsListStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// Proves external implementability: a plain badge-row list built purely from
+/// the public configuration + theme tokens — no ThemeKit-internal APIs beyond
+/// what any app target could reach.
+private struct BadgeRowSavedCardsListStyle: SavedCardsListStyle {
+    func makeBody(configuration: SavedCardsListConfiguration) -> some View {
+        BadgeRowChrome(configuration: configuration)
+    }
+
+    private struct BadgeRowChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: SavedCardsListConfiguration
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: configuration.spacing(.xs)) {
+                ForEach(configuration.cards) { card in
+                    Button { configuration.onSelect(card.id) } label: {
+                        HStack(spacing: configuration.spacing(.sm)) {
+                            Badge(card.brand.label.isEmpty ? "Card" : card.brand.label)
+                                .badgeStyle(configuration.isSelected(card) ? .success : .info)
+                                .size(.small)
+                            Text(configuration.title(for: card))
+                                .textStyle(.labelBase600)
+                                .foregroundStyle(theme.text(.textPrimary))
+                            Spacer(minLength: 0)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+}
+
+#Preview("SavedCardsListStyle — presets × light/dark") {
+    struct Demo: View {
+        @State private var cardID: String? = "visa"
+        let cards = [
+            SavedCard(id: "visa", brand: .visa, last4: "4242",
+                      holder: "Alex Morgan", expiryMonth: 8, expiryYear: 2032),
+            SavedCard(id: "mc", brand: .mastercard, last4: "4444",
+                      holder: "Alex Morgan", expiryMonth: 1, expiryYear: 2031),
+            SavedCard(id: "old", brand: .amex, last4: "0005",
+                      holder: "Alex Morgan", expiryMonth: 3, expiryYear: 2020),
+        ]
+
+        var body: some View {
+            PreviewMatrix("SavedCardsListStyle") {
+                PreviewCase("List (default)") {
+                    SavedCardsList(cards, selection: $cardID).onDelete { _ in }.onAddNew { }
+                }
+                PreviewCase("Wallet") {
+                    SavedCardsList(cards, selection: $cardID)
+                        .onDelete { _ in }.onAddNew { }
+                        .savedCardsListStyle(.wallet)
+                }
+                PreviewCase("Stack") {
+                    SavedCardsList(cards, selection: $cardID)
+                        .onDelete { _ in }.onAddNew { }
+                        .savedCardsListStyle(.stack)
+                }
+                PreviewCase("Grid") {
+                    SavedCardsList(cards, selection: $cardID)
+                        .onDelete { _ in }.onAddNew { }
+                        .savedCardsListStyle(.grid)
+                        .frame(width: 320)
+                }
+                PreviewCase("Custom (in-preview)") {
+                    SavedCardsList(cards, selection: $cardID)
+                        .savedCardsListStyle(BadgeRowSavedCardsListStyle())
+                }
+            }
+        }
+    }
+    return Demo()
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/StickyBookingBar.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/StickyBookingBar.swift
@@ -7,17 +7,25 @@
 //  left and a primary action on the right. Token-bound; pin it with
 //  `.safeAreaInset(edge: .bottom) { StickyBookingBar(…) }`.
 //
-//  Chrome is style-driven: set a ``BarStyle`` with `.barStyle(_:)` and the bar
-//  hands its price + CTA row to the style as a `.bottom`-edge
-//  ``BarStyleConfiguration`` (`surface(_:)` / `showsShadow(_:)` still win over
-//  the style's own fill/shadow). With no style set, the original chrome — flat
-//  fill, top hairline overlay, tab-bar shadow — renders pixel-identically
-//  (that shadowed chrome cannot be produced by the stock `DefaultBarStyle`,
-//  so the untouched default keeps the legacy look).
+//  Two independent style axes (ADR-0004 §6):
+//  - **Content** — set a ``StickyBookingBarStyle`` with `.stickyBookingBarStyle(_:)`
+//    to rearrange the price block / CTA / secondary-CTA units (`.standard`
+//    default, `.stacked`, `.split`, or a custom style). The component still
+//    owns every live control (the CTA's action/`.enabled`/`.loading`, the
+//    price-tap disclosure, the secondary action) — styles arrange the
+//    pre-wired units, never re-wire them (`StickyBookingBarStyle.swift`).
+//  - **Chrome** — set a ``BarStyle`` with `.barStyle(_:)` and the bar hands its
+//    arranged content to the style as a `.bottom`-edge ``BarStyleConfiguration``
+//    (`surface(_:)` / `showsShadow(_:)` still win over the style's own
+//    fill/shadow). With no `BarStyle` set, the original chrome — flat fill,
+//    top hairline overlay, tab-bar shadow — renders pixel-identically (that
+//    shadowed chrome cannot be produced by the stock `DefaultBarStyle`, so the
+//    untouched default keeps the legacy look).
 //
 //  ```swift
 //  StickyBookingBar("Book now") { checkout() }
 //      .price(9_600).original(12_000).discountBadge("-20%").note("2 rooms · 4 nights")
+//      .stickyBookingBarStyle(.stacked)
 //  ```
 //
 
@@ -28,6 +36,7 @@ public struct StickyBookingBar: View {
     @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
     @Environment(\.barStyle) private var barStyle
+    @Environment(\.stickyBookingBarStyle) private var style
     @Environment(\.formatDefaults) private var formatDefaults
     @Environment(\.locale) private var locale
     @Environment(\.controlSize) private var controlSize   // R3 — native size axis
@@ -69,19 +78,21 @@ public struct StickyBookingBar: View {
     }
 
     public var body: some View {
+        let arranged = style.makeBody(configuration: configuration)
         if barStyle.isDefault {
             // No `.barStyle(_:)` set — the original flat fill + top hairline
             // overlay + tab-bar shadow.
-            row
+            arranged
                 .background(theme.background(surfaceOverride ?? .bgWhite))
                 .overlay(alignment: .top) { Rectangle().fill(theme.border(.borderPrimary)).frame(height: 1) }
                 .modifier(BarShadow(on: showsShadowOverride ?? true))
         } else {
-            // The whole price + CTA row is the configuration's content — both
-            // blocks are far wider than the 44pt accessory slots the built-in
-            // styles overlay, so neither maps to leading/trailing.
+            // The active `StickyBookingBarStyle`'s arranged content is the
+            // configuration's content — both blocks are far wider than the
+            // 44pt accessory slots the built-in `BarStyle`s overlay, so
+            // neither maps to leading/trailing.
             barStyle.makeBody(configuration: BarStyleConfiguration(leading: nil,
-                                                                   content: AnyView(row),
+                                                                   content: arranged,
                                                                    trailing: nil,
                                                                    edge: .bottom))
                 .environment(\.barChromeOverrides,
@@ -90,26 +101,31 @@ public struct StickyBookingBar: View {
         }
     }
 
-    private var row: some View {
-        HStack(alignment: .center, spacing: density.scale(Theme.SpacingKey.md.value)) {
-            if let leadingSlot {
-                leadingSlot
-            } else {
-                priceBlock
-            }
-            Spacer(minLength: 8)
-            if let trailingSlot {
-                trailingSlot
-            } else {
-                ctaArea
-            }
-        }
-        .padding(.horizontal, density.scale(Theme.SpacingKey.md.value))
-        .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
-        .frame(maxWidth: .infinity)
+    /// The pre-wired units + typed signals handed to the active
+    /// ``StickyBookingBarStyle`` (ADR-0004, Class B) — this component keeps
+    /// every live control (action, `.enabled`, `.loading`, price-tap); styles
+    /// only arrange the units below, never re-wire them.
+    private var configuration: StickyBookingBarConfiguration {
+        StickyBookingBarConfiguration(
+            // `priceBlockContent` also renders a chevron-only tap target when
+            // `.onPriceTap(_:)` is set without a price — nil out only when
+            // there is truly nothing to show (matches the pre-style render).
+            priceBlock: (price == nil && onPriceTapAction == nil) ? nil : AnyView(priceBlockContent),
+            cta: AnyView(ctaButton),
+            secondaryCta: secondaryCtaUnit,
+            leading: leadingSlot,
+            trailing: trailingSlot,
+            hasPrice: price != nil,
+            discountBadge: discountText,
+            isEnabled: isEnabled,
+            isLoading: isLoading,
+            accent: accent,
+            surfaceKey: surfaceOverride,
+            density: density,
+            locale: locale)
     }
 
-    @ViewBuilder private var priceBlock: some View {
+    @ViewBuilder private var priceBlockContent: some View {
         if let onPriceTapAction {
             Button { onPriceTapAction() } label: {
                 HStack(spacing: Theme.SpacingKey.xs.value) {
@@ -136,20 +152,23 @@ public struct StickyBookingBar: View {
         return b
     }
 
-    /// The action cluster: an optional outline secondary button beside the CTA.
-    private var ctaArea: some View {
-        HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            if let secondaryTitle, let onSecondary {
-                ThemeButton(secondaryTitle) { onSecondary() }
-                    .color(accentSemantic).variant(.outline).size(ctaSize)
-                    .disabled(!isEnabled)
-            }
-            button
-        }
+    /// The outline secondary action beside the CTA (`.secondaryAction(_:action:)`),
+    /// or `nil` when unset. `.fullWidth()`-capable so `.stacked`/`.split`
+    /// styles can stretch it; `.standard` restores its intrinsic footprint
+    /// with `.fixedSize(horizontal:vertical:)` (see `StickyBookingBarStyle`).
+    private var secondaryCtaUnit: AnyView? {
+        guard let secondaryTitle, let onSecondary else { return nil }
+        return AnyView(
+            ThemeButton(secondaryTitle) { onSecondary() }
+                .color(accentSemantic).variant(.outline).size(ctaSize).fullWidth()
+                .disabled(!isEnabled)
+        )
     }
 
-    private var button: some View {
-        themeButton.disabled(!isEnabled)
+    /// The primary CTA, `.fullWidth()`-capable for the same reason as
+    /// ``secondaryCtaUnit``.
+    private var ctaButton: some View {
+        themeButton.fullWidth().disabled(!isEnabled)
     }
     private var themeButton: ThemeButton {
         var b = ThemeButton(ctaTitle) { action() }.color(accentSemantic).size(ctaSize).loading(isLoading)

--- a/Sources/ThemeKitTravel/Components/Organisms/StickyBookingBarStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/StickyBookingBarStyle.swift
@@ -1,0 +1,334 @@
+//
+//  StickyBookingBarStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``StickyBookingBar`` (ADR-0004, Wave 3 — Class B). The
+//  bar owns every *live control* — the CTA's action/`.enabled`/`.loading`, the
+//  price-tap disclosure, the secondary action — so re-wiring them per style
+//  would duplicate interaction logic. Instead the configuration hands styles
+//  **pre-wired, type-erased units** (a price block, a primary CTA, an optional
+//  secondary CTA) plus typed signals; styles arrange the units, never re-wire
+//  them. Three built-ins:
+//
+//    .standard  price block left / CTA (+ secondary) right — today's bar. Default.
+//    .stacked   note+price above a full-width CTA (+ secondary at its natural width)
+//    .split     secondary and primary share the row evenly — a paired action row
+//
+//      StickyBookingBar("Book now") { checkout() }
+//          .price(9_600).original(12_000).discountBadge("-20%")
+//          .stickyBookingBarStyle(.stacked)
+//
+//  One law (ADR-0004 §6, unchanged from before this ADR): this protocol
+//  arranges *content*; the bar's `BarStyle` chrome (surface fill, hairline,
+//  shadow) stays **outside** this protocol and keeps painting around whatever
+//  a `StickyBookingBarStyle` arranges — `.barStyle(_:)` still reskins the
+//  chrome independently of `.stickyBookingBarStyle(_:)`. The token theme
+//  colors everything.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The pre-wired inputs a ``StickyBookingBarStyle`` arranges. `cta` and
+/// `secondaryCta` are built `.fullWidth()`-capable so `.stacked`/`.split` can
+/// stretch them edge-to-edge; ``StandardStickyBookingBarStyle`` restores the
+/// classic content-sized footprint with `.fixedSize(horizontal:vertical:)`
+/// (a pure layout ask, not a re-wire — see its chrome). Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no price → no price block, no secondary action →
+/// no secondary slot).
+public struct StickyBookingBarConfiguration {
+    /// The built-in price display — note, struck original, discount badge and
+    /// price (`PriceBreakdown`), wrapped in a disclosure-chevron button when
+    /// `.onPriceTap(_:)` was set. `nil` precisely when ``hasPrice`` is `false`.
+    public let priceBlock: AnyView?
+    /// The primary CTA — title, icon, color, `.enabled`/`.loading` fully wired.
+    /// Built `.fullWidth()`-capable (see the type header).
+    public let cta: AnyView
+    /// An outline secondary action beside the CTA (`.secondaryAction(_:action:)`),
+    /// `nil` when unset. Also built `.fullWidth()`-capable.
+    public let secondaryCta: AnyView?
+    /// Full replacement for the price side (`.leading { }`) — wins over ``priceBlock``.
+    public let leading: AnyView?
+    /// Full replacement for the CTA side (`.trailing { }`) — wins over ``cta``/``secondaryCta``.
+    public let trailing: AnyView?
+
+    /// Whether a price was set — precisely when ``priceBlock`` is non-nil.
+    public let hasPrice: Bool
+    /// The raw discount text (e.g. "-20%"), already rendered inline inside
+    /// ``priceBlock`` — exposed for styles that want it *outside* the price
+    /// stack (a corner ribbon, a chip next to the CTA…).
+    public let discountBadge: String?
+    /// `.enabled(_:)` — already baked into ``cta``/``secondaryCta``; exposed so
+    /// a style can dim or hide accessories it adds of its own.
+    public let isEnabled: Bool
+    /// `.loading(_:)` — already baked into ``cta``.
+    public let isLoading: Bool
+    /// Brand-chrome accent (`.accent(_:)`), or `nil` for the theme's hero
+    /// tokens — the color already baked into ``cta``/``secondaryCta``.
+    public let accent: SemanticColor?
+    /// Explicit surface fill (`.surface(_:)`), or `nil` to let the active
+    /// `BarStyle` choose its own — resolve via ``surface(default:)``.
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component.
+    public let locale: Locale
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so `.componentDensity`
+    /// compacts or airs out the bar.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+}
+
+// MARK: - Protocol
+
+/// Defines a `StickyBookingBar`'s content arrangement — the price/CTA units,
+/// never the bar chrome. Implement `makeBody` to lay out the configuration's
+/// pre-wired units. Set one with `.stickyBookingBarStyle(_:)`; the default is
+/// ``StandardStickyBookingBarStyle``. The active ``BarStyle`` (`.barStyle(_:)`)
+/// still paints the surface/hairline/shadow around whatever this style
+/// arranges (ADR-0004 §6) — that delegation is unchanged by this protocol.
+public protocol StickyBookingBarStyle {
+    associatedtype Body: View
+    @MainActor @ViewBuilder func makeBody(configuration: StickyBookingBarConfiguration) -> Body
+}
+
+// MARK: - .standard (default — today's bar, verbatim)
+
+/// Price block left, CTA (+ optional outline secondary) right — today's
+/// ``StickyBookingBar`` look, extracted verbatim.
+public struct StandardStickyBookingBarStyle: StickyBookingBarStyle {
+    public init() {}
+    public func makeBody(configuration: StickyBookingBarConfiguration) -> some View {
+        StandardStickyBookingBarChrome(configuration: configuration)
+    }
+}
+
+private struct StandardStickyBookingBarChrome: View {
+    let configuration: StickyBookingBarConfiguration
+
+    var body: some View {
+        HStack(alignment: .center, spacing: configuration.spacing(.md)) {
+            if let leading = configuration.leading {
+                leading
+            } else if let priceBlock = configuration.priceBlock {
+                priceBlock
+            }
+            Spacer(minLength: 8)
+            if let trailing = configuration.trailing {
+                trailing
+            } else {
+                ctaArea
+            }
+        }
+        .padding(.horizontal, configuration.spacing(.md))
+        .padding(.vertical, configuration.spacing(.sm))
+        .frame(maxWidth: .infinity)
+    }
+
+    /// The pre-wired CTA units restored to their intrinsic footprint.
+    /// `.fixedSize(horizontal:vertical:)` asks each unit for its own ideal
+    /// width instead of the space this row would otherwise offer it, which
+    /// reproduces the classic content-sized, trailing-aligned CTA
+    /// pixel-for-pixel even though both units are `.fullWidth()`-capable.
+    private var ctaArea: some View {
+        HStack(spacing: configuration.spacing(.sm)) {
+            if let secondaryCta = configuration.secondaryCta {
+                secondaryCta.fixedSize(horizontal: true, vertical: false)
+            }
+            configuration.cta.fixedSize(horizontal: true, vertical: false)
+        }
+    }
+}
+
+// MARK: - .stacked (note+price above a full-width CTA)
+
+/// The price block on its own row, a full-width CTA beneath it — an outline
+/// secondary action (when set) keeps its natural width leading the CTA row.
+/// Reads better than `.standard` at narrow widths or with a long CTA title.
+public struct StackedStickyBookingBarStyle: StickyBookingBarStyle {
+    public init() {}
+    public func makeBody(configuration: StickyBookingBarConfiguration) -> some View {
+        StackedStickyBookingBarChrome(configuration: configuration)
+    }
+}
+
+private struct StackedStickyBookingBarChrome: View {
+    let configuration: StickyBookingBarConfiguration
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            if let leading = configuration.leading {
+                leading
+            } else if let priceBlock = configuration.priceBlock {
+                priceBlock
+            }
+            ctaRow
+        }
+        .padding(.horizontal, configuration.spacing(.md))
+        .padding(.vertical, configuration.spacing(.sm))
+        .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder private var ctaRow: some View {
+        if let trailing = configuration.trailing {
+            trailing
+        } else {
+            HStack(spacing: configuration.spacing(.sm)) {
+                if let secondaryCta = configuration.secondaryCta {
+                    secondaryCta.fixedSize(horizontal: true, vertical: false)
+                }
+                configuration.cta   // left `.fullWidth()` — stretches to fill the row
+            }
+        }
+    }
+}
+
+// MARK: - .split (secondary + primary action pair)
+
+/// An optional price block on top, then the secondary and primary actions
+/// sharing the row evenly beneath it — a paired confirm/cancel-style row.
+/// With no secondary action set, the CTA alone fills the row (same footprint
+/// as `.stacked`'s CTA row).
+public struct SplitStickyBookingBarStyle: StickyBookingBarStyle {
+    public init() {}
+    public func makeBody(configuration: StickyBookingBarConfiguration) -> some View {
+        SplitStickyBookingBarChrome(configuration: configuration)
+    }
+}
+
+private struct SplitStickyBookingBarChrome: View {
+    let configuration: StickyBookingBarConfiguration
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+            if let leading = configuration.leading {
+                leading
+            } else if let priceBlock = configuration.priceBlock {
+                priceBlock
+            }
+            actionRow
+        }
+        .padding(.horizontal, configuration.spacing(.md))
+        .padding(.vertical, configuration.spacing(.sm))
+        .frame(maxWidth: .infinity)
+    }
+
+    /// Secondary and primary share the row evenly — both units are built
+    /// `.fullWidth()`-capable, so an unadorned `HStack` splits the available
+    /// width between them without either needing an explicit fraction.
+    @ViewBuilder private var actionRow: some View {
+        if let trailing = configuration.trailing {
+            trailing
+        } else if let secondaryCta = configuration.secondaryCta {
+            HStack(spacing: configuration.spacing(.sm)) {
+                secondaryCta
+                configuration.cta
+            }
+        } else {
+            configuration.cta
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension StickyBookingBarStyle where Self == StandardStickyBookingBarStyle {
+    /// Price block left / CTA (+ secondary) right — today's bar. The default.
+    static var standard: StandardStickyBookingBarStyle { StandardStickyBookingBarStyle() }
+}
+public extension StickyBookingBarStyle where Self == StackedStickyBookingBarStyle {
+    /// Note+price above a full-width CTA — reads better at narrow widths.
+    static var stacked: StackedStickyBookingBarStyle { StackedStickyBookingBarStyle() }
+}
+public extension StickyBookingBarStyle where Self == SplitStickyBookingBarStyle {
+    /// Secondary and primary actions share the row evenly — a paired action row.
+    static var split: SplitStickyBookingBarStyle { SplitStickyBookingBarStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyStickyBookingBarStyle: StickyBookingBarStyle {
+    private let _makeBody: @MainActor (StickyBookingBarConfiguration) -> AnyView
+    init<S: StickyBookingBarStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: StickyBookingBarConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct StickyBookingBarStyleKey: EnvironmentKey {
+    static let defaultValue = AnyStickyBookingBarStyle(StandardStickyBookingBarStyle())
+}
+
+extension EnvironmentValues {
+    var stickyBookingBarStyle: AnyStickyBookingBarStyle {
+        get { self[StickyBookingBarStyleKey.self] }
+        set { self[StickyBookingBarStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``StickyBookingBarStyle`` for `StickyBookingBar`s in this view
+    /// and its descendants. Independent of `.barStyle(_:)` (ADR-0004 §6): this
+    /// arranges the price/CTA content, `.barStyle(_:)` paints the bar chrome
+    /// around it.
+    func stickyBookingBarStyle<S: StickyBookingBarStyle>(_ style: sending S) -> some View {
+        environment(\.stickyBookingBarStyle, AnyStickyBookingBarStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — proves the protocol is
+/// externally implementable: an accent ribbon built from the raw
+/// `discountBadge` *signal* (not the pre-wired `priceBlock` unit) beside the
+/// action pair.
+private struct RibbonStickyBookingBarStyle: StickyBookingBarStyle {
+    func makeBody(configuration: StickyBookingBarConfiguration) -> some View {
+        RibbonChrome(configuration: configuration)
+    }
+
+    private struct RibbonChrome: View {
+        let configuration: StickyBookingBarConfiguration
+
+        var body: some View {
+            HStack(spacing: configuration.spacing(.sm)) {
+                if let discountBadge = configuration.discountBadge {
+                    Badge(discountBadge).badgeStyle(.error).variant(.solid).size(.small)
+                }
+                Spacer(minLength: configuration.spacing(.sm))
+                if let secondaryCta = configuration.secondaryCta {
+                    secondaryCta.fixedSize(horizontal: true, vertical: false)
+                }
+                configuration.cta.fixedSize(horizontal: true, vertical: false)
+            }
+            .padding(configuration.spacing(.md))
+        }
+    }
+}
+
+#Preview("StickyBookingBarStyle — presets × light/dark") {
+    let priced = StickyBookingBar("Book now") { }
+        .note("2 rooms · 4 nights").original(12_000).discountBadge("-20%").price(9_600).ctaIcon("arrow.right")
+    let withSecondary = StickyBookingBar("Continue") { }
+        .price(4_320).note("2 travellers").secondaryAction("Hold fare") { }
+    let noPrice = StickyBookingBar("Confirm") { }
+        .secondaryAction("Cancel") { }
+    return PreviewMatrix("StickyBookingBarStyle") {
+        PreviewCase("Standard (default)") { priced }
+        PreviewCase("Standard · with secondary") { withSecondary }
+        PreviewCase("Stacked") { priced.stickyBookingBarStyle(.stacked) }
+        PreviewCase("Stacked · with secondary") { withSecondary.stickyBookingBarStyle(.stacked) }
+        PreviewCase("Split · action pair") { withSecondary.stickyBookingBarStyle(.split) }
+        PreviewCase("Split · no price") { noPrice.stickyBookingBarStyle(.split) }
+        PreviewCase("Custom (in-preview)") { withSecondary.stickyBookingBarStyle(RibbonStickyBookingBarStyle()) }
+    }
+}

--- a/Sources/ThemeKitTravel/Resources/Localizable.xcstrings
+++ b/Sources/ThemeKitTravel/Resources/Localizable.xcstrings
@@ -113,6 +113,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Cards": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Cards you save at checkout will appear here.": {
       "extractionState": "manual",
       "generatesSymbol": false
@@ -134,6 +138,14 @@
       "generatesSymbol": false
     },
     "Clear recent airports": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Collapse": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Collapse saved cards stack": {
       "extractionState": "manual",
       "generatesSymbol": false
     },
@@ -265,6 +277,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Other": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Passengers": {
       "extractionState": "manual",
       "generatesSymbol": false
@@ -313,11 +329,19 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Saved cards, %@ cards, collapsed": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Search flights": {
       "extractionState": "manual",
       "generatesSymbol": false
     },
     "See options": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Shows every card in the stack": {
       "extractionState": "manual",
       "generatesSymbol": false
     },
@@ -358,6 +382,10 @@
       "generatesSymbol": false
     },
     "Visa required": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Wallets": {
       "extractionState": "manual",
       "generatesSymbol": false
     },

--- a/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
+++ b/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
@@ -35,7 +35,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) card ending \(d)",
             "%@ card ending %@", 2,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsList.swift:409")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsListStyle.swift:171")
         assertKey(
             "\(d) children",
             "%@ children", 1,
@@ -52,6 +52,10 @@ final class L10nKeyInvariantTests: XCTestCase {
             "\(d) installments",
             "%@ installments", 1,
             site: "Sources/ThemeKit/Components/Molecules/InstallmentPicker.swift:56")
+        assertKey(
+            "\(d) items",
+            "%@ items", 1,
+            site: "Sources/ThemeKitTravel/Components/Organisms/FareSummaryStyle.swift:488")
         assertKey(
             "\(d) left",
             "%@ left", 1,
@@ -120,13 +124,13 @@ final class L10nKeyInvariantTests: XCTestCase {
             "\(d)% saturation, \(d)% brightness",
             "%@%% saturation, %@%% brightness", 2,
             site: "Sources/ThemeKit/Components/Molecules/ColorArea.swift:126")
+    }
+
+    func testInterpolatedKeyShapes2() {
         assertKey(
             "\(d)% to \(d)",
             "%@%% to %@", 2,
             site: "Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift:169")
-    }
-
-    func testInterpolatedKeyShapes2() {
         assertKey(
             "\(d)/mo",
             "%@/mo", 1,
@@ -178,7 +182,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Card ending \(d)",
             "Card ending %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsList.swift:408")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsListStyle.swift:170")
         assertKey(
             "Close \(d)",
             "Close %@", 1,
@@ -202,7 +206,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Expires \(d)",
             "Expires %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsList.swift:401")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsListStyle.swift:164")
         assertKey(
             "Increase \(d)",
             "Increase %@", 1,
@@ -214,7 +218,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "More about \(d)",
             "More about %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/FareSummary.swift:101")
+            site: "Sources/ThemeKitTravel/Components/Organisms/FareSummaryStyle.swift:154")
         assertKey(
             "Move to \(d)",
             "Move to %@", 1,
@@ -223,13 +227,13 @@ final class L10nKeyInvariantTests: XCTestCase {
             "Page \(d)",
             "Page %@", 1,
             site: "Sources/ThemeKit/Components/Molecules/Pagination.swift:131")
+    }
+
+    func testInterpolatedKeyShapes3() {
         assertKey(
             "Page \(d) of \(d)",
             "Page %@ of %@", 2,
             site: "Sources/ThemeKit/Components/Organisms/PagingCarousel.swift:84")
-    }
-
-    func testInterpolatedKeyShapes3() {
         assertKey(
             "Passenger \(d), seat \(d)",
             "Passenger %@, seat %@", 2,
@@ -237,7 +241,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Payment method, \(d) options",
             "Payment method, %@ options", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelector.swift:118")
+            site: "Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelector.swift:165")
         assertKey(
             "React with \(d), \(d) reactions",
             "React with %@, %@ reactions", 2,
@@ -249,7 +253,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Remove card ending \(d)",
             "Remove card ending %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsList.swift:209")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsListStyle.swift:246")
         assertKey(
             "Resend code in \(d)s",
             "Resend code in %@s", 1,
@@ -261,7 +265,11 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Saved cards, \(d) cards",
             "Saved cards, %@ cards", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsList.swift:111")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsList.swift:139")
+        assertKey(
+            "Saved cards, \(d) cards, collapsed",
+            "Saved cards, %@ cards, collapsed", 1,
+            site: "Sources/ThemeKitTravel/Components/Organisms/SavedCardsListStyle.swift:633")
         assertKey(
             "Seat \(d)",
             "Seat %@", 1,

--- a/docs/templates/ThemeKit.xcstrings
+++ b/docs/templates/ThemeKit.xcstrings
@@ -30,6 +30,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "%@ items": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "%@ left": {
       "comment": "Text shown in the trailing corner of a text input, indicating how many characters are left to be entered. The argument is the number of remaining characters.",
       "extractionState": "manual",
@@ -378,6 +382,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Cards": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Cards you save at checkout will appear here.": {
       "extractionState": "manual",
       "generatesSymbol": false
@@ -450,6 +458,14 @@
       "generatesSymbol": false
     },
     "Collapse actions": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Collapse fare details": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Collapse saved cards stack": {
       "extractionState": "manual",
       "generatesSymbol": false
     },
@@ -661,6 +677,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Expand fare details": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Expanded": {
       "comment": "Accessibility value of an open dropdown trigger.",
       "extractionState": "manual",
@@ -756,6 +776,10 @@
       "generatesSymbol": false
     },
     "Hex color": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Hide breakdown": {
       "extractionState": "manual",
       "generatesSymbol": false
     },
@@ -1232,6 +1256,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Saved cards, %@ cards, collapsed": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Score": {
       "comment": "ScoreBadge: VoiceOver label.",
       "extractionState": "manual",
@@ -1305,6 +1333,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Show breakdown": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Show fare breakdown": {
       "extractionState": "manual",
       "generatesSymbol": false
@@ -1325,6 +1357,10 @@
       "generatesSymbol": false
     },
     "Show preview": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Shows every card in the stack": {
       "extractionState": "manual",
       "generatesSymbol": false
     },
@@ -1526,6 +1562,10 @@
       "generatesSymbol": false
     },
     "Visa required": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "Wallets": {
       "extractionState": "manual",
       "generatesSymbol": false
     },


### PR DESCRIPTION
Third wave of **ADR-0004** (per-component Style protocols). Six Booking-&-payment components each gain their own full Style protocol — five Class-A plus `StickyBookingBar` (Class-B). Every default preset reproduces today's render pixel-for-pixel; additive.

| Component | Protocol → modifier | Presets | Class |
|---|---|---|---|
| PaymentMethodSelector | `.paymentMethodSelectorStyle(_:)` | `.list` · `.grid` · `.carousel` · `.compactList` · `.sectioned` | A |
| SavedCardsList | `.savedCardsListStyle(_:)` | `.list` · `.wallet` · `.stack` · `.grid` | A |
| FareFamilyCard | `.fareFamilyCardStyle(_:)` | `.stacked` · `.column` · `.row` · `.accordion` | A |
| FareSummary | `.fareSummaryStyle(_:)` | `.list` · `.receipt` · `.collapsed` | A |
| AncillaryCard | `.ancillaryCardStyle(_:)` | `.row` · `.tile` · `.banner` | A |
| StickyBookingBar | `.stickyBookingBarStyle(_:)` | `.standard` · `.stacked` · `.split` | B |

**22 presets** across 6 protocols.

## Notes
- **StickyBookingBar (Class B):** hands styles the pre-wired price-block + CTA units; the `BarStyle` chrome delegation stays **outside** the new protocol (component arranges content → hands it to the active `BarStyle`). 
- **FareSummary:** money hues stay **semantic-fixed** (discount green, hero total) — no accent axis.
- **Deprecate-forward:** existing `.variant(_:)`/`.layout(_:)` deprecate-forward to the style accessors; explicit modifier wins over the env style; enums stay public (removed next major).
- **l10n** catalogs regenerated (drift gate green).
- **Known follow-up:** 34 deprecation *warnings* at un-migrated Demo/Tests call sites — harmless (renders identically); to be swept before the enums are removed.

## Build note
Implemented by parallel `sr-ios-dev` agents; integration fixed 3 root compile issues (two `return`-in-`ViewBuilder` previews + a preview modifier-ordering sweep — style env modifier must be last in the chain).

## Verification
`swift build` **0 errors** · **312 tests pass** (incl. l10n gate) · **Demo BUILD SUCCEEDED** (iOS Simulator; 34 non-fatal deprecation warnings).

Part of the ADR-0004 6-wave plan. Waves 4–5 to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)