### PR TITLE
feat(travel): Style-protocol Wave 4 — Passenger & day-of-travel cluster (ADR-0004)

### DIFF
--- a/Sources/ThemeKitCore/Resources/Localizable.xcstrings
+++ b/Sources/ThemeKitCore/Resources/Localizable.xcstrings
@@ -780,6 +780,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Now boarding": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Occupied": {
       "comment": "A description of a seat's state: \"Occupied\", \"Selected\" or \"Available\".",
       "extractionState": "manual",

--- a/Sources/ThemeKitTravel/Components/Molecules/LayoverRow.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/LayoverRow.swift
@@ -4,27 +4,34 @@
 //
 //  Molecule. A connection / layover indicator between two flight segments — a
 //  centered pill ("2h 15m layover · Istanbul (IST)") flanked by dashed lines, with
-//  an optional short/long-connection warning. Token-bound.
+//  an optional short/long-connection warning. Presentation is style-driven
+//  (``LayoverRowStyle``, ADR-0004) — set once per screen via
+//  `.layoverRowStyle(_:)`. Token-bound.
 //
 //  ```swift
 //  LayoverRow(duration: "2h 15m", airport: "Istanbul (IST)").warning("Short connection")
+//      .layoverRowStyle(.pill)   // .line (default) / .pill / .banner
 //  ```
 //
 
 import SwiftUI
 import ThemeKit
 
-/// Presentation of a ``LayoverRow``: the stock centered `.line` label, a soft
-/// `.pill` capsule sitting on the lines, or a full-width tinted `.banner` band.
+/// Presentation of a ``LayoverRow`` — superseded by ``LayoverRowStyle`` (each
+/// case maps 1:1 to a preset — `.line`/`.pill`/`.banner`); kept for source
+/// compatibility until the next major, together with the deprecated
+/// ``LayoverRow/variant(_:)`` modifier.
 public enum LayoverVariant: Sendable { case line, pill, banner }
 
 /// Style of the flanking connector lines: `.dashed` (default), `.solid`, or
-/// `.hidden` (lines removed; the label stays centered).
+/// `.hidden` (lines removed; the label stays centered). Stays a knob — it
+/// composes with every ``LayoverRowStyle`` preset rather than being one.
 public enum LayoverLineStyle: Sendable { case dashed, solid, hidden }
 
 public struct LayoverRow: View {
-    @Environment(\.theme) private var theme
+    @Environment(\.layoverRowStyle) private var envStyle
     @Environment(\.componentDensity) private var density
+    @Environment(\.locale) private var locale
 
     private let duration: String
     private let airport: String
@@ -37,80 +44,33 @@ public struct LayoverRow: View {
     private var layoverLabel: String { layoverLabelOverride ?? String(themeKit: "layover") }
     private var systemImage = "clock.arrow.2.circlepath"
     private var accent: SemanticColor?
-    private var variant: LayoverVariant = .line
     private var lineStyleValue: LayoverLineStyle = .dashed
+    /// Set by the deprecated ``variant(_:)`` modifier — an explicitly chosen
+    /// per-instance style wins over an ancestor's `.layoverRowStyle(_:)`
+    /// (source-behavior stability during the enum's deprecation window).
+    private var explicitStyle: AnyLayoverRowStyle?
 
     public init(duration: String, airport: String) {   // R1
         self.duration = duration
         self.airport = airport
     }
 
-    private var warningColor: Color { warningTone?.base ?? theme.foreground(.systemcolorsFgWarning) }
-    private var accentBase: Color { warningText != nil ? warningColor : ((accent ?? .neutral).base) }
-    /// Semantic tone that tints the pill / banner chrome.
-    private var chromeTone: SemanticColor { warningText != nil ? (warningTone ?? .warning) : (accent ?? .neutral) }
-
     public var body: some View {
-        VStack(spacing: 4) {
-            switch variant {
-            case .line:
-                HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-                    lines
-                    labelContent
-                    lines
-                }
-            case .pill:
-                HStack(spacing: 0) {
-                    lines
-                    labelContent
-                        .padding(.horizontal, density.scale(Theme.SpacingKey.sm.value))
-                        .padding(.vertical, Theme.SpacingKey.xs.value)
-                        .background(chromeTone.soft, in: Capsule(style: .continuous))
-                    lines
-                }
-            case .banner:
-                labelContent
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
-                    .padding(.horizontal, Theme.SpacingKey.sm.value)
-                    .background(chromeTone.bg,
-                                in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
-            }
-            if let warningText {
-                HStack(spacing: 4) {
-                    Image(systemName: "exclamationmark.triangle.fill").textStyle(.overline500)
-                    Text(warningText).textStyle(.overline400)
-                }
-                .foregroundStyle(warningColor)
-            }
-        }
+        let configuration = LayoverRowConfiguration(
+            duration: duration, airport: airport,
+            warningText: warningText, warningTone: warningTone,
+            layoverLabel: layoverLabel, systemImage: systemImage,
+            lineStyle: lineStyleValue, accent: accent,
+            density: density, locale: locale
+        )
+        (explicitStyle ?? envStyle).makeBody(configuration: configuration)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilitySummary(configuration))
     }
 
-    private var labelContent: some View {
-        HStack(spacing: 5) {
-            Image(systemName: systemImage).textStyle(.labelSm600).foregroundStyle(accentBase)
-            Text("\(duration) \(layoverLabel) · \(airport)")
-                .textStyle(.overline500).foregroundStyle(theme.text(.textSecondary)).fixedSize()
-        }
-    }
-
-    @ViewBuilder private var lines: some View {
-        switch lineStyleValue {
-        case .dashed:
-            Line().stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
-                .frame(height: 1).frame(maxWidth: .infinity)
-        case .solid:
-            Line().stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: 1))
-                .frame(height: 1).frame(maxWidth: .infinity)
-        case .hidden:
-            Color.clear.frame(height: 1).frame(maxWidth: .infinity)
-        }
-    }
-
-    private struct Line: Shape {
-        func path(in rect: CGRect) -> Path {
-            Path { p in p.move(to: CGPoint(x: 0, y: rect.midY)); p.addLine(to: CGPoint(x: rect.width, y: rect.midY)) }
-        }
+    private func accessibilitySummary(_ configuration: LayoverRowConfiguration) -> String {
+        guard let warningText else { return configuration.label }
+        return "\(configuration.label). \(warningText)"
     }
 }
 
@@ -124,9 +84,20 @@ public extension LayoverRow {
     func warning(_ text: String?, tone: SemanticColor = .warning) -> Self {
         copy { $0.warningText = text; $0.warningTone = tone }
     }
-    /// Presentation: the stock centered `.line` label (default), a soft `.pill`
-    /// capsule on the lines, or a full-width tinted `.banner` band.
-    func variant(_ v: LayoverVariant) -> Self { copy { $0.variant = v } }
+    /// Presentation — superseded by the style axis: prefer
+    /// `.layoverRowStyle(.line/.pill/.banner)`, settable once per screen via
+    /// the environment. This modifier keeps working and, when called, wins
+    /// over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .layoverRowStyle(.line/.pill/.banner) instead")
+    func variant(_ v: LayoverVariant) -> Self {
+        copy {
+            switch v {
+            case .line: $0.explicitStyle = AnyLayoverRowStyle(LineLayoverRowStyle())
+            case .pill: $0.explicitStyle = AnyLayoverRowStyle(PillLayoverRowStyle())
+            case .banner: $0.explicitStyle = AnyLayoverRowStyle(BannerLayoverRowStyle())
+            }
+        }
+    }
     /// Style of the flanking connector lines — `.dashed` (default), `.solid`,
     /// or `.hidden`.
     func lineStyle(_ s: LayoverLineStyle) -> Self { copy { $0.lineStyleValue = s } }
@@ -147,8 +118,12 @@ public extension LayoverRow {
         PreviewCase("Default") { LayoverRow(duration: "2h 15m", airport: "Istanbul (IST)") }
         PreviewCase("Warning") { LayoverRow(duration: "0h 45m", airport: "Ankara (ESB)").warning("Short connection — 45 min") }
         PreviewCase("Accent + icon") { LayoverRow(duration: "5h 30m", airport: "Frankfurt (FRA)").accent(.info).icon("airplane.arrival") }
-        PreviewCase("Pill") { LayoverRow(duration: "2h 15m", airport: "Istanbul (IST)").variant(.pill).accent(.info) }
-        PreviewCase("Banner") { LayoverRow(duration: "5h 30m", airport: "Frankfurt (FRA)").variant(.banner).accent(.info) }
+        PreviewCase("Pill") {
+            LayoverRow(duration: "2h 15m", airport: "Istanbul (IST)").accent(.info).layoverRowStyle(.pill)
+        }
+        PreviewCase("Banner") {
+            LayoverRow(duration: "5h 30m", airport: "Frankfurt (FRA)").accent(.info).layoverRowStyle(.banner)
+        }
         PreviewCase("Solid + hidden lines") {
             VStack(spacing: 12) {
                 LayoverRow(duration: "1h 05m", airport: "Vienna (VIE)").lineStyle(.solid)
@@ -157,8 +132,11 @@ public extension LayoverRow {
         }
         PreviewCase("Warning tone (error)") {
             LayoverRow(duration: "0h 35m", airport: "Ankara (ESB)")
-                .variant(.pill)
                 .warning("Very short connection — 35 min", tone: .error)
+                .layoverRowStyle(.pill)
+        }
+        PreviewCase("Deprecated .variant(_:) still works") {
+            LayoverRow(duration: "2h 15m", airport: "Istanbul (IST)").variant(.banner).accent(.success)
         }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Molecules/LayoverRowStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/LayoverRowStyle.swift
@@ -1,0 +1,346 @@
+//
+//  LayoverRowStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``LayoverRow`` — promotes the former ``LayoverVariant``
+//  enum (ADR-0004) so the connector's presentation is a swappable style,
+//  settable once per screen via the environment. Three built-ins map 1:1 to
+//  the old variant cases:
+//
+//    .line    the stock centered label flanked by connector lines — default
+//    .pill    the label sits in a soft, tone-tinted capsule on the lines
+//    .banner  a full-width tone-tinted band, no flanking lines
+//
+//      LayoverRow(duration: "2h 15m", airport: "Istanbul (IST)")
+//          .warning("Short connection")
+//          .layoverRowStyle(.pill)
+//
+//  Component style arranges content; the token theme colors everything. The
+//  flanking connector is drawn with a horizontal `Path`, which is symmetric
+//  under mirroring, so no `.flipsForRightToLeftLayoutDirection(true)` is
+//  needed (unlike an asymmetric arc/curve).
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``LayoverRowStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no warning → no warning line, no space reserved).
+public struct LayoverRowConfiguration {
+    /// Layover duration, already formatted by the caller ("2h 15m").
+    public let duration: String
+    /// Airport label, e.g. "Istanbul (IST)".
+    public let airport: String
+    /// A short/long-connection warning shown below; `nil` hides the line.
+    public let warningText: String?
+    /// The warning's semantic tone (`.warning(_:tone:)`); resolved against
+    /// ``warningColor(_:)`` — falls back to `.warning` chrome, the theme's
+    /// warning foreground for the raw color.
+    public let warningTone: SemanticColor?
+    /// Localised "layover" word (English default), re-resolved every body
+    /// pass so a live language switch is never frozen at init.
+    public let layoverLabel: String
+    /// SF Symbol for the connector's centered glyph (`.icon(_:)`).
+    public let systemImage: String
+    /// Style of the flanking connector lines — `.dashed` (default), `.solid`,
+    /// or `.hidden`. Stays a knob (not a preset): it composes with every style.
+    public let lineStyle: LayoverLineStyle
+    /// Brand-chrome accent (`.accent(_:)`), or `nil` for the neutral default.
+    public let accent: SemanticColor?
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component. No dates/numbers
+    /// are formatted here today; carried for additive-safe future use and so
+    /// custom styles can format against the caller's locale.
+    public let locale: Locale
+
+    /// "2h 15m layover · Istanbul (IST)" — the connector's centered label.
+    public var label: String { "\(duration) \(layoverLabel) · \(airport)" }
+    /// `true` when a connection warning was set.
+    public var hasWarning: Bool { warningText != nil }
+    /// The warning's resolved color — explicit tone, else the theme's warning
+    /// foreground (the value the built-ins hardcoded before the tone axis
+    /// existed).
+    public func warningColor(_ theme: Theme) -> Color {
+        warningTone?.base ?? theme.foreground(.systemcolorsFgWarning)
+    }
+    /// The connector icon/label tint: the warning color while warning, else
+    /// the accent's base (neutral by default).
+    public func accentColor(_ theme: Theme) -> Color {
+        hasWarning ? warningColor(theme) : (accent ?? .neutral).base
+    }
+    /// Semantic tone that tints the pill / banner chrome.
+    public var chromeTone: SemanticColor { hasWarning ? (warningTone ?? .warning) : (accent ?? .neutral) }
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out the row.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+}
+
+// MARK: - Protocol
+
+/// Defines a `LayoverRow`'s entire presentation. Implement `makeBody` to lay
+/// out the configuration's connector data. Set one with `.layoverRowStyle(_:)`;
+/// the default is ``LineLayoverRowStyle``.
+public protocol LayoverRowStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: LayoverRowConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// A flanking connector segment shared by `.line` and `.pill` — `.dashed`
+/// (default), `.solid`, or `.hidden` (an invisible spacer, keeping the label
+/// centered).
+private struct LayoverRowConnectorLine: View {
+    @Environment(\.theme) private var theme
+    let lineStyle: LayoverLineStyle
+
+    var body: some View {
+        switch lineStyle {
+        case .dashed:
+            LayoverRowConnectorShape()
+                .stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+                .frame(height: 1).frame(maxWidth: .infinity)
+        case .solid:
+            LayoverRowConnectorShape()
+                .stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: 1))
+                .frame(height: 1).frame(maxWidth: .infinity)
+        case .hidden:
+            Color.clear.frame(height: 1).frame(maxWidth: .infinity)
+        }
+    }
+}
+
+/// A single horizontal segment — symmetric under mirroring, so no RTL flip
+/// is required.
+private struct LayoverRowConnectorShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        Path { p in p.move(to: CGPoint(x: 0, y: rect.midY)); p.addLine(to: CGPoint(x: rect.width, y: rect.midY)) }
+    }
+}
+
+/// Icon + "2h 15m layover · Istanbul (IST)" — the connector's centered label,
+/// shared verbatim (raw `Image` + `.textStyle`, matching the pre-style render
+/// exactly — `Icon`'s fixed size ramp has no 12pt-semibold tier) by every
+/// built-in.
+private struct LayoverRowLabel: View {
+    @Environment(\.theme) private var theme
+    let configuration: LayoverRowConfiguration
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: configuration.systemImage)
+                .textStyle(.labelSm600)
+                .foregroundStyle(configuration.accentColor(theme))
+            Text(configuration.label)
+                .textStyle(.overline500).foregroundStyle(theme.text(.textSecondary)).fixedSize()
+        }
+    }
+}
+
+/// The short/long-connection warning line shown below the connector, in every
+/// built-in — verbatim raw `Image` + `.textStyle`, same reasoning as
+/// ``LayoverRowLabel``.
+private struct LayoverRowWarningLine: View {
+    @Environment(\.theme) private var theme
+    let configuration: LayoverRowConfiguration
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "exclamationmark.triangle.fill").textStyle(.overline500)
+            if let warningText = configuration.warningText {
+                Text(warningText).textStyle(.overline400)
+            }
+        }
+        .foregroundStyle(configuration.warningColor(theme))
+    }
+}
+
+// MARK: - .line (default)
+
+/// Today's ``LayoverRow`` look, extracted verbatim: the centered label
+/// flanked by connector lines on both sides.
+public struct LineLayoverRowStyle: LayoverRowStyle {
+    public init() {}
+    public func makeBody(configuration: LayoverRowConfiguration) -> some View {
+        LineLayoverRowChrome(configuration: configuration)
+    }
+}
+
+private struct LineLayoverRowChrome: View {
+    let configuration: LayoverRowConfiguration
+
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: configuration.spacing(.sm)) {
+                LayoverRowConnectorLine(lineStyle: configuration.lineStyle)
+                LayoverRowLabel(configuration: configuration)
+                LayoverRowConnectorLine(lineStyle: configuration.lineStyle)
+            }
+            if configuration.hasWarning { LayoverRowWarningLine(configuration: configuration) }
+        }
+    }
+}
+
+// MARK: - .pill
+
+/// The label sits in a soft, tone-tinted capsule on the connector lines.
+public struct PillLayoverRowStyle: LayoverRowStyle {
+    public init() {}
+    public func makeBody(configuration: LayoverRowConfiguration) -> some View {
+        PillLayoverRowChrome(configuration: configuration)
+    }
+}
+
+private struct PillLayoverRowChrome: View {
+    let configuration: LayoverRowConfiguration
+
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 0) {
+                LayoverRowConnectorLine(lineStyle: configuration.lineStyle)
+                LayoverRowLabel(configuration: configuration)
+                    .padding(.horizontal, configuration.spacing(.sm))
+                    .padding(.vertical, Theme.SpacingKey.xs.value)
+                    .background(configuration.chromeTone.soft, in: Capsule(style: .continuous))
+                LayoverRowConnectorLine(lineStyle: configuration.lineStyle)
+            }
+            if configuration.hasWarning { LayoverRowWarningLine(configuration: configuration) }
+        }
+    }
+}
+
+// MARK: - .banner
+
+/// A full-width, tone-tinted band — no flanking connector lines.
+public struct BannerLayoverRowStyle: LayoverRowStyle {
+    public init() {}
+    public func makeBody(configuration: LayoverRowConfiguration) -> some View {
+        BannerLayoverRowChrome(configuration: configuration)
+    }
+}
+
+private struct BannerLayoverRowChrome: View {
+    let configuration: LayoverRowConfiguration
+
+    var body: some View {
+        VStack(spacing: 4) {
+            LayoverRowLabel(configuration: configuration)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, configuration.spacing(.sm))
+                .padding(.horizontal, Theme.SpacingKey.sm.value)
+                .background(configuration.chromeTone.bg,
+                            in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
+            if configuration.hasWarning { LayoverRowWarningLine(configuration: configuration) }
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension LayoverRowStyle where Self == LineLayoverRowStyle {
+    /// The centered label flanked by connector lines. The default.
+    static var line: LineLayoverRowStyle { LineLayoverRowStyle() }
+}
+public extension LayoverRowStyle where Self == PillLayoverRowStyle {
+    /// The label in a soft, tone-tinted capsule sitting on the connector lines.
+    static var pill: PillLayoverRowStyle { PillLayoverRowStyle() }
+}
+public extension LayoverRowStyle where Self == BannerLayoverRowStyle {
+    /// A full-width, tone-tinted band — no flanking lines.
+    static var banner: BannerLayoverRowStyle { BannerLayoverRowStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyLayoverRowStyle: LayoverRowStyle {
+    private let _makeBody: @MainActor (LayoverRowConfiguration) -> AnyView
+    init<S: LayoverRowStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: LayoverRowConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct LayoverRowStyleKey: EnvironmentKey {
+    static let defaultValue = AnyLayoverRowStyle(LineLayoverRowStyle())
+}
+
+extension EnvironmentValues {
+    var layoverRowStyle: AnyLayoverRowStyle {
+        get { self[LayoverRowStyleKey.self] }
+        set { self[LayoverRowStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``LayoverRowStyle`` for `LayoverRow`s in this view and its
+    /// descendants — one itinerary screen can restyle every connection at once.
+    func layoverRowStyle<S: LayoverRowStyle>(_ style: sending S) -> some View {
+        environment(\.layoverRowStyle, AnyLayoverRowStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// Proves external implementability: a compact one-line summary built purely
+/// on the public configuration + theme tokens — no lines, no chrome.
+private struct MinimalLayoverRowStyle: LayoverRowStyle {
+    func makeBody(configuration: LayoverRowConfiguration) -> some View {
+        MinimalLayoverRowChrome(configuration: configuration)
+    }
+
+    private struct MinimalLayoverRowChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: LayoverRowConfiguration
+
+        var body: some View {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                Icon(systemName: configuration.systemImage).size(.xs).color(configuration.accentColor(theme))
+                Text(configuration.label).textStyle(.overline500).foregroundStyle(theme.text(.textSecondary))
+                if configuration.hasWarning {
+                    Icon(systemName: "exclamationmark.triangle.fill")
+                        .size(.xs)
+                        .color(configuration.warningColor(theme))
+                }
+            }
+            .padding(.horizontal, Theme.SpacingKey.sm.value)
+            .padding(.vertical, Theme.SpacingKey.xs.value)
+            .background(theme.background(.bgSecondaryLight), in: Capsule(style: .continuous))
+        }
+    }
+}
+
+#Preview("LayoverRowStyle — presets × light/dark") {
+    PreviewMatrix("LayoverRowStyle") {
+        PreviewCase("Line (default)") {
+            LayoverRow(duration: "2h 15m", airport: "Istanbul (IST)")
+        }
+        PreviewCase("Line · warning") {
+            LayoverRow(duration: "0h 45m", airport: "Ankara (ESB)")
+                .warning("Short connection — 45 min")
+        }
+        PreviewCase("Pill") {
+            LayoverRow(duration: "2h 15m", airport: "Istanbul (IST)")
+                .accent(.info)
+                .layoverRowStyle(.pill)
+        }
+        PreviewCase("Banner") {
+            LayoverRow(duration: "5h 30m", airport: "Frankfurt (FRA)")
+                .accent(.info)
+                .layoverRowStyle(.banner)
+        }
+        PreviewCase("Banner · warning tone (error)") {
+            LayoverRow(duration: "0h 35m", airport: "Ankara (ESB)")
+                .warning("Very short connection — 35 min", tone: .error)
+                .layoverRowStyle(.banner)
+        }
+        PreviewCase("Custom (in-preview)") {
+            LayoverRow(duration: "1h 05m", airport: "Vienna (VIE)")
+                .layoverRowStyle(MinimalLayoverRowStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Molecules/PassengerRow.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/PassengerRow.swift
@@ -4,22 +4,26 @@
 //
 //  Molecule. A traveller summary row — an avatar or icon, a name with an optional
 //  type badge (Adult / Child / Infant), a subtitle, an optional seat chip and status,
-//  and a trailing edit / chevron. Token-bound; the row of a passengers list.
+//  and a trailing edit / chevron. Presentation is style-driven
+//  (``PassengerRowStyle``, ADR-0004) — set once per list via
+//  `.passengerRowStyle(_:)`. Token-bound; the row of a passengers list.
 //
 //  ```swift
 //  PassengerRow("İsa Mercan").type("Adult").subtitle("Passport · TR12345").seat("14C").onEdit { }
+//      .passengerRowStyle(.card)      // .row (default) / .card / .compact
 //  ```
 //
 
 import SwiftUI
 import ThemeKit
 
-/// Trailing accessory of a ``PassengerRow``.
+/// Trailing accessory of a ``PassengerRow`` (the ``RowPassengerRowStyle`` preset).
 public enum PassengerAccessory: Sendable { case none, chevron }
 
 public struct PassengerRow: View {
-    @Environment(\.theme) private var theme
+    @Environment(\.passengerRowStyle) private var style
     @Environment(\.componentDensity) private var density
+    @Environment(\.locale) private var locale
 
     private let name: String
     private let action: () -> Void
@@ -37,7 +41,7 @@ public struct PassengerRow: View {
     private var accessory: PassengerAccessory = .none
     private var accent: SemanticColor?
     private var bordered = false
-    private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    private var surfaceKey: Theme.BackgroundColorKey?
     private var selectionBinding: Binding<Bool>?
     private var customTrailing: AnyView?
 
@@ -46,81 +50,33 @@ public struct PassengerRow: View {
         self.action = action
     }
 
-    private var accentBase: Color { (accent ?? .primary).base }
-    private var isSelected: Bool { selectionBinding?.wrappedValue ?? false }
-    private var rowShape: RoundedRectangle {
-        RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
-    }
-
     public var body: some View {
-        Button {
-            selectionBinding?.wrappedValue.toggle()
-            action()
-        } label: {
-            HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
-                if let selectionBinding {
-                    // Visual-only — the whole row is the toggle target.
-                    Checkbox(isChecked: selectionBinding)
-                        .accent(accent)
-                        .allowsHitTesting(false)
-                }
-                leading
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
-                        Text(name).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
-                        if let typeText { Badge(typeText).badgeStyle(typeStyle).variant(.soft).size(.small).fixedSize() }
-                    }
-                    if let subtitle { Text(subtitle).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary)).lineLimit(1) }
-                }
-                Spacer(minLength: 6)
-                trailing
-            }
-            .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
-            .padding(.horizontal, bordered ? density.scale(Theme.SpacingKey.sm.value) : 0)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(bordered ? theme.background(surfaceKey) : .clear, in: rowShape)
-            .overlay { if bordered { rowShape.stroke(theme.border(.borderPrimary), lineWidth: 1) } }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel([name, typeText, seat.map { String(themeKit: "seat \($0)") }, statusText].compactMap { $0 }.joined(separator: ", "))
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-
-    @ViewBuilder private var leading: some View {
-        if let avatarContent {
-            Avatar(avatarContent).size(.md)
-        } else {
-            Image(systemName: systemImage).font(.system(size: 30)).foregroundStyle(accentBase)
-        }
-    }
-
-    @ViewBuilder private var trailing: some View {
-        HStack(spacing: 8) {
-            if let seat {
-                Text(seat).textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary))
-                    .padding(.horizontal, 8).frame(height: 24)
-                    .background(theme.background(.bgElevatorTertiary), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
-            }
-            if let statusText { Badge(statusText).badgeStyle(statusStyle).variant(.soft).size(.small) }
-            if let customTrailing {
-                customTrailing
-            } else if let onEdit {
-                Button { onEdit() } label: {
-                    Image(systemName: "pencil").textStyle(.labelBase600).foregroundStyle(accentBase)
-                        .frame(width: 44, height: 44).contentShape(Rectangle())
-                }.buttonStyle(.plain).accessibilityLabel(String(themeKit: "Edit"))
-            } else if let onRemove {
-                Button { onRemove() } label: {
-                    Image(systemName: "xmark").textStyle(.labelSm600).foregroundStyle(theme.text(.textTertiary))
-                        .frame(width: 44, height: 44).contentShape(Rectangle())
-                }.buttonStyle(.plain).accessibilityLabel(String(themeKit: "Remove"))
-            } else if accessory == .chevron {
-                Image(systemName: "chevron.right").font(.system(size: 12, weight: .semibold)).foregroundStyle(theme.text(.textTertiary)).mirrorsInRTL()
-                    .accessibilityHidden(true)   // decorative disclosure indicator
-            }
-        }
+        // The arrangement is owned by the active `PassengerRowStyle`; the
+        // component only gathers its typed summary and composes the row's tap
+        // handler (selection toggle + the caller's action, ADR-0004 §4).
+        let configuration = PassengerRowConfiguration(
+            name: name,
+            type: typeText,
+            typeStyle: typeStyle,
+            subtitle: subtitle,
+            seat: seat,
+            status: statusText,
+            statusStyle: statusStyle,
+            avatar: avatarContent,
+            systemImage: systemImage,
+            accessory: accessory,
+            isBordered: bordered,
+            surfaceKey: surfaceKey,
+            isSelected: selectionBinding?.wrappedValue ?? false,
+            selectBinding: selectionBinding,
+            trailing: customTrailing,
+            onEdit: onEdit,
+            onRemove: onRemove,
+            accent: accent,
+            action: { selectionBinding?.wrappedValue.toggle(); action() },
+            density: density,
+            locale: locale)
+        style.makeBody(configuration: configuration)
     }
 }
 

--- a/Sources/ThemeKitTravel/Components/Molecules/PassengerRowStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/PassengerRowStyle.swift
@@ -1,0 +1,503 @@
+//
+//  PassengerRowStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``PassengerRow`` (ADR-0004): the configuration hands
+//  styles the *typed traveller summary* (name, type, seat, status, avatar…),
+//  not pre-laid content, so a style owns the entire arrangement. Three built-ins:
+//
+//    .row      leading avatar/icon, name + type badge, subtitle, and a trailing
+//              seat chip / status badge / edit·remove·chevron — today's row,
+//              flush by default, optionally bordered. Default.
+//    .card     bordered card: avatar, name + type + subtitle, seat/status
+//              trailing, and prominent circular edit/remove affordances.
+//    .compact  a dense single line: name, seat, chevron — no avatar, type
+//              badge, subtitle or status.
+//
+//      PassengerRow("İsa Mercan").type("Adult").subtitle("Passport · TR12345678")
+//          .seat("14C").onEdit { }
+//          .passengerRowStyle(.card)
+//
+//  Component style arranges content; token theme colors everything. Selection
+//  is ``ControllableState`` per ADR-0004 §4 — the configuration exposes the
+//  read state (`isSelected`) and the mirrored `selectBinding` for rendering the
+//  checkbox, but the actual toggle write happens through `action`, composed
+//  once by the component so no style duplicates the toggle mechanics.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``PassengerRowStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no type → no badge, no seat → no chip, no
+/// edit/remove → a plain chevron or nothing).
+public struct PassengerRowConfiguration {
+    /// The traveller's display name.
+    public let name: String
+    /// Passenger type badge text, e.g. "Adult" / "Child" / "Infant"; `nil` hides it.
+    public let type: String?
+    /// The type badge's style (default `.neutral`).
+    public let typeStyle: BadgeStyle
+    /// A secondary line under the name, e.g. "Passport · TR12345678".
+    public let subtitle: String?
+    /// Trailing seat text, e.g. "14C"; `nil` hides it.
+    public let seat: String?
+    /// Trailing status badge text, e.g. "Checked in"; `nil` hides it.
+    public let status: String?
+    /// The status badge's style (default `.success`).
+    public let statusStyle: BadgeStyle
+    /// Custom avatar content; `nil` falls back to ``systemImage``.
+    public let avatar: AvatarContent?
+    /// SF Symbol used when no ``avatar`` is set.
+    public let systemImage: String
+    /// Trailing disclosure affordance drawn when no edit/remove/custom trailing
+    /// content is present (``.row`` only — ``.compact`` always shows a chevron).
+    public let accessory: PassengerAccessory
+    /// Wrap in a bordered/surfaced shell (``PassengerRow/bordered(_:)``).
+    /// ``.card`` always renders bordered and ignores this flag.
+    public let isBordered: Bool
+    /// Explicit surface fill, or `nil` to let the style choose its own default
+    /// (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Selection state — mirrors ``selectBinding``'s value, `false` when the
+    /// row isn't selectable.
+    public let isSelected: Bool
+    /// Selection-checkbox binding; `nil` = not selectable (no checkbox drawn).
+    /// Visual only — styles never write to it; the toggle happens through
+    /// ``action``, already composed by the component.
+    public let selectBinding: Binding<Bool>?
+    /// Replacement for the built-in trailing accessory (``.row``/``.card``);
+    /// `nil` = built-in edit/remove/chevron precedence.
+    public let trailing: AnyView?
+    /// Edit action; takes precedence over ``onRemove`` in the built-in trailing area.
+    public let onEdit: (() -> Void)?
+    /// Remove action; drawn when ``onEdit`` is `nil`.
+    public let onRemove: (() -> Void)?
+    /// Brand-chrome accent, or `nil` for the theme's primary semantic.
+    public let accent: SemanticColor?
+    /// The row's whole-row tap handler — already composed with the selection
+    /// toggle by the component (ADR-0004 §4); styles call it directly and
+    /// never write to ``selectBinding`` themselves.
+    public let action: () -> Void
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component. The built-ins render
+    /// preformatted strings, but custom styles that format dates/numbers must
+    /// use it so injected locales (and RTL demos) render correctly.
+    public let locale: Locale
+
+    /// The `accent(_:)` override's base, else the primary semantic's base — the
+    /// value the built-ins hardcoded before the accent axis existed.
+    public var accentBase: Color { (accent ?? .primary).base }
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so `.componentDensity`
+    /// compacts or airs out the row.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// The row's spoken summary — name, type, seat, status. Every built-in
+    /// applies it to the row's combined `accessibilityElement`.
+    public var accessibilityLabel: String {
+        [name, type, seat.map { String(themeKit: "seat \($0)") }, status]
+            .compactMap { $0 }
+            .joined(separator: ", ")
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `PassengerRow`'s entire presentation. Implement `makeBody` to lay
+/// out the configuration's traveller summary. Set one with
+/// `.passengerRowStyle(_:)`; the default is ``RowPassengerRowStyle``.
+public protocol PassengerRowStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: PassengerRowConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The leading avatar/icon shared by `.row` and `.card` — the custom
+/// ``PassengerRowConfiguration/avatar`` when set, else a person-glyph icon
+/// tinted with ``PassengerRowConfiguration/accentBase``.
+private struct PassengerRowAvatar: View {
+    let configuration: PassengerRowConfiguration
+    var size: AvatarSize = .md
+
+    var body: some View {
+        if let avatar = configuration.avatar {
+            Avatar(avatar).size(size)
+        } else {
+            Image(systemName: configuration.systemImage)
+                .font(.system(size: size.rawValue * 0.75))
+                .foregroundStyle(configuration.accentBase)
+        }
+    }
+}
+
+/// The selection checkbox mirrored by every selectable preset — visual only;
+/// the actual toggle happens through ``PassengerRowConfiguration/action``,
+/// composed once by the component (ADR-0004 §4).
+private struct PassengerRowSelectionCheckbox: View {
+    let configuration: PassengerRowConfiguration
+
+    var body: some View {
+        if let binding = configuration.selectBinding {
+            Checkbox(isChecked: binding)
+                .accent(configuration.accent)
+                .allowsHitTesting(false)
+        }
+    }
+}
+
+/// The passenger-type badge next to the name; draws nothing when unset.
+private struct PassengerRowTypeBadge: View {
+    let configuration: PassengerRowConfiguration
+    var body: some View {
+        if let type = configuration.type {
+            Badge(type).badgeStyle(configuration.typeStyle).variant(.soft).size(.small).fixedSize()
+        }
+    }
+}
+
+/// The trailing seat chip; draws nothing when unset.
+private struct PassengerRowSeatChip: View {
+    @Environment(\.theme) private var theme
+    let seat: String
+
+    var body: some View {
+        Text(seat).textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary))
+            .padding(.horizontal, 8).frame(height: 24)
+            .background(theme.background(.bgElevatorTertiary),
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
+    }
+}
+
+/// The trailing status badge; draws nothing when unset.
+private struct PassengerRowStatusBadge: View {
+    let configuration: PassengerRowConfiguration
+    var body: some View {
+        if let status = configuration.status {
+            Badge(status).badgeStyle(configuration.statusStyle).variant(.soft).size(.small)
+        }
+    }
+}
+
+// MARK: - .row
+
+/// Today's ``PassengerRow`` look, extracted verbatim: leading avatar/icon,
+/// name + type badge, subtitle, and a trailing seat chip / status badge /
+/// edit·remove·chevron — flush by default, optionally bordered. Default.
+public struct RowPassengerRowStyle: PassengerRowStyle {
+    public init() {}
+    public func makeBody(configuration: PassengerRowConfiguration) -> some View {
+        RowPassengerRowChrome(configuration: configuration)
+    }
+}
+
+private struct RowPassengerRowChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: PassengerRowConfiguration
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
+    }
+
+    var body: some View {
+        Button(action: configuration.action) {
+            HStack(spacing: configuration.spacing(.sm)) {
+                PassengerRowSelectionCheckbox(configuration: configuration)
+                PassengerRowAvatar(configuration: configuration)
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(configuration.name).textStyle(.labelBase700)
+                            .foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
+                        PassengerRowTypeBadge(configuration: configuration)
+                    }
+                    if let subtitle = configuration.subtitle {
+                        Text(subtitle).textStyle(.bodySm400)
+                            .foregroundStyle(theme.text(.textSecondary)).lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 6)
+                trailing
+            }
+            .padding(.vertical, configuration.spacing(.sm))
+            .padding(.horizontal, configuration.isBordered ? configuration.spacing(.sm) : 0)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(configuration.isBordered ? theme.background(configuration.surface(default: .bgBase)) : .clear,
+                        in: shape)
+            .overlay { if configuration.isBordered { shape.stroke(theme.border(.borderPrimary), lineWidth: 1) } }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(configuration.accessibilityLabel)
+        .accessibilityAddTraits(configuration.isSelected ? .isSelected : [])
+    }
+
+    @ViewBuilder private var trailing: some View {
+        HStack(spacing: 8) {
+            if let seat = configuration.seat { PassengerRowSeatChip(seat: seat) }
+            PassengerRowStatusBadge(configuration: configuration)
+            if let custom = configuration.trailing {
+                custom
+            } else if let onEdit = configuration.onEdit {
+                Button { onEdit() } label: {
+                    Image(systemName: "pencil").textStyle(.labelBase600).foregroundStyle(configuration.accentBase)
+                        .frame(width: 44, height: 44).contentShape(Rectangle())
+                }.buttonStyle(.plain).accessibilityLabel(String(themeKit: "Edit"))
+            } else if let onRemove = configuration.onRemove {
+                Button { onRemove() } label: {
+                    Image(systemName: "xmark").textStyle(.labelSm600).foregroundStyle(theme.text(.textTertiary))
+                        .frame(width: 44, height: 44).contentShape(Rectangle())
+                }.buttonStyle(.plain).accessibilityLabel(String(themeKit: "Remove"))
+            } else if configuration.accessory == .chevron {
+                Image(systemName: "chevron.right").font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(theme.text(.textTertiary)).mirrorsInRTL()
+                    .accessibilityHidden(true)   // decorative disclosure indicator
+            }
+        }
+    }
+}
+
+// MARK: - .card
+
+/// A bordered card: avatar, name + type badge, subtitle, seat chip + status
+/// badge trailing, and prominent circular edit/remove affordances — a
+/// standalone passenger tile (e.g. a review-step summary list).
+public struct CardPassengerRowStyle: PassengerRowStyle {
+    public init() {}
+    public func makeBody(configuration: PassengerRowConfiguration) -> some View {
+        CardPassengerRowChrome(configuration: configuration)
+    }
+}
+
+private struct CardPassengerRowChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: PassengerRowConfiguration
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+    }
+
+    var body: some View {
+        Button(action: configuration.action) {
+            VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+                HStack(alignment: .top, spacing: configuration.spacing(.sm)) {
+                    PassengerRowSelectionCheckbox(configuration: configuration)
+                    PassengerRowAvatar(configuration: configuration, size: .lg)
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 6) {
+                            Text(configuration.name).textStyle(.labelBase700)
+                                .foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
+                            PassengerRowTypeBadge(configuration: configuration)
+                        }
+                        if let subtitle = configuration.subtitle {
+                            Text(subtitle).textStyle(.bodySm400)
+                                .foregroundStyle(theme.text(.textSecondary)).lineLimit(2)
+                        }
+                    }
+                    Spacer(minLength: 6)
+                    VStack(alignment: .trailing, spacing: 4) {
+                        if let seat = configuration.seat { PassengerRowSeatChip(seat: seat) }
+                        PassengerRowStatusBadge(configuration: configuration)
+                    }
+                }
+                if let custom = configuration.trailing {
+                    custom
+                } else if configuration.onEdit != nil || configuration.onRemove != nil {
+                    actionsRow
+                }
+            }
+            .padding(configuration.spacing(.md))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(theme.background(configuration.surface(default: .bgWhite)), in: shape)
+            .overlay { shape.stroke(theme.border(.borderPrimary), lineWidth: 1) }
+            .contentShape(shape)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(configuration.accessibilityLabel)
+        .accessibilityAddTraits(configuration.isSelected ? .isSelected : [])
+    }
+
+    /// The prominent edit (soft-filled circle) / remove (``CloseButton``) pair —
+    /// composed from existing ThemeKit atoms/molecules, not hand-rolled glyphs.
+    private var actionsRow: some View {
+        HStack(spacing: configuration.spacing(.sm)) {
+            Spacer(minLength: 0)
+            if let onEdit = configuration.onEdit {
+                ThemeButton(action: onEdit)
+                    .icon(leading: "pencil")
+                    .shape(.circle)
+                    .variant(.soft)
+                    .color(configuration.accent ?? .primary)
+                    .size(.small)
+                    .accessibilityLabel(String(themeKit: "Edit"))
+            }
+            if let onRemove = configuration.onRemove {
+                CloseButton(action: onRemove)
+                    .tint(.error)
+                    .controlSize(.small)
+                    .accessibilityLabel(String(themeKit: "Remove"))
+            }
+        }
+    }
+}
+
+// MARK: - .compact
+
+/// A dense single line — name, seat, chevron — no avatar, type badge,
+/// subtitle or status. Long passenger rosters with little vertical room.
+public struct CompactPassengerRowStyle: PassengerRowStyle {
+    public init() {}
+    public func makeBody(configuration: PassengerRowConfiguration) -> some View {
+        CompactPassengerRowChrome(configuration: configuration)
+    }
+}
+
+private struct CompactPassengerRowChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: PassengerRowConfiguration
+
+    var body: some View {
+        Button(action: configuration.action) {
+            HStack(spacing: configuration.spacing(.sm)) {
+                PassengerRowSelectionCheckbox(configuration: configuration)
+                Text(configuration.name).textStyle(.labelBase700)
+                    .foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
+                Spacer(minLength: 6)
+                if let seat = configuration.seat {
+                    Text(seat).textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary)).lineLimit(1)
+                }
+                Icon(systemName: "chevron.right").size(.xs).color(theme.text(.textTertiary))
+                    .mirrorsInRTL()
+                    .accessibilityHidden(true)   // decorative disclosure indicator
+            }
+            .padding(.vertical, configuration.spacing(.xs))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(configuration.accessibilityLabel)
+        .accessibilityAddTraits(configuration.isSelected ? .isSelected : [])
+    }
+}
+
+// MARK: - Static accessors
+
+public extension PassengerRowStyle where Self == RowPassengerRowStyle {
+    /// Leading avatar/icon, name + type badge, subtitle, trailing seat chip /
+    /// status badge / edit·remove·chevron — today's row. The default.
+    static var row: RowPassengerRowStyle { RowPassengerRowStyle() }
+}
+public extension PassengerRowStyle where Self == CardPassengerRowStyle {
+    /// Bordered card with prominent circular edit/remove affordances.
+    static var card: CardPassengerRowStyle { CardPassengerRowStyle() }
+}
+public extension PassengerRowStyle where Self == CompactPassengerRowStyle {
+    /// Dense single line: name, seat, chevron.
+    static var compact: CompactPassengerRowStyle { CompactPassengerRowStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyPassengerRowStyle: PassengerRowStyle {
+    private let _makeBody: @MainActor (PassengerRowConfiguration) -> AnyView
+    init<S: PassengerRowStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: PassengerRowConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct PassengerRowStyleKey: EnvironmentKey {
+    static let defaultValue = AnyPassengerRowStyle(RowPassengerRowStyle())
+}
+
+extension EnvironmentValues {
+    var passengerRowStyle: AnyPassengerRowStyle {
+        get { self[PassengerRowStyleKey.self] }
+        set { self[PassengerRowStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``PassengerRowStyle`` for `PassengerRow`s in this view and its
+    /// descendants — a passengers list sets it once for every row.
+    func passengerRowStyle<S: PassengerRowStyle>(_ style: sending S) -> some View {
+        environment(\.passengerRowStyle, AnyPassengerRowStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a soft accent capsule row with the name and seat only.
+private struct CapsulePassengerRowStyle: PassengerRowStyle {
+    func makeBody(configuration: PassengerRowConfiguration) -> some View {
+        CapsuleChrome(configuration: configuration)
+    }
+
+    private struct CapsuleChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: PassengerRowConfiguration
+
+        var body: some View {
+            Button(action: configuration.action) {
+                HStack(spacing: configuration.spacing(.sm)) {
+                    Text(configuration.name).textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary))
+                    if let seat = configuration.seat {
+                        Text(seat).textStyle(.overline500).foregroundStyle(configuration.accentBase)
+                    }
+                }
+                .padding(.vertical, configuration.spacing(.xs))
+                .padding(.horizontal, configuration.spacing(.sm))
+                .background((configuration.accent ?? .primary).soft, in: Capsule(style: .continuous))
+                .contentShape(Capsule(style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(configuration.accessibilityLabel)
+        }
+    }
+}
+
+#Preview("PassengerRowStyle — presets × light/dark") {
+    PreviewMatrix("PassengerRowStyle") {
+        PreviewCase("Row (default)") {
+            PassengerRow("İsa Mercan").type("Adult").subtitle("Passport · TR12345678").seat("14C").onEdit { }
+        }
+        PreviewCase("Row · bordered + status") {
+            PassengerRow("Ada Mercan").type("Child").status("Checked in").accessory(.chevron)
+                .bordered().surface(.bgWhite)
+        }
+        PreviewCase("Card") {
+            PassengerRow("Mia Doe").type("Infant", style: .info).subtitle("No seat required").seat("—")
+                .status("Pending").onEdit { }.onRemove { }
+                .passengerRowStyle(.card)
+        }
+        PreviewCase("Card · accent") {
+            PassengerRow("John Doe").type("Adult").subtitle("Frequent flyer").seat("2A")
+                .onRemove { }.accent(.success)
+                .passengerRowStyle(.card)
+        }
+        PreviewCase("Compact") {
+            VStack(spacing: 4) {
+                PassengerRow("Sam Doe").seat("11C").passengerRowStyle(.compact)
+                PassengerRow("Alex Doe").seat("11D").passengerRowStyle(.compact)
+            }
+        }
+        PreviewCase("Custom (in-preview)") {
+            PassengerRow("Kate Lin").seat("7A").accent(.info)
+                .passengerRowStyle(CapsulePassengerRowStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/BoardingPass.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/BoardingPass.swift
@@ -5,20 +5,24 @@
 //  Organism. A wallet-style boarding pass — airline + flight header, a passenger
 //  name, a from→to route with times, a labelled detail grid (gate / seat / boarding
 //  / terminal) and a perforated stub carrying a barcode (or QR) and booking ref.
-//  Reuses ``TicketStub`` (perforation) and ``Barcode`` / ``QRCode``. Token-bound.
+//  Token-bound. The entire layout is style-driven (ADR-0004): the component
+//  gathers the typed configuration and the active ``BoardingPassStyle`` lays it
+//  out — `.classic` (default, horizontal ``TicketStub`` tear + trailing code),
+//  `.wallet` (QR-dominant vertical Apple-Wallet-style pass, two-column details)
+//  or `.strip` (one-row gate strip: passenger name / seat / mini code).
 //
-//  CardStyle exemption (deliberate): the shell here is the decorative perforated
-//  ticket surface — ``TicketStub`` carves the side notches out of its fill with a
-//  `destinationOut` composite, so the fill, notches, perforation and elevation
-//  shadow are one inseparable unit. Routing any of it through the environment
-//  `CardStyle` would paint the notches shut (a style draws a plain rounded-rect
-//  fill/border). The whole shell therefore stays with `TicketStub`;
-//  `.cardStyle(_:)` intentionally has no effect on this component.
+//  CardStyle note (per-preset, ADR-0004 §4): on the tear presets
+//  (`.classic`/`.wallet`) the perforated ``TicketStub`` shell — fill, notches,
+//  perforation and elevation shadow — is one inseparable unit owned by the
+//  preset, so `.cardStyle(_:)` is a documented no-op there (a card style would
+//  paint the notches shut). `.strip` draws no tear and routes its shell through
+//  the active `CardStyle`, so `.cardStyle(_:)` applies to it.
 //
 //  ```swift
-//  BoardingPass(passenger: "İsa Mercan", from: "SAW", to: "BER")
+//  BoardingPass(passenger: "Jordan Lee", from: "SAW", to: "BER")
 //      .airline("Pegasus").flightNo("PC 1234").times(departure: "13:15", arrival: "16:05")
-//      .gate("A12").seat("14C").boarding("12:45").barcode("PC1234SAWBER14C")
+//      .gate("A12", seat: "14C", boarding: "12:45").barcode("PC1234SAWBER14C")
+//      .boardingPassStyle(.wallet)   // .classic / .strip / custom
 //  ```
 //
 
@@ -30,7 +34,7 @@ public struct BoardingPass: View {
     /// point constants (medium reproduces the classic 72pt QR / 48pt barcode).
     public enum CodeSize: String, CaseIterable, Sendable { case small, medium, large }
 
-    /// Arrangement of the labelled detail cells.
+    /// Arrangement of the labelled detail cells (honoured by ``ClassicBoardingPassStyle``).
     public enum DetailsLayout: String, CaseIterable, Sendable {
         /// One horizontal row (the classic layout).
         case row
@@ -38,8 +42,9 @@ public struct BoardingPass: View {
         case grid
     }
 
-    @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
+    @Environment(\.locale) private var locale
+    @Environment(\.boardingPassStyle) private var style
 
     private let passenger: String
     private let from: String
@@ -55,6 +60,13 @@ public struct BoardingPass: View {
     private var arrival: String?
     private var date: String?
     private var details: [(String, String)] = []   // gate/seat/boarding/terminal…
+    /// Typed mirrors of the common detail cells — kept in step with `details`
+    /// by the `.gate(...)` convenience so styles (e.g. `.strip`) can read
+    /// ``BoardingPassConfiguration/seat`` without parsing labelled tuples.
+    private var gateValue: String?
+    private var seatValue: String?
+    private var boardingValue: String?
+    private var terminalValue: String?
     private var bookingRef: String?
     private var passengerLabelOverride: String?
     /// Render-time default — re-resolves through the localization chain on
@@ -63,7 +75,8 @@ public struct BoardingPass: View {
     private var barcodeValue: String?
     private var qrValue: String?
     private var accent: SemanticColor?
-    private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    /// `nil` = the active style's default surface (`.bgBase` for the built-ins).
+    private var surfaceKey: Theme.BackgroundColorKey?
     private var elevation: CardElevation = .elevated
     private var radiusRole: Theme.RadiusRole = .box
     private var showsPerforation = true
@@ -79,141 +92,24 @@ public struct BoardingPass: View {
         self.to = to
     }
 
-    // deferred: accent-fallback unification — keeps the `.primary` fallback
-    // (matching AncillaryCard/StickyBookingBar would be visually breaking here).
-    private var accentBase: Color { (accent ?? .primary).base }
-
-    /// Internal point constants behind the `CodeSize` ramp (token rule: ramp
-    /// enums map to private CGFloats; no raw sizes in the public signature).
-    private var qrSide: CGFloat {
-        switch codeSize { case .small: return 56; case .medium: return 72; case .large: return 96 }
-    }
-    private var barcodeHeight: CGFloat {
-        switch codeSize { case .small: return 36; case .medium: return 48; case .large: return 64 }
-    }
-
     public var body: some View {
-        // Decorative-shell exception: the perforated `TicketStub` surface (fill +
-        // notches + tear line + shadow) is the chrome here and is kept as-is —
-        // see the header note. `.surface()`/`.elevation()` feed it directly.
-        TicketStub {
-            VStack(alignment: .leading, spacing: density.scale(Theme.SpacingKey.md.value)) {
-                if let headerSlot { headerSlot } else { header }
-                route
-                if !details.isEmpty { detailArea }
-            }
-        }
-        .stub { if let customStub { customStub } else { stub } }
-        .cornerRadius(radiusRole)
-        .perforation(showsPerforation)
-        .dashColor(dashKey)
-        .elevation(elevation)
-        .surface(surfaceKey)
-    }
-
-    private var header: some View {
-        HStack {
-            HStack(spacing: 6) {
-                Image(systemName: airlineIcon).font(.system(size: 14)).foregroundStyle(accentBase)
-                    .accessibilityHidden(true)   // decorative airline glyph
-                if let airline { Text(airline).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)) }
-            }
-            Spacer()
-            VStack(alignment: .trailing, spacing: 1) {
-                if let flightNo { Text(flightNo).textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary)) }
-                if let cabin { Text(cabin).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary)) }
-            }
-        }
-    }
-
-    private var route: some View {
-        HStack(alignment: .center) {
-            routeCol(from, city: fromCity, time: departure, alignment: .leading)
-            Spacer(minLength: 8)
-            VStack(spacing: 2) {
-                if let date { Text(date).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary)) }
-                Image(systemName: "airplane").font(.system(size: 16)).foregroundStyle(accentBase).mirrorsInRTL()
-                    .accessibilityHidden(true)   // decorative route glyph
-            }
-            Spacer(minLength: 8)
-            routeCol(to, city: toCity, time: arrival, alignment: .trailing)
-        }
-    }
-
-    private func routeCol(_ code: String, city: String?, time: String?, alignment: HorizontalAlignment) -> some View {
-        VStack(alignment: alignment, spacing: 1) {
-            Text(code).textStyle(.displaySm).foregroundStyle(theme.text(.textPrimary))
-            if let city { Text(city).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary)).lineLimit(1) }
-            if let time { Text(time).textStyle(.labelBase700).foregroundStyle(accentBase) }
-        }
-        .fixedSize()
-    }
-
-    @ViewBuilder private var detailArea: some View {
-        switch detailsLayout {
-        case .row: detailRow
-        case .grid: detailTwoColumnGrid
-        }
-    }
-
-    private var detailRow: some View {
-        HStack(alignment: .top, spacing: density.scale(Theme.SpacingKey.md.value)) {
-            ForEach(Array(details.enumerated()), id: \.offset) { _, item in
-                detailCell(item)
-            }
-            Spacer(minLength: 0)
-        }
-    }
-
-    /// Two-column layout — pairs of cells per `GridRow`, so five details wrap
-    /// to three rows instead of clipping off the trailing edge.
-    private var detailTwoColumnGrid: some View {
-        Grid(alignment: .leading,
-             horizontalSpacing: density.scale(Theme.SpacingKey.md.value),
-             verticalSpacing: density.scale(Theme.SpacingKey.sm.value)) {
-            ForEach(Array(stride(from: 0, to: details.count, by: 2)), id: \.self) { index in
-                GridRow {
-                    detailCell(details[index])
-                        .gridColumnAlignment(.leading)
-                    if index + 1 < details.count {
-                        detailCell(details[index + 1])
-                            .gridColumnAlignment(.leading)
-                    } else {
-                        Color.clear.gridCellUnsizedAxes([.horizontal, .vertical])
-                    }
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func detailCell(_ item: (String, String)) -> some View {
-        VStack(alignment: .leading, spacing: 1) {
-            Text(item.0).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
-            Text(item.1).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
-        }
-    }
-
-    private var stub: some View {
-        HStack(spacing: density.scale(Theme.SpacingKey.md.value)) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(passengerLabel).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
-                Text(passenger).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
-                if let bookingRef {
-                    Text(bookingRef).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
-                }
-            }
-            Spacer(minLength: 6)
-            code
-        }
-    }
-
-    @ViewBuilder private var code: some View {
-        if let qrValue {
-            QRCode(qrValue).size(qrSide)
-        } else if let barcodeValue {
-            Barcode(barcodeValue).height(barcodeHeight).showsValue()
-        }
+        let configuration = BoardingPassConfiguration(
+            passenger: passenger, from: from, to: to,
+            fromCity: fromCity, toCity: toCity,
+            departure: departure, arrival: arrival, date: date,
+            airline: airline, airlineIcon: airlineIcon,
+            flightNo: flightNo, cabin: cabin,
+            details: details,
+            gate: gateValue, seat: seatValue, boarding: boardingValue, terminal: terminalValue,
+            bookingRef: bookingRef, passengerLabel: passengerLabel,
+            barcodeValue: barcodeValue, qrValue: qrValue,
+            codeSize: codeSize, detailsLayout: detailsLayout,
+            accent: accent, surfaceKey: surfaceKey, elevation: elevation,
+            radiusRole: radiusRole, showsPerforation: showsPerforation, dashKey: dashKey,
+            header: headerSlot, stub: customStub,
+            density: density, locale: locale
+        )
+        style.makeBody(configuration: configuration)
     }
 }
 
@@ -227,10 +123,18 @@ public extension BoardingPass {
     func times(departure: String?, arrival: String?) -> Self { copy { $0.departure = departure; $0.arrival = arrival } }
     func date(_ text: String?) -> Self { copy { $0.date = text } }
     /// The labelled detail cells (gate / seat / boarding / terminal…), in order.
-    func details(_ items: [(String, String)]) -> Self { copy { $0.details = items } }
+    /// Clears the typed ``BoardingPassConfiguration/gate``/``BoardingPassConfiguration/seat``
+    /// mirrors — call `.gate(...)` instead when a style needs the typed fields.
+    func details(_ items: [(String, String)]) -> Self {
+        copy {
+            $0.details = items
+            $0.gateValue = nil; $0.seatValue = nil; $0.boardingValue = nil; $0.terminalValue = nil
+        }
+    }
     /// Convenience for the common gate / seat / boarding trio.
     func gate(_ gate: String? = nil, seat: String? = nil, boarding: String? = nil, terminal: String? = nil) -> Self {
         copy {
+            $0.gateValue = gate; $0.seatValue = seat; $0.boardingValue = boarding; $0.terminalValue = terminal
             var d: [(String, String)] = []
             if let terminal { d.append((String(themeKit: "Terminal"), terminal)) }
             if let gate { d.append((String(themeKit: "Gate"), gate)) }
@@ -249,20 +153,20 @@ public extension BoardingPass {
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accent = color } }
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
     func elevation(_ e: CardElevation) -> Self { copy { $0.elevation = e } }
-    /// Replaces the built-in passenger / booking-ref / code stub with custom
-    /// content — forwarded to ``TicketStub``'s stub slot below the tear line.
+    /// Replaces the built-in stub with custom content — forwarded to the active
+    /// style's tear-off / trailing area (ignored by presets with no stub, e.g. `.strip`).
     func stub<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.customStub = AnyView(content()) } }
     /// Replaces the built-in airline / flight-number header row.
     func header<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.headerSlot = AnyView(content()) } }
     /// Footprint of the stub's QR / barcode (default `.medium` — the classic sizes).
     func codeSize(_ s: CodeSize) -> Self { copy { $0.codeSize = s } }
-    /// Detail-cell arrangement: one `.row` (default) or a two-column `.grid`.
+    /// Detail-cell arrangement: one `.row` (default) or a two-column `.grid` — honoured by `.classic`.
     func detailsLayout(_ l: DetailsLayout) -> Self { copy { $0.detailsLayout = l } }
-    /// Outer corner radius (radius role token, default `.box`) — forwarded to ``TicketStub``.
+    /// Outer corner radius (radius role token, default `.box`) — forwarded to the active style.
     func cornerRadius(_ role: Theme.RadiusRole) -> Self { copy { $0.radiusRole = role } }
-    /// Draw the dashed perforation across the tear line (default on) — forwarded to ``TicketStub``.
+    /// Draw the dashed perforation across the tear line (default on) — tear presets only.
     func perforation(_ on: Bool = true) -> Self { copy { $0.showsPerforation = on } }
-    /// Perforation dash colour (border token key, default `.borderPrimary`) — forwarded to ``TicketStub``.
+    /// Perforation dash colour (border token key, default `.borderPrimary`) — tear presets only.
     func dashColor(_ key: Theme.BorderColorKey) -> Self { copy { $0.dashKey = key } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
@@ -275,7 +179,7 @@ public extension BoardingPass {
 #Preview {
     ScrollView {
         VStack(spacing: 20) {
-            BoardingPass(passenger: "İsa Mercan", from: "SAW", to: "BER")
+            BoardingPass(passenger: "Jordan Lee", from: "SAW", to: "BER")
                 .airline("Pegasus").flightNo("PC 1234").cabin("Economy")
                 .cities(from: "Istanbul", to: "Berlin").times(departure: "13:15", arrival: "16:05").date("13 Sep")
                 .gate("A12", seat: "14C", boarding: "12:45", terminal: "1")
@@ -313,10 +217,11 @@ public extension BoardingPass {
     }
 }
 
-// The perforated ticket shell is exempt from `CardStyle` (see header note):
-// under `.cardStyle(.outlined)` the pass renders identically to the default.
-#Preview("Card-style exempt shell") {
-    BoardingPass(passenger: "İsa Mercan", from: "SAW", to: "BER")
+// The tear shell is per-preset chrome (see header note): on the `.classic`
+// default, `.cardStyle(.outlined)` renders identically to the default — the
+// no-op is deliberate. Swap to `.strip` (`.boardingPassStyle(.strip)`) and it applies.
+#Preview("Card-style no-op on the default tear preset") {
+    BoardingPass(passenger: "Jordan Lee", from: "SAW", to: "BER")
         .airline("Pegasus").flightNo("PC 1234")
         .times(departure: "13:15", arrival: "16:05")
         .gate("A12", seat: "14C", boarding: "12:45")

--- a/Sources/ThemeKitTravel/Components/Organisms/BoardingPassStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/BoardingPassStyle.swift
@@ -1,0 +1,570 @@
+//
+//  BoardingPassStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``BoardingPass`` (ADR-0004, Wave 4 · Class A) — the
+//  configuration hands styles the *typed pass data* (passenger, route, flight,
+//  the labelled detail cells, booking ref, barcode/QR), not pre-laid content, so
+//  a style owns the entire layout. Three built-ins:
+//
+//    .classic   header/passenger/route/details + horizontal TicketStub tear and
+//               a trailing barcode/QR stub — today's pass. Default.
+//    .wallet    QR-dominant vertical pass — the code and passenger name fill the
+//               tear-off stub, two-column details above (Apple Wallet pass).
+//    .strip     one-row gate strip: passenger name / seat / a mini QR or barcode.
+//
+//  Chrome ownership (ADR-0004 §4): the old component-wide `TicketStub`/`CardStyle`
+//  exemption dissolves into per-preset facts — `.classic` and `.wallet` own the
+//  perforated ``TicketStub`` chrome inside `makeBody` (fill, notches, perforation
+//  and elevation shadow are one inseparable unit), so `.cardStyle(_:)` is a
+//  documented no-op on those two; `.strip` draws no tear and routes its shell
+//  through the active `CardStyle`, so `.cardStyle(_:)` applies to it. The tear
+//  helpers (``BoardingPassCode``, the header/route/detail building blocks below)
+//  stay available to any custom style that wants the pass look.
+//
+//      BoardingPass(passenger: "Jordan Lee", from: "IST", to: "LHR")
+//          .airline("Anadolu Air").times(departure: "09:20", arrival: "12:15")
+//          .gate("A12", seat: "14C").qr("TK2434ISTLHR14C")
+//          .boardingPassStyle(.wallet)   // .classic / .strip / custom
+//
+//  Component style arranges content; shell style paints chrome; token theme
+//  colors everything.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``BoardingPassStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no airline → glyph only, no details → no detail
+/// area, no barcode/QR → no code).
+public struct BoardingPassConfiguration {
+    /// The passenger's display name — every style's required subject.
+    public let passenger: String
+    /// Origin IATA-style code.
+    public let from: String
+    /// Destination IATA-style code.
+    public let to: String
+    public let fromCity: String?
+    public let toCity: String?
+    /// Pre-formatted departure display string (the component takes strings).
+    public let departure: String?
+    /// Pre-formatted arrival display string.
+    public let arrival: String?
+    /// Pre-formatted flight date ("13 Sep").
+    public let date: String?
+    public let airline: String?
+    /// SF Symbol used when the header renders no custom slot.
+    public let airlineIcon: String
+    public let flightNo: String?
+    public let cabin: String?
+    /// The labelled detail cells (gate / seat / boarding / terminal…), in the
+    /// order supplied via `.details(_:)` or the `.gate(...)` convenience.
+    public let details: [(String, String)]
+    /// Typed convenience mirrors of the common cells — set via `.gate(...)`;
+    /// `nil` when the caller populated `.details(_:)` directly, or never set
+    /// that particular cell. ``BoardingPassStyle/strip`` reads ``seat``.
+    public let gate: String?
+    public let seat: String?
+    public let boarding: String?
+    public let terminal: String?
+    public let bookingRef: String?
+    /// Render-time resolved "Passenger" caption — re-resolves through the
+    /// localization chain on every body pass, so a live language switch is
+    /// never frozen at init.
+    public let passengerLabel: String
+    /// A Code-128 barcode value; `nil` when ``qrValue`` (or neither) is set.
+    public let barcodeValue: String?
+    /// A QR value; takes precedence over ``barcodeValue`` when both are set.
+    public let qrValue: String?
+    /// Footprint of the dominant-code presets' QR/barcode (`.strip` uses its
+    /// own fixed mini footprint instead — see ``BoardingPassConfiguration``'s
+    /// header note on genuine, non-token dimensions).
+    public let codeSize: BoardingPass.CodeSize
+    /// Detail-cell arrangement honoured by ``ClassicBoardingPassStyle``; other
+    /// presets pick their own fixed arrangement (`.wallet` always grids).
+    public let detailsLayout: BoardingPass.DetailsLayout
+    /// Accent (`BoardingPass.accent(_:)`), or `nil` for the component's
+    /// documented `.primary` fallback — resolve via ``accentBase``/``accentOnSolid``.
+    public let accent: SemanticColor?
+    /// Explicit surface fill, or `nil` to let the style choose its default
+    /// (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Surface elevation: none / soft / elevated.
+    public let elevation: CardElevation
+    /// Corner-radius role (`BoardingPass.cornerRadius(_:)`, default `.box`) —
+    /// forwarded to the tear presets' ``TicketStub`` and to `.strip`'s `CardStyle` shell.
+    public let radiusRole: Theme.RadiusRole
+    /// Draw the dashed perforation across the tear line (tear presets only).
+    public let showsPerforation: Bool
+    /// Perforation dash colour (border token key).
+    public let dashKey: Theme.BorderColorKey
+    /// Custom header slot (`.header { }`); `nil` = the built-in airline/flight row.
+    public let header: AnyView?
+    /// Custom stub slot (`.stub { }`); `nil` = the built-in stub for that preset.
+    public let stub: AnyView?
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component. `BoardingPass` takes
+    /// pre-formatted display strings (no raw `Date`s), so today's built-ins
+    /// don't format with it — carried for parity with the suite's shared
+    /// configuration essentials, and available to any custom style that does.
+    public let locale: Locale
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so `.componentDensity`
+    /// compacts or airs out the pass.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    // deferred: accent-fallback unification — keeps the `.primary` fallback
+    // (matching AncillaryCard/StickyBookingBar would be visually breaking here).
+    /// Accent for the airline glyph, route plane and duration.
+    public var accentBase: Color { (accent ?? .primary).base }
+    /// Content colour on top of a solid accent fill.
+    public var accentOnSolid: Color { (accent ?? .primary).onSolid }
+
+    /// Internal point constants behind the `CodeSize` ramp (token rule: ramp
+    /// enums map to private CGFloats; no raw sizes in the public signature).
+    public var qrSide: CGFloat {
+        switch codeSize { case .small: return 56; case .medium: return 72; case .large: return 96 }
+    }
+    public var barcodeHeight: CGFloat {
+        switch codeSize { case .small: return 36; case .medium: return 48; case .large: return 64 }
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `BoardingPass`'s entire presentation. Implement `makeBody` to lay
+/// out the configuration's pass data. Set one with `.boardingPassStyle(_:)`;
+/// the default is ``ClassicBoardingPassStyle``.
+public protocol BoardingPassStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: BoardingPassConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The airline/flight header row shared by `.classic` and `.wallet`: glyph +
+/// airline name leading, flight number + cabin trailing.
+private struct BoardingPassHeaderRow: View {
+    @Environment(\.theme) private var theme
+    let configuration: BoardingPassConfiguration
+
+    var body: some View {
+        HStack {
+            HStack(spacing: 6) {
+                Image(systemName: configuration.airlineIcon).font(.system(size: 14))
+                    .foregroundStyle(configuration.accentBase)
+                    .accessibilityHidden(true)   // decorative airline glyph
+                if let airline = configuration.airline {
+                    Text(airline).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+                }
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 1) {
+                if let flightNo = configuration.flightNo {
+                    Text(flightNo).textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary))
+                }
+                if let cabin = configuration.cabin {
+                    Text(cabin).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+                }
+            }
+        }
+    }
+}
+
+/// The from→to route track shared by `.classic` and `.wallet`: codes + cities
+/// on the ends, the accented plane (mirrored under RTL) and date centered.
+private struct BoardingPassRouteRow: View {
+    @Environment(\.theme) private var theme
+    let configuration: BoardingPassConfiguration
+
+    var body: some View {
+        HStack(alignment: .center) {
+            column(configuration.from, city: configuration.fromCity, time: configuration.departure, alignment: .leading)
+            Spacer(minLength: 8)
+            VStack(spacing: 2) {
+                if let date = configuration.date {
+                    Text(date).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+                }
+                Image(systemName: "airplane").font(.system(size: 16))
+                    .foregroundStyle(configuration.accentBase).mirrorsInRTL()
+                    .accessibilityHidden(true)   // decorative route glyph
+            }
+            Spacer(minLength: 8)
+            column(configuration.to, city: configuration.toCity, time: configuration.arrival, alignment: .trailing)
+        }
+    }
+
+    private func column(_ code: String, city: String?, time: String?, alignment: HorizontalAlignment) -> some View {
+        VStack(alignment: alignment, spacing: 1) {
+            Text(code).textStyle(.displaySm).foregroundStyle(theme.text(.textPrimary))
+            if let city { Text(city).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary)).lineLimit(1) }
+            if let time { Text(time).textStyle(.labelBase700).foregroundStyle(configuration.accentBase) }
+        }
+        .fixedSize()
+    }
+}
+
+/// One labelled detail cell ("GATE" / "A12") — shared by the row and grid arrangements.
+private struct BoardingPassDetailCell: View {
+    @Environment(\.theme) private var theme
+    let item: (String, String)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(item.0).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+            Text(item.1).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+        }
+    }
+}
+
+/// One horizontal row of detail cells — `.classic`'s `.row` layout.
+private struct BoardingPassDetailRow: View {
+    let configuration: BoardingPassConfiguration
+
+    var body: some View {
+        HStack(alignment: .top, spacing: configuration.spacing(.md)) {
+            ForEach(Array(configuration.details.enumerated()), id: \.offset) { _, item in
+                BoardingPassDetailCell(item: item)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+/// A two-column grid of detail cells — pairs of cells per `GridRow`, so five
+/// details wrap to three rows instead of clipping off the trailing edge.
+/// `.classic`'s `.grid` layout; `.wallet` always uses this arrangement.
+private struct BoardingPassDetailGrid: View {
+    let configuration: BoardingPassConfiguration
+
+    var body: some View {
+        Grid(alignment: .leading,
+             horizontalSpacing: configuration.spacing(.md),
+             verticalSpacing: configuration.spacing(.sm)) {
+            ForEach(Array(stride(from: 0, to: configuration.details.count, by: 2)), id: \.self) { index in
+                GridRow {
+                    BoardingPassDetailCell(item: configuration.details[index])
+                        .gridColumnAlignment(.leading)
+                    if index + 1 < configuration.details.count {
+                        BoardingPassDetailCell(item: configuration.details[index + 1])
+                            .gridColumnAlignment(.leading)
+                    } else {
+                        Color.clear.gridCellUnsizedAxes([.horizontal, .vertical])
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// `.classic`'s detail area — honours ``BoardingPassConfiguration/detailsLayout``.
+private struct BoardingPassDetailArea: View {
+    let configuration: BoardingPassConfiguration
+
+    var body: some View {
+        switch configuration.detailsLayout {
+        case .row: BoardingPassDetailRow(configuration: configuration)
+        case .grid: BoardingPassDetailGrid(configuration: configuration)
+        }
+    }
+}
+
+/// The stub's barcode/QR — QR wins when both are set. Shared by `.classic`'s
+/// trailing code and `.wallet`'s dominant centered code.
+private struct BoardingPassCode: View {
+    let configuration: BoardingPassConfiguration
+
+    var body: some View {
+        if let qr = configuration.qrValue {
+            QRCode(qr).size(configuration.qrSide)
+        } else if let barcode = configuration.barcodeValue {
+            Barcode(barcode).height(configuration.barcodeHeight).showsValue()
+        }
+    }
+}
+
+// MARK: - .classic — today's look (header / route / details / tear / stub)
+
+/// The default: header row, route, an optional detail area above a horizontal
+/// ``TicketStub`` tear, and a passenger/booking-ref/code stub below it. Owns
+/// the `TicketStub` chrome, so `.cardStyle(_:)` is a no-op on this preset.
+public struct ClassicBoardingPassStyle: BoardingPassStyle {
+    public init() {}
+    public func makeBody(configuration: BoardingPassConfiguration) -> some View {
+        TicketStub {
+            VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
+                if let header = configuration.header { header } else { BoardingPassHeaderRow(configuration: configuration) }
+                BoardingPassRouteRow(configuration: configuration)
+                if !configuration.details.isEmpty { BoardingPassDetailArea(configuration: configuration) }
+            }
+        }
+        .stub {
+            if let stub = configuration.stub { stub } else { ClassicBoardingPassStub(configuration: configuration) }
+        }
+        .cornerRadius(configuration.radiusRole)
+        .perforation(configuration.showsPerforation)
+        .dashColor(configuration.dashKey)
+        .elevation(configuration.elevation)
+        .surface(configuration.surface(default: .bgBase))
+    }
+}
+
+/// `.classic`'s built-in stub: passenger label/name/booking-ref leading, the
+/// code trailing.
+private struct ClassicBoardingPassStub: View {
+    @Environment(\.theme) private var theme
+    let configuration: BoardingPassConfiguration
+
+    var body: some View {
+        HStack(spacing: configuration.spacing(.md)) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(configuration.passengerLabel).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+                Text(configuration.passenger).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
+                if let bookingRef = configuration.bookingRef {
+                    Text(bookingRef).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                }
+            }
+            Spacer(minLength: 6)
+            BoardingPassCode(configuration: configuration)
+        }
+    }
+}
+
+// MARK: - .wallet — QR-dominant vertical (Apple Wallet pass)
+
+/// A vertical pass with the code and passenger name filling the tear-off stub —
+/// the header, route and a two-column detail grid sit above the tear; the code
+/// dominates below it. Owns the `TicketStub` chrome, so `.cardStyle(_:)` is a
+/// no-op on this preset.
+public struct WalletBoardingPassStyle: BoardingPassStyle {
+    public init() {}
+    public func makeBody(configuration: BoardingPassConfiguration) -> some View {
+        TicketStub {
+            VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
+                if let header = configuration.header { header } else { BoardingPassHeaderRow(configuration: configuration) }
+                BoardingPassRouteRow(configuration: configuration)
+                if !configuration.details.isEmpty { BoardingPassDetailGrid(configuration: configuration) }
+            }
+        }
+        .stub {
+            if let stub = configuration.stub { stub } else { WalletBoardingPassStub(configuration: configuration) }
+        }
+        .cornerRadius(configuration.radiusRole)
+        .perforation(configuration.showsPerforation)
+        .dashColor(configuration.dashKey)
+        .elevation(configuration.elevation)
+        .surface(configuration.surface(default: .bgBase))
+    }
+}
+
+/// `.wallet`'s built-in stub: the dominant, centered code above the centered
+/// passenger name/booking-ref — the Apple Wallet "big barcode, name below" read.
+private struct WalletBoardingPassStub: View {
+    @Environment(\.theme) private var theme
+    let configuration: BoardingPassConfiguration
+
+    var body: some View {
+        VStack(spacing: configuration.spacing(.sm)) {
+            BoardingPassCode(configuration: configuration)
+            VStack(spacing: 2) {
+                Text(configuration.passengerLabel).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+                Text(configuration.passenger).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
+                if let bookingRef = configuration.bookingRef {
+                    Text(bookingRef).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .multilineTextAlignment(.center)
+    }
+}
+
+// MARK: - .strip — one-row gate strip
+
+/// A dense, tearless row for gate-side lists: passenger name, the seat (when
+/// set) and a mini code. Draws no tear and routes its shell through the active
+/// `CardStyle`, so `.cardStyle(_:)` applies to this preset.
+public struct StripBoardingPassStyle: BoardingPassStyle {
+    public init() {}
+    public func makeBody(configuration: BoardingPassConfiguration) -> some View {
+        StripBoardingPassChrome(configuration: configuration)
+    }
+}
+
+private struct StripBoardingPassChrome: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.cardStyle) private var cardStyle
+    let configuration: BoardingPassConfiguration
+
+    /// A dense strip's code is deliberately mini — a fixed constant, not the
+    /// dominant-code presets' `codeSize` ramp (token rule: a genuine dimension
+    /// with no semantic token stays a fixed constant, never an arbitrary knob).
+    private let miniQRSide: CGFloat = 32
+    private let miniBarcodeHeight: CGFloat = 24
+
+    var body: some View {
+        cardStyle.makeBody(configuration: CardStyleConfiguration(
+            content: AnyView(row),
+            elevation: configuration.elevation,
+            surfaceKey: configuration.surface(default: .bgBase),
+            radius: configuration.radiusRole))
+    }
+
+    private var row: some View {
+        HStack(spacing: configuration.spacing(.sm)) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(configuration.passengerLabel).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+                Text(configuration.passenger).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary)).lineLimit(1)
+            }
+            if let seat = configuration.seat {
+                DividerView().axis(.vertical)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(String(themeKit: "Seat")).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
+                    Text(seat).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
+                }
+            }
+            Spacer(minLength: configuration.spacing(.sm))
+            miniCode
+        }
+        .padding(configuration.spacing(.sm))
+        .frame(minHeight: 44)
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder private var miniCode: some View {
+        if let qr = configuration.qrValue {
+            QRCode(qr).size(miniQRSide)
+        } else if let barcode = configuration.barcodeValue {
+            Barcode(barcode).height(miniBarcodeHeight)
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension BoardingPassStyle where Self == ClassicBoardingPassStyle {
+    /// Header/passenger/route/details + horizontal tear + barcode stub. The default.
+    static var classic: ClassicBoardingPassStyle { ClassicBoardingPassStyle() }
+}
+public extension BoardingPassStyle where Self == WalletBoardingPassStyle {
+    /// QR-dominant vertical pass, two-column details — Apple Wallet style.
+    static var wallet: WalletBoardingPassStyle { WalletBoardingPassStyle() }
+}
+public extension BoardingPassStyle where Self == StripBoardingPassStyle {
+    /// One-row gate strip: passenger name / seat / mini code.
+    static var strip: StripBoardingPassStyle { StripBoardingPassStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyBoardingPassStyle: BoardingPassStyle {
+    private let _makeBody: @MainActor (BoardingPassConfiguration) -> AnyView
+    init<S: BoardingPassStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: BoardingPassConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct BoardingPassStyleKey: EnvironmentKey {
+    static let defaultValue = AnyBoardingPassStyle(ClassicBoardingPassStyle())
+}
+
+extension EnvironmentValues {
+    var boardingPassStyle: AnyBoardingPassStyle {
+        get { self[BoardingPassStyleKey.self] }
+        set { self[BoardingPassStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``BoardingPassStyle`` for `BoardingPass`es in this view and its
+    /// descendants — one screen can mix archetypes per section.
+    func boardingPassStyle<S: BoardingPassStyle>(_ style: sending S) -> some View {
+        environment(\.boardingPassStyle, AnyBoardingPassStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+private func sampleBoardingPass() -> BoardingPass {
+    BoardingPass(passenger: "Jordan Lee", from: "IST", to: "LHR")
+        .airline("Anadolu Air").flightNo("TK 2434").cabin("Economy")
+        .cities(from: "Istanbul", to: "London").times(departure: "09:20", arrival: "12:15").date("18 Jul")
+        .gate("A12", seat: "14C", boarding: "08:40", terminal: "1")
+        .bookingRef("PNR: X7K2QF").barcode("TK2434ISTLHR14C")
+}
+
+private func denseBoardingPass() -> BoardingPass {
+    BoardingPass(passenger: "Priya Nair", from: "AMS", to: "CDG")
+        .airline("Blue Wings").flightNo("BW 810")
+        .times(departure: "18:05", arrival: "19:20")
+        .details([("Terminal", "2"), ("Gate", "B4"), ("Boarding", "17:35"), ("Seat", "22A"), ("Zone", "1")])
+        .qr("BW810AMSCDG22A").codeSize(.large)
+}
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a solid-accent "now boarding" banner with no `TicketStub` at all,
+/// proving the protocol is externally implementable.
+private struct GateAnnouncementBoardingPassStyle: BoardingPassStyle {
+    func makeBody(configuration: BoardingPassConfiguration) -> some View {
+        GateAnnouncementChrome(configuration: configuration)
+    }
+
+    private struct GateAnnouncementChrome: View {
+        let configuration: BoardingPassConfiguration
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+                Text(String(themeKit: "Now boarding")).textStyle(.overline500)
+                    .foregroundStyle(configuration.accentOnSolid)
+                HStack {
+                    Text("\(configuration.from) → \(configuration.to)")
+                        .textStyle(.headingSm).foregroundStyle(configuration.accentOnSolid)
+                    Spacer()
+                    if let gate = configuration.gate {
+                        Text(gate).textStyle(.labelLg700).foregroundStyle(configuration.accentOnSolid)
+                    }
+                }
+                Text(configuration.passenger).textStyle(.bodySm400).foregroundStyle(configuration.accentOnSolid)
+            }
+            .padding(configuration.spacing(.md))
+            .background((configuration.accent ?? .primary).solid,
+                        in: RoundedRectangle(cornerRadius: configuration.radiusRole.value, style: .continuous))
+        }
+    }
+}
+
+#Preview("BoardingPassStyle — presets × light/dark") {
+    PreviewMatrix("BoardingPassStyle", rtl: true) {
+        PreviewCase("Classic (default)") { sampleBoardingPass().frame(maxWidth: 320) }
+        PreviewCase("Classic · accent") {
+            sampleBoardingPass().accent(.info).boardingPassStyle(.classic).frame(maxWidth: 320)
+        }
+        PreviewCase("Wallet") { sampleBoardingPass().boardingPassStyle(.wallet).frame(maxWidth: 280) }
+        PreviewCase("Wallet · large QR") {
+            denseBoardingPass().accent(.success).boardingPassStyle(.wallet).frame(maxWidth: 280)
+        }
+        PreviewCase("Strip") { sampleBoardingPass().boardingPassStyle(.strip).frame(maxWidth: 320) }
+        PreviewCase("Strip · no seat") {
+            BoardingPass(passenger: "Chris Bailey", from: "ESB", to: "SAW")
+                .times(departure: "07:00", arrival: "08:10")
+                .barcode("PC9021ESBSAW")
+                .boardingPassStyle(.strip)
+                .frame(maxWidth: 320)
+        }
+        PreviewCase("Custom (in-preview)") {
+            sampleBoardingPass().accent(.warning).boardingPassStyle(GateAnnouncementBoardingPassStyle()).frame(maxWidth: 320)
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/CheckInFlow.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/CheckInFlow.swift
@@ -16,6 +16,15 @@
 //  initial states only. Page transitions slide directionally on leading /
 //  trailing edges (mirrored under RTL automatically), gated by `MicroMotion`.
 //
+//  Style (ADR-0004, Class B): the component owns every live unit (selection,
+//  page identity/transition/motion, dock wiring) — arrangement is delegated
+//  to the active ``CheckInFlowStyle`` (`CheckInFlowStyle.swift`) via
+//  `.checkInFlowStyle(_:)`. `.steps`/`.bar` are the former
+//  ``CheckInProgressStyle`` cases, deprecate-forwarded through
+//  `.progressStyle(_:)`; `.paged` is new. Navigation (advance/back/jump) and
+//  the `canAdvance`/`onComplete` gates stay in the component — styles only
+//  arrange the pre-wired `Steps` header, page and dock units.
+//
 //  ```swift
 //  CheckInFlow(steps: [.init("Passengers", state: .active),
 //                      .init("Seats", state: .todo),
@@ -49,7 +58,11 @@ public enum PageTransition: Sendable { case slide, fade, none }
 public enum StepperPlacement: Sendable { case top, leading }
 
 /// The progress chrome itself: the `Steps` markers (default) or a thin
-/// determinate `ProgressBar`.
+/// determinate `ProgressBar`. Superseded by ``CheckInFlowStyle`` (ADR-0004) —
+/// `.steps` and `.bar` map 1:1 onto ``CheckInFlowStyle/steps`` and
+/// ``CheckInFlowStyle/bar`` (plus the new ``CheckInFlowStyle/paged``); the
+/// enum remains for source compatibility via the deprecated
+/// ``CheckInFlow/progressStyle(_:)`` and is removed at the next major.
 public enum CheckInProgressStyle: Sendable { case steps, bar }
 
 /// A check-in journey scaffold — `Steps` header + the current page + a
@@ -60,6 +73,9 @@ public struct CheckInFlow<Page: View>: View {
     @Environment(\.isReadOnly) private var isReadOnly
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.componentDensity) private var envDensity
+    @Environment(\.locale) private var locale
+    @Environment(\.checkInFlowStyle) private var envStyle
 
     private let steps: [Steps.Step]
     private let page: (Int) -> Page
@@ -95,7 +111,10 @@ public struct CheckInFlow<Page: View>: View {
     private var pageTransitionValue: PageTransition = .slide
     private var stepperSizeValue: StepsSize = .medium
     private var stepperPlacementValue: StepperPlacement = .top
-    private var progressStyleValue: CheckInProgressStyle = .steps
+    /// Style set by the deprecated ``progressStyle(_:)`` modifier — wins over
+    /// the environment style (ADR-0004 §5 — source-behavior stability during
+    /// the enum's deprecation window).
+    private var explicitStyle: AnyCheckInFlowStyle?
 
     /// R1 — the step definitions + controlled index + per-step page builder.
     /// The binding is the change channel; observe with `.onChange(of:)` at the
@@ -150,52 +169,41 @@ public struct CheckInFlow<Page: View>: View {
         if steps.isEmpty {
             EmptyView()
         } else {
-            Group {
-                if showsStepperValue, stepperPlacementValue == .leading, progressStyleValue == .steps {
-                    // Leading rail: vertical Steps beside the page area.
-                    HStack(alignment: .top, spacing: 0) {
-                        header(axis: .vertical)
-                            .padding(.horizontal, Theme.SpacingKey.md.value)
-                            .padding(.vertical, Theme.SpacingKey.sm.value)
-                        pageContainer
-                    }
-                } else {
-                    VStack(spacing: 0) {
-                        if showsStepperValue {
-                            progressChrome
-                                .padding(.horizontal, Theme.SpacingKey.md.value)
-                                .padding(.vertical, Theme.SpacingKey.sm.value)
-                        }
-                        pageContainer
-                    }
-                }
-            }
-            .buttonDock {
-                if let dockSlot {
-                    // Custom dock: the caller owns Back/Continue semantics —
-                    // canAdvance gating and onComplete become its job.
-                    dockSlot.allowsHitTesting(!isReadOnly)
-                } else {
-                    dock
-                }
-            }
-            .accessibilityElement(children: .contain)
+            // ADR-0004 §5 — an explicit (deprecated `.progressStyle(_:)`) style
+            // wins over the ancestor `.checkInFlowStyle(_:)` environment style.
+            (explicitStyle ?? envStyle).makeBody(configuration: configuration)
         }
     }
 
-    /// The `.progressStyle(_:)` switch: Steps markers or a determinate bar.
+    /// The pre-wired units + typed signals handed to the active
+    /// ``CheckInFlowStyle``. Built unconditionally every render — styles
+    /// arrange, they never re-wire (ADR-0004 §2.2).
     @MainActor
-    @ViewBuilder
-    private var progressChrome: some View {
-        switch progressStyleValue {
-        case .steps:
-            header(axis: .horizontal)
-        case .bar:
-            // Step titles are internal to the neutral `Steps.Step`, so the
-            // announcement is positional ("Step 2 of 3").
-            ProgressBar(value: Double(currentIndex + 1) / Double(max(steps.count, 1)))
-                .progressLabel(String(themeKitTravel: "Step \(currentIndex + 1) of \(steps.count)"))
+    private var configuration: CheckInFlowConfiguration {
+        CheckInFlowConfiguration(
+            stepsHeader: AnyView(header(axis: stepperPlacementValue == .leading ? .vertical : .horizontal)),
+            page: AnyView(pageContainer),
+            dock: dockUnit,
+            currentIndex: currentIndex,
+            stepCount: steps.count,
+            canAdvance: advanceAllowed,
+            showsStepper: showsStepperValue,
+            placement: stepperPlacementValue,
+            accent: accent,
+            density: envDensity,
+            locale: locale)
+    }
+
+    /// The wired dock unit: the caller's `.dock { }` replacement (read-only
+    /// gated) or the built-in Back/Continue `ButtonGroup`.
+    @MainActor
+    private var dockUnit: AnyView {
+        if let dockSlot {
+            // Custom dock: the caller owns Back/Continue semantics —
+            // canAdvance gating and onComplete become its job.
+            return AnyView(dockSlot.allowsHitTesting(!isReadOnly))
         }
+        return AnyView(dock)
     }
 
     @MainActor
@@ -349,8 +357,9 @@ public extension CheckInFlow {
         copy { $0.onCompleteAction = action }
     }
 
-    /// Show or hide the `Steps` header — hide for compact hosts that provide
-    /// their own progress chrome.
+    /// Show or hide the progress chrome — whichever ``CheckInFlowStyle`` is
+    /// active (`Steps` header, bar or dot pager) — for compact hosts that
+    /// provide their own.
     func showsStepper(_ on: Bool = true) -> Self { copy { $0.showsStepperValue = on } }
 
     /// Semantic tint for the done/active step markers; `nil` (default) keeps
@@ -386,13 +395,24 @@ public extension CheckInFlow {
     func stepperSize(_ s: StepsSize) -> Self { copy { $0.stepperSizeValue = s } }
 
     /// Progress-chrome placement: `.top` (default) or `.leading` — a vertical
-    /// `Steps` rail beside the page (steps style only; the `.bar` progress
-    /// style always renders on top).
+    /// `Steps` rail beside the page. Only ``CheckInFlowStyle/steps`` honors a
+    /// `.leading` rail; `.bar` and `.paged` always render their own chrome
+    /// on top.
     func stepperPlacement(_ p: StepperPlacement) -> Self { copy { $0.stepperPlacementValue = p } }
 
-    /// Progress chrome: `.steps` markers (default) or `.bar` — a thin
-    /// determinate `ProgressBar` announcing "Step N of M".
-    func progressStyle(_ s: CheckInProgressStyle) -> Self { copy { $0.progressStyleValue = s } }
+    /// Progress chrome: `.steps` markers or `.bar` — superseded by the style
+    /// axis: prefer `.checkInFlowStyle(.steps/.bar/.paged)`, settable once per
+    /// screen via the environment. This modifier keeps working and, when
+    /// called, wins over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .checkInFlowStyle(.steps/.bar/.paged) instead")
+    func progressStyle(_ s: CheckInProgressStyle) -> Self {
+        copy {
+            switch s {
+            case .steps: $0.explicitStyle = AnyCheckInFlowStyle(StepsCheckInFlowStyle())
+            case .bar: $0.explicitStyle = AnyCheckInFlowStyle(BarCheckInFlowStyle())
+            }
+        }
+    }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -478,11 +498,11 @@ public extension CheckInFlow {
                     ], selection: $barStep) { index in
                         Text("Step \(index + 1)").textStyle(.bodyBase400).padding()
                     }
-                    .progressStyle(.bar)
                     .pageTransition(.fade)
                     .dockLayout(.stretch)
                     .buttonSize(.large)
                     .frame(height: 200)
+                    .checkInFlowStyle(.bar)
 
                     // Leading vertical rail + small tappable markers.
                     CheckInFlow(steps: [

--- a/Sources/ThemeKitTravel/Components/Organisms/CheckInFlowStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/CheckInFlowStyle.swift
@@ -1,0 +1,359 @@
+//
+//  CheckInFlowStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``CheckInFlow`` — a Class B protocol of ADR-0004
+//  (per-component style protocols). The component owns the live progression
+//  state (`ControllableState` selection, page identity, motion, dock wiring)
+//  — the configuration hands styles **pre-wired, type-erased units** (the
+//  `Steps` header, the current page, the wired Back/Continue dock) plus typed
+//  signals (current index, step count, the advance gate, accent, density,
+//  locale). Styles ARRANGE the units; they never rebuild the `Steps` markers,
+//  the page transition or the dock buttons. Three built-ins:
+//
+//    .steps   `Steps` header (top, or a leading rail via `.stepperPlacement(.leading)`)
+//             + the page + the docked Back/Continue run — today's flow. Default.
+//    .bar     promotes ``CheckInProgressStyle/bar``: a thin determinate
+//             `ProgressBar` announcing "Step N of M" instead of the `Steps` markers.
+//    .paged   a minimal page-dot pager (the stock `StepIndicator` atom) above
+//             the page — the lightest-weight progress chrome.
+//
+//      CheckInFlow(steps: steps, selection: $step) { index in page(index) }
+//          .canAdvance { $0 == 1 ? !seats.isEmpty : true }
+//          .onComplete { finishCheckIn() }
+//          .checkInFlowStyle(.paged)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the token
+//  theme colors everything (there is no shell chrome to delegate — the
+//  scaffold has no surface/card of its own). Motion is resolved in the
+//  component (`MicroMotion` ∧ ¬Reduce Motion): the page unit already carries
+//  its transition + animation, and the dock unit already carries its
+//  enablement/titles — styles never read the motion environment or rebuild
+//  either.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The pre-wired inputs a ``CheckInFlowStyle`` arranges. The `AnyView` unit
+/// fields are fully interactive/wired by the component — place them, never
+/// rebuild them. The typed fields are read-only signals for arrangement
+/// decisions; a preset that doesn't need one simply ignores it (e.g. `.bar`
+/// and `.paged` build their own progress chrome from ``currentIndex``/
+/// ``stepCount`` and never touch ``stepsHeader``).
+public struct CheckInFlowConfiguration {
+    // MARK: Pre-wired units — fully interactive; styles arrange, never re-wire.
+
+    /// The wired `Steps` header: axis (`.top` → horizontal, `.leading` → a
+    /// vertical rail — see ``placement``), the tappable-jump callback
+    /// (`.stepsTappable(_:)`), marker size (`.stepperSize(_:)`) and the
+    /// accent-tinted marker (`.accent(_:)`) are already applied. `.steps`-
+    /// shaped presets place it; other presets build their own chrome instead.
+    public let stepsHeader: AnyView
+    /// The current step's page content: identity (`.id(_:)`), the directional
+    /// slide/fade/none transition (`.pageTransition(_:)`) and the
+    /// `MicroMotion`-gated animation are already wired. Every preset places
+    /// it as-is.
+    public let page: AnyView
+    /// The wired Back / Continue dock: either the built-in `ButtonGroup`
+    /// (titles, the last-step "Done" swap, the `canAdvance` gate, size and
+    /// layout are already resolved) or the caller's `.dock { }` replacement.
+    /// Read-only hit-testing is already applied.
+    public let dock: AnyView
+
+    // MARK: Typed signals for arrangement decisions.
+
+    /// Zero-based index of the step currently on screen.
+    public let currentIndex: Int
+    /// Total step count.
+    public let stepCount: Int
+    /// `true` when the dock's advancing button is enabled (the
+    /// ``CheckInFlow/canAdvance(_:)`` gate) — exposed for a custom style that
+    /// wants to reflect the gate outside the dock itself; the built-ins don't
+    /// need it since ``dock`` already disables its own button.
+    public let canAdvance: Bool
+    /// `false` hides the progress chrome entirely, whichever preset is active
+    /// (`Steps` header, bar or dot pager) — for compact hosts that supply
+    /// their own (``CheckInFlow/showsStepper(_:)``). The page and dock still
+    /// render.
+    public let showsStepper: Bool
+    /// Where ``stepsHeader`` sits relative to the page:
+    /// (``CheckInFlow/stepperPlacement(_:)``). Only `.steps`-shaped presets
+    /// honor a `.leading` rail; `.bar` and `.paged` always render their own
+    /// chrome above the page, matching their pre-style behavior.
+    public let placement: StepperPlacement
+    /// Semantic tint for the active/done markers (``CheckInFlow/accent(_:)``);
+    /// `nil` keeps the theme's hero tokens. Already baked into ``stepsHeader``;
+    /// exposed here for a custom bar/pager-shaped style that wants to tint its
+    /// own chrome the same way.
+    public let accent: SemanticColor?
+    /// The environment's component density, captured by the component — scale
+    /// a preset's own chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component.
+    public let locale: Locale
+
+    /// Density-scaled spacing — use for a preset's own chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out the flow (the pre-wired units
+    /// already scale their own internals).
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+}
+
+// MARK: - Protocol
+
+/// Defines a `CheckInFlow`'s entire presentation. Implement `makeBody` to
+/// arrange the configuration's pre-wired units. Set one with
+/// `.checkInFlowStyle(_:)`; the default is ``StepsCheckInFlowStyle``.
+public protocol CheckInFlowStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: CheckInFlowConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+private extension View {
+    /// The dock-pinned, accessibility-contained shell every built-in preset
+    /// wraps its arrangement in — the scaffold has no surface of its own, so
+    /// this is the entire "chrome" a preset needs beyond its own layout.
+    func checkInFlowShell(dock: AnyView) -> some View {
+        buttonDock { dock }
+            .accessibilityElement(children: .contain)
+    }
+}
+
+// MARK: - .steps (default)
+
+/// Today's `CheckInFlow` look, extracted verbatim: the `Steps` header — on
+/// top, or as a leading vertical rail beside the page when
+/// `.stepperPlacement(.leading)` is set — the current page, and the docked
+/// Back/Continue run.
+public struct StepsCheckInFlowStyle: CheckInFlowStyle {
+    public init() {}
+    public func makeBody(configuration: CheckInFlowConfiguration) -> some View {
+        StepsCheckInFlowChrome(configuration: configuration)
+    }
+}
+
+private struct StepsCheckInFlowChrome: View {
+    let configuration: CheckInFlowConfiguration
+
+    var body: some View {
+        Group {
+            if configuration.showsStepper, configuration.placement == .leading {
+                HStack(alignment: .top, spacing: 0) {
+                    configuration.stepsHeader
+                        .padding(.horizontal, Theme.SpacingKey.md.value)
+                        .padding(.vertical, Theme.SpacingKey.sm.value)
+                    configuration.page
+                }
+            } else {
+                VStack(spacing: 0) {
+                    if configuration.showsStepper {
+                        configuration.stepsHeader
+                            .padding(.horizontal, Theme.SpacingKey.md.value)
+                            .padding(.vertical, Theme.SpacingKey.sm.value)
+                    }
+                    configuration.page
+                }
+            }
+        }
+        .checkInFlowShell(dock: configuration.dock)
+    }
+}
+
+// MARK: - .bar
+
+/// A thin determinate `ProgressBar` ("Step N of M") instead of the `Steps`
+/// markers — promotes the former ``CheckInProgressStyle/bar`` knob. Always
+/// renders on top; it never honors ``CheckInFlowConfiguration/placement``.
+public struct BarCheckInFlowStyle: CheckInFlowStyle {
+    public init() {}
+    public func makeBody(configuration: CheckInFlowConfiguration) -> some View {
+        BarCheckInFlowChrome(configuration: configuration)
+    }
+}
+
+private struct BarCheckInFlowChrome: View {
+    let configuration: CheckInFlowConfiguration
+
+    /// Step titles are internal to the neutral `Steps.Step`, so the
+    /// announcement is positional ("Step 2 of 3").
+    private var fraction: Double {
+        Double(configuration.currentIndex + 1) / Double(max(configuration.stepCount, 1))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if configuration.showsStepper {
+                ProgressBar(value: fraction)
+                    .progressLabel(String(
+                        themeKitTravel: "Step \(configuration.currentIndex + 1) of \(configuration.stepCount)"))
+                    .padding(.horizontal, Theme.SpacingKey.md.value)
+                    .padding(.vertical, Theme.SpacingKey.sm.value)
+            }
+            configuration.page
+        }
+        .checkInFlowShell(dock: configuration.dock)
+    }
+}
+
+// MARK: - .paged
+
+/// A minimal page-dot pager above the page — the lightest-weight progress
+/// chrome, composed from the stock ``StepIndicator`` atom (never
+/// re-implemented). No titles, no leading-rail variant.
+public struct PagedCheckInFlowStyle: CheckInFlowStyle {
+    public init() {}
+    public func makeBody(configuration: CheckInFlowConfiguration) -> some View {
+        PagedCheckInFlowChrome(configuration: configuration)
+    }
+}
+
+private struct PagedCheckInFlowChrome: View {
+    let configuration: CheckInFlowConfiguration
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if configuration.showsStepper {
+                StepIndicator(current: configuration.currentIndex, total: configuration.stepCount)
+                    .padding(.vertical, configuration.spacing(.sm))
+            }
+            configuration.page
+        }
+        .checkInFlowShell(dock: configuration.dock)
+    }
+}
+
+// MARK: - Static accessors
+
+public extension CheckInFlowStyle where Self == StepsCheckInFlowStyle {
+    /// `Steps` header (top, or a leading rail) + page + docked Back/Continue
+    /// — today's flow. The default.
+    static var steps: StepsCheckInFlowStyle { StepsCheckInFlowStyle() }
+}
+public extension CheckInFlowStyle where Self == BarCheckInFlowStyle {
+    /// A thin determinate `ProgressBar` ("Step N of M") instead of `Steps` markers.
+    static var bar: BarCheckInFlowStyle { BarCheckInFlowStyle() }
+}
+public extension CheckInFlowStyle where Self == PagedCheckInFlowStyle {
+    /// A minimal page-dot pager (`StepIndicator`) above the page.
+    static var paged: PagedCheckInFlowStyle { PagedCheckInFlowStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyCheckInFlowStyle: CheckInFlowStyle {
+    private let _makeBody: @MainActor (CheckInFlowConfiguration) -> AnyView
+    init<S: CheckInFlowStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: CheckInFlowConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct CheckInFlowStyleKey: EnvironmentKey {
+    static let defaultValue = AnyCheckInFlowStyle(StepsCheckInFlowStyle())
+}
+
+extension EnvironmentValues {
+    var checkInFlowStyle: AnyCheckInFlowStyle {
+        get { self[CheckInFlowStyleKey.self] }
+        set { self[CheckInFlowStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``CheckInFlowStyle`` for `CheckInFlow`s in this view and its
+    /// descendants — a compact host can run `.paged` while a full-screen
+    /// check-in keeps `.steps`.
+    func checkInFlowStyle<S: CheckInFlowStyle>(_ style: sending S) -> some View {
+        environment(\.checkInFlowStyle, AnyCheckInFlowStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — a plain "Step N of M"
+/// label instead of `Steps`, a bar or a pager. Proves external
+/// implementability: it only reads typed signals and places the pre-wired
+/// units, never rebuilds them.
+private struct LabelCheckInFlowStyle: CheckInFlowStyle {
+    func makeBody(configuration: CheckInFlowConfiguration) -> some View {
+        LabelCheckInFlowChrome(configuration: configuration)
+    }
+
+    private struct LabelCheckInFlowChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: CheckInFlowConfiguration
+
+        var body: some View {
+            VStack(spacing: 0) {
+                if configuration.showsStepper {
+                    Text("Step \(configuration.currentIndex + 1) of \(configuration.stepCount)")
+                        .textStyle(.overline500)
+                        .foregroundStyle(configuration.accent?.base ?? theme.text(.textSecondary))
+                        .padding(.vertical, configuration.spacing(.sm))
+                }
+                configuration.page
+            }
+            .checkInFlowShell(dock: configuration.dock)
+        }
+    }
+}
+
+private let previewStepTitles = ["Passengers", "Seats", "Boarding pass"]
+
+private func previewSteps() -> [Steps.Step] {
+    previewStepTitles.map { Steps.Step($0, state: .todo) }
+}
+
+@MainActor private func previewPage(_ index: Int) -> some View {
+    VStack(spacing: Theme.SpacingKey.sm.value) {
+        Text(previewStepTitles[index]).textStyle(.headingSm)
+        Text("Review the details, then continue.").textStyle(.bodyBase400)
+    }
+    .padding(Theme.SpacingKey.md.value)
+}
+
+#Preview("CheckInFlowStyle — presets × light/dark") {
+    PreviewMatrix("CheckInFlowStyle") {
+        PreviewCase(".steps (default)") {
+            CheckInFlow(steps: previewSteps(), initiallyAt: 1) { previewPage($0) }
+                .frame(height: 260)
+                .checkInFlowStyle(.steps)
+        }
+        PreviewCase(".bar") {
+            CheckInFlow(steps: previewSteps(), initiallyAt: 1) { previewPage($0) }
+                .frame(height: 220)
+                .checkInFlowStyle(.bar)
+        }
+        PreviewCase(".paged") {
+            CheckInFlow(steps: previewSteps(), initiallyAt: 1) { previewPage($0) }
+                .frame(height: 220)
+                .checkInFlowStyle(.paged)
+        }
+        PreviewCase("Custom (in-preview) — label chrome") {
+            CheckInFlow(steps: previewSteps(), initiallyAt: 1) { previewPage($0) }
+                .accent(.success)
+                .frame(height: 220)
+                .checkInFlowStyle(LabelCheckInFlowStyle())
+        }
+    }
+}
+
+#Preview("Leading rail (.steps) & .paged — XL type / RTL") {
+    PreviewMatrix("CheckInFlow — leading rail & paged", schemes: [.light], dynamicType: true, rtl: true) {
+        PreviewCase(".steps — leading rail") {
+            CheckInFlow(steps: previewSteps(), initiallyAt: 1) { previewPage($0) }
+                .stepperPlacement(.leading)
+                .frame(height: 260)
+                .checkInFlowStyle(.steps)
+        }
+        PreviewCase(".paged") {
+            CheckInFlow(steps: previewSteps(), initiallyAt: 1) { previewPage($0) }
+                .frame(height: 220)
+                .checkInFlowStyle(.paged)
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightTracker.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightTracker.swift
@@ -4,15 +4,20 @@
 //
 //  Edition organism (F3.3 · ADR §9.9). The live status/gate screen — status
 //  badge, route with an en-route progress treatment, schedule vs estimate,
-//  gate/terminal/belt facts and a phase timeline. Composes ThemeKit's neutral
-//  `Card`, `FlightStatusBadge`, `FlightRoute`, `KeyValueTable` and `Steps` —
-//  nothing is re-implemented here.
+//  gate/terminal/belt facts and a phase timeline. The arrangement is owned by
+//  the active ``FlightTrackerStyle`` from the environment (ADR-0004): the
+//  component gathers its typed live-status data into a
+//  ``FlightTrackerConfiguration`` and hands it to the style — `.board`
+//  (default) is today's tracker verbatim, `.compact`/`.timeline`/`.banner`
+//  swap the whole layout, and apps can implement their own. Card-shaped
+//  presets keep composing the neutral `Card`, so `.cardStyle(_:)` still swaps
+//  the chrome independently.
 //
 //  Stateless by construction (house rule 1): the app polls or streams and
 //  re-renders with a fresh `FlightStatusInfo` — no `Task`, no timers. Delay
 //  rendering: when an estimate differs from the scheduled time, the scheduled
 //  time strikes through in `textTertiary` and the estimate renders in the
-//  status tone (`FlightStatus.semantic`).
+//  status tone (`FlightStatus.semantic`) — see `FlightTrackerConfiguration`.
 //
 //  ## Status-change announcement pattern (a11y live region)
 //  The header is one combined VoiceOver element ("Skyline Air, IST to LHR,
@@ -21,33 +26,40 @@
 //  watches that transition with `.onChange(of: info.status)` and posts an
 //  `AccessibilityNotification.Announcement`, gated to an actual value change,
 //  so VoiceOver interrupts with "Delayed, estimated departure 2:20 PM" the
-//  moment the poll flips the status. This only fires while the same
-//  `FlightTracker` stays in the hierarchy (identity-preserving re-render); if
-//  a host rebuilds the screen from scratch it should post its own announcement.
+//  moment the poll flips the status. This lives on the component's card
+//  shell — not in any style — so it keeps firing under every preset. This
+//  only fires while the same `FlightTracker` stays in the hierarchy
+//  (identity-preserving re-render); if a host rebuilds the screen from
+//  scratch it should post its own announcement.
 //
 //  ```swift
 //  FlightTracker(info)
 //      .progress(0.62)
 //      .updated(lastPoll)
 //      .details([("Aircraft", "A321neo")])
+//      .flightTrackerStyle(.timeline)
 //  ```
 //
 
 import SwiftUI
 import ThemeKit
 
-/// Layout archetype of a ``FlightTracker``: the full status board (`.board`,
-/// default) or a one-row status strip (`.compact`) for lists and widgets.
+/// Layout archetype of a ``FlightTracker``. Superseded by ``FlightTrackerStyle``
+/// (ADR-0004) — every case maps 1:1 to a preset (`.board` →
+/// `.flightTrackerStyle(.board)`, `.compact` → `.flightTrackerStyle(.compact)`,
+/// plus the new `.timeline`/`.banner`); the enum remains for source
+/// compatibility and is removed at the next major.
 public enum FlightTrackerVariant: Sendable { case board, compact }
 
 /// The live flight status board — badge, route + progress, schedule vs
 /// estimate, gate/terminal/belt facts and a phase timeline, on a `Card` shell.
 public struct FlightTracker: View {
-    @Environment(\.theme) private var theme
     @Environment(\.locale) private var locale
     @Environment(\.isReadOnly) private var isReadOnly
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.componentDensity) private var density
+    @Environment(\.flightTrackerStyle) private var envStyle
 
     private let info: FlightStatusInfo
 
@@ -57,13 +69,16 @@ public struct FlightTracker: View {
     private var extraDetails: [(String, String)] = []
     private var timelineVisible = true
     private var accentOverride: SemanticColor?
-    private var surfaceKey: Theme.BackgroundColorKey = .bgWhite
+    /// `nil` → the style's own default surface (the built-ins use `.bgWhite`).
+    private var surfaceKey: Theme.BackgroundColorKey?
     private var elevationValue: CardElevation = .soft
     private var footerSlot: AnyView?
-    private var variantValue: FlightTrackerVariant = .board
+    /// Style set by the deprecated `.variant(_:)`; wins over the environment
+    /// style (ADR-0004 §5 — source-behavior stability during migration).
+    private var explicitStyle: AnyFlightTrackerStyle?
     private var showsFactsValue = true
     private var showsEstimatesValue = true
-    /// Replaces the built-in airline/route/badge header (`.board` only).
+    /// Replaces the built-in airline/route/badge header (`.board`/`.timeline`).
     private var headerSlot: AnyView?
     private var checkInTitleOverride: String?
     private var boardingTitleOverride: String?
@@ -81,9 +96,9 @@ public struct FlightTracker: View {
 
     // MARK: Derived
 
-    /// Tone for the progress treatment and estimates: the explicit accent, or
-    /// the status's own semantic colour (`FlightStatus.semantic`).
-    private var tone: SemanticColor { accentOverride ?? info.status.semantic }
+    /// The active style: the deprecated `.variant(_:)`'s explicit choice wins
+    /// over the ancestor `.flightTrackerStyle(_:)` (ADR-0004 §5).
+    private var resolvedStyle: AnyFlightTrackerStyle { explicitStyle ?? envStyle }
 
     private var motion: Animation? {
         MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion)
@@ -93,292 +108,52 @@ public struct FlightTracker: View {
         progressValue.map { min(max($0, 0), 1) }
     }
 
-    private var timeFormat: Date.FormatStyle {
-        Date.FormatStyle(date: .omitted, time: .shortened).locale(locale)
-    }
-
-    /// An estimate "counts" only when it moves the schedule by a minute or more.
-    private func meaningfulEstimate(_ estimate: Date?, vs scheduled: Date) -> Date? {
-        guard let estimate, abs(estimate.timeIntervalSince(scheduled)) >= 60 else { return nil }
-        return estimate
-    }
-
-    private var departureEstimate: Date? { meaningfulEstimate(info.estimatedDeparture, vs: info.leg.departure) }
-    private var arrivalEstimate: Date? { meaningfulEstimate(info.estimatedArrival, vs: info.leg.arrival) }
-
-    /// "+35m" delay shown on the badge while the flight is delayed.
-    private var delayText: String? {
-        guard info.status == .delayed, let estimate = departureEstimate else { return nil }
-        let minutes = Int(estimate.timeIntervalSince(info.leg.departure) / 60)
-        guard minutes > 0 else { return nil }
-        let h = minutes / 60, m = minutes % 60
-        return h > 0 ? "+\(h)h \(m)m" : "+\(m)m"
+    /// "Updated 2 minutes ago" — formatted with the environment locale.
+    private var updatedText: String? {
+        updatedDate.map {
+            String(themeKitTravel: "Updated \($0.formatted(.relative(presentation: .named).locale(locale)))")
+        }
     }
 
     // MARK: Body
 
     public var body: some View {
-        let card = Card {
-            switch variantValue {
-            case .board: content
-            case .compact: compactStrip
+        // The arrangement is owned by the active `FlightTrackerStyle`; the
+        // status-change announcement and the progress-motion animation stay
+        // *here*, wrapping the style's output, so both keep firing under
+        // every preset (see the header doc's a11y note).
+        let configuration = FlightTrackerConfiguration(
+            statusInfo: info,
+            progress: clampedProgress,
+            updatedText: updatedText,
+            details: extraDetails,
+            showsTimeline: timelineVisible,
+            showsFacts: showsFactsValue,
+            showsEstimates: showsEstimatesValue,
+            checkInTitle: checkInTitleOverride ?? String(themeKitTravel: "Check-in"),
+            boardingTitle: boardingTitleOverride ?? String(themeKitTravel: "Boarding"),
+            departedTitle: departedTitleOverride ?? String(themeKitTravel: "Departed"),
+            arrivedTitle: arrivedTitleOverride ?? String(themeKitTravel: "Arrived"),
+            contentPadding: contentPaddingKey,
+            progressContent: progressSlot,
+            header: headerSlot,
+            footer: footerSlot,
+            timelineSize: timelineSizeValue,
+            accent: accentOverride,
+            surfaceKey: surfaceKey,
+            elevation: elevationValue,
+            isReadOnly: isReadOnly,
+            density: density,
+            locale: locale)
+        resolvedStyle.makeBody(configuration: configuration)
+            .animation(motion, value: clampedProgress)
+            // Live-region pattern: announce the transition, gated to a real change.
+            .onChange(of: info.status) { oldValue, newValue in
+                guard oldValue != newValue else { return }
+                AccessibilityNotification.Announcement(
+                    [newValue.label, configuration.estimateSummary()].compactMap { $0 }.joined(separator: ", ")
+                ).post()
             }
-        }
-            .contentPadding(contentPaddingKey)
-            .surface(surfaceKey)
-            .elevation(elevationValue)
-        Group {
-            if let footerSlot {
-                card.footer {
-                    // Read-only surfaces block interaction in slot-hosted
-                    // actions too — the only tappable area the tracker can host.
-                    footerSlot.allowsHitTesting(!isReadOnly)
-                }
-            } else {
-                card
-            }
-        }
-        .animation(motion, value: clampedProgress)
-        // Live-region pattern: announce the transition, gated to a real change.
-        .onChange(of: info.status) { oldValue, newValue in
-            guard oldValue != newValue else { return }
-            AccessibilityNotification.Announcement(
-                [newValue.label, estimateSummary].compactMap { $0 }.joined(separator: ", ")
-            ).post()
-        }
-    }
-
-    private var content: some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
-            if let headerSlot { headerSlot } else { header }
-            route
-            if showsEstimatesValue, departureEstimate != nil || arrivalEstimate != nil {
-                estimateRows
-            }
-            if showsFactsValue, !factRows.isEmpty {
-                KeyValueTable(rows: factRows)
-            }
-            if timelineVisible {
-                Steps(phases).size(timelineSizeValue)
-            }
-            if let updatedDate {
-                updatedCaption(updatedDate)
-            }
-        }
-    }
-
-    // MARK: Compact variant — one-row status strip
-
-    /// One combined VoiceOver element, like the board header; the status
-    /// announcement `onChange` on the card shell covers this variant too.
-    private var compactStrip: some View {
-        HStack(spacing: Theme.SpacingKey.sm.value) {
-            FlightStatusBadge(info.status).time(delayText)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("\(info.leg.origin) – \(info.leg.destination)")
-                    .textStyle(.labelBase600)
-                    .foregroundStyle(theme.text(.textPrimary))
-                Text(info.leg.airline)
-                    .textStyle(.bodySm400)
-                    .foregroundStyle(theme.text(.textSecondary))
-            }
-            .lineLimit(1)
-            Spacer(minLength: Theme.SpacingKey.sm.value)
-            if showsEstimatesValue, let estimate = departureEstimate ?? arrivalEstimate {
-                Text(estimate.formatted(timeFormat))
-                    .textStyle(.labelBase600)
-                    .foregroundStyle(tone.base)
-            } else {
-                Text(info.leg.departure.formatted(timeFormat))
-                    .textStyle(.labelBase600)
-                    .foregroundStyle(theme.text(.textSecondary))
-            }
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(headerSummary)
-    }
-
-    // MARK: Header — one combined VoiceOver element
-
-    private var header: some View {
-        HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.sm.value) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(info.leg.airline)
-                    .textStyle(.labelLg600)
-                    .foregroundStyle(theme.text(.textPrimary))
-                Text("\(info.leg.origin) – \(info.leg.destination)")
-                    .textStyle(.bodySm400)
-                    .foregroundStyle(theme.text(.textSecondary))
-            }
-            Spacer(minLength: Theme.SpacingKey.sm.value)
-            FlightStatusBadge(info.status).time(delayText)
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(headerSummary)
-    }
-
-    /// "Skyline Air, IST to LHR, Delayed, estimated departure 2:20 PM".
-    private var headerSummary: String {
-        [
-            info.leg.airline,
-            String(themeKitTravel: "\(info.leg.origin) to \(info.leg.destination)"),
-            info.status.label,
-            estimateSummary,
-        ].compactMap { $0 }.joined(separator: ", ")
-    }
-
-    private var estimateSummary: String? {
-        if let estimate = departureEstimate {
-            return String(themeKitTravel: "estimated departure \(estimate.formatted(timeFormat))")
-        }
-        if let estimate = arrivalEstimate {
-            return String(themeKitTravel: "estimated arrival \(estimate.formatted(timeFormat))")
-        }
-        return nil
-    }
-
-    // MARK: Route + progress treatment
-
-    @ViewBuilder
-    private var route: some View {
-        VStack(spacing: Theme.SpacingKey.sm.value) {
-            FlightRoute(
-                from: info.leg.origin, to: info.leg.destination,
-                departure: info.leg.departure, arrival: info.leg.arrival
-            )
-            .stops(info.leg.stops)
-            if let fraction = clampedProgress {
-                if let progressSlot {
-                    progressSlot(fraction)
-                } else {
-                    RouteProgressTrack(fraction: fraction, tone: tone)
-                }
-            }
-        }
-    }
-
-    // MARK: Schedule vs estimate
-
-    private var estimateRows: some View {
-        VStack(spacing: 0) {
-            if let estimate = departureEstimate {
-                estimateRow(String(themeKitTravel: "Departure"), scheduled: info.leg.departure, estimate: estimate)
-            }
-            if departureEstimate != nil && arrivalEstimate != nil {
-                DividerView().size(.small)
-            }
-            if let estimate = arrivalEstimate {
-                estimateRow(String(themeKitTravel: "Arrival"), scheduled: info.leg.arrival, estimate: estimate)
-            }
-        }
-    }
-
-    private func estimateRow(_ label: String, scheduled: Date, estimate: Date) -> some View {
-        HStack {
-            Text(label)
-                .textStyle(.bodyBase400)
-                .foregroundStyle(theme.text(.textSecondary))
-            Spacer(minLength: Theme.SpacingKey.md.value)
-            HStack(spacing: Theme.SpacingKey.xs.value) {
-                Text(scheduled.formatted(timeFormat))
-                    .textStyle(.bodyBase400)
-                    .strikethrough()
-                    .foregroundStyle(theme.text(.textTertiary))
-                Text(estimate.formatted(timeFormat))
-                    .textStyle(.labelBase600)
-                    .foregroundStyle(tone.base)
-            }
-        }
-        .padding(.vertical, Theme.SpacingKey.sm.value)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(String(
-            themeKitTravel: "\(label): scheduled \(scheduled.formatted(timeFormat)), estimated \(estimate.formatted(timeFormat))"
-        ))
-    }
-
-    // MARK: Facts — gate / terminal / desk / belt (+ caller details)
-
-    private var factRows: [KeyValueTable.Row] {
-        var rows: [KeyValueTable.Row] = []
-        if let terminal = info.terminal { rows.append(.init(String(themeKitTravel: "Terminal"), value: terminal)) }
-        if let gate = info.gate { rows.append(.init(String(themeKitTravel: "Gate"), value: gate)) }
-        if let desk = info.checkInDesk { rows.append(.init(String(themeKitTravel: "Check-in desk"), value: desk)) }
-        if let belt = info.baggageBelt { rows.append(.init(String(themeKitTravel: "Baggage belt"), value: belt)) }
-        if let aircraft = info.aircraft { rows.append(.init(String(themeKitTravel: "Aircraft"), value: aircraft)) }
-        rows.append(contentsOf: extraDetails.map { .init($0.0, value: $0.1) })
-        return rows
-    }
-
-    // MARK: Phase timeline — Check-in → Boarding → Departed → Arrived
-
-    private var phases: [Steps.Step] {
-        let titles = (
-            checkIn: checkInTitleOverride ?? String(themeKitTravel: "Check-in"),
-            boarding: boardingTitleOverride ?? String(themeKitTravel: "Boarding"),
-            departed: departedTitleOverride ?? String(themeKitTravel: "Departed"),
-            arrived: arrivedTitleOverride ?? String(themeKitTravel: "Arrived")
-        )
-        let states: [StepState]
-        switch info.status {
-        case .onTime, .delayed: states = [.active, .todo, .todo, .todo]
-        case .boarding:         states = [.done, .active, .todo, .todo]
-        case .gateClosed:       states = [.done, .done, .active, .todo]
-        case .departed:         states = [.done, .done, .done, .active]
-        case .arrived:          states = [.done, .done, .done, .done]
-        case .cancelled:        states = [.done, .error, .todo, .todo]
-        }
-        return [
-            .init(titles.checkIn, state: states[0]),
-            .init(titles.boarding, state: states[1]),
-            .init(titles.departed, state: states[2]),
-            // While en route, the Ant `percent` ring mirrors the route progress.
-            .init(titles.arrived, state: states[3],
-                  percent: states[3] == .active ? clampedProgress : nil),
-        ]
-    }
-
-    // MARK: Updated caption
-
-    private func updatedCaption(_ date: Date) -> some View {
-        Text(String(themeKitTravel: "Updated \(date.formatted(.relative(presentation: .named).locale(locale)))"))
-            .textStyle(.bodySm400)
-            .foregroundStyle(theme.text(.textTertiary))
-    }
-}
-
-// MARK: - Route progress track (private — the §9.9 "progress treatment")
-
-/// A token-fed en-route bar under the `FlightRoute` path: a hairline track, a
-/// status-tinted fill and an airplane glyph riding the fill's leading→trailing
-/// edge. Built from leading-aligned layout so it mirrors under RTL; the glyph
-/// flips with the layout direction.
-private struct RouteProgressTrack: View {
-    let fraction: Double
-    let tone: SemanticColor
-    @Environment(\.theme) private var theme
-
-    var body: some View {
-        GeometryReader { geo in
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(theme.border(.borderPrimary))
-                    .frame(height: 3)
-                Capsule()
-                    .fill(tone.solid)
-                    .frame(width: max(6, geo.size.width * fraction), height: 3)
-                    .overlay(alignment: .trailing) {
-                        Image(systemName: "airplane")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(tone.base)
-                            .flipsForRightToLeftLayoutDirection(true)
-                    }
-            }
-            .frame(width: geo.size.width, height: geo.size.height)
-        }
-        .frame(height: 16)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(String(themeKitTravel: "Flight progress"))
-        .accessibilityValue(String(themeKitTravel: "\(Int((fraction * 100).rounded())) percent"))
     }
 }
 
@@ -402,8 +177,10 @@ public extension FlightTracker {
     /// `nil` (default) derives from the status (`FlightStatus.semantic`).
     func accent(_ color: SemanticColor?) -> Self { copy { $0.accentOverride = color } }
 
-    /// Surface fill for the card shell (background token key, default `.bgWhite`)
-    /// — threaded into the active `CardStyle` via the composed `Card`.
+    /// Surface fill for the card shell (background token key). When unset,
+    /// the active ``FlightTrackerStyle`` picks its own default (`.board`/
+    /// `.compact`/`.timeline` use `.bgWhite`) — threaded into the active
+    /// `CardStyle` via the composed `Card`.
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
 
     /// Card shell elevation: none / soft (default) / elevated.
@@ -416,19 +193,29 @@ public extension FlightTracker {
         copy { $0.footerSlot = AnyView(content()) }
     }
 
-    /// Layout archetype: `.board` (default, the full status card) or
-    /// `.compact` — a one-row badge + route + time strip for lists/widgets.
-    func variant(_ v: FlightTrackerVariant) -> Self { copy { $0.variantValue = v } }
+    /// Layout archetype. Maps 1:1 onto the ``FlightTrackerStyle`` presets and,
+    /// when called, wins over the environment style (source-behavior
+    /// stability during migration — ADR-0004 §5).
+    @available(*, deprecated,
+               message: "Use .flightTrackerStyle(_:) — e.g. .variant(.compact) becomes .flightTrackerStyle(.compact)")
+    func variant(_ v: FlightTrackerVariant) -> Self {
+        copy {
+            switch v {
+            case .board: $0.explicitStyle = AnyFlightTrackerStyle(BoardFlightTrackerStyle())
+            case .compact: $0.explicitStyle = AnyFlightTrackerStyle(CompactFlightTrackerStyle())
+            }
+        }
+    }
 
-    /// Show the gate/terminal/desk/belt facts grid (default on; `.board` only).
+    /// Show the gate/terminal/desk/belt facts grid (default on; `.board`/`.timeline`).
     func showsFacts(_ on: Bool = true) -> Self { copy { $0.showsFactsValue = on } }
 
-    /// Show the schedule-vs-estimate rows (and the `.compact` estimate time)
-    /// when estimates differ meaningfully from the schedule (default on).
+    /// Show the schedule-vs-estimate rows (and the `.compact`/`.banner`
+    /// estimate time) when estimates differ meaningfully from the schedule (default on).
     func showsEstimates(_ on: Bool = true) -> Self { copy { $0.showsEstimatesValue = on } }
 
     /// Replaces the built-in airline/route/badge header (canonical
-    /// `.header { }` slot; `.board` variant). The status-change VoiceOver
+    /// `.header { }` slot; `.board`/`.timeline`). The status-change VoiceOver
     /// announcement lives on the card shell, not the header — it keeps firing
     /// with a custom header.
     func header<V: View>(@ViewBuilder _ content: () -> V) -> Self {
@@ -531,10 +318,10 @@ public extension FlightTracker {
         VStack(spacing: Theme.SpacingKey.lg.value) {
             // Compact strips — delayed shows the estimate in the status tone.
             FlightTracker(.init(leg: leg, status: .departed))
-                .variant(.compact)
+                .flightTrackerStyle(.compact)
             FlightTracker(.init(leg: leg, status: .delayed,
                                 estimatedDeparture: dep.addingTimeInterval(45 * 60)))
-                .variant(.compact)
+                .flightTrackerStyle(.compact)
 
             // Header slot + custom progress content + renamed phases.
             FlightTracker(.init(leg: leg, status: .departed, gate: "B12", terminal: "1"))

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightTrackerStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightTrackerStyle.swift
@@ -1,0 +1,678 @@
+//
+//  FlightTrackerStyle.swift
+//  ThemeKitTravel
+//
+//  The styling hook for ``FlightTracker`` (ADR-0004, Wave 4 — Class A). The
+//  configuration hands styles the *typed live-status data* (status, gate/
+//  terminal/belt facts, estimates, progress), not pre-laid content, so a style
+//  owns the entire arrangement. Four built-ins:
+//
+//    .board     badge + route/progress + facts + phase timeline — today's
+//               tracker, verbatim. Default.
+//    .compact   one-row status strip for lists and widgets.
+//    .timeline  phase-first vertical spine, each phase carrying its own fact
+//               (check-in desk, gate + terminal, aircraft, baggage belt).
+//    .banner    status-tone strip for push-style surfaces — no card shell.
+//
+//      FlightTracker(info)
+//          .progress(0.62)
+//          .updated(lastPoll)
+//          .flightTrackerStyle(.timeline)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the shell
+//  `CardStyle` paints *chrome* (card-shaped presets keep composing the neutral
+//  `Card`, so `.cardStyle(_:)` still swaps its chrome independently); the
+//  token theme colors everything. The status-change VoiceOver announcement
+//  and the progress-motion animation stay on ``FlightTracker``'s card shell
+//  (the component), not in any style, so both keep firing under every preset.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``FlightTrackerStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — every built-in degrades gracefully when
+/// optional data is absent (no gate → no gate fact/description, no progress →
+/// no progress treatment).
+public struct FlightTrackerConfiguration {
+    /// The live operational status snapshot — every style's primary subject.
+    public let statusInfo: FlightStatusInfo
+    /// En-route progress 0...1, already clamped; `nil` hides the progress
+    /// treatment (`.board`/`.timeline`'s active-phase ring).
+    public let progress: Double?
+    /// Pre-formatted "Updated 2 minutes ago" caption; `nil` hides it.
+    public let updatedText: String?
+    /// Caller-supplied extra fact pairs (`FlightTracker/details(_:)`), e.g.
+    /// `[("Meal", "Included")]` — resolve alongside ``statusInfo`` via
+    /// ``detailRows()``, or on their own via ``extraDetailRows()``.
+    public let details: [(String, String)]
+    /// Show the Check-in → Boarding → Departed → Arrived phase timeline
+    /// (`.board`/`.timeline` only).
+    public let showsTimeline: Bool
+    /// Show the gate/terminal/desk/belt/aircraft facts (`.board`/`.timeline`).
+    public let showsFacts: Bool
+    /// Show the schedule-vs-estimate rows (and the `.compact`/`.banner`
+    /// estimate time) when estimates differ meaningfully from the schedule.
+    public let showsEstimates: Bool
+    /// Resolved phase-timeline titles (override, else the stock English-generic
+    /// wording) — already localized, re-resolved every body pass.
+    public let checkInTitle: String
+    public let boardingTitle: String
+    public let departedTitle: String
+    public let arrivedTitle: String
+    /// Inner content padding, as a spacing token — card-shaped presets feed
+    /// the composed `Card`.
+    public let contentPadding: Theme.SpacingKey
+    /// Replaces the built-in route progress track, built per clamped 0...1
+    /// fraction. The replacement must carry its own accessibility value.
+    public let progressContent: ((Double) -> AnyView)?
+    /// Replacement for the built-in airline/route/badge header
+    /// (`.header { }`); `nil` = built-in.
+    public let header: AnyView?
+    /// Bottom-aligned accessory area (`.footer { }`), forwarded to the
+    /// composed `Card`'s footer slot by card-shaped styles.
+    public let footer: AnyView?
+    /// Marker/label size of the phase timeline.
+    public let timelineSize: StepsSize
+    /// Semantic tint override; `nil` derives from the status
+    /// (`FlightStatus.semantic`) — resolve via ``tone()``.
+    public let accent: SemanticColor?
+    /// Explicit surface fill, or `nil` to let the style choose its own
+    /// default (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Card shell elevation, fed to the active `CardStyle` by card-shaped styles.
+    public let elevation: CardElevation
+    /// Read-only surfaces disable the footer slot's hit-testing — the only
+    /// tappable area a tracker style can host.
+    public let isReadOnly: Bool
+    /// The environment's component density, captured by the component — scale
+    /// chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — use it for every
+    /// date/number string so injected locales (and RTL demos) render correctly.
+    public let locale: Locale
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out the tracker.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// The `accent(_:)` override, else the status's own semantic tone
+    /// (`FlightStatus.semantic`) — the single source of truth for status
+    /// colouring across the flight family.
+    public func tone() -> SemanticColor { accent ?? statusInfo.status.semantic }
+
+    /// Shared time formatting, in the captured locale, so every style speaks
+    /// one language.
+    public func time(_ date: Date) -> String {
+        date.formatted(Date.FormatStyle(date: .omitted, time: .shortened).locale(locale))
+    }
+
+    /// An estimate "counts" only when it moves the schedule by a minute or more.
+    private func meaningfulEstimate(_ estimate: Date?, vs scheduled: Date) -> Date? {
+        guard let estimate, abs(estimate.timeIntervalSince(scheduled)) >= 60 else { return nil }
+        return estimate
+    }
+    /// Estimated departure, or `nil` when it doesn't differ meaningfully from schedule.
+    public var departureEstimate: Date? { meaningfulEstimate(statusInfo.estimatedDeparture, vs: statusInfo.leg.departure) }
+    /// Estimated arrival, or `nil` when it doesn't differ meaningfully from schedule.
+    public var arrivalEstimate: Date? { meaningfulEstimate(statusInfo.estimatedArrival, vs: statusInfo.leg.arrival) }
+
+    /// "+35m" delay text while the flight is delayed with a meaningful
+    /// departure estimate — feeds `FlightStatusBadge.time(_:)`.
+    public var delayText: String? {
+        guard statusInfo.status == .delayed, let estimate = departureEstimate else { return nil }
+        let minutes = Int(estimate.timeIntervalSince(statusInfo.leg.departure) / 60)
+        guard minutes > 0 else { return nil }
+        let h = minutes / 60, m = minutes % 60
+        return h > 0 ? "+\(h)h \(m)m" : "+\(m)m"
+    }
+
+    /// "Skyline Air, IST to LHR, Delayed, estimated departure 2:20 PM" — the
+    /// header/strip's combined VoiceOver label, shared by every preset that
+    /// renders one accessibility element for its identity row.
+    public func headerSummary() -> String {
+        [
+            statusInfo.leg.airline,
+            String(themeKitTravel: "\(statusInfo.leg.origin) to \(statusInfo.leg.destination)"),
+            statusInfo.status.label,
+            estimateSummary(),
+        ].compactMap { $0 }.joined(separator: ", ")
+    }
+
+    /// "estimated departure 2:20 PM" / "estimated arrival …", or `nil` when
+    /// neither estimate differs meaningfully from schedule.
+    public func estimateSummary() -> String? {
+        if let estimate = departureEstimate {
+            return String(themeKitTravel: "estimated departure \(time(estimate))")
+        }
+        if let estimate = arrivalEstimate {
+            return String(themeKitTravel: "estimated arrival \(time(estimate))")
+        }
+        return nil
+    }
+
+    /// The gate/terminal/check-in-desk/baggage-belt/aircraft facts plus the
+    /// caller's ``details`` pairs, merged into `KeyValueTable` rows — the
+    /// `.board`/`.compact` facts grid.
+    public func detailRows() -> [KeyValueTable.Row] {
+        var rows: [KeyValueTable.Row] = []
+        if let terminal = statusInfo.terminal { rows.append(.init(String(themeKitTravel: "Terminal"), value: terminal)) }
+        if let gate = statusInfo.gate { rows.append(.init(String(themeKitTravel: "Gate"), value: gate)) }
+        if let desk = statusInfo.checkInDesk { rows.append(.init(String(themeKitTravel: "Check-in desk"), value: desk)) }
+        if let belt = statusInfo.baggageBelt { rows.append(.init(String(themeKitTravel: "Baggage belt"), value: belt)) }
+        if let aircraft = statusInfo.aircraft { rows.append(.init(String(themeKitTravel: "Aircraft"), value: aircraft)) }
+        rows.append(contentsOf: extraDetailRows())
+        return rows
+    }
+
+    /// Only the caller-supplied ``details`` pairs, as `KeyValueTable` rows —
+    /// for styles that already fold the statusInfo facts into another
+    /// treatment (e.g. `.timeline`'s per-phase descriptions).
+    public func extraDetailRows() -> [KeyValueTable.Row] { details.map { .init($0.0, value: $0.1) } }
+
+    /// Check-in → Boarding → Departed → Arrived phase timeline. The active
+    /// phase's percent ring mirrors ``progress`` while en route (Ant Steps
+    /// `percent`). With `showsDescriptions` on, each phase carries its own
+    /// fact — check-in desk, gate + terminal, aircraft, baggage belt — the
+    /// `.timeline` preset's per-phase detail.
+    public func phases(showsDescriptions: Bool = false) -> [Steps.Step] {
+        let states: [StepState]
+        switch statusInfo.status {
+        case .onTime, .delayed: states = [.active, .todo, .todo, .todo]
+        case .boarding:         states = [.done, .active, .todo, .todo]
+        case .gateClosed:       states = [.done, .done, .active, .todo]
+        case .departed:         states = [.done, .done, .done, .active]
+        case .arrived:          states = [.done, .done, .done, .done]
+        case .cancelled:        states = [.done, .error, .todo, .todo]
+        }
+        let gateAndTerminal = [statusInfo.gate, statusInfo.terminal].compactMap { $0 }.joined(separator: " · ")
+        let descriptions: [String?] = showsDescriptions
+            ? [statusInfo.checkInDesk, gateAndTerminal.isEmpty ? nil : gateAndTerminal,
+               statusInfo.aircraft, statusInfo.baggageBelt]
+            : [nil, nil, nil, nil]
+        return [
+            .init(checkInTitle, description: descriptions[0], state: states[0]),
+            .init(boardingTitle, description: descriptions[1], state: states[1]),
+            .init(departedTitle, description: descriptions[2], state: states[2]),
+            // While en route, the Ant `percent` ring mirrors the route progress.
+            .init(arrivedTitle, description: descriptions[3], state: states[3],
+                  percent: states[3] == .active ? progress : nil),
+        ]
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `FlightTracker`'s entire presentation. Implement `makeBody` to
+/// lay out the configuration's live-status data. Set one with
+/// `.flightTrackerStyle(_:)`; the default is ``BoardFlightTrackerStyle``.
+public protocol FlightTrackerStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: FlightTrackerConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The neutral `Card` shell every card-shaped preset composes (ADR-0004 §6):
+/// content padding, surface fill and elevation come from the configuration,
+/// the footer slot forwards to `Card`'s own footer with read-only-aware hit
+/// testing, and the active `CardStyle` keeps painting the chrome underneath.
+private struct TrackerCardShell<Content: View>: View {
+    let configuration: FlightTrackerConfiguration
+    let content: () -> Content
+
+    init(configuration: FlightTrackerConfiguration, @ViewBuilder content: @escaping () -> Content) {
+        self.configuration = configuration
+        self.content = content
+    }
+
+    var body: some View {
+        let card = Card(content: content)
+            .contentPadding(configuration.contentPadding)
+            .surface(configuration.surface(default: .bgWhite))
+            .elevation(configuration.elevation)
+        if let footer = configuration.footer {
+            card.footer { footer.allowsHitTesting(!configuration.isReadOnly) }
+        } else {
+            card
+        }
+    }
+}
+
+/// One combined VoiceOver element: airline/route + status badge. Shared by
+/// `.board` and `.timeline`.
+private struct TrackerHeader: View {
+    @Environment(\.theme) private var theme
+    let configuration: FlightTrackerConfiguration
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: configuration.spacing(.sm)) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(configuration.statusInfo.leg.airline)
+                    .textStyle(.labelLg600).foregroundStyle(theme.text(.textPrimary))
+                Text("\(configuration.statusInfo.leg.origin) – \(configuration.statusInfo.leg.destination)")
+                    .textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+            }
+            Spacer(minLength: configuration.spacing(.sm))
+            FlightStatusBadge(configuration.statusInfo.status).time(configuration.delayText)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(configuration.headerSummary())
+    }
+}
+
+/// The `FlightRoute` path plus the en-route progress treatment underneath —
+/// the built-in track, or the caller's `progressContent(_:)` replacement.
+private struct TrackerRouteProgress: View {
+    let configuration: FlightTrackerConfiguration
+
+    var body: some View {
+        VStack(spacing: configuration.spacing(.sm)) {
+            FlightRoute(from: configuration.statusInfo.leg.origin, to: configuration.statusInfo.leg.destination,
+                        departure: configuration.statusInfo.leg.departure, arrival: configuration.statusInfo.leg.arrival)
+                .stops(configuration.statusInfo.leg.stops)
+            if let fraction = configuration.progress {
+                if let progressContent = configuration.progressContent {
+                    progressContent(fraction)
+                } else {
+                    RouteProgressTrack(fraction: fraction, tone: configuration.tone())
+                }
+            }
+        }
+    }
+}
+
+/// A token-fed en-route bar under the `FlightRoute` path: a hairline track, a
+/// status-tinted fill and an airplane glyph riding the fill's leading→trailing
+/// edge. Built from leading-aligned layout so it mirrors under RTL; the glyph
+/// flips with the layout direction.
+private struct RouteProgressTrack: View {
+    let fraction: Double
+    let tone: SemanticColor
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(theme.border(.borderPrimary))
+                    .frame(height: 3)
+                Capsule()
+                    .fill(tone.solid)
+                    .frame(width: max(6, geo.size.width * fraction), height: 3)
+                    .overlay(alignment: .trailing) {
+                        Image(systemName: "airplane")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(tone.base)
+                            .flipsForRightToLeftLayoutDirection(true)
+                    }
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+        }
+        .frame(height: 16)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(themeKitTravel: "Flight progress"))
+        .accessibilityValue(String(themeKitTravel: "\(Int((fraction * 100).rounded())) percent"))
+    }
+}
+
+/// Schedule-vs-estimate rows for departure and/or arrival. Shared by `.board`
+/// and `.timeline`.
+private struct TrackerEstimateRows: View {
+    let configuration: FlightTrackerConfiguration
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let estimate = configuration.departureEstimate {
+                TrackerEstimateRow(configuration: configuration, label: String(themeKitTravel: "Departure"),
+                                    scheduled: configuration.statusInfo.leg.departure, estimate: estimate)
+            }
+            if configuration.departureEstimate != nil && configuration.arrivalEstimate != nil {
+                DividerView().size(.small)
+            }
+            if let estimate = configuration.arrivalEstimate {
+                TrackerEstimateRow(configuration: configuration, label: String(themeKitTravel: "Arrival"),
+                                    scheduled: configuration.statusInfo.leg.arrival, estimate: estimate)
+            }
+        }
+    }
+}
+
+private struct TrackerEstimateRow: View {
+    @Environment(\.theme) private var theme
+    let configuration: FlightTrackerConfiguration
+    let label: String
+    let scheduled: Date
+    let estimate: Date
+
+    var body: some View {
+        HStack {
+            Text(label).textStyle(.bodyBase400).foregroundStyle(theme.text(.textSecondary))
+            Spacer(minLength: configuration.spacing(.md))
+            HStack(spacing: configuration.spacing(.xs)) {
+                Text(configuration.time(scheduled))
+                    .textStyle(.bodyBase400).strikethrough().foregroundStyle(theme.text(.textTertiary))
+                Text(configuration.time(estimate))
+                    .textStyle(.labelBase600).foregroundStyle(configuration.tone().base)
+            }
+        }
+        .padding(.vertical, configuration.spacing(.sm))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(
+            themeKitTravel: "\(label): scheduled \(configuration.time(scheduled)), estimated \(configuration.time(estimate))"
+        ))
+    }
+}
+
+/// "Updated 2 minutes ago" caption. Shared by every preset.
+private struct TrackerUpdatedCaption: View {
+    @Environment(\.theme) private var theme
+    let text: String
+
+    var body: some View {
+        Text(text).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary))
+    }
+}
+
+/// The one-row status strip: badge, identity, trailing time. Shared by
+/// `.compact` (inside the `Card` shell) and `.banner` (bare).
+private struct TrackerCompactStrip: View {
+    @Environment(\.theme) private var theme
+    let configuration: FlightTrackerConfiguration
+
+    var body: some View {
+        HStack(spacing: configuration.spacing(.sm)) {
+            FlightStatusBadge(configuration.statusInfo.status).time(configuration.delayText)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(configuration.statusInfo.leg.origin) – \(configuration.statusInfo.leg.destination)")
+                    .textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+                Text(configuration.statusInfo.leg.airline)
+                    .textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+            }
+            .lineLimit(1)
+            Spacer(minLength: configuration.spacing(.sm))
+            trailingTime
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(configuration.headerSummary())
+    }
+
+    @ViewBuilder private var trailingTime: some View {
+        if configuration.showsEstimates, let estimate = configuration.departureEstimate ?? configuration.arrivalEstimate {
+            Text(configuration.time(estimate)).textStyle(.labelBase600).foregroundStyle(configuration.tone().base)
+        } else {
+            Text(configuration.time(configuration.statusInfo.leg.departure))
+                .textStyle(.labelBase600).foregroundStyle(theme.text(.textSecondary))
+        }
+    }
+}
+
+// MARK: - .board (default — badge + route/progress + facts + phase timeline)
+
+/// Today's ``FlightTracker`` look, extracted verbatim: header (airline, route,
+/// status badge), the route with its en-route progress treatment, schedule vs
+/// estimate, the gate/terminal/desk/belt facts grid and the phase timeline —
+/// all inside the composed `Card` shell.
+public struct BoardFlightTrackerStyle: FlightTrackerStyle {
+    public init() {}
+    public func makeBody(configuration: FlightTrackerConfiguration) -> some View {
+        BoardChrome(configuration: configuration)
+    }
+}
+
+private struct BoardChrome: View {
+    let configuration: FlightTrackerConfiguration
+
+    var body: some View {
+        TrackerCardShell(configuration: configuration) {
+            VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
+                if let header = configuration.header { header } else { TrackerHeader(configuration: configuration) }
+                TrackerRouteProgress(configuration: configuration)
+                if configuration.showsEstimates,
+                   configuration.departureEstimate != nil || configuration.arrivalEstimate != nil {
+                    TrackerEstimateRows(configuration: configuration)
+                }
+                if configuration.showsFacts, !configuration.detailRows().isEmpty {
+                    KeyValueTable(rows: configuration.detailRows())
+                }
+                if configuration.showsTimeline {
+                    Steps(configuration.phases()).size(configuration.timelineSize)
+                }
+                if let updatedText = configuration.updatedText {
+                    TrackerUpdatedCaption(text: updatedText)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - .compact (one-row status strip)
+
+/// A one-row badge + identity + time strip for lists and widgets, inside the
+/// composed `Card` shell. The status-change VoiceOver announcement on the
+/// component's card shell covers this preset too.
+public struct CompactFlightTrackerStyle: FlightTrackerStyle {
+    public init() {}
+    public func makeBody(configuration: FlightTrackerConfiguration) -> some View {
+        CompactChrome(configuration: configuration)
+    }
+}
+
+private struct CompactChrome: View {
+    let configuration: FlightTrackerConfiguration
+
+    var body: some View {
+        TrackerCardShell(configuration: configuration) {
+            TrackerCompactStrip(configuration: configuration)
+        }
+    }
+}
+
+// MARK: - .timeline (phase-first vertical spine w/ per-phase facts)
+
+/// The Check-in → Boarding → Departed → Arrived spine leads the layout, each
+/// phase carrying its own fact (check-in desk, gate + terminal, aircraft,
+/// baggage belt) as a `Steps` description — a tracker-app detail view, inside
+/// the composed `Card` shell. Caller-supplied ``FlightTrackerConfiguration/details``
+/// (not already folded into a phase) still render as a small facts table.
+public struct TimelineFlightTrackerStyle: FlightTrackerStyle {
+    public init() {}
+    public func makeBody(configuration: FlightTrackerConfiguration) -> some View {
+        TimelineChrome(configuration: configuration)
+    }
+}
+
+private struct TimelineChrome: View {
+    let configuration: FlightTrackerConfiguration
+
+    var body: some View {
+        TrackerCardShell(configuration: configuration) {
+            VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
+                if let header = configuration.header { header } else { TrackerHeader(configuration: configuration) }
+                if configuration.showsTimeline {
+                    Steps(configuration.phases(showsDescriptions: true))
+                        .axis(.vertical)
+                        .size(configuration.timelineSize)
+                }
+                if configuration.showsEstimates,
+                   configuration.departureEstimate != nil || configuration.arrivalEstimate != nil {
+                    TrackerEstimateRows(configuration: configuration)
+                }
+                if configuration.showsFacts, !configuration.extraDetailRows().isEmpty {
+                    KeyValueTable(rows: configuration.extraDetailRows())
+                }
+                if let updatedText = configuration.updatedText {
+                    TrackerUpdatedCaption(text: updatedText)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - .banner (status-tone strip for push-style surfaces)
+
+/// A chrome-free, status-tone-tinted strip for push-style surfaces (an in-app
+/// notification, a home-screen widget row) — no `Card` shell, so
+/// `.cardStyle(_:)`/``FlightTrackerConfiguration/surfaceKey`` don't apply
+/// here; the fill comes from the status tone itself.
+public struct BannerFlightTrackerStyle: FlightTrackerStyle {
+    public init() {}
+    public func makeBody(configuration: FlightTrackerConfiguration) -> some View {
+        BannerChrome(configuration: configuration)
+    }
+}
+
+private struct BannerChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: FlightTrackerConfiguration
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.xs)) {
+            HStack(spacing: configuration.spacing(.sm)) {
+                FlightStatusBadge(configuration.statusInfo.status)
+                    .time(configuration.delayText)
+                    .flightStatusBadgeStyle(.dot)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("\(configuration.statusInfo.leg.origin) – \(configuration.statusInfo.leg.destination)")
+                        .textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+                    Text(configuration.statusInfo.leg.airline)
+                        .textStyle(.overline400).foregroundStyle(theme.text(.textSecondary))
+                }
+                .lineLimit(1)
+                Spacer(minLength: configuration.spacing(.sm))
+                trailingTime
+            }
+            if let updatedText = configuration.updatedText {
+                TrackerUpdatedCaption(text: updatedText)
+            }
+        }
+        .padding(configuration.spacing(.sm))
+        .background(configuration.tone().soft,
+                    in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(configuration.headerSummary())
+    }
+
+    @ViewBuilder private var trailingTime: some View {
+        if configuration.showsEstimates, let estimate = configuration.departureEstimate ?? configuration.arrivalEstimate {
+            Text(configuration.time(estimate)).textStyle(.labelBase600).foregroundStyle(configuration.tone().accent)
+        } else {
+            Text(configuration.time(configuration.statusInfo.leg.departure))
+                .textStyle(.labelBase600).foregroundStyle(theme.text(.textSecondary))
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension FlightTrackerStyle where Self == BoardFlightTrackerStyle {
+    /// Badge + route/progress + facts + phase timeline — today's tracker. The default.
+    static var board: BoardFlightTrackerStyle { BoardFlightTrackerStyle() }
+}
+public extension FlightTrackerStyle where Self == CompactFlightTrackerStyle {
+    /// A one-row status strip for lists and widgets.
+    static var compact: CompactFlightTrackerStyle { CompactFlightTrackerStyle() }
+}
+public extension FlightTrackerStyle where Self == TimelineFlightTrackerStyle {
+    /// Phase-first vertical spine, each phase carrying its own fact.
+    static var timeline: TimelineFlightTrackerStyle { TimelineFlightTrackerStyle() }
+}
+public extension FlightTrackerStyle where Self == BannerFlightTrackerStyle {
+    /// A status-tone strip for push-style surfaces — no card shell.
+    static var banner: BannerFlightTrackerStyle { BannerFlightTrackerStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyFlightTrackerStyle: FlightTrackerStyle {
+    private let _makeBody: @MainActor (FlightTrackerConfiguration) -> AnyView
+    init<S: FlightTrackerStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: FlightTrackerConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct FlightTrackerStyleKey: EnvironmentKey {
+    static let defaultValue = AnyFlightTrackerStyle(BoardFlightTrackerStyle())
+}
+
+extension EnvironmentValues {
+    var flightTrackerStyle: AnyFlightTrackerStyle {
+        get { self[FlightTrackerStyleKey.self] }
+        set { self[FlightTrackerStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``FlightTrackerStyle`` for `FlightTracker`s in this view and
+    /// its descendants — one screen can mix archetypes per section.
+    func flightTrackerStyle<S: FlightTrackerStyle>(_ style: sending S) -> some View {
+        environment(\.flightTrackerStyle, AnyFlightTrackerStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a status dot + route one-liner, no card shell at all.
+private struct DotRowFlightTrackerStyle: FlightTrackerStyle {
+    func makeBody(configuration: FlightTrackerConfiguration) -> some View {
+        DotRowChrome(configuration: configuration)
+    }
+
+    private struct DotRowChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: FlightTrackerConfiguration
+
+        var body: some View {
+            HStack(spacing: configuration.spacing(.sm)) {
+                Circle().fill(configuration.tone().solid).frame(width: 8, height: 8)
+                Text("\(configuration.statusInfo.leg.origin) → \(configuration.statusInfo.leg.destination)")
+                    .textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary))
+                Spacer()
+                Text(configuration.statusInfo.status.label)
+                    .textStyle(.overline500).foregroundStyle(configuration.tone().base)
+            }
+            .padding(configuration.spacing(.sm))
+            .background(theme.background(configuration.surface(default: .bgSecondaryLight)),
+                        in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+        }
+    }
+}
+
+#Preview("FlightTrackerStyle — presets × light/dark") {
+    let dep = Date().addingTimeInterval(2 * 3_600)
+    let leg = FlightLeg(airline: "Skyline Air", from: "IST", to: "LHR",
+                        departure: dep, arrival: dep.addingTimeInterval(4 * 3_600))
+    let onTime = FlightStatusInfo(leg: leg, status: .onTime, gate: "B12", terminal: "1", checkInDesk: "34–38")
+    let delayed = FlightStatusInfo(leg: leg, status: .delayed, gate: "B12", terminal: "1",
+                                   estimatedDeparture: dep.addingTimeInterval(35 * 60),
+                                   estimatedArrival: dep.addingTimeInterval(4 * 3_600 + 35 * 60),
+                                   aircraft: "A321neo")
+    let boarding = FlightStatusInfo(leg: leg, status: .boarding, gate: "B12", terminal: "1", baggageBelt: "7")
+
+    return PreviewMatrix("FlightTrackerStyle") {
+        PreviewCase(".board (default)") {
+            FlightTracker(onTime).updated(Date().addingTimeInterval(-120)).flightTrackerStyle(.board)
+        }
+        PreviewCase(".compact") {
+            FlightTracker(delayed).flightTrackerStyle(.compact)
+        }
+        PreviewCase(".timeline") {
+            FlightTracker(boarding).updated(Date().addingTimeInterval(-60)).flightTrackerStyle(.timeline)
+        }
+        PreviewCase(".banner") {
+            FlightTracker(delayed).flightTrackerStyle(.banner)
+        }
+        PreviewCase("Custom (in-preview)") {
+            FlightTracker(delayed).flightTrackerStyle(DotRowFlightTrackerStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/PassengerForm.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PassengerForm.swift
@@ -6,10 +6,10 @@
 //  date of birth / nationality / travel document — bound to a `PassengerDraft`.
 //  Distinct from `PassengerRow` (a display row for review screens).
 //
-//  Composes neutral ThemeKit fields (`Fieldset`, `TextInput`, `SelectBox`,
-//  `DateField`); all of them inherit `FieldDefaults` / `FieldStyle` from the
-//  environment, so the form re-skins with the subtree's field chrome and needs
-//  no style protocol of its own (structure, not skinnable chrome).
+//  Composes neutral ThemeKit fields (`TextInput`, `SelectBox`, `DateField`);
+//  all of them inherit `FieldDefaults` / `FieldStyle` from the environment,
+//  so the form re-skins with the subtree's field chrome. Section chrome
+//  (`Fieldset`, `Card`, or none) is now the ``PassengerFormStyle`` axis below.
 //
 //  Controlled-only (ADR-F4): a traveler form the app can't read is useless.
 //  Multi-passenger checkout is the app's `ForEach` of `PassengerForm`s — the
@@ -30,6 +30,15 @@
 //  has validated the field" gate as `.field`). Their focus analogs are
 //  best-effort: DateField opens its picker, SelectBox renders its focus ring.
 //
+//  Style (ADR-0004, Class B): the component owns every live field unit
+//  (bindings, validator wiring, focus) — arrangement is delegated to the
+//  active ``PassengerFormStyle`` (`PassengerFormStyle.swift`) via
+//  `.passengerFormStyle(_:)`. `.stacked`/`.flat`/`.grouped` are the former
+//  `PassengerFormLayout` cases, deprecate-forwarded through `.layout(_:)`;
+//  `.carded` is new. Validation, live re-validation, the `.tint(_:)` accent
+//  and the container accessibility label stay applied by the component
+//  around the style's output — styles only arrange pre-wired field-run units.
+//
 
 import SwiftUI
 import ThemeKit
@@ -47,6 +56,12 @@ public enum PassengerFormField: Hashable, Sendable, CaseIterable {
 /// Section chrome of a ``PassengerForm``: two `Fieldset`s (`.stacked`, the
 /// default), bare fields with plain section titles (`.flat`), or every field
 /// inside one `Fieldset` (`.grouped`).
+///
+/// Superseded by ``PassengerFormStyle`` (ADR-0004) — every case maps 1:1
+/// onto a preset (`.stacked` → `.passengerFormStyle(.stacked)` and so on,
+/// plus the new `.carded`); the enum remains for source compatibility via
+/// the deprecated ``PassengerForm/layout(_:)`` and is removed at the next
+/// major.
 public enum PassengerFormLayout: Sendable { case stacked, flat, grouped }
 
 // MARK: - PassengerForm
@@ -72,6 +87,8 @@ public struct PassengerForm: View {
     @Environment(\.theme) private var theme
     @Environment(\.locale) private var locale
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.componentDensity) private var envDensity
+    @Environment(\.passengerFormStyle) private var envStyle
 
     private let title: String
     @Binding private var draft: PassengerDraft
@@ -90,7 +107,9 @@ public struct PassengerForm: View {
     /// Section titles: `nil` = built-in, `""` = section renders without a title.
     private var personalTitleOverride: String?
     private var documentTitleOverride: String?
-    private var layoutValue: PassengerFormLayout = .stacked
+    /// Style set by the deprecated `.layout(_:)`; wins over the environment
+    /// style (ADR-0004 §5 — source-behavior stability during migration).
+    private var explicitStyle: AnyPassengerFormStyle?
     /// Extra caller fields appended after the document section.
     private var additionalFieldsSlot: AnyView?
     private var genderOptions: [PassengerGender] = Array(PassengerGender.allCases)
@@ -147,54 +166,43 @@ public struct PassengerForm: View {
     // MARK: Body
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.md.value) {
-            if let customHeader {
-                customHeader
-            } else {
-                titleHeader
+        // The arrangement is owned by the active `PassengerFormStyle`
+        // (ADR-0004 Class B): the field-run units below are pre-wired and
+        // fully interactive (bindings, validator wiring, focus); the style
+        // arranges them, never re-wires them.
+        let configuration = PassengerFormConfiguration(
+            personalFields: personalFields.isEmpty ? nil : AnyView(fieldRun(personalFields)),
+            documentFields: documentFields.isEmpty ? nil : AnyView(fieldRun(documentFields)),
+            groupedFields: fieldList.isEmpty ? nil : AnyView(fieldRun(fieldList)),
+            header: customHeader ?? AnyView(titleHeader),
+            footer: customFooter,
+            additionalFields: additionalFieldsSlot,
+            personalTitle: resolvedPersonalTitle,
+            documentTitle: resolvedDocumentTitle,
+            groupedTitle: resolvedGroupedTitle,
+            accent: accent,
+            density: envDensity,
+            locale: locale)
+        let style = explicitStyle ?? envStyle   // explicit (deprecated .layout) wins — ADR-0004 §5
+        return style.makeBody(configuration: configuration)
+            .tint(accent?.base)
+            // Live canonical re-validation for the select/date fields (see
+            // header note): same gate as `.field(_:in:)` — only once the
+            // form has validated the field (a failed submit or a prior
+            // live pass).
+            .onChange(of: draft) { _, newDraft in
+                guard let form else { return }
+                let values = newDraft.formValues
+                for field in Self.canonicalRevalidated
+                where fieldList.contains(field) && form.messages.index(forKey: field) != nil {
+                    form.validate(field, values[field] ?? "")
+                }
             }
-
-            switch layoutValue {
-            case .stacked:
-                if !personalFields.isEmpty {
-                    section(title: resolvedPersonalTitle, fields: personalFields, chrome: true)
-                }
-                if !documentFields.isEmpty {
-                    section(title: resolvedDocumentTitle, fields: documentFields, chrome: true)
-                }
-            case .flat:
-                if !personalFields.isEmpty {
-                    section(title: resolvedPersonalTitle, fields: personalFields, chrome: false)
-                }
-                if !documentFields.isEmpty {
-                    section(title: resolvedDocumentTitle, fields: documentFields, chrome: false)
-                }
-            case .grouped:
-                if !fieldList.isEmpty {
-                    section(title: resolvedGroupedTitle, fields: fieldList, chrome: true)
-                }
-            }
-
-            if let additionalFieldsSlot { additionalFieldsSlot }
-
-            if let customFooter { customFooter }
-        }
-        .tint(accent?.base)
-        // Live canonical re-validation for the select/date fields (see header
-        // note): same gate as `.field(_:in:)` — only once the form has
-        // validated the field (a failed submit or a prior live pass).
-        .onChange(of: draft) { _, newDraft in
-            guard let form else { return }
-            let values = newDraft.formValues
-            for field in Self.canonicalRevalidated
-            where fieldList.contains(field) && form.messages.index(forKey: field) != nil {
-                form.validate(field, values[field] ?? "")
-            }
-        }
-        // A labeled container: VoiceOver announces the traveler ("Passenger 1,
-        // Adult") before stepping into the fields, which self-label.
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(title)
+            // A labeled container: VoiceOver announces the traveler
+            // ("Passenger 1, Adult") before stepping into the fields, which
+            // self-label.
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(title)
     }
 
     // MARK: Sub-views
@@ -232,25 +240,6 @@ public struct PassengerForm: View {
         case nil: return String(themeKitTravel: "Traveler details")
         case "": return nil
         case let custom: return custom
-        }
-    }
-
-    /// One section: `Fieldset` chrome (or a plain labeled stack for `.flat` /
-    /// title-less sections) around the ordered, column-aware field run.
-    @ViewBuilder
-    private func section(title: String?, fields: [PassengerFormField], chrome: Bool) -> some View {
-        if chrome, let title {
-            Fieldset(title) { fieldRun(fields) }
-        } else {
-            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
-                if let title {
-                    Text(title)
-                        .textStyle(.labelBase700)
-                        .foregroundStyle(theme.text(.textPrimary))
-                        .accessibilityAddTraits(.isHeader)
-                }
-                fieldRun(fields)
-            }
         }
     }
 
@@ -466,8 +455,19 @@ public extension PassengerForm {
 
     /// Section chrome: `.stacked` (two `Fieldset`s, default), `.flat` (bare
     /// fields + plain titles, no fieldset chrome), or `.grouped` (everything
-    /// in one `Fieldset`).
-    func layout(_ l: PassengerFormLayout) -> Self { copy { $0.layoutValue = l } }
+    /// in one `Fieldset`). Maps 1:1 onto the ``PassengerFormStyle`` presets
+    /// and, when called, wins over the environment style (source-behavior
+    /// stability during migration — ADR-0004 §5).
+    @available(*, deprecated, message: "Use .passengerFormStyle(_:) — e.g. .passengerFormStyle(.flat)")
+    func layout(_ l: PassengerFormLayout) -> Self {
+        copy {
+            switch l {
+            case .stacked: $0.explicitStyle = AnyPassengerFormStyle(StackedPassengerFormStyle())
+            case .flat: $0.explicitStyle = AnyPassengerFormStyle(FlatPassengerFormStyle())
+            case .grouped: $0.explicitStyle = AnyPassengerFormStyle(GroupedPassengerFormStyle())
+            }
+        }
+    }
 
     /// Extra caller-owned fields appended after the document section (before
     /// the footer) — e.g. a frequent-flyer number. The slot inherits the
@@ -587,23 +587,23 @@ public extension PassengerForm {
         var body: some View {
             ScrollView {
                 VStack(alignment: .leading, spacing: Theme.SpacingKey.lg.value) {
-                    // Flat layout, custom labels, side-by-side names, trimmed genders.
+                    // Flat style, custom labels, side-by-side names, trimmed genders.
                     PassengerForm("Traveler 1", draft: $flat)
-                        .layout(.flat)
                         .columns(2)
                         .label("First name", for: .givenName)
                         .label("Last name", for: .familyName)
                         .genders([.female, .male])
                         .sectionTitles(personal: "Who is flying?", document: "")
+                        .passengerFormStyle(.flat)
 
-                    // Grouped layout + additional caller field after the documents.
+                    // Grouped style + additional caller field after the documents.
                     PassengerForm("Traveler 2", draft: $grouped)
-                        .layout(.grouped)
                         .sectionTitles(personal: "Traveler details")
                         .additionalFields {
                             TextInput("Frequent flyer number", text: $loyalty)
                                 .keyboard(capitalization: .characters)
                         }
+                        .passengerFormStyle(.grouped)
                 }
                 .padding()
             }

--- a/Sources/ThemeKitTravel/Components/Organisms/PassengerFormStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PassengerFormStyle.swift
@@ -1,0 +1,374 @@
+//
+//  PassengerFormStyle.swift
+//  ThemeKitTravel
+//
+//  The styling hook for ``PassengerForm`` — a Class B protocol of ADR-0004
+//  (per-component style protocols). The component owns the live field units
+//  (bindings, `FormValidator` wiring, focus) — the configuration hands
+//  styles **pre-wired, type-erased field-unit runs** (one per section) plus
+//  typed signals (section titles, accent, density, locale). Styles ARRANGE
+//  the units; they never rebuild or re-wire them. Four built-ins:
+//
+//    .stacked   two `Fieldset`s (personal details, travel document) —
+//               today's render. Default.
+//    .flat      the same two sections with plain titles, no `Fieldset`
+//               chrome.
+//    .grouped   every rendered field under one legend, in one `Fieldset`.
+//    .carded    each non-empty section in its own `Card`.
+//
+//      PassengerForm("Passenger 1 · Adult", draft: $traveler)
+//          .documentRequired()
+//          .validator(form)
+//          .passengerFormStyle(.carded)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; shell
+//  components (`Fieldset`/`Card`) paint their own chrome; the token theme
+//  colors everything. Validation (ADR-F6), live canonical re-validation, the
+//  `.tint(_:)` accent and the container accessibility label are all applied
+//  by the component *around* the style's output (see `PassengerForm.body`)
+//  — styles never touch validator state and never need to re-apply the tint.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The pre-wired inputs a ``PassengerFormStyle`` arranges. The `AnyView`
+/// field-run units are fully interactive (text fields, selects, date pickers
+/// already bound to the draft and wired into the validator) — place them,
+/// never rebuild them. The typed fields are read-only signals for
+/// arrangement decisions; the field wiring and validator state never leave
+/// the component.
+public struct PassengerFormConfiguration {
+    // Pre-wired field units — fully interactive; styles arrange, never re-wire.
+    /// The personal-details field run (name / gender / date of birth /
+    /// nationality, in `fields(_:)` order); `nil` when none of those fields
+    /// are rendered.
+    public let personalFields: AnyView?
+    /// The travel-document field run (number / expiry, in `fields(_:)`
+    /// order); `nil` when neither is rendered.
+    public let documentFields: AnyView?
+    /// Every rendered field in one run, in raw `fields(_:)` order (spans
+    /// both sections, unsplit) — the unit a single-legend arrangement
+    /// (``groupedTitle``) presents. `nil` when no fields are rendered.
+    public let groupedFields: AnyView?
+    /// The title header — the `.header { }` slot content, or the built-in
+    /// title `Text`; always present. Arrange it, never rebuild it.
+    public let header: AnyView
+    /// Bottom-aligned accessory area (`.footer { }`); `nil` = none.
+    public let footer: AnyView?
+    /// Extra caller-owned fields (`.additionalFields { }`), appended after
+    /// the document section; `nil` = none. Inherits the subtree's
+    /// `FieldStyle`/`FieldDefaults`; validation of slot fields is the
+    /// caller's.
+    public let additionalFields: AnyView?
+
+    // Typed signals for arrangement decisions.
+    /// Resolved personal-section legend for ``personalFields``; `nil`
+    /// renders the section without a title (`sectionTitles(personal: "")`
+    /// asked for that).
+    public let personalTitle: String?
+    /// Resolved document-section legend for ``documentFields``; same `nil`
+    /// convention as ``personalTitle``.
+    public let documentTitle: String?
+    /// Resolved single legend for ``groupedFields``.
+    public let groupedTitle: String?
+    /// Accent tint (`accent(_:)`); `nil` inherits the surrounding tint. The
+    /// component already applies it via `.tint(_:)` around the whole style
+    /// output, so built-in presets don't need to re-apply it — it's exposed
+    /// for a custom style's own chrome (e.g. an accented section border).
+    public let accent: SemanticColor?
+    /// The environment's component density, captured by the component —
+    /// scale a preset's own chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component.
+    public let locale: Locale
+
+    /// Density-scaled spacing — use for a preset's own chrome padding/gaps
+    /// so `.componentDensity` compacts or airs it out (the field units
+    /// already scale their own internals).
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+}
+
+// MARK: - Protocol
+
+/// Defines a `PassengerForm`'s entire presentation. Implement `makeBody` to
+/// arrange the configuration's pre-wired field-unit runs. Set one with
+/// `.passengerFormStyle(_:)`; the default is ``StackedPassengerFormStyle``.
+public protocol PassengerFormStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: PassengerFormConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// `Fieldset` chrome (or a plain labeled stack for chrome-less / title-less
+/// sections) around a pre-wired field-run unit — shared by `.stacked` and
+/// `.flat`, the exact anatomy `PassengerForm` rendered before this style
+/// existed. `title == nil` (an explicit `sectionTitles(…: "")`) always
+/// drops the `Fieldset` chrome too, matching the pre-style behavior.
+private struct PassengerFormSection: View {
+    @Environment(\.theme) private var theme
+    let title: String?
+    let unit: AnyView
+    var chrome = true
+
+    var body: some View {
+        if chrome, let title {
+            Fieldset(title) { unit }
+        } else {
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                if let title {
+                    Text(title)
+                        .textStyle(.labelBase700)
+                        .foregroundStyle(theme.text(.textPrimary))
+                        .accessibilityAddTraits(.isHeader)
+                }
+                unit
+            }
+        }
+    }
+}
+
+// MARK: - .stacked (default)
+
+/// Today's `PassengerForm` look, extracted verbatim: the title header, a
+/// `Fieldset` for personal details, a `Fieldset` for the travel document,
+/// the additional-fields slot, then the footer.
+public struct StackedPassengerFormStyle: PassengerFormStyle {
+    public init() {}
+    public func makeBody(configuration c: PassengerFormConfiguration) -> some View {
+        VStack(alignment: .leading, spacing: c.spacing(.md)) {
+            c.header
+            if let personalFields = c.personalFields {
+                PassengerFormSection(title: c.personalTitle, unit: personalFields)
+            }
+            if let documentFields = c.documentFields {
+                PassengerFormSection(title: c.documentTitle, unit: documentFields)
+            }
+            if let additionalFields = c.additionalFields { additionalFields }
+            if let footer = c.footer { footer }
+        }
+    }
+}
+
+// MARK: - .flat
+
+/// The same two sections as `.stacked`, without `Fieldset` chrome — a plain
+/// label above each field run instead of a bordered box.
+public struct FlatPassengerFormStyle: PassengerFormStyle {
+    public init() {}
+    public func makeBody(configuration c: PassengerFormConfiguration) -> some View {
+        VStack(alignment: .leading, spacing: c.spacing(.md)) {
+            c.header
+            if let personalFields = c.personalFields {
+                PassengerFormSection(title: c.personalTitle, unit: personalFields, chrome: false)
+            }
+            if let documentFields = c.documentFields {
+                PassengerFormSection(title: c.documentTitle, unit: documentFields, chrome: false)
+            }
+            if let additionalFields = c.additionalFields { additionalFields }
+            if let footer = c.footer { footer }
+        }
+    }
+}
+
+// MARK: - .grouped
+
+/// Every rendered field under one legend, in one `Fieldset` — no split
+/// between personal details and the travel document.
+public struct GroupedPassengerFormStyle: PassengerFormStyle {
+    public init() {}
+    public func makeBody(configuration c: PassengerFormConfiguration) -> some View {
+        VStack(alignment: .leading, spacing: c.spacing(.md)) {
+            c.header
+            if let groupedFields = c.groupedFields {
+                PassengerFormSection(title: c.groupedTitle, unit: groupedFields)
+            }
+            if let additionalFields = c.additionalFields { additionalFields }
+            if let footer = c.footer { footer }
+        }
+    }
+}
+
+// MARK: - .carded
+
+/// Each non-empty section in its own `Card` — a more separated look for
+/// screens that already use `Card` for other booking-flow blocks.
+public struct CardedPassengerFormStyle: PassengerFormStyle {
+    public init() {}
+    public func makeBody(configuration c: PassengerFormConfiguration) -> some View {
+        VStack(alignment: .leading, spacing: c.spacing(.md)) {
+            c.header
+            if let personalFields = c.personalFields {
+                Card(c.personalTitle) { personalFields }
+                    .contentPadding(.md)
+            }
+            if let documentFields = c.documentFields {
+                Card(c.documentTitle) { documentFields }
+                    .contentPadding(.md)
+            }
+            if let additionalFields = c.additionalFields { additionalFields }
+            if let footer = c.footer { footer }
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension PassengerFormStyle where Self == StackedPassengerFormStyle {
+    /// Two `Fieldset`s (personal details, travel document) — today's render.
+    /// The default.
+    static var stacked: StackedPassengerFormStyle { StackedPassengerFormStyle() }
+}
+public extension PassengerFormStyle where Self == FlatPassengerFormStyle {
+    /// The same two sections, with plain titles instead of `Fieldset` chrome.
+    static var flat: FlatPassengerFormStyle { FlatPassengerFormStyle() }
+}
+public extension PassengerFormStyle where Self == GroupedPassengerFormStyle {
+    /// Every rendered field under one legend, in one `Fieldset`.
+    static var grouped: GroupedPassengerFormStyle { GroupedPassengerFormStyle() }
+}
+public extension PassengerFormStyle where Self == CardedPassengerFormStyle {
+    /// Each non-empty section in its own `Card`.
+    static var carded: CardedPassengerFormStyle { CardedPassengerFormStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyPassengerFormStyle: PassengerFormStyle {
+    private let _makeBody: @MainActor (PassengerFormConfiguration) -> AnyView
+    init<S: PassengerFormStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: PassengerFormConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct PassengerFormStyleKey: EnvironmentKey {
+    static let defaultValue = AnyPassengerFormStyle(StackedPassengerFormStyle())
+}
+
+extension EnvironmentValues {
+    var passengerFormStyle: AnyPassengerFormStyle {
+        get { self[PassengerFormStyleKey.self] }
+        set { self[PassengerFormStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``PassengerFormStyle`` for `PassengerForm`s in this view and
+    /// its descendants — a booking flow can run `.carded` while a dense
+    /// review step keeps `.flat`.
+    func passengerFormStyle<S: PassengerFormStyle>(_ style: sending S) -> some View {
+        environment(\.passengerFormStyle, AnyPassengerFormStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — a two-column layout that
+/// places the personal and document sections side by side. Proves external
+/// implementability: it never touches field wiring, only arranges the
+/// pre-wired units.
+private struct SplitPassengerFormStyle: PassengerFormStyle {
+    func makeBody(configuration: PassengerFormConfiguration) -> some View {
+        SplitChrome(configuration: configuration)
+    }
+
+    private struct SplitChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: PassengerFormConfiguration
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
+                configuration.header
+                HStack(alignment: .top, spacing: configuration.spacing(.md)) {
+                    if let personalFields = configuration.personalFields {
+                        column(title: configuration.personalTitle, unit: personalFields)
+                    }
+                    if let documentFields = configuration.documentFields {
+                        column(title: configuration.documentTitle, unit: documentFields)
+                    }
+                }
+                if let additionalFields = configuration.additionalFields { additionalFields }
+                if let footer = configuration.footer { footer }
+            }
+        }
+
+        private func column(title: String?, unit: AnyView) -> some View {
+            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+                if let title {
+                    Text(title)
+                        .textStyle(.overline500)
+                        .foregroundStyle(theme.text(.textTertiary))
+                }
+                unit
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+/// Preview-only harness: owns the `@State` draft each interactive case binds to.
+private struct PassengerFormStyleHarness<Content: View>: View {
+    @State private var draft: PassengerDraft
+    private let content: (Binding<PassengerDraft>) -> Content
+
+    init(_ draft: PassengerDraft, @ViewBuilder content: @escaping (Binding<PassengerDraft>) -> Content) {
+        self._draft = State(initialValue: draft)
+        self.content = content
+    }
+
+    var body: some View { content($draft) }
+}
+
+private func styleDraft() -> PassengerDraft {
+    var draft = PassengerDraft()
+    draft.givenName = "Ada"
+    draft.familyName = "Lovelace"
+    draft.gender = .female
+    draft.dateOfBirth = Calendar.current.date(byAdding: .year, value: -34, to: .now)
+    draft.nationality = "GB"
+    draft.documentNumber = "X1234567"
+    draft.documentExpiry = Calendar.current.date(byAdding: .year, value: 5, to: .now)
+    return draft
+}
+
+#Preview("PassengerFormStyle — presets × light/dark") {
+    PreviewMatrix("PassengerFormStyle") {
+        PreviewCase(".stacked (default)") {
+            PassengerFormStyleHarness(styleDraft()) {
+                PassengerForm("Passenger 1 · Adult", draft: $0).documentRequired()
+            }
+        }
+        PreviewCase(".flat") {
+            PassengerFormStyleHarness(styleDraft()) {
+                PassengerForm("Passenger 1 · Adult", draft: $0)
+                    .documentRequired()
+                    .passengerFormStyle(.flat)
+            }
+        }
+        PreviewCase(".grouped") {
+            PassengerFormStyleHarness(styleDraft()) {
+                PassengerForm("Passenger 1 · Adult", draft: $0)
+                    .documentRequired()
+                    .passengerFormStyle(.grouped)
+            }
+        }
+        PreviewCase(".carded") {
+            PassengerFormStyleHarness(styleDraft()) {
+                PassengerForm("Passenger 1 · Adult", draft: $0)
+                    .documentRequired()
+                    .passengerFormStyle(.carded)
+            }
+        }
+        PreviewCase("Custom (in-preview) — split columns") {
+            PassengerFormStyleHarness(styleDraft()) {
+                PassengerForm("Passenger 1 · Adult", draft: $0)
+                    .documentRequired()
+                    .passengerFormStyle(SplitPassengerFormStyle())
+            }
+        }
+    }
+}

--- a/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
+++ b/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
@@ -138,7 +138,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d): scheduled \(d), estimated \(d)",
             "%@: scheduled %@, estimated %@", 3,
-            site: "Sources/ThemeKitTravel/Components/Organisms/FlightTracker.swift:294")
+            site: "Sources/ThemeKitTravel/Components/Organisms/FlightTrackerStyle.swift:368")
         assertKey(
             "\(d)h \(d)m",
             "%@h %@m", 2,
@@ -281,7 +281,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Step \(d) of \(d)",
             "Step %@ of %@", 2,
-            site: "Sources/ThemeKitTravel/Components/Organisms/CheckInFlow.swift:197")
+            site: "Sources/ThemeKitTravel/Components/Organisms/CheckInFlowStyle.swift:191")
         assertKey(
             "The file is larger than the \(d) KB limit.",
             "The file is larger than the %@ KB limit.", 1,
@@ -297,7 +297,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Updated \(d)",
             "Updated %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/FlightTracker.swift:343")
+            site: "Sources/ThemeKitTravel/Components/Organisms/FlightTracker.swift:114")
         assertKey(
             "down \(d)",
             "down %@", 1,
@@ -305,15 +305,15 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "estimated arrival \(d)",
             "estimated arrival %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/FlightTracker.swift:235")
+            site: "Sources/ThemeKitTravel/Components/Organisms/FlightTrackerStyle.swift:156")
         assertKey(
             "estimated departure \(d)",
             "estimated departure %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/FlightTracker.swift:232")
+            site: "Sources/ThemeKitTravel/Components/Organisms/FlightTrackerStyle.swift:153")
         assertKey(
             "seat \(d)",
             "seat %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Molecules/PassengerRow.swift:87")
+            site: "Sources/ThemeKitTravel/Components/Molecules/PassengerRowStyle.swift:109")
         assertKey(
             "up \(d)",
             "up %@", 1,

--- a/docs/templates/ThemeKit.xcstrings
+++ b/docs/templates/ThemeKit.xcstrings
@@ -1008,6 +1008,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "Now boarding": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "Occupied": {
       "comment": "A description of a seat's state: \"Occupied\", \"Selected\" or \"Available\".",
       "extractionState": "manual",


### PR DESCRIPTION
Fourth wave of **ADR-0004** (per-component Style protocols). Six Passenger-&-day-of-travel components each gain their own full Style protocol — two Class-B (`PassengerForm`, `CheckInFlow`) plus four Class-A. Every default preset reproduces today's render pixel-for-pixel; additive.

| Component | Protocol → modifier | Presets | Class |
|---|---|---|---|
| PassengerForm | `.passengerFormStyle(_:)` | `.stacked` · `.flat` · `.grouped` · `.carded` | B |
| CheckInFlow | `.checkInFlowStyle(_:)` | `.steps` · `.bar` · `.paged` | B |
| PassengerRow | `.passengerRowStyle(_:)` | `.row` · `.card` · `.compact` | A |
| BoardingPass | `.boardingPassStyle(_:)` | `.classic` · `.wallet` · `.strip` | A |
| FlightTracker | `.flightTrackerStyle(_:)` | `.board` · `.compact` · `.timeline` · `.banner` | A |
| LayoverRow | `.layoverRowStyle(_:)` | `.line` · `.pill` · `.banner` | A |

**20 presets** across 6 protocols.

## Notes
- **Class B** (`PassengerForm`/`CheckInFlow`): styles arrange pre-wired field/nav units; validator/navigation/selection wiring stays in the component (`CheckInFlow<Page>`'s generic Page never leaks into the protocol via the erased units).
- **BoardingPass:** the TicketStub tear chrome is owned per-preset (`.classic`/`.wallet` own it; `.strip` is card-shelled) — blanket exemption dissolved.
- **FlightTracker:** the status-change a11y live-region announcement stays in the component (covers every preset).
- **Deprecate-forward:** existing `.variant(_:)`/`.layout(_:)`/`.progressStyle(_:)` deprecate-forward; explicit wins over env style; enums stay public.
- **l10n** catalogs regenerated (drift gate green).

## Verification
`swift build` **0 errors** · **312 tests pass** (incl. l10n gate) · **Demo BUILD SUCCEEDED** (iOS Simulator). Integration fixed one root (a `#Preview` helper needed `@MainActor`).

Part of the ADR-0004 6-wave plan. Wave 5 (final) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)