### PR TITLE
feat(travel): Style-protocol Wave 5 — Seats & filters (ADR-0004, FINAL wave)

### DIFF
--- a/Sources/ThemeKitTravel/Components/Atoms/SeatCell.swift
+++ b/Sources/ThemeKitTravel/Components/Atoms/SeatCell.swift
@@ -7,8 +7,14 @@
 //  silhouette (rounded / circle / seatback) and a recommended star. Composed by
 //  ``SeatMap`` but reusable on its own for bespoke seat grids.
 //
-//  NOTE: this atom predates the copy-on-write modifier convention — its knobs
-//  are DEFAULTED init params by design. COW migration deferred to next major.
+//  Presentation is style-driven (``SeatCellStyle``, ADR-0004): `.rounded`
+//  (default) / `.circle` / `.seatback`, settable once per screen via
+//  `.seatCellStyle(_:)`. See `SeatCellStyle.swift` for the full anatomy.
+//
+//  NOTE: this atom predates the copy-on-write modifier convention — its other
+//  knobs (palette, display, size…) are DEFAULTED init params by design. Full
+//  COW migration deferred to next major; `SeatCellStyle` is this atom's
+//  modernization path for its one look axis, the silhouette.
 //
 
 import SwiftUI
@@ -25,9 +31,10 @@ public enum SeatSelectionEmphasis: Sendable {
 }
 
 public struct SeatCell: View {
-    @Environment(\.theme) private var theme
     @Environment(\.formatDefaults) private var formatDefaults
     @Environment(\.locale) private var locale
+    @Environment(\.componentDensity) private var density
+    @Environment(\.seatCellStyle) private var envStyle
 
     // Content (R1) + state.
     private let seat: Seat
@@ -45,6 +52,10 @@ public struct SeatCell: View {
     private let selectionEmphasis: SeatSelectionEmphasis
     private let action: () -> Void
 
+    /// - Parameter shape: **Deprecated** — prefer `.seatCellStyle(_:)`; kept for source
+    ///   compatibility. A non-default value (`.circle`/`.seatback`) still wins over an
+    ///   ancestor `.seatCellStyle(_:)` (ADR-0004 §5's source-behavior stability); the
+    ///   default `.rounded` falls through to the environment style.
     public init(_ seat: Seat,
                 size: CGFloat = 44,
                 isSelected: Bool = false,
@@ -77,6 +88,8 @@ public struct SeatCell: View {
 
     /// Omitted-currency form — resolves the code from the environment:
     /// `formatDefaults.currencyCode` → `locale.currency` → `"USD"` (§10).
+    /// - Parameter shape: **Deprecated** — prefer `.seatCellStyle(_:)`; see the
+    ///   designated init's parameter doc for the explicit/environment precedence rule.
     public init(_ seat: Seat,
                 size: CGFloat = 44,
                 isSelected: Bool = false,
@@ -109,6 +122,8 @@ public struct SeatCell: View {
     /// Token-stepped size overload — `size:` takes a ``SeatSizeRamp`` instead of
     /// raw points (compact 36 · regular 44 · large 52 · xl 60). A `nil`
     /// `currencyCode` resolves from the environment like the omitted-currency init.
+    /// - Parameter shape: **Deprecated** — prefer `.seatCellStyle(_:)`; see the
+    ///   designated init's parameter doc for the explicit/environment precedence rule.
     public init(_ seat: Seat,
                 size ramp: SeatSizeRamp,
                 isSelected: Bool = false,
@@ -142,118 +157,43 @@ public struct SeatCell: View {
         currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
 
+    /// The deprecated `shape:` init param's own preset, when it requested a
+    /// non-default silhouette. `.rounded` is indistinguishable from "not set"
+    /// — it's the shared default of both the parameter and
+    /// ``RoundedSeatCellStyle`` — so it falls through to the environment
+    /// style, letting an ancestor `.seatCellStyle(_:)` take effect for the
+    /// common (default-shape) call site. An explicit `.circle`/`.seatback`
+    /// still wins over the environment (ADR-0004 §5's source-behavior
+    /// stability) — pre-existing call sites (e.g. ``SeatMap``, which forwards
+    /// its own `.seatShape(_:)` knob here) keep rendering exactly what they
+    /// render today.
+    private var explicitStyle: AnySeatCellStyle? {
+        switch shape {
+        case .rounded: return nil
+        case .circle: return AnySeatCellStyle(CircleSeatCellStyle())
+        case .seatback: return AnySeatCellStyle(SeatbackSeatCellStyle())
+        }
+    }
+
     public var body: some View {
-        let cellShape = shape.anyShape(cornerRadius: Theme.RadiusRole.selector.value)
-        Button(action: action) {
-            cellShape
-                .fill(fillColor)
-                .overlay(cellShape.stroke(strokeColor, lineWidth: strokeWidth))
-                .overlay(glyph)
-                .overlay(alignment: .topTrailing) { if showsStar { recommendedStar } }
-                .frame(width: size, height: size)
-                .opacity(isSelectable || isSelected ? 1 : 0.55)
-        }
-        .buttonStyle(.plain)
-        .disabled(!isSelectable && !isSelected)
-        .accessibilityLabel(a11yLabel)
-        .accessibilityValue(a11yValue)
-        .accessibilityHint(isSelectable ? "Double-tap to \(isSelected ? "deselect" : "select")" : "")
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-
-    private var showsStar: Bool { isRecommended && isSelectable && !isSelected }
-
-    // MARK: Content
-
-    @ViewBuilder private var glyph: some View {
-        if let customContent {
-            customContent(SeatContext(seat: seat, isSelected: isSelected, isOccupied: seat.isOccupied, assignedInitials: assignedInitials))
-        } else {
-            defaultContent
-        }
-    }
-
-    @ViewBuilder private var defaultContent: some View {
-        switch display {
-        case .number:
-            Text(seat.id).textStyle(.overline500).foregroundStyle(contentColor)
-                .minimumScaleFactor(0.5).lineLimit(1).padding(.horizontal, 2)
-        case .initials where assignedInitials != nil:
-            Text(assignedInitials ?? "").textStyle(.labelSm600).foregroundStyle(contentColor)
-        case .initialsAndNumber:
-            VStack(spacing: 0) {
-                if let assignedInitials { Text(assignedInitials).textStyle(.labelSm600).foregroundStyle(contentColor) }
-                Text(seat.id).textStyle(.overline400).foregroundStyle(contentColor.opacity(0.75))
-                    .minimumScaleFactor(0.5).lineLimit(1)
-            }
-            .padding(.horizontal, 2)
-        case .icon, .initials:
-            iconGlyph
-        }
-    }
-
-    // Glyphs step through the type ramp (Dynamic Type for free) instead of
-    // hardcoded point sizes.
-    @ViewBuilder private var iconGlyph: some View {
-        if let assignedInitials {
-            Text(assignedInitials).textStyle(.labelSm600).foregroundStyle(contentColor)
-        } else if isSelected {
-            Image(systemName: "checkmark").textStyle(.labelSm700).foregroundStyle(contentColor)
-        } else if seat.isOccupied {
-            Image(systemName: "xmark").textStyle(.labelSm600).foregroundStyle(contentColor)
-        } else {
-            Image(systemName: seat.tier.glyph).textStyle(.labelSm600).foregroundStyle(contentColor)
-        }
-    }
-
-    private var recommendedStar: some View {
-        Image(systemName: recommendedSymbol)
-            .font(.system(size: 8, weight: .bold))
-            .foregroundStyle(theme.foreground(.systemcolorsFgWarning))
-            .padding(2)
-            .background(theme.background(.bgBase), in: Circle())
-            .offset(x: 3, y: -3)
-    }
-
-    // MARK: Colours
-
-    private var fillColor: Color {
-        if isSelected { return palette.selectedColors(theme: theme).fill }
-        if seat.isOccupied { return palette.occupiedColors(theme: theme).fill }
-        return palette.colors(for: seat.tier, theme: theme).fill
-    }
-    private var strokeColor: Color {
-        if isSelected {
-            return selectionEmphasis == .border ? palette.selectedColors(theme: theme).stroke : .clear
-        }
-        if seat.isOccupied { return palette.occupiedColors(theme: theme).stroke }
-        return palette.colors(for: seat.tier, theme: theme).stroke
-    }
-    private var strokeWidth: CGFloat {
-        guard isSelected else { return 1 }
-        return selectionEmphasis == .border ? 2 : 0
-    }
-    private var contentColor: Color {
-        if isSelected { return palette.selectedColors(theme: theme).content }
-        if seat.isOccupied { return palette.occupiedColors(theme: theme).content }
-        return theme.text(.textSecondary)
-    }
-
-    // MARK: Accessibility
-
-    private var a11yLabel: String {
-        var s = String(themeKit: "Seat \(seat.id)")
-        if seat.tier != .standard { s += ", \(seat.tier.label)" }   // tier.label is already bridge-localized
-        return s
-    }
-    private var a11yValue: String {
-        if seat.isOccupied { return String(themeKit: "Occupied") }
-        if !isSelectable { return String(themeKit: "Unavailable") }
-        if isSelected { return String(themeKit: "Selected") }
-        if let price = seat.price {
-            return String(themeKit: "Available, \(price.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0))))")
-        }
-        return String(themeKit: "Available")
+        let configuration = SeatCellConfiguration(
+            seat: seat,
+            isSelected: isSelected,
+            isSelectable: isSelectable,
+            isRecommended: isRecommended,
+            recommendedSymbol: recommendedSymbol,
+            assignedInitials: assignedInitials,
+            display: display,
+            customContent: customContent,
+            palette: palette,
+            selectionEmphasis: selectionEmphasis,
+            shape: shape,
+            size: size,
+            currencyCode: resolvedCurrency,
+            density: density,
+            locale: locale,
+            action: action)
+        (explicitStyle ?? envStyle).makeBody(configuration: configuration)
     }
 }
 

--- a/Sources/ThemeKitTravel/Components/Atoms/SeatCellStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Atoms/SeatCellStyle.swift
@@ -1,0 +1,373 @@
+//
+//  SeatCellStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``SeatCell`` (ADR-0004, Wave 5). An atom has no layout
+//  anatomy to swap — these three presets promote ``SeatShape``, the one knob
+//  that *is* the look, so the seat-map family answers to the same
+//  `.xStyle(_:)` mental model as the rest of the suite, settable once per
+//  screen via the environment. Every other knob (``SeatSelectionEmphasis``,
+//  size, palette, display content) stays a *configuration* field — it
+//  composes with any preset, including custom ones. Selected/occupied chroma
+//  is always **palette**-driven; no style may invent its own free accent.
+//
+//    .rounded   continuous-corner rounded square — today's cell. Default.
+//    .circle    a circle.
+//    .seatback  a squircle with a concave backrest notch.
+//
+//      SeatCell(Seat("12A"), isSelected: true)
+//          .seatCellStyle(.circle)
+//
+//  Doubles as this pre-COW atom's modernization path (`SeatCell.swift:10–12`):
+//  the deprecated `shape:` init param still selects one of these three presets
+//  directly when set to a non-default silhouette (explicit wins over an
+//  ancestor `.seatCellStyle(_:)` — ADR-0004 §5's source-behavior stability); a
+//  `SeatCell(...)` that never touches `shape:` picks up the environment style
+//  like any other ThemeKit component. No major/COW migration needed.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``SeatCellStyle`` renders. Fields a given style doesn't
+/// use are simply ignored — the built-ins degrade gracefully when optional
+/// data is absent (no ``customContent`` → the built-in ``display`` mode, no
+/// ``assignedInitials`` → the tier/state glyph).
+public struct SeatCellConfiguration {
+    /// The seat and its fare tier — drives the tier fill/stroke and glyph.
+    public let seat: Seat
+    /// Selected state.
+    public let isSelected: Bool
+    /// Whether the seat can be tapped (occupied/blocked seats stay tappable
+    /// while already selected, so they can be deselected).
+    public let isSelectable: Bool
+    /// Recommended flag; resolve via ``showsStar``.
+    public let isRecommended: Bool
+    /// SF Symbol for the recommended star.
+    public let recommendedSymbol: String
+    /// Assigned passenger initials, in passenger-assignment mode.
+    public let assignedInitials: String?
+    /// How the built-in inner content is drawn — icon / number / initials / both.
+    public let display: SeatDisplay
+    /// Fully custom inner content, replacing ``display`` entirely when set.
+    public let customContent: ((SeatContext) -> AnyView)?
+    /// Tier/selected/occupied colour mapping — resolve via
+    /// ``fillColor(theme:)`` / ``strokeColor(theme:)`` / ``contentColor(theme:)``.
+    /// Selected and occupied chroma are always **palette**-driven; a style
+    /// must never invent its own accent for either state.
+    public let palette: SeatPalette
+    /// How a selected seat is emphasized — a ring (default) or fill alone.
+    public let selectionEmphasis: SeatSelectionEmphasis
+    /// The silhouette this cell was constructed to draw. Informational: the
+    /// three built-ins each draw their own named shape regardless of this
+    /// field (so an ancestor `.seatCellStyle(_:)` reliably wins for the
+    /// common default-shape call site — see the file header); a custom style
+    /// may honour it to reproduce the caller-requested silhouette instead.
+    public let shape: SeatShape
+    /// The cell's side, in points.
+    public let size: CGFloat
+    /// Already-resolved currency code (the component's FormatDefaults chain),
+    /// used for the a11y price value.
+    public let currencyCode: String
+    /// The environment's component density, captured by the component — scale
+    /// any chrome a custom style adds with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component.
+    public let locale: Locale
+    /// The tap action.
+    public let action: () -> Void
+
+    /// Convenience read-out of ``Seat/isOccupied``.
+    public var isOccupied: Bool { seat.isOccupied }
+    /// Whether the recommended star should be drawn — hidden once selected or
+    /// unselectable, so it never competes with the checkmark/✕ glyph.
+    public var showsStar: Bool { isRecommended && isSelectable && !isSelected }
+
+    /// The cell's fill, resolved through ``palette`` for the current state.
+    public func fillColor(theme: Theme) -> Color {
+        if isSelected { return palette.selectedColors(theme: theme).fill }
+        if seat.isOccupied { return palette.occupiedColors(theme: theme).fill }
+        return palette.colors(for: seat.tier, theme: theme).fill
+    }
+    /// The cell's stroke, resolved through ``palette`` — `.fill` emphasis
+    /// drops the selected ring (`.clear`).
+    public func strokeColor(theme: Theme) -> Color {
+        if isSelected {
+            return selectionEmphasis == .border ? palette.selectedColors(theme: theme).stroke : .clear
+        }
+        if seat.isOccupied { return palette.occupiedColors(theme: theme).stroke }
+        return palette.colors(for: seat.tier, theme: theme).stroke
+    }
+    /// The stroke width — 2 pt selected ring (`.border` emphasis), 0 pt for
+    /// `.fill` emphasis, 1 pt hairline otherwise.
+    public var strokeWidth: CGFloat {
+        guard isSelected else { return 1 }
+        return selectionEmphasis == .border ? 2 : 0
+    }
+    /// The inner content's colour, resolved through ``palette``.
+    public func contentColor(theme: Theme) -> Color {
+        if isSelected { return palette.selectedColors(theme: theme).content }
+        if seat.isOccupied { return palette.occupiedColors(theme: theme).content }
+        return theme.text(.textSecondary)
+    }
+
+    /// Density-scaled spacing, for any chrome a custom style adds around the cell.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// "Seat 12A" / "Seat 12A, Business" — the accessibility label every
+    /// built-in shares.
+    public var accessibilityLabel: String {
+        var s = String(themeKit: "Seat \(seat.id)")
+        if seat.tier != .standard { s += ", \(seat.tier.label)" }   // tier.label is already bridge-localized
+        return s
+    }
+    /// "Occupied" / "Unavailable" / "Selected" / "Available, $129" / "Available".
+    public var accessibilityValue: String {
+        if seat.isOccupied { return String(themeKit: "Occupied") }
+        if !isSelectable { return String(themeKit: "Unavailable") }
+        if isSelected { return String(themeKit: "Selected") }
+        if let price = seat.price {
+            return String(themeKit: "Available, \(price.formatted(.currency(code: currencyCode).precision(.fractionLength(0))))")
+        }
+        return String(themeKit: "Available")
+    }
+    /// The select/deselect hint, or empty when the seat can't be tapped.
+    public var accessibilityHint: String {
+        isSelectable ? "Double-tap to \(isSelected ? "deselect" : "select")" : ""
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `SeatCell`'s entire presentation. Implement `makeBody` to draw
+/// the configuration's seat. Set one with `.seatCellStyle(_:)`; the default
+/// is ``RoundedSeatCellStyle``.
+public protocol SeatCellStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: SeatCellConfiguration) -> Body
+}
+
+// MARK: - Shared chrome (private to the built-ins)
+
+/// The button/overlay stack every built-in shares — only the silhouette
+/// (`shape`) differs between `.rounded` / `.circle` / `.seatback`; every other
+/// pixel (fill, stroke, glyph, star, a11y) is identical, so the three presets
+/// are thin wrappers over this one chrome, each pinning its own shape.
+private struct SeatCellChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: SeatCellConfiguration
+    let shape: SeatShape
+
+    var body: some View {
+        let cellShape = shape.anyShape(cornerRadius: Theme.RadiusRole.selector.value)
+        Button(action: configuration.action) {
+            cellShape
+                .fill(configuration.fillColor(theme: theme))
+                .overlay(cellShape.stroke(configuration.strokeColor(theme: theme), lineWidth: configuration.strokeWidth))
+                .overlay(glyph)
+                .overlay(alignment: .topTrailing) { if configuration.showsStar { recommendedStar } }
+                .frame(width: configuration.size, height: configuration.size)
+                .opacity(configuration.isSelectable || configuration.isSelected ? 1 : 0.55)
+        }
+        .buttonStyle(.plain)
+        .disabled(!configuration.isSelectable && !configuration.isSelected)
+        .accessibilityLabel(configuration.accessibilityLabel)
+        .accessibilityValue(configuration.accessibilityValue)
+        .accessibilityHint(configuration.accessibilityHint)
+        .accessibilityAddTraits(configuration.isSelected ? .isSelected : [])
+    }
+
+    // MARK: Content
+
+    @ViewBuilder private var glyph: some View {
+        if let customContent = configuration.customContent {
+            customContent(SeatContext(
+                seat: configuration.seat, isSelected: configuration.isSelected,
+                isOccupied: configuration.seat.isOccupied, assignedInitials: configuration.assignedInitials))
+        } else {
+            defaultContent
+        }
+    }
+
+    @ViewBuilder private var defaultContent: some View {
+        switch configuration.display {
+        case .number:
+            Text(configuration.seat.id).textStyle(.overline500).foregroundStyle(contentColor)
+                .minimumScaleFactor(0.5).lineLimit(1).padding(.horizontal, 2)
+        case .initials where configuration.assignedInitials != nil:
+            Text(configuration.assignedInitials ?? "").textStyle(.labelSm600).foregroundStyle(contentColor)
+        case .initialsAndNumber:
+            VStack(spacing: 0) {
+                if let assignedInitials = configuration.assignedInitials {
+                    Text(assignedInitials).textStyle(.labelSm600).foregroundStyle(contentColor)
+                }
+                Text(configuration.seat.id).textStyle(.overline400).foregroundStyle(contentColor.opacity(0.75))
+                    .minimumScaleFactor(0.5).lineLimit(1)
+            }
+            .padding(.horizontal, 2)
+        case .icon, .initials:
+            iconGlyph
+        }
+    }
+
+    /// The inner content's colour, resolved through the configuration's palette.
+    private var contentColor: Color { configuration.contentColor(theme: theme) }
+
+    // Glyphs step through the type ramp (Dynamic Type for free) instead of
+    // hardcoded point sizes.
+    @ViewBuilder private var iconGlyph: some View {
+        if let assignedInitials = configuration.assignedInitials {
+            Text(assignedInitials).textStyle(.labelSm600).foregroundStyle(contentColor)
+        } else if configuration.isSelected {
+            Image(systemName: "checkmark").textStyle(.labelSm700).foregroundStyle(contentColor)
+        } else if configuration.seat.isOccupied {
+            Image(systemName: "xmark").textStyle(.labelSm600).foregroundStyle(contentColor)
+        } else {
+            Image(systemName: configuration.seat.tier.glyph).textStyle(.labelSm600).foregroundStyle(contentColor)
+        }
+    }
+
+    private var recommendedStar: some View {
+        Image(systemName: configuration.recommendedSymbol)
+            .font(.system(size: 8, weight: .bold))
+            .foregroundStyle(theme.foreground(.systemcolorsFgWarning))
+            .padding(2)
+            .background(theme.background(.bgBase), in: Circle())
+            .offset(x: 3, y: -3)
+    }
+}
+
+// MARK: - .rounded
+
+/// A continuous-corner rounded square — today's cell, extracted verbatim. Default.
+public struct RoundedSeatCellStyle: SeatCellStyle {
+    public init() {}
+    public func makeBody(configuration: SeatCellConfiguration) -> some View {
+        SeatCellChrome(configuration: configuration, shape: .rounded)
+    }
+}
+
+// MARK: - .circle
+
+/// A circular cell — the shared chrome, a round silhouette.
+public struct CircleSeatCellStyle: SeatCellStyle {
+    public init() {}
+    public func makeBody(configuration: SeatCellConfiguration) -> some View {
+        SeatCellChrome(configuration: configuration, shape: .circle)
+    }
+}
+
+// MARK: - .seatback
+
+/// A squircle with a concave backrest notch cut into its top edge — the
+/// seat-back silhouette.
+public struct SeatbackSeatCellStyle: SeatCellStyle {
+    public init() {}
+    public func makeBody(configuration: SeatCellConfiguration) -> some View {
+        SeatCellChrome(configuration: configuration, shape: .seatback)
+    }
+}
+
+// MARK: - Static accessors
+
+public extension SeatCellStyle where Self == RoundedSeatCellStyle {
+    /// Continuous-corner rounded square — today's cell. The default.
+    static var rounded: RoundedSeatCellStyle { RoundedSeatCellStyle() }
+}
+public extension SeatCellStyle where Self == CircleSeatCellStyle {
+    /// A circle.
+    static var circle: CircleSeatCellStyle { CircleSeatCellStyle() }
+}
+public extension SeatCellStyle where Self == SeatbackSeatCellStyle {
+    /// A squircle with a concave backrest notch — the seat-back silhouette.
+    static var seatback: SeatbackSeatCellStyle { SeatbackSeatCellStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnySeatCellStyle: SeatCellStyle {
+    private let _makeBody: @MainActor (SeatCellConfiguration) -> AnyView
+    init<S: SeatCellStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: SeatCellConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct SeatCellStyleKey: EnvironmentKey {
+    static let defaultValue = AnySeatCellStyle(RoundedSeatCellStyle())
+}
+
+extension EnvironmentValues {
+    var seatCellStyle: AnySeatCellStyle {
+        get { self[SeatCellStyleKey.self] }
+        set { self[SeatCellStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``SeatCellStyle`` for `SeatCell`s in this view and its
+    /// descendants — a seat map sets it once for the whole cabin.
+    func seatCellStyle<S: SeatCellStyle>(_ style: sending S) -> some View {
+        environment(\.seatCellStyle, AnySeatCellStyle(style))
+    }
+}
+
+// MARK: - Preview
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a flat swatch with no ring/star chrome, proving the configuration
+/// alone is enough to draw a legitimate seat cell from outside the module.
+private struct FlatSwatchSeatCellStyle: SeatCellStyle {
+    func makeBody(configuration: SeatCellConfiguration) -> some View {
+        FlatSwatchChrome(configuration: configuration)
+    }
+
+    private struct FlatSwatchChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: SeatCellConfiguration
+
+        var body: some View {
+            Button(action: configuration.action) {
+                RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
+                    .fill(configuration.fillColor(theme: theme))
+                    .overlay(
+                        Text(configuration.seat.id).textStyle(.overline500)
+                            .foregroundStyle(configuration.contentColor(theme: theme)))
+                    .frame(width: configuration.size, height: configuration.size)
+                    .opacity(configuration.isSelectable || configuration.isSelected ? 1 : 0.55)
+            }
+            .buttonStyle(.plain)
+            .disabled(!configuration.isSelectable && !configuration.isSelected)
+            .accessibilityLabel(configuration.accessibilityLabel)
+            .accessibilityValue(configuration.accessibilityValue)
+        }
+    }
+}
+
+// `.seatCellStyle(_:)` is applied once to the row, not per cell — exactly
+// how a real cabin screen would set it (see the file header).
+@MainActor private func seatCellStatesRow(_ style: some SeatCellStyle) -> some View {
+    HStack(spacing: Theme.SpacingKey.sm.value) {
+        SeatCell(Seat("1A"), isSelected: true, action: {})
+        SeatCell(Seat("1B", tier: .business), action: {})
+        SeatCell(Seat("1C", occupied: true), action: {})
+        SeatCell(Seat("1D"), isRecommended: true, action: {})
+        SeatCell(Seat("1E"), isSelectable: false, action: {})
+    }
+    .seatCellStyle(style)
+}
+
+#Preview("SeatCellStyle — presets × states × light/dark") {
+    PreviewMatrix("SeatCellStyle") {
+        PreviewCase("Rounded (default)") { seatCellStatesRow(.rounded) }
+        PreviewCase("Circle") { seatCellStatesRow(.circle) }
+        PreviewCase("Seatback") { seatCellStatesRow(.seatback) }
+        PreviewCase("Seatback · fill emphasis, accent palette") {
+            SeatCell(Seat("2A"), isSelected: true, palette: SeatPalette().selected(.accent), selectionEmphasis: .fill, action: {})
+                .seatCellStyle(.seatback)
+        }
+        PreviewCase("Custom (in-preview, flat swatch)") { seatCellStatesRow(FlatSwatchSeatCellStyle()) }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Molecules/SeatLegend.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/SeatLegend.swift
@@ -5,14 +5,29 @@
 //  Molecule. A key for a ``SeatMap`` — the fare tiers present, plus Selected and
 //  Occupied — wrapping to rows. Tier *and* selected/occupied colours come from a
 //  ``SeatPalette`` so it matches whatever the map (or a brand override) uses.
-//  Configuration flows through chainable copy-on-write modifiers (R2); the
-//  original init parameters remain for source compatibility.
+//
+//  The *arrangement* is owned by the active ``SeatLegendStyle`` from the
+//  environment (ADR-0004): the component gathers its typed data into a
+//  `SeatLegendConfiguration` and hands it to the style — `.rows(perRow: 3)`
+//  (default) is today's wrapping grid verbatim, `.vertical` stacks one entry
+//  per line, `.inline` draws a single unwrapped row, and apps can implement
+//  their own. The deprecated `.orientation(_:)` / `.perRow(_:)` modifiers
+//  forward to the matching preset and, when called, win over an ancestor's
+//  environment style. Configuration flows through chainable copy-on-write
+//  modifiers (R2); the original init parameters remain for source
+//  compatibility.
 //
 
 import SwiftUI
 import ThemeKit
 
 /// How a ``SeatLegend`` lays out its entries.
+///
+/// Superseded by ``SeatLegendStyle`` (each case maps 1:1 to a preset —
+/// `.rows` → ``RowsSeatLegendStyle``, `.vertical` → ``VerticalSeatLegendStyle``,
+/// `.inline` → ``InlineSeatLegendStyle``); kept for source compatibility until
+/// the next major, together with the deprecated ``SeatLegend/orientation(_:)``
+/// modifier.
 public enum SeatLegendOrientation: Sendable {
     /// Wraps into rows of `perRow(_:)` entries — the default.
     case rows
@@ -23,8 +38,9 @@ public enum SeatLegendOrientation: Sendable {
 }
 
 public struct SeatLegend: View {
-    @Environment(\.theme) private var theme
     @Environment(\.componentDensity) private var density
+    @Environment(\.locale) private var locale
+    @Environment(\.seatLegendStyle) private var envStyle
 
     // Appearance/state — mutated only through the modifiers below (R2). The
     // init params are kept as a convenience/back-compat surface.
@@ -33,10 +49,14 @@ public struct SeatLegend: View {
     private var perRow: Int
     private var showsSelected = true
     private var showsOccupied = true
-    private var extraEntries: [(label: String, color: SemanticColor)] = []
+    private var extraEntries: [SeatLegendCustomEntry] = []
     private var swatchShape: SeatShape = .rounded
     private var swatchRamp: SeatSizeRamp?
-    private var orientation: SeatLegendOrientation = .rows
+    /// Bookkeeping for the deprecated `.orientation(_:)` modifier — an
+    /// explicitly chosen per-instance orientation wins over an ancestor's
+    /// `.seatLegendStyle(_:)` (source-behavior stability during the enum's
+    /// deprecation window). `nil` → environment style.
+    private var explicitOrientation: SeatLegendOrientation?
 
     public init(tiers: [SeatTier] = [.standard], palette: SeatPalette = .default, perRow: Int = 3) {
         self.tiers = tiers
@@ -44,70 +64,32 @@ public struct SeatLegend: View {
         self.perRow = max(1, perRow)
     }
 
-    private struct Entry: Identifiable { let fill: Color; let border: Color; let label: String; var id: String { label } }
-
-    private var entries: [Entry] {
-        var e = tiers.map { tier -> Entry in
-            let c = palette.colors(for: tier, theme: theme)
-            return Entry(fill: c.fill, border: c.stroke, label: tier.label)
+    /// The style the deprecated `.orientation(_:)` / `.perRow(_:)` modifiers
+    /// mapped to, or `nil` when neither was called (the normal path — the
+    /// environment style renders). `perRow` diverging from the shipped default
+    /// (3) is treated as an explicit signal too, since the pre-ADR `perRow:`
+    /// init parameter fed the exact same knob directly.
+    private var explicitStyle: AnySeatLegendStyle? {
+        switch explicitOrientation {
+        case .vertical: return AnySeatLegendStyle(VerticalSeatLegendStyle())
+        case .inline: return AnySeatLegendStyle(InlineSeatLegendStyle())
+        case .rows: return AnySeatLegendStyle(RowsSeatLegendStyle(perRow: perRow))
+        case nil: return perRow == 3 ? nil : AnySeatLegendStyle(RowsSeatLegendStyle(perRow: perRow))
         }
-        e += extraEntries.map { Entry(fill: $0.color.bg, border: $0.color.base, label: $0.label) }
-        if showsSelected {
-            let selected = palette.selectedColors(theme: theme)
-            e.append(Entry(fill: selected.fill, border: selected.stroke, label: String(themeKit: "Selected")))
-        }
-        if showsOccupied {
-            let occupied = palette.occupiedColors(theme: theme)
-            e.append(Entry(fill: occupied.fill, border: occupied.stroke, label: String(themeKit: "Occupied")))
-        }
-        return e
     }
 
     public var body: some View {
-        let items = entries
-        switch orientation {
-        case .rows:
-            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
-                ForEach(Array(stride(from: 0, to: items.count, by: perRow)), id: \.self) { start in
-                    HStack(spacing: density.scale(Theme.SpacingKey.md.value)) {
-                        ForEach(items[start..<min(start + perRow, items.count)]) { swatch($0) }
-                        Spacer(minLength: 0)
-                    }
-                }
-            }
-        case .vertical:
-            VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
-                ForEach(items) { swatch($0) }
-            }
-        case .inline:
-            HStack(spacing: density.scale(Theme.SpacingKey.md.value)) {
-                ForEach(items) { swatch($0) }
-            }
-        }
-    }
-
-    // Legend swatches are keys, not touch targets — the ramp maps to a scaled-
-    // down side so `.swatchSize(.large)` tracks a larger map without dwarfing
-    // the labels.
-    private var swatchSide: CGFloat {
-        switch swatchRamp {
-        case nil, .regular: return 14
-        case .compact: return 12
-        case .large: return 17
-        case .xl: return 20
-        }
-    }
-
-    private func swatch(_ entry: Entry) -> some View {
-        let shape = swatchShape.anyShape(cornerRadius: 4)
-        return HStack(spacing: Theme.SpacingKey.xs.value) {
-            shape.fill(entry.fill)
-                .overlay(shape.stroke(entry.border, lineWidth: 1))
-                .frame(width: swatchSide, height: swatchSide)
-            Text(entry.label).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
-                .fixedSize(horizontal: true, vertical: false)
-        }
-        .accessibilityElement(children: .combine)
+        let configuration = SeatLegendConfiguration(
+            tiers: tiers,
+            palette: palette,
+            showsSelected: showsSelected,
+            showsOccupied: showsOccupied,
+            customEntries: extraEntries,
+            swatchShape: swatchShape,
+            swatchSize: swatchRamp ?? .regular,
+            density: density,
+            locale: locale)
+        (explicitStyle ?? envStyle).makeBody(configuration: configuration)
     }
 
     /// Backward-compatible: adds a "Premium econ." key to the default legend.
@@ -126,7 +108,11 @@ public extension SeatLegend {
     /// The palette the swatches resolve their colours from — pass the same one
     /// the map uses so the key always matches.
     func palette(_ palette: SeatPalette) -> Self { copy { $0.palette = palette } }
-    /// Entries per row in the default `.rows` orientation.
+    /// Entries per row in the `.rows` style — superseded by the style axis:
+    /// prefer `.seatLegendStyle(.rows(perRow:))`, settable once per screen via
+    /// the environment. This modifier keeps working and, when called, wins
+    /// over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .seatLegendStyle(.rows(perRow:)) instead")
     func perRow(_ count: Int) -> Self { copy { $0.perRow = max(1, count) } }
     /// Whether the synthetic "Selected" entry is appended (default `true`).
     func showsSelected(_ on: Bool = true) -> Self { copy { $0.showsSelected = on } }
@@ -136,15 +122,20 @@ public extension SeatLegend {
     /// token's soft background and strokes with its base shade, matching how
     /// tier overrides resolve.
     func entry(_ label: String, color: SemanticColor) -> Self {
-        copy { $0.extraEntries.append((label: label, color: color)) }
+        copy { $0.extraEntries.append(SeatLegendCustomEntry(label: label, color: color)) }
     }
     /// The swatch silhouette — pass the map's ``SeatShape`` so the key matches
     /// the seats (``SeatMap`` forwards its own automatically).
     func swatchShape(_ shape: SeatShape) -> Self { copy { $0.swatchShape = shape } }
     /// Steps the swatch size alongside a map using the same ``SeatSizeRamp``.
     func swatchSize(_ ramp: SeatSizeRamp) -> Self { copy { $0.swatchRamp = ramp } }
-    /// Layout direction of the entries: `.rows` (wrap, default) · `.vertical` · `.inline`.
-    func orientation(_ orientation: SeatLegendOrientation) -> Self { copy { $0.orientation = orientation } }
+    /// Layout direction of the entries — superseded by the style axis: prefer
+    /// `.seatLegendStyle(.rows(perRow:))` / `.seatLegendStyle(.vertical)` /
+    /// `.seatLegendStyle(.inline)`, settable once per screen via the
+    /// environment. This modifier keeps working and, when called, wins over an
+    /// ancestor's environment style.
+    @available(*, deprecated, message: "Use .seatLegendStyle(.rows(perRow:)/.vertical/.inline) instead")
+    func orientation(_ orientation: SeatLegendOrientation) -> Self { copy { $0.explicitOrientation = orientation } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -163,8 +154,9 @@ public extension SeatLegend {
                        palette: SeatPalette().selected(.accent).occupied(.warning))
         }
         PreviewCase("Chained config (R2)") {
-            SeatLegend().tiers([.standard, .business]).perRow(2)
+            SeatLegend().tiers([.standard, .business])
                 .palette(SeatPalette().selected(.purple))
+                .seatLegendStyle(.rows(perRow: 2))
         }
         PreviewCase("Custom entry, tiers only") {
             SeatLegend(tiers: [.standard, .extraLegroom])
@@ -174,9 +166,11 @@ public extension SeatLegend {
         PreviewCase("Seatback swatches, large") {
             SeatLegend(tiers: [.standard, .exit]).swatchShape(.seatback).swatchSize(.large)
         }
-        PreviewCase("Vertical") { SeatLegend(tiers: [.standard, .exit]).orientation(.vertical) }
+        PreviewCase("Vertical (env style)") {
+            SeatLegend(tiers: [.standard, .exit]).seatLegendStyle(.vertical)
+        }
         PreviewCase("Inline, circle") {
-            SeatLegend(tiers: [.standard]).orientation(.inline).swatchShape(.circle)
+            SeatLegend(tiers: [.standard]).swatchShape(.circle).seatLegendStyle(.inline)
         }
     }
 }

--- a/Sources/ThemeKitTravel/Components/Molecules/SeatLegendStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/SeatLegendStyle.swift
@@ -1,0 +1,336 @@
+//
+//  SeatLegendStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``SeatLegend`` — a Class A style protocol of ADR-0004
+//  (per-component style protocols): the configuration hands styles the *typed*
+//  legend data (resolved tiers, palette, selected/occupied flags, custom
+//  entries…), not pre-laid content, so a style owns the entire arrangement.
+//  Three built-ins, promoting the former ``SeatLegendOrientation`` enum:
+//
+//    .rows(perRow:)  wraps entries into rows of `perRow` (floored at 1) —
+//                    today's key, verbatim. `.rows(perRow: 3)` is the default.
+//    .vertical       one entry per line.
+//    .inline         a single unwrapped row.
+//
+//      SeatLegend(tiers: [.standard, .exit])
+//          .seatLegendStyle(.vertical)
+//
+//  Tier *and* selected/occupied colours always come from the configuration's
+//  ``SeatLegendConfiguration/palette`` (a ``SeatPalette``) — never the style —
+//  so a legend always matches whatever ``SeatMap`` (or a brand override) uses.
+//  The component style only arranges the resolved swatches; the token theme
+//  colors everything.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// A caller-supplied legend key (``SeatLegend/entry(_:color:)``), e.g. "Bassinet".
+/// The swatch fills with the token's soft background and strokes with its base
+/// shade, matching how tier overrides resolve.
+public struct SeatLegendCustomEntry: Sendable {
+    public let label: String
+    public let color: SemanticColor
+
+    public init(label: String, color: SemanticColor) {
+        self.label = label
+        self.color = color
+    }
+}
+
+/// One resolved legend key — a swatch fill/border pair plus its label. Returned
+/// by ``SeatLegendConfiguration/entries(theme:)`` for a style to draw; a custom
+/// style never derives colours itself, it only lays these out.
+public struct SeatLegendEntry: Identifiable, Sendable {
+    public let fill: Color
+    public let border: Color
+    public let label: String
+    public var id: String { label }
+}
+
+/// The typed inputs a ``SeatLegendStyle`` lays out. Fields a given style doesn't
+/// use are simply ignored — every built-in degrades gracefully when optional
+/// data is absent (no custom entries → no extra keys, no premium tier → no
+/// premium key).
+public struct SeatLegendConfiguration {
+    /// The fare tiers to key, in display order.
+    public let tiers: [SeatTier]
+    /// The palette every swatch resolves its colours from — tier fills/strokes
+    /// and the synthetic Selected/Occupied entries all route through it, so the
+    /// legend always matches whatever the map (or a brand override) uses.
+    public let palette: SeatPalette
+    /// Whether the synthetic "Selected" entry is appended (default `true`).
+    public let showsSelected: Bool
+    /// Whether the synthetic "Occupied" entry is appended (default `true`).
+    public let showsOccupied: Bool
+    /// Caller-supplied extra keys (``SeatLegend/entry(_:color:)``), appended
+    /// after the tier entries and before Selected/Occupied.
+    public let customEntries: [SeatLegendCustomEntry]
+    /// The swatch silhouette — matches whatever ``SeatMap``/``SeatCell`` draws.
+    public let swatchShape: SeatShape
+    /// The swatch size ramp (``SeatLegend/swatchSize(_:)``); resolves to
+    /// ``swatchSide`` in points.
+    public let swatchSize: SeatSizeRamp
+    /// The environment's component density, captured by the component — scale
+    /// chrome gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component, for parity with the
+    /// rest of the suite (no date/number formatting needed by the built-ins
+    /// today, but a custom style may localize its own labels with it).
+    public let locale: Locale
+
+    /// Density-scaled spacing — use for chrome gaps so `.componentDensity`
+    /// compacts or airs out the legend.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// The swatch square's side, in points, stepped by ``swatchSize``. Legend
+    /// swatches are keys, not touch targets — the ramp maps to a scaled-down
+    /// side so `.swatchSize(.large)` tracks a larger map without dwarfing the
+    /// labels.
+    public var swatchSide: CGFloat {
+        switch swatchSize {
+        case .compact: return 12
+        case .regular: return 14
+        case .large: return 17
+        case .xl: return 20
+        }
+    }
+
+    /// The resolved legend keys, in draw order: tiers, then ``customEntries``,
+    /// then the synthetic Selected/Occupied entries. Every colour comes from
+    /// ``palette`` (or a custom entry's own semantic color) — styles only lay
+    /// these out.
+    public func entries(theme: Theme) -> [SeatLegendEntry] {
+        var e = tiers.map { tier -> SeatLegendEntry in
+            let c = palette.colors(for: tier, theme: theme)
+            return SeatLegendEntry(fill: c.fill, border: c.stroke, label: tier.label)
+        }
+        e += customEntries.map { SeatLegendEntry(fill: $0.color.bg, border: $0.color.base, label: $0.label) }
+        if showsSelected {
+            let selected = palette.selectedColors(theme: theme)
+            e.append(SeatLegendEntry(fill: selected.fill, border: selected.stroke, label: String(themeKit: "Selected")))
+        }
+        if showsOccupied {
+            let occupied = palette.occupiedColors(theme: theme)
+            e.append(SeatLegendEntry(fill: occupied.fill, border: occupied.stroke, label: String(themeKit: "Occupied")))
+        }
+        return e
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `SeatLegend`'s entire presentation. Implement `makeBody` to lay
+/// out the configuration's resolved keys. Set one with `.seatLegendStyle(_:)`;
+/// the default is ``RowsSeatLegendStyle`` with 3 entries per row.
+public protocol SeatLegendStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: SeatLegendConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// One legend key: silhouette swatch + label — shared by all three built-ins,
+/// extracted verbatim from the pre-style component.
+private struct SeatLegendSwatch: View {
+    @Environment(\.theme) private var theme
+    let configuration: SeatLegendConfiguration
+    let entry: SeatLegendEntry
+
+    var body: some View {
+        // Legend swatches are keys, not touch targets — the corner radius stays
+        // a fixed constant (a genuine dimension with no semantic token).
+        let shape = configuration.swatchShape.anyShape(cornerRadius: 4)
+        HStack(spacing: Theme.SpacingKey.xs.value) {
+            shape.fill(entry.fill)
+                .overlay(shape.stroke(entry.border, lineWidth: 1))
+                .frame(width: configuration.swatchSide, height: configuration.swatchSide)
+            Text(entry.label).textStyle(.bodySm400).foregroundStyle(theme.text(.textSecondary))
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - .rows(perRow:)
+
+/// Today's ``SeatLegend`` look, extracted verbatim: entries wrap into rows of
+/// `perRow` (floored at 1). `.rows(perRow: 3)` is the default.
+public struct RowsSeatLegendStyle: SeatLegendStyle {
+    /// Entries per row (floored at 1).
+    public let perRow: Int
+
+    public init(perRow: Int = 3) { self.perRow = max(1, perRow) }
+
+    public func makeBody(configuration: SeatLegendConfiguration) -> some View {
+        RowsSeatLegendChrome(configuration: configuration, perRow: perRow)
+    }
+}
+
+private struct RowsSeatLegendChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: SeatLegendConfiguration
+    let perRow: Int
+
+    var body: some View {
+        let items = configuration.entries(theme: theme)
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+            ForEach(Array(stride(from: 0, to: items.count, by: perRow)), id: \.self) { start in
+                HStack(spacing: configuration.spacing(.md)) {
+                    ForEach(items[start..<min(start + perRow, items.count)]) {
+                        SeatLegendSwatch(configuration: configuration, entry: $0)
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - .vertical
+
+/// One entry per line.
+public struct VerticalSeatLegendStyle: SeatLegendStyle {
+    public init() {}
+    public func makeBody(configuration: SeatLegendConfiguration) -> some View {
+        VerticalSeatLegendChrome(configuration: configuration)
+    }
+}
+
+private struct VerticalSeatLegendChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: SeatLegendConfiguration
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
+            ForEach(configuration.entries(theme: theme)) {
+                SeatLegendSwatch(configuration: configuration, entry: $0)
+            }
+        }
+    }
+}
+
+// MARK: - .inline
+
+/// A single unwrapped row.
+public struct InlineSeatLegendStyle: SeatLegendStyle {
+    public init() {}
+    public func makeBody(configuration: SeatLegendConfiguration) -> some View {
+        InlineSeatLegendChrome(configuration: configuration)
+    }
+}
+
+private struct InlineSeatLegendChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: SeatLegendConfiguration
+
+    var body: some View {
+        HStack(spacing: configuration.spacing(.md)) {
+            ForEach(configuration.entries(theme: theme)) {
+                SeatLegendSwatch(configuration: configuration, entry: $0)
+            }
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension SeatLegendStyle where Self == RowsSeatLegendStyle {
+    /// Wraps entries into rows of `perRow` (floored at 1) — today's key. The
+    /// default is `.rows(perRow: 3)`.
+    static func rows(perRow: Int = 3) -> RowsSeatLegendStyle { RowsSeatLegendStyle(perRow: perRow) }
+}
+public extension SeatLegendStyle where Self == VerticalSeatLegendStyle {
+    /// One entry per line.
+    static var vertical: VerticalSeatLegendStyle { VerticalSeatLegendStyle() }
+}
+public extension SeatLegendStyle where Self == InlineSeatLegendStyle {
+    /// A single unwrapped row.
+    static var inline: InlineSeatLegendStyle { InlineSeatLegendStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnySeatLegendStyle: SeatLegendStyle {
+    private let _makeBody: @MainActor (SeatLegendConfiguration) -> AnyView
+    init<S: SeatLegendStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: SeatLegendConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct SeatLegendStyleKey: EnvironmentKey {
+    static let defaultValue = AnySeatLegendStyle(RowsSeatLegendStyle())
+}
+
+extension EnvironmentValues {
+    var seatLegendStyle: AnySeatLegendStyle {
+        get { self[SeatLegendStyleKey.self] }
+        set { self[SeatLegendStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``SeatLegendStyle`` for `SeatLegend`s in this view and its
+    /// descendants — one screen can restyle every legend at once.
+    func seatLegendStyle<S: SeatLegendStyle>(_ style: sending S) -> some View {
+        environment(\.seatLegendStyle, AnySeatLegendStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a cloud of colored pill badges instead of square swatches. Colours
+/// still come entirely from ``SeatLegendConfiguration/entries(theme:)`` — the
+/// custom style only lays them out.
+private struct PillCloudSeatLegendStyle: SeatLegendStyle {
+    func makeBody(configuration: SeatLegendConfiguration) -> some View {
+        PillCloudChrome(configuration: configuration)
+    }
+
+    private struct PillCloudChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: SeatLegendConfiguration
+
+        var body: some View {
+            HStack(spacing: Theme.SpacingKey.xs.value) {
+                ForEach(configuration.entries(theme: theme)) { entry in
+                    Text(entry.label)
+                        .textStyle(.overline500)
+                        .foregroundStyle(entry.border)
+                        .padding(.horizontal, Theme.SpacingKey.sm.value)
+                        .padding(.vertical, Theme.SpacingKey.xs.value)
+                        .background(entry.fill, in: Capsule())
+                        .overlay(Capsule().stroke(entry.border, lineWidth: 1))
+                }
+            }
+        }
+    }
+}
+
+#Preview("SeatLegendStyle — presets × light/dark") {
+    let tiers: [SeatTier] = [.standard, .extraLegroom, .exit, .business]
+    PreviewMatrix("SeatLegendStyle") {
+        PreviewCase("Rows (default, 3 per row)") { SeatLegend(tiers: tiers) }
+        PreviewCase("Rows · 2 per row") {
+            SeatLegend(tiers: tiers).seatLegendStyle(.rows(perRow: 2))
+        }
+        PreviewCase("Vertical") {
+            SeatLegend(tiers: tiers).seatLegendStyle(.vertical)
+        }
+        PreviewCase("Inline") {
+            SeatLegend(tiers: [.standard, .exit]).seatLegendStyle(.inline)
+        }
+        PreviewCase("Accent palette · vertical") {
+            SeatLegend(tiers: [.standard, .exit], palette: SeatPalette().selected(.purple).occupied(.warning))
+                .seatLegendStyle(.vertical)
+        }
+        PreviewCase("Custom (in-preview)") {
+            SeatLegend(tiers: tiers).seatLegendStyle(PillCloudSeatLegendStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/FilterBar.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FilterBar.swift
@@ -12,6 +12,12 @@
 //      .size(.large).accent(.turquoise)
 //  ```
 //
+//  The *arrangement* is owned by the active ``FilterBarStyle`` from the environment
+//  (ADR-0004): the component gathers its typed data into a `FilterBarConfiguration`
+//  and hands it to the style — `.chips` (default) is today's bar verbatim, `.segmented`
+//  and `.stacked` swap the whole layout, and apps can implement their own. See
+//  `FilterBarStyle.swift`.
+//
 
 import SwiftUI
 import ThemeKit
@@ -38,7 +44,9 @@ public enum FilterBarSize: Sendable { case small, medium, large }
 /// Chip selection look. `.solid` fills selected chips with the accent; `.outlined`
 /// is the design-system pill — a light hero-soft fill + a 2pt hero border when
 /// selected, a soft hairline when not (matches the Figma "Filter Section" tabs).
-/// `.ghost` draws no chrome at rest — selected chips gain a soft accent fill.
+/// `.ghost` draws no chrome at rest — selected chips gain a soft accent fill. A
+/// paint knob that composes with every ``FilterBarStyle`` preset (ADR-0004 §3) —
+/// it never becomes a style axis of its own.
 public enum FilterChipStyle: Sendable { case solid, outlined, ghost }
 
 /// How chips select. `.multiple` (default) toggles independently; `.single`
@@ -50,7 +58,9 @@ public enum FilterSelectionMode: Sendable { case multiple, single }
 public enum FilterLeadingShape: Sendable { case adaptive, circle }
 
 public struct FilterBar: View {
-    @Environment(\.theme) private var theme
+    @Environment(\.componentDensity) private var density
+    @Environment(\.filterBarStyle) private var style
+    @Environment(\.locale) private var locale
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -77,207 +87,66 @@ public struct FilterBar: View {
     private var leadingShapeVariant: FilterLeadingShape = .adaptive
     private var chipSurfaceKey: Theme.BackgroundColorKey = .bgWhite
     private var selectionModeValue: FilterSelectionMode = .multiple
-    private var clearAllTitle: String?
+    private var clearAllTitleOverride: String?
+    /// Render-time default — re-resolves through the localization chain on
+    /// every body pass, so a live language switch is never frozen at init.
+    private var clearAllTitle: String { clearAllTitleOverride ?? String(themeKit: "Clear") }
     private var onClearAllAction: (() -> Void)?
     private var overflowFadeValue = false
     private var trailingSlot: AnyView?
-
-    @State private var collapsed = false
-    @State private var scrolledID: String?
 
     public init(_ chips: [QuickFilter], selection: Binding<Set<String>>) {   // R1
         self.chips = chips
         self._selection = selection
     }
 
-    // MARK: Derived sizing / colours (token-fed)
-
-    private var controlHeight: CGFloat { switch size { case .small: 34; case .medium: 40; case .large: 48 } }
-    private var chipTextStyle: TextStyle { switch size { case .small: .labelSm600; case .medium: .labelBase600; case .large: .labelMd600 } }
-    private var iconSize: CGFloat { switch size { case .small: 13; case .medium: 15; case .large: 17 } }
-    private var chipHPad: CGFloat { switch size { case .small: 12; case .medium: 16; case .large: 20 } }
-    private var accentBg: Color { accentColor.map { $0.solid } ?? theme.background(.bgHero) }
-    private var accentFg: Color { accentColor.map { $0.onSolid } ?? theme.text(.textSecondaryInverse) }
-    private var chipOffText: Color { accentColor.map { $0.base } ?? theme.foreground(.fgHero) }
-    private var hasLeading: Bool { onFilter != nil || onSort != nil }
-
     // MARK: Body
 
     public var body: some View {
-        HStack(spacing: spacing) {
-            if hasLeading {
-                HStack(spacing: spacing) {
-                    if let onFilter { action(filterIcon, filterTitle, onFilter) }
-                    if let onSort { action(sortIcon, sortTitle, onSort) }
-                }
-                .fixedSize()
-            }
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: spacing) {
-                    ForEach(chips) { chipView($0).id($0.id) }
-                    if onClearAllAction != nil, !selection.isEmpty {
-                        clearAllChip
-                    }
-                }
-                .padding(.trailing, 4)
-                .scrollTargetLayout()
-            }
-            .scrollPosition(id: $scrolledID, anchor: .leading)
-            .mask { overflowMask }
-            if let trailingSlot {
-                trailingSlot.fixedSize()
-            }
-        }
-        .frame(height: controlHeight)
-        .onChange(of: scrolledID) { _, newID in
-            // Collapse once the first chip has scrolled past the leading edge. Driven by
-            // the anchored item id (not a measured offset), so it's immune to the frame
-            // change that collapsing the buttons causes.
-            guard collapsible, hasLeading else { return }
-            let shouldCollapse = newID != nil && newID != chips.first?.id
-            if shouldCollapse != collapsed {
-                // Reduce-Motion / microAnimations gate: nil animation snaps.
-                withAnimation(MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion)) {
-                    collapsed = shouldCollapse
-                }
-            }
-        }
+        // The arrangement is owned by the active `FilterBarStyle` (ADR-0004);
+        // motion is resolved *here* (MicroMotion ∧ ¬Reduce Motion) so styles
+        // never read the motion environment. Selection stays a `Binding` in
+        // the component — styles only see the read snapshot + a toggle
+        // closure (ADR-0004's ControllableState rule).
+        let configuration = FilterBarConfiguration(
+            filters: chips,
+            selection: selection,
+            selectionMode: selectionModeValue,
+            toggleFilter: toggle,
+            onFilter: onFilter,
+            onSort: onSort,
+            filterTitle: filterTitle,
+            sortTitle: sortTitle,
+            filterIcon: filterIcon,
+            sortIcon: sortIcon,
+            clearAllTitle: clearAllTitle,
+            onClearAll: onClearAllAction.map { action in
+                { selection.removeAll(); action() }
+            },
+            collapsible: collapsible,
+            size: size,
+            chipStyle: chipStyleVariant,
+            leadingShape: leadingShapeVariant,
+            chipSurfaceKey: chipSurfaceKey,
+            overflowFade: overflowFadeValue,
+            trailing: trailingSlot,
+            accent: accentColor,
+            spacing: spacing,
+            isMotionEnabled: micro && !reduceMotion,
+            density: density,
+            locale: locale)
+        style.makeBody(configuration: configuration)
     }
 
-    /// Trailing-edge gradient fade hinting at overflowed chips. Built with
-    /// `UnitPoint.leading → .trailing`, which resolve against the layout
-    /// direction — so the fade sits on the correct edge under RTL.
-    @ViewBuilder private var overflowMask: some View {
-        if overflowFadeValue {
-            LinearGradient(
-                stops: [
-                    .init(color: .black, location: 0),
-                    .init(color: .black, location: 0.92),
-                    .init(color: .clear, location: 1),
-                ],
-                startPoint: .leading, endPoint: .trailing
-            )
-        } else {
-            Rectangle()
-        }
-    }
-
-    /// The trailing ghost "Clear" chip — visible only while a selection exists.
-    private var clearAllChip: some View {
-        Button {
-            selection.removeAll()
-            onClearAllAction?()
-        } label: {
-            HStack(spacing: Theme.SpacingKey.xs.value) {
-                Image(systemName: "xmark").font(.system(size: iconSize, weight: .semibold))
-                Text(clearAllTitle ?? String(themeKit: "Clear")).textStyle(chipTextStyle).fixedSize()
-            }
-            .foregroundStyle(accentColor?.base ?? theme.foreground(.fgHero))
-            .padding(.horizontal, chipHPad)
-            .frame(minHeight: controlHeight)
-            .contentShape(Capsule())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(String(themeKit: "Clear all filters"))
-    }
-
-    @ViewBuilder private func action(_ icon: String, _ title: String, _ handler: @escaping () -> Void) -> some View {
-        Button(action: handler) {
-            if leadingShapeVariant == .circle {
-                // Fixed accent circle (icon-only) — the Figma "Filter Section" look.
-                Image(systemName: icon).font(.system(size: iconSize, weight: .semibold))
-                    .foregroundStyle(accentFg)
-                    .frame(width: controlHeight, height: controlHeight)
-                    .background(accentBg, in: Circle())
-            } else {
-                HStack(spacing: 6) {
-                    Image(systemName: icon).font(.system(size: iconSize, weight: .semibold))
-                    if !collapsed { Text(title).textStyle(chipTextStyle).fixedSize() }
-                }
-                .foregroundStyle(accentFg)
-                .padding(.horizontal, collapsed ? 0 : chipHPad)
-                .frame(width: collapsed ? controlHeight : nil, height: controlHeight)
-                .background(accentBg, in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
-            }
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(title)
-    }
-
-    private func chipView(_ chip: QuickFilter) -> some View {
-        let isOn = selection.contains(chip.id)
-        return Button {
-            toggle(chip.id, isOn: isOn)
-        } label: {
-            HStack(spacing: Theme.SpacingKey.xs.value) {
-                if let symbol = chip.systemImage {
-                    Image(systemName: symbol).font(.system(size: iconSize, weight: .semibold))
-                }
-                Text(chip.title).textStyle(chipTextStyle)
-                if let count = chip.count {
-                    countPill(count, isOn: isOn)
-                }
-            }
-            .foregroundStyle(chipTextColor(isOn: isOn))
-            .padding(.horizontal, chipHPad)
-            .frame(minHeight: controlHeight)
-            .background(chipFill(isOn: isOn), in: Capsule())
-            // strokeBorder (not stroke) insets the line fully inside the pill,
-            // so the 2pt selected border isn't clipped at the tight top/bottom
-            // curves — a centered stroke would bleed outside and look distorted.
-            .overlay(Capsule().strokeBorder(chipBorderColor(isOn: isOn),
-                                            lineWidth: chipStyleVariant == .outlined && isOn ? 2 : 1))
-            .fixedSize()
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(chip.count.map { "\(chip.title), \($0)" } ?? chip.title)
-        .accessibilityAddTraits(isOn ? .isSelected : [])
-    }
-
-    /// Selection semantics per ``FilterSelectionMode``.
-    private func toggle(_ id: String, isOn: Bool) {
+    /// Selection semantics per ``FilterSelectionMode`` — the mutation stays on
+    /// the component's `Binding`; styles call this and never touch
+    /// `selection` directly.
+    private func toggle(_ id: String) {
         switch selectionModeValue {
         case .multiple:
-            if isOn { selection.remove(id) } else { selection.insert(id) }
+            if selection.contains(id) { selection.remove(id) } else { selection.insert(id) }
         case .single:
-            selection = isOn ? [] : [id]
-        }
-    }
-
-    /// Trailing count pill — SemanticColor ladder steps, no raw colors.
-    private func countPill(_ count: Int, isOn: Bool) -> some View {
-        let tone = accentColor ?? .primary
-        let solidSelected = chipStyleVariant == .solid && isOn
-        return Text("\(count)")
-            .textStyle(.labelSm600)
-            .foregroundStyle(solidSelected ? tone.onSolid : tone.strong)
-            .padding(.horizontal, Theme.SpacingKey.xs.value)
-            .background(solidSelected ? tone.active : tone.soft, in: Capsule())
-    }
-
-    // Chip colors per style (token-fed).
-    private func chipTextColor(isOn: Bool) -> Color {
-        switch chipStyleVariant {
-        case .outlined: return theme.text(.textPrimary)
-        case .ghost: return isOn ? (accentColor?.strong ?? theme.foreground(.fgHero)) : theme.text(.textSecondary)
-        case .solid: return isOn ? accentFg : chipOffText
-        }
-    }
-    private func chipFill(isOn: Bool) -> Color {
-        switch chipStyleVariant {
-        case .outlined: return isOn ? (accentColor?.soft ?? SemanticColor.primary.soft) : theme.background(chipSurfaceKey)
-        case .ghost: return isOn ? (accentColor ?? .primary).soft : .clear
-        case .solid: return isOn ? accentBg : theme.background(chipSurfaceKey)
-        }
-    }
-    private func chipBorderColor(isOn: Bool) -> Color {
-        switch chipStyleVariant {
-        case .outlined:
-            return isOn ? (accentColor?.border ?? theme.border(.borderHero)) : theme.background(.bgElevatorTertiary)
-        case .ghost:
-            return .clear
-        case .solid:
-            return isOn ? Color.clear : theme.border(.borderPrimary)
+            selection = selection.contains(id) ? [] : [id]
         }
     }
 }
@@ -296,11 +165,13 @@ public extension FilterBar {
         copy { $0.sortTitleOverride = title; $0.sortIcon = icon; $0.onSort = action }
     }
     /// Whether the leading buttons collapse to icons on scroll (default on).
+    /// Only the `.chips` style has a scroll axis to gate this on.
     func collapsible(_ on: Bool = true) -> Self { copy { $0.collapsible = on } }
     /// Overall size (heights + typography): small / medium (default) / large.
     func size(_ size: FilterBarSize) -> Self { copy { $0.size = size } }
     /// Chip selection look — `.solid` (accent fill) or `.outlined` (the
-    /// design-system light-blue + hero-border pill).
+    /// design-system light-blue + hero-border pill). Composes with every
+    /// ``FilterBarStyle`` preset.
     func chipStyle(_ style: FilterChipStyle) -> Self { copy { $0.chipStyleVariant = style } }
     /// Leading Filter/Sort button shape — `.adaptive` (collapsing text) or
     /// `.circle` (a fixed accent circle, icon-only).
@@ -322,10 +193,11 @@ public extension FilterBar {
     /// then calls `perform` (analytics, refetch…).
     func onClearAll(_ title: String = String(themeKit: "Clear"),
                     perform action: @escaping () -> Void) -> Self {
-        copy { $0.clearAllTitle = title; $0.onClearAllAction = action }
+        copy { $0.clearAllTitleOverride = title; $0.onClearAllAction = action }
     }
     /// Fades the scroller's trailing edge with a gradient mask as an overflow
     /// hint (RTL-safe — `UnitPoint.leading/.trailing` mirror with the layout).
+    /// Only the `.chips` style has a scroll axis to fade.
     func overflowFade(_ on: Bool = true) -> Self { copy { $0.overflowFadeValue = on } }
     /// Accessory pinned after the chip scroller (canonical `.trailing { }`
     /// slot) — e.g. a results counter or a "View map" link. Evaluated
@@ -342,55 +214,50 @@ public extension FilterBar {
 }
 
 #Preview {
-    struct Demo: View {
-        @State private var sel: Set<String> = ["8"]
-        var body: some View {
-            VStack(spacing: 20) {
-                FilterBar([
-                    QuickFilter("8+ rating", id: "8"), QuickFilter("Ultra all-inclusive"), QuickFilter("All-inclusive"),
-                    QuickFilter("Seafront"), QuickFilter("Aquapark"), QuickFilter("Free cancellation"),
-                ], selection: $sel)
-                .onFilter { }.onSort { }
-                FilterBar([QuickFilter("Cheapest"), QuickFilter("Fastest"), QuickFilter("Direct")], selection: $sel)
-                    .size(.small).accent(.turquoise).onFilter { }
-                // Figma "Filter Section" look — outlined pills + circle buttons.
-                FilterBar([QuickFilter("Cheapest", id: "8"), QuickFilter("Fastest"),
-                           QuickFilter("Fast & Cheap"), QuickFilter("Direct")], selection: $sel)
-                    .chipStyle(.outlined).leadingShape(.circle).size(.small)
-                    .onFilter { }.onSort { }
-                // Outlined honors the accent — turquoise soft fill + turquoise border.
-                FilterBar([QuickFilter("Beachfront", id: "8"), QuickFilter("Pool"),
-                           QuickFilter("Spa")], selection: $sel)
-                    .accent(.turquoise).chipStyle(.outlined).size(.small)
-                // Unselected chips on a tinted surface.
-                FilterBar([QuickFilter("Breakfast", id: "8"), QuickFilter("Pet friendly"),
-                           QuickFilter("Parking")], selection: $sel)
-                    .chipSurface(.bgSecondaryLight).size(.small)
-                // Icons + counts, single-select, clear-all ghost chip, overflow fade.
-                FilterBar([
-                    QuickFilter("Beach", id: "8", systemImage: "beach.umbrella", count: 24),
-                    QuickFilter("Pool", systemImage: "figure.pool.swim", count: 9),
-                    QuickFilter("Spa", systemImage: "sparkles", count: 3),
-                    QuickFilter("Gym", systemImage: "dumbbell", count: 12),
-                ], selection: $sel)
-                    .selectionMode(.single)
-                    .onClearAll { }
-                    .overflowFade()
-                    .size(.small)
-                // Ghost chips + a trailing pinned slot.
-                FilterBar([QuickFilter("Cheapest", id: "8"), QuickFilter("Fastest"),
-                           QuickFilter("Direct")], selection: $sel)
-                    .chipStyle(.ghost).size(.small)
-                    .trailing {
-                        Text("128 stays").textStyle(.labelSm600)
-                            .padding(.horizontal, Theme.SpacingKey.sm.value)
-                    }
-                // Token-fed spacing overload.
-                FilterBar([QuickFilter("Nonstop", id: "8"), QuickFilter("Refundable")], selection: $sel)
-                    .spacing(Theme.SpacingKey.md).size(.small).onFilter { }
+    @Previewable @State var sel: Set<String> = ["8"]
+    VStack(spacing: 20) {
+        FilterBar([
+            QuickFilter("8+ rating", id: "8"), QuickFilter("Ultra all-inclusive"), QuickFilter("All-inclusive"),
+            QuickFilter("Seafront"), QuickFilter("Aquapark"), QuickFilter("Free cancellation"),
+        ], selection: $sel)
+        .onFilter { }.onSort { }
+        FilterBar([QuickFilter("Cheapest"), QuickFilter("Fastest"), QuickFilter("Direct")], selection: $sel)
+            .size(.small).accent(.turquoise).onFilter { }
+        // Figma "Filter Section" look — outlined pills + circle buttons.
+        FilterBar([QuickFilter("Cheapest", id: "8"), QuickFilter("Fastest"),
+                   QuickFilter("Fast & Cheap"), QuickFilter("Direct")], selection: $sel)
+            .chipStyle(.outlined).leadingShape(.circle).size(.small)
+            .onFilter { }.onSort { }
+        // Outlined honors the accent — turquoise soft fill + turquoise border.
+        FilterBar([QuickFilter("Beachfront", id: "8"), QuickFilter("Pool"),
+                   QuickFilter("Spa")], selection: $sel)
+            .accent(.turquoise).chipStyle(.outlined).size(.small)
+        // Unselected chips on a tinted surface.
+        FilterBar([QuickFilter("Breakfast", id: "8"), QuickFilter("Pet friendly"),
+                   QuickFilter("Parking")], selection: $sel)
+            .chipSurface(.bgSecondaryLight).size(.small)
+        // Icons + counts, single-select, clear-all ghost chip, overflow fade.
+        FilterBar([
+            QuickFilter("Beach", id: "8", systemImage: "beach.umbrella", count: 24),
+            QuickFilter("Pool", systemImage: "figure.pool.swim", count: 9),
+            QuickFilter("Spa", systemImage: "sparkles", count: 3),
+            QuickFilter("Gym", systemImage: "dumbbell", count: 12),
+        ], selection: $sel)
+            .selectionMode(.single)
+            .onClearAll { }
+            .overflowFade()
+            .size(.small)
+        // Ghost chips + a trailing pinned slot.
+        FilterBar([QuickFilter("Cheapest", id: "8"), QuickFilter("Fastest"),
+                   QuickFilter("Direct")], selection: $sel)
+            .chipStyle(.ghost).size(.small)
+            .trailing {
+                Text("128 stays").textStyle(.labelSm600)
+                    .padding(.horizontal, Theme.SpacingKey.sm.value)
             }
-            .padding(.vertical)
-        }
+        // Token-fed spacing overload.
+        FilterBar([QuickFilter("Nonstop", id: "8"), QuickFilter("Refundable")], selection: $sel)
+            .spacing(Theme.SpacingKey.md).size(.small).onFilter { }
     }
-    return Demo()
+    .padding(.vertical)
 }

--- a/Sources/ThemeKitTravel/Components/Organisms/FilterBarStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FilterBarStyle.swift
@@ -1,0 +1,641 @@
+//
+//  FilterBarStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``FilterBar`` — the Class A style protocol of
+//  ADR-0004: the configuration hands styles the *typed* filter data (chips,
+//  selection, leading actions…), not pre-laid content, so a style owns the
+//  whole arrangement. Three built-ins:
+//
+//    .chips      pinned Filter/Sort actions + a horizontally-scrolling chip
+//                row that collapses the actions to icon-only on scroll —
+//                today's bar. Default.
+//    .segmented  fixed equal-width segments, no scrolling — every filter
+//                fully visible at once. Best for a small, stable filter set.
+//    .stacked    the actions row above a wrapping chip row — every chip
+//                visible without horizontal scroll.
+//
+//      FilterBar([QuickFilter("8+ rating"), QuickFilter("Seafront"), …], selection: $active)
+//          .onFilter { openFilters() }.onSort { openSort() }
+//          .filterBarStyle(.segmented)
+//
+//  `FilterChipStyle`/`leadingShape` remain configuration knobs *within* every
+//  preset (ADR-0004 §3) — they're paint, not anatomy, so they aren't promoted
+//  to styles of their own. FilterBar has no card/bar shell to delegate to
+//  (ADR-0004 §6); presets paint their own chrome directly, and the token
+//  theme colors everything. The component resolves MicroMotion / Reduce
+//  Motion before calling a style — styles read
+//  ``FilterBarConfiguration/isMotionEnabled``, never the motion environment.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``FilterBarStyle`` lays out. Fields a given style
+/// doesn't use are simply ignored — `.segmented`/`.stacked` have no scrolling
+/// axis, so they ignore ``collapsible`` and ``overflowFade``.
+public struct FilterBarConfiguration {
+    /// The chip data — title + optional icon/count.
+    public let filters: [QuickFilter]
+    /// The bound selection's current read snapshot. Styles never mutate it
+    /// directly — call ``toggleFilter`` (the selection-mode logic and the
+    /// `Binding` mutation stay in the component, ADR-0004's ControllableState
+    /// rule).
+    public let selection: Set<String>
+    /// `.multiple` (default) toggles chips independently; `.single` keeps at
+    /// most one chip on. Informational for styles that render selection state
+    /// differently per mode; toggling itself always goes through
+    /// ``toggleFilter``.
+    public let selectionMode: FilterSelectionMode
+    /// Flips one chip's selection, honoring ``selectionMode``.
+    public let toggleFilter: (String) -> Void
+    /// The pinned leading Filter action; `nil` hides it.
+    public let onFilter: (() -> Void)?
+    /// The pinned leading Sort action; `nil` hides it.
+    public let onSort: (() -> Void)?
+    /// Localized title for the Filter action (re-resolved every body pass).
+    public let filterTitle: String
+    /// Localized title for the Sort action (re-resolved every body pass).
+    public let sortTitle: String
+    /// SF Symbol for the Filter action.
+    public let filterIcon: String
+    /// SF Symbol for the Sort action.
+    public let sortIcon: String
+    /// Localized title for the trailing "Clear" affordance.
+    public let clearAllTitle: String
+    /// Empties the selection and notifies the caller; `nil` hides the
+    /// affordance (also hidden whenever ``selection`` is empty).
+    public let onClearAll: (() -> Void)?
+    /// Whether the leading actions collapse to icon-only on scroll — presets
+    /// without a scrolling axis ignore this.
+    public let collapsible: Bool
+    /// Overall control sizing: heights, icon size, chip padding, type scale.
+    public let size: FilterBarSize
+    /// Chip paint — solid / outlined / ghost. A knob *within* every preset
+    /// (ADR-0004 §3), never a style axis of its own.
+    public let chipStyle: FilterChipStyle
+    /// Leading-action shape — adaptive (collapsing text) or a fixed circle.
+    public let leadingShape: FilterLeadingShape
+    /// Surface token for the unselected chip fill.
+    public let chipSurfaceKey: Theme.BackgroundColorKey
+    /// Trailing-edge overflow gradient hint — presets without horizontal
+    /// scroll ignore this.
+    public let overflowFade: Bool
+    /// Accessory slot pinned after the chip row (canonical `.trailing { }`).
+    public let trailing: AnyView?
+    /// Token-fed accent for actions and selected chips; `nil` = theme hero.
+    public let accent: SemanticColor?
+    /// The explicit `spacing(_:)` override — the primary gap between the
+    /// leading actions, the chips and the trailing slot. Honored as-is
+    /// (never density-scaled): it's already an explicit override, the same
+    /// way ``chipSurfaceKey`` overrides a style's own default surface.
+    public let spacing: CGFloat
+    /// Micro-animations resolved by the component (`MicroMotion` ∧ ¬Reduce
+    /// Motion) — gate the collapse animation on this; never read the motion
+    /// environment.
+    public let isMotionEnabled: Bool
+    /// The environment's component density, captured by the component — scale
+    /// secondary chrome gaps (that have no dedicated override) with
+    /// ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — use it for every
+    /// formatted number so injected locales (and RTL demos) render correctly.
+    public let locale: Locale
+
+    /// Density-scaled spacing for chrome gaps with no explicit override
+    /// (e.g. the icon↔title gap inside a chip). Distinct from the ``spacing``
+    /// property, which is the explicit, un-scaled `.spacing(_:)` override.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// The solid accent fill for a selected `.solid` chip / leading action —
+    /// the explicit `accent(_:)` override, else the theme's hero background.
+    public func accentFill(_ theme: Theme) -> Color { accent.map { $0.solid } ?? theme.background(.bgHero) }
+    /// The foreground atop ``accentFill(_:)`` — contrast-safe on the solid fill.
+    public func onAccentFill(_ theme: Theme) -> Color {
+        accent.map { $0.onSolid } ?? theme.text(.textSecondaryInverse)
+    }
+    /// Accent used as a plain text/icon tint on a neutral surface (unselected
+    /// `.solid` chip text, the `.ghost` fallback, the Clear affordance).
+    public func accentTint(_ theme: Theme) -> Color { accent.map { $0.base } ?? theme.foreground(.fgHero) }
+
+    /// A count formatted with the captured locale (grouping separators honor
+    /// injected locales) — shared by every preset's trailing count pill.
+    public func formattedCount(_ n: Int) -> String { n.formatted(.number.locale(locale)) }
+}
+
+// MARK: - Protocol
+
+/// Defines a `FilterBar`'s entire presentation. Implement `makeBody` to lay
+/// out the configuration's filter data. Set one with `.filterBarStyle(_:)`;
+/// the default is ``ChipsFilterBarStyle``.
+public protocol FilterBarStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: FilterBarConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// Pure `size` → dimension mapping, unaffected by density (density scales
+/// gaps, not dimensions — `ComponentDensity.swift`'s documented split).
+/// File-private so every preset shares one source of truth without adding
+/// public surface.
+private extension FilterBarSize {
+    var controlHeight: CGFloat {
+        switch self { case .small: 34; case .medium: 40; case .large: 48 }
+    }
+    var chipTextStyle: TextStyle {
+        switch self { case .small: .labelSm600; case .medium: .labelBase600; case .large: .labelMd600 }
+    }
+    var iconSize: CGFloat {
+        switch self { case .small: 13; case .medium: 15; case .large: 17 }
+    }
+    var chipHPad: CGFloat {
+        switch self { case .small: 12; case .medium: 16; case .large: 20 }
+    }
+}
+
+/// Chip text / fill / border colors for a given ``FilterChipStyle`` — shared
+/// by every preset that renders pill chips or segments. Token-fed throughout;
+/// reproduces `FilterBar`'s pre-style color logic exactly.
+private struct FilterChipPalette {
+    let text: Color
+    let fill: Color
+    let border: Color
+    let borderWidth: CGFloat
+
+    init(isOn: Bool, configuration: FilterBarConfiguration, theme: Theme) {
+        let accent = configuration.accent
+        switch configuration.chipStyle {
+        case .outlined:
+            text = theme.text(.textPrimary)
+            fill = isOn ? (accent?.soft ?? SemanticColor.primary.soft) : theme.background(configuration.chipSurfaceKey)
+            border = isOn ? (accent?.border ?? theme.border(.borderHero)) : theme.background(.bgElevatorTertiary)
+            borderWidth = isOn ? 2 : 1
+        case .ghost:
+            text = isOn ? (accent?.strong ?? theme.foreground(.fgHero)) : theme.text(.textSecondary)
+            fill = isOn ? (accent ?? .primary).soft : .clear
+            border = .clear
+            borderWidth = 1
+        case .solid:
+            text = isOn ? configuration.onAccentFill(theme) : configuration.accentTint(theme)
+            fill = isOn ? configuration.accentFill(theme) : theme.background(configuration.chipSurfaceKey)
+            border = isOn ? .clear : theme.border(.borderPrimary)
+            borderWidth = 1
+        }
+    }
+}
+
+/// The trailing count pill on a chip, e.g. "Seafront · 12". Shared across
+/// presets — `SemanticColor` ladder steps, no raw colors.
+private struct FilterCountPill: View {
+    let count: Int
+    let isOn: Bool
+    let configuration: FilterBarConfiguration
+
+    var body: some View {
+        let tone = configuration.accent ?? .primary
+        let solidSelected = configuration.chipStyle == .solid && isOn
+        Text(configuration.formattedCount(count))
+            .textStyle(.labelSm600)
+            .foregroundStyle(solidSelected ? tone.onSolid : tone.strong)
+            .padding(.horizontal, configuration.spacing(.xs))
+            .background(solidSelected ? tone.active : tone.soft, in: Capsule())
+    }
+}
+
+/// One pinned leading action (Filter/Sort). `.adaptive` shows text that
+/// collapses to an icon when `collapsed` is set; `.circle` is always
+/// icon-only. Shared by every preset — only `.chips` ever passes
+/// `collapsed: true` (it's the only preset with a scroll axis to gate on).
+private struct FilterLeadingAction: View {
+    @Environment(\.theme) private var theme
+    let icon: String
+    let title: String
+    let configuration: FilterBarConfiguration
+    let collapsed: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            if configuration.leadingShape == .circle {
+                Image(systemName: icon).font(.system(size: configuration.size.iconSize, weight: .semibold))
+                    .foregroundStyle(configuration.onAccentFill(theme))
+                    .frame(width: configuration.size.controlHeight, height: configuration.size.controlHeight)
+                    .background(configuration.accentFill(theme), in: Circle())
+            } else {
+                HStack(spacing: 6) {
+                    Image(systemName: icon).font(.system(size: configuration.size.iconSize, weight: .semibold))
+                    if !collapsed { Text(title).textStyle(configuration.size.chipTextStyle).fixedSize() }
+                }
+                .foregroundStyle(configuration.onAccentFill(theme))
+                .padding(.horizontal, collapsed ? 0 : configuration.size.chipHPad)
+                .frame(width: collapsed ? configuration.size.controlHeight : nil, height: configuration.size.controlHeight)
+                .background(configuration.accentFill(theme),
+                            in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+    }
+}
+
+/// One selectable pill chip (icon + title + count). Shared by `.chips` and
+/// `.stacked` — both lay chips out as individually-shaped capsules.
+private struct FilterChipPill: View {
+    @Environment(\.theme) private var theme
+    let chip: QuickFilter
+    let configuration: FilterBarConfiguration
+
+    private var isOn: Bool { configuration.selection.contains(chip.id) }
+
+    var body: some View {
+        let palette = FilterChipPalette(isOn: isOn, configuration: configuration, theme: theme)
+        Button {
+            configuration.toggleFilter(chip.id)
+        } label: {
+            HStack(spacing: configuration.spacing(.xs)) {
+                if let symbol = chip.systemImage {
+                    Image(systemName: symbol).font(.system(size: configuration.size.iconSize, weight: .semibold))
+                }
+                Text(chip.title).textStyle(configuration.size.chipTextStyle)
+                if let count = chip.count {
+                    FilterCountPill(count: count, isOn: isOn, configuration: configuration)
+                }
+            }
+            .foregroundStyle(palette.text)
+            .padding(.horizontal, configuration.size.chipHPad)
+            .frame(minHeight: configuration.size.controlHeight)
+            .background(palette.fill, in: Capsule())
+            // strokeBorder (not stroke) insets the line fully inside the pill,
+            // so the 2pt selected border isn't clipped at the tight top/bottom
+            // curves — a centered stroke would bleed outside and look distorted.
+            .overlay(Capsule().strokeBorder(palette.border, lineWidth: palette.borderWidth))
+            .fixedSize()
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(chip.count.map { "\(chip.title), \($0)" } ?? chip.title)
+        .accessibilityAddTraits(isOn ? .isSelected : [])
+    }
+}
+
+/// The trailing ghost "Clear" chip — visible only while a selection exists.
+/// Shared by every preset.
+private struct FilterClearAllChip: View {
+    @Environment(\.theme) private var theme
+    let configuration: FilterBarConfiguration
+
+    var body: some View {
+        Button {
+            configuration.onClearAll?()
+        } label: {
+            HStack(spacing: configuration.spacing(.xs)) {
+                Image(systemName: "xmark").font(.system(size: configuration.size.iconSize, weight: .semibold))
+                Text(configuration.clearAllTitle).textStyle(configuration.size.chipTextStyle).fixedSize()
+            }
+            .foregroundStyle(configuration.accentTint(theme))
+            .padding(.horizontal, configuration.size.chipHPad)
+            .frame(minHeight: configuration.size.controlHeight)
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(themeKit: "Clear all filters"))
+    }
+}
+
+// MARK: - .chips
+
+/// Today's ``FilterBar`` look, extracted verbatim: pinned leading Filter/Sort
+/// actions (collapsing to icon-only once the first chip scrolls past the
+/// leading edge) followed by a horizontally-scrolling chip row, with an
+/// optional trailing-edge overflow fade and a trailing accessory slot.
+public struct ChipsFilterBarStyle: FilterBarStyle {
+    public init() {}
+    public func makeBody(configuration: FilterBarConfiguration) -> some View {
+        ChipsFilterBarChrome(configuration: configuration)
+    }
+}
+
+private struct ChipsFilterBarChrome: View {
+    let configuration: FilterBarConfiguration
+
+    @State private var collapsed = false
+    @State private var scrolledID: String?
+
+    private var hasLeading: Bool { configuration.onFilter != nil || configuration.onSort != nil }
+
+    var body: some View {
+        HStack(spacing: configuration.spacing) {
+            if hasLeading {
+                HStack(spacing: configuration.spacing) {
+                    if let onFilter = configuration.onFilter {
+                        FilterLeadingAction(icon: configuration.filterIcon, title: configuration.filterTitle,
+                                             configuration: configuration, collapsed: collapsed, action: onFilter)
+                    }
+                    if let onSort = configuration.onSort {
+                        FilterLeadingAction(icon: configuration.sortIcon, title: configuration.sortTitle,
+                                             configuration: configuration, collapsed: collapsed, action: onSort)
+                    }
+                }
+                .fixedSize()
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: configuration.spacing) {
+                    ForEach(configuration.filters) {
+                        FilterChipPill(chip: $0, configuration: configuration).id($0.id)
+                    }
+                    if configuration.onClearAll != nil, !configuration.selection.isEmpty {
+                        FilterClearAllChip(configuration: configuration)
+                    }
+                }
+                .padding(.trailing, 4)
+                .scrollTargetLayout()
+            }
+            .scrollPosition(id: $scrolledID, anchor: .leading)
+            .mask { overflowMask }
+            if let trailing = configuration.trailing {
+                trailing.fixedSize()
+            }
+        }
+        .frame(height: configuration.size.controlHeight)
+        .onChange(of: scrolledID) { _, newID in
+            // Collapse once the first chip has scrolled past the leading edge. Driven by
+            // the anchored item id (not a measured offset), so it's immune to the frame
+            // change that collapsing the buttons causes.
+            guard configuration.collapsible, hasLeading else { return }
+            let shouldCollapse = newID != nil && newID != configuration.filters.first?.id
+            if shouldCollapse != collapsed {
+                // Reduce-Motion / microAnimations gate: nil animation snaps. Resolved by
+                // the component into `isMotionEnabled` — never read the motion environment.
+                withAnimation(configuration.isMotionEnabled ? Motion.fast.animation : nil) {
+                    collapsed = shouldCollapse
+                }
+            }
+        }
+    }
+
+    /// Trailing-edge gradient fade hinting at overflowed chips. Built with
+    /// `UnitPoint.leading → .trailing`, which resolve against the layout
+    /// direction — so the fade sits on the correct edge under RTL.
+    @ViewBuilder private var overflowMask: some View {
+        if configuration.overflowFade {
+            LinearGradient(
+                stops: [
+                    .init(color: .black, location: 0),
+                    .init(color: .black, location: 0.92),
+                    .init(color: .clear, location: 1),
+                ],
+                startPoint: .leading, endPoint: .trailing
+            )
+        } else {
+            Rectangle()
+        }
+    }
+}
+
+// MARK: - .segmented
+
+/// Fixed equal-width segments in one bordered row — no scrolling, every
+/// filter fully visible at once. The pinned leading actions (never
+/// collapsing — there's no scroll to gate on) sit before the segments; a
+/// Clear affordance and the trailing slot sit after.
+public struct SegmentedFilterBarStyle: FilterBarStyle {
+    public init() {}
+    public func makeBody(configuration: FilterBarConfiguration) -> some View {
+        SegmentedFilterBarChrome(configuration: configuration)
+    }
+}
+
+private struct SegmentedFilterBarChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: FilterBarConfiguration
+
+    var body: some View {
+        HStack(spacing: configuration.spacing) {
+            if let onFilter = configuration.onFilter {
+                FilterLeadingAction(icon: configuration.filterIcon, title: configuration.filterTitle,
+                                     configuration: configuration, collapsed: false, action: onFilter)
+            }
+            if let onSort = configuration.onSort {
+                FilterLeadingAction(icon: configuration.sortIcon, title: configuration.sortTitle,
+                                     configuration: configuration, collapsed: false, action: onSort)
+            }
+            segments
+            if configuration.onClearAll != nil, !configuration.selection.isEmpty {
+                FilterClearAllChip(configuration: configuration)
+            }
+            if let trailing = configuration.trailing {
+                trailing.fixedSize()
+            }
+        }
+        .frame(height: configuration.size.controlHeight)
+    }
+
+    private var segments: some View {
+        HStack(spacing: 0) {
+            ForEach(configuration.filters) { segment($0) }
+        }
+        .frame(height: configuration.size.controlHeight)
+        .background(theme.background(configuration.chipSurfaceKey))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
+                .strokeBorder(theme.border(.borderPrimary), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+    }
+
+    /// One equal-width cell. Deliberately borderless per-segment (the outer
+    /// row already draws the container border) so `.outlined`/`.ghost`
+    /// contribute only fill + text color here, keeping the segmented shape
+    /// coherent across every ``FilterChipStyle``.
+    private func segment(_ chip: QuickFilter) -> some View {
+        let isOn = configuration.selection.contains(chip.id)
+        let palette = FilterChipPalette(isOn: isOn, configuration: configuration, theme: theme)
+        return Button {
+            configuration.toggleFilter(chip.id)
+        } label: {
+            HStack(spacing: configuration.spacing(.xs)) {
+                if let symbol = chip.systemImage {
+                    Image(systemName: symbol).font(.system(size: configuration.size.iconSize, weight: .semibold))
+                }
+                Text(chip.title).textStyle(configuration.size.chipTextStyle).lineLimit(1)
+                if let count = chip.count {
+                    FilterCountPill(count: count, isOn: isOn, configuration: configuration)
+                }
+            }
+            .foregroundStyle(palette.text)
+            .padding(.horizontal, configuration.size.chipHPad)
+            .frame(maxWidth: .infinity, minHeight: configuration.size.controlHeight)
+            .background(palette.fill)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(chip.count.map { "\(chip.title), \($0)" } ?? chip.title)
+        .accessibilityAddTraits(isOn ? .isSelected : [])
+    }
+}
+
+// MARK: - .stacked
+
+/// The pinned actions row (Filter/Sort/trailing slot) above a wrapping chip
+/// row — every chip visible without horizontal scroll. RTL-safe via the
+/// injected `layoutDirection` on ``FlowLayout``.
+public struct StackedFilterBarStyle: FilterBarStyle {
+    public init() {}
+    public func makeBody(configuration: FilterBarConfiguration) -> some View {
+        StackedFilterBarChrome(configuration: configuration)
+    }
+}
+
+private struct StackedFilterBarChrome: View {
+    @Environment(\.layoutDirection) private var layoutDirection
+    let configuration: FilterBarConfiguration
+
+    private var hasActionsRow: Bool {
+        configuration.onFilter != nil || configuration.onSort != nil || configuration.trailing != nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing) {
+            if hasActionsRow {
+                HStack(spacing: configuration.spacing) {
+                    if let onFilter = configuration.onFilter {
+                        FilterLeadingAction(icon: configuration.filterIcon, title: configuration.filterTitle,
+                                             configuration: configuration, collapsed: false, action: onFilter)
+                    }
+                    if let onSort = configuration.onSort {
+                        FilterLeadingAction(icon: configuration.sortIcon, title: configuration.sortTitle,
+                                             configuration: configuration, collapsed: false, action: onSort)
+                    }
+                    Spacer(minLength: 0)
+                    if let trailing = configuration.trailing { trailing }
+                }
+            }
+            FlowLayout(spacing: configuration.spacing, lineSpacing: configuration.spacing,
+                       layoutDirection: layoutDirection) {
+                ForEach(configuration.filters) { FilterChipPill(chip: $0, configuration: configuration) }
+                if configuration.onClearAll != nil, !configuration.selection.isEmpty {
+                    FilterClearAllChip(configuration: configuration)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension FilterBarStyle where Self == ChipsFilterBarStyle {
+    /// Pinned Filter/Sort actions + a horizontally-scrolling chip row that
+    /// collapses the actions to icon-only on scroll — today's bar. The default.
+    static var chips: ChipsFilterBarStyle { ChipsFilterBarStyle() }
+}
+public extension FilterBarStyle where Self == SegmentedFilterBarStyle {
+    /// Fixed equal-width segments, no scrolling — every filter fully visible
+    /// at once. Best for a small, stable filter set.
+    static var segmented: SegmentedFilterBarStyle { SegmentedFilterBarStyle() }
+}
+public extension FilterBarStyle where Self == StackedFilterBarStyle {
+    /// The actions row above a wrapping chip row — every chip visible without
+    /// horizontal scroll.
+    static var stacked: StackedFilterBarStyle { StackedFilterBarStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyFilterBarStyle: FilterBarStyle {
+    private let _makeBody: @MainActor (FilterBarConfiguration) -> AnyView
+    init<S: FilterBarStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: FilterBarConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct FilterBarStyleKey: EnvironmentKey {
+    static let defaultValue = AnyFilterBarStyle(ChipsFilterBarStyle())
+}
+
+extension EnvironmentValues {
+    var filterBarStyle: AnyFilterBarStyle {
+        get { self[FilterBarStyleKey.self] }
+        set { self[FilterBarStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``FilterBarStyle`` for `FilterBar`s in this view and its
+    /// descendants — one screen can mix archetypes per section.
+    func filterBarStyle<S: FilterBarStyle>(_ style: sending S) -> some View {
+        environment(\.filterBarStyle, AnyFilterBarStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a plain underline-tab row, no chip chrome at all.
+private struct UnderlineFilterBarStyle: FilterBarStyle {
+    func makeBody(configuration: FilterBarConfiguration) -> some View {
+        UnderlineFilterBarChrome(configuration: configuration)
+    }
+
+    private struct UnderlineFilterBarChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: FilterBarConfiguration
+
+        var body: some View {
+            HStack(spacing: configuration.spacing(.md)) {
+                ForEach(configuration.filters) { chip in
+                    let isOn = configuration.selection.contains(chip.id)
+                    Button {
+                        configuration.toggleFilter(chip.id)
+                    } label: {
+                        VStack(spacing: 4) {
+                            Text(chip.title).textStyle(.labelBase600)
+                                .foregroundStyle(isOn ? configuration.accentTint(theme) : theme.text(.textSecondary))
+                            Rectangle()
+                                .fill(isOn ? configuration.accentTint(theme) : Color.clear)
+                                .frame(height: 2)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(chip.title)
+                    .accessibilityAddTraits(isOn ? .isSelected : [])
+                }
+            }
+        }
+    }
+}
+
+#Preview("FilterBarStyle — presets × light/dark") {
+    @Previewable @State var sel: Set<String> = ["8"]
+    let chips = [
+        QuickFilter("8+ rating", id: "8", systemImage: "star.fill", count: 24),
+        QuickFilter("Seafront", systemImage: "beach.umbrella", count: 9),
+        QuickFilter("All-inclusive", count: 3),
+        QuickFilter("Free cancellation"),
+    ]
+    PreviewMatrix("FilterBarStyle") {
+        PreviewCase("Chips (default)") {
+            FilterBar(chips, selection: $sel)
+                .onFilter { }.onSort { }.onClearAll { }
+                .filterBarStyle(.chips)
+        }
+        PreviewCase("Segmented") {
+            FilterBar(chips, selection: $sel)
+                .onFilter { }.accent(.turquoise)
+                .filterBarStyle(.segmented)
+        }
+        PreviewCase("Stacked") {
+            FilterBar(chips, selection: $sel)
+                .onFilter { }.onSort { }.onClearAll { }
+                .chipStyle(.outlined)
+                .frame(width: 260)
+                .filterBarStyle(.stacked)
+        }
+        PreviewCase("Custom (in-preview)") {
+            FilterBar(chips, selection: $sel)
+                .filterBarStyle(UnderlineFilterBarStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift
@@ -13,6 +13,13 @@
 //  position, not by letter (that ambiguity is inherent). Use `.aisleWidth` for a
 //  tighter gap.
 //
+//  The *arrangement* is owned by the active ``SeatMapStyle`` from the environment
+//  (ADR-0004, Class B): the component builds the cabin grid, passenger rail, deck
+//  selector, legend and summary bar — fully wired (selection, pinch-to-zoom, deck
+//  filtering) — into a `SeatMapConfiguration` and hands it to the style. `.cabin`
+//  (default) is today's arrangement verbatim; `.grid` and `.schematic` rearrange
+//  the same units; apps can implement their own. See `SeatMapStyle.swift`.
+//
 
 import SwiftUI
 import ThemeKit
@@ -43,6 +50,7 @@ public struct SeatMap: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.formatDefaults) private var formatDefaults
     @Environment(\.locale) private var locale
+    @Environment(\.seatMapStyle) private var style
 
     private let sections: [SeatSection]
     private let index: SeatIndex
@@ -72,6 +80,7 @@ public struct SeatMap: View {
     private var seatShape: SeatShape = .rounded
     private var legendPlacement: LegendPlacement = .bottom
     private var fuselageSurfaceKey: Theme.BackgroundColorKey = .bgSecondaryLight
+    private var surfaceKey: Theme.BackgroundColorKey?
     private var deckLabelProvider: ((Int) -> String)?
     private var zoomBinding: Binding<CGFloat>?
     private var sectionHeaderSlot: ((String) -> AnyView)?
@@ -108,19 +117,33 @@ public struct SeatMap: View {
     }
 
     public var body: some View {
-        VStack(spacing: density.scale(Theme.SpacingKey.md.value)) {
-            if passengerMode {
-                PassengerRail(passengers: passengers, assignment: assignment ?? .constant([:]), active: $activePassenger, accent: accentOverride)
-            }
-            if index.floors.count > 1 {
+        style.makeBody(configuration: configuration)
+    }
+
+    /// The pre-wired units + typed signals handed to the active
+    /// ``SeatMapStyle`` (ADR-0004, Class B): the grid, rail, deck selector,
+    /// legend and summary bar are already *built* — a style arranges them,
+    /// never re-wires selection/zoom/deck state (that stays here).
+    private var configuration: SeatMapConfiguration {
+        SeatMapConfiguration(
+            cabinGrid: AnyView(cabin.modifier(PinchZoom(enabled: zoomable, zoom: zoomBinding ?? $zoom))),
+            passengerRail: passengerMode ? AnyView(
+                PassengerRail(passengers: passengers, assignment: assignment ?? .constant([:]),
+                              active: $activePassenger, accent: accentOverride)
+            ) : nil,
+            deckSelector: index.floors.count > 1 ? AnyView(
                 DeckSelector(floors: index.floors, active: $activeFloor, accent: accentOverride,
                              label: deckLabelProvider ?? { (floor: Int) in String(themeKit: "Deck \(floor)") })
-            }
-            if legendVisible, legendPlacement == .top { legendView }
-            cabin.modifier(PinchZoom(enabled: zoomable, zoom: zoomBinding ?? $zoom))
-            if legendVisible, legendPlacement == .bottom { legendView }
-            if showsInfo || summarySlot != nil { summaryView }
-        }
+            ) : nil,
+            legend: legendVisible ? AnyView(legendView) : nil,
+            summaryBar: (showsInfo || summarySlot != nil) ? AnyView(summaryView) : nil,
+            selectedCount: selection.count,
+            accent: accentOverride,
+            surfaceKey: surfaceKey,
+            seatShape: seatShape,
+            legendPlacement: legendPlacement,
+            density: density,
+            locale: locale)
     }
 
     private var legendVisible: Bool { showsLegend && legendPlacement != .hidden }
@@ -368,6 +391,11 @@ public extension SeatMap {
     func legendPlacement(_ placement: LegendPlacement) -> Self { copy { $0.legendPlacement = placement } }
     /// Surface fill of the fuselage frame (default `.bgSecondaryLight`).
     func fuselageSurface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.fuselageSurfaceKey = key } }
+    /// Explicit surface fill for a ``SeatMapStyle`` preset that draws its own
+    /// chrome around the units (e.g. ``SchematicSeatMapStyle``'s fuselage
+    /// silhouette). `.cabin`/`.grid` don't draw chrome, so they ignore it;
+    /// unset, each preset falls back to its own default.
+    func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
     /// Custom deck-pill titles for multi-deck cabins, e.g. `{ $0 == 1 ? "Main" : "Upper" }`.
     func deckLabel(_ label: @escaping (Int) -> String) -> Self { copy { $0.deckLabelProvider = label } }
     /// Pinch-to-zoom with the zoom scale exposed through the caller's binding —
@@ -571,7 +599,9 @@ private struct ExitBand: View {
 
 /// The aircraft body used by `SeatMap.fuselage()` — a tapered nose + cockpit hint.
 /// `surfaceKey` comes from `SeatMap.fuselageSurface(_:)` (default `.bgSecondaryLight`).
-private struct FuselageView: View {
+/// Internal (not `private`) so ``SchematicSeatMapStyle`` (`SeatMapStyle.swift`)
+/// can reuse the same silhouette for its fuselage-framed preset.
+struct FuselageView: View {
     @Environment(\.theme) private var theme
     var surfaceKey: Theme.BackgroundColorKey = .bgSecondaryLight
     var body: some View {

--- a/Sources/ThemeKitTravel/Components/Organisms/SeatMapStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SeatMapStyle.swift
@@ -1,0 +1,377 @@
+//
+//  SeatMapStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``SeatMap`` — a Class B protocol of ADR-0004
+//  (per-component style protocols). Unlike Class A (typed data the style lays
+//  out itself), this component owns *live interactive controls* — selection,
+//  pinch-to-zoom, deck filtering, passenger assignment — so the configuration
+//  hands styles **pre-wired, type-erased units**: the built cabin grid, the
+//  passenger rail, the deck selector, the legend and the summary bar. Styles
+//  ARRANGE these units; they never re-wire them. Three built-ins:
+//
+//    .cabin      rail + deck selector + grid + legend + summary — today's
+//                arrangement. Default.
+//    .grid       the bare seat grid, chrome-less — no rail, deck selector,
+//                legend or summary, even when the component built them
+//                (venue-picker style).
+//    .schematic  the grid framed in a fuselage silhouette with wing and
+//                exit-door markers along its sides.
+//
+//      SeatMap(columns: "ABC DEF", rows: Array(1...30), selection: $picked) { … }
+//          .legend().showsSeatInfo()
+//          .seatMapStyle(.schematic)
+//
+//  One law (ADR-0004 §6): the component style arranges *content*; the token
+//  theme colors everything (there is no delegated shell here — SeatMap draws
+//  its own chrome, so a style that wants chrome, like `.schematic`, draws it
+//  itself). Selection, zoom and deck state stay in the component — a style
+//  never touches them, it only decides where the pre-built units go.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The pre-wired units + typed signals a ``SeatMapStyle`` arranges. The
+/// `AnyView` fields are fully interactive (selection, zoom and deck-filtering
+/// are already wired) — place them, never rebuild them. The typed fields are
+/// read-only signals for arrangement decisions; the component's `@State`
+/// (zoom, focused seat, active passenger/deck) never leaves the component.
+public struct SeatMapConfiguration {
+    // Pre-wired units — fully interactive; styles arrange, never re-wire.
+    /// The built cabin grid — sections, rows, seats — with selection,
+    /// pinch-to-zoom and deck filtering already wired. Every built-in style
+    /// renders this; ``GridSeatMapStyle`` renders *only* this.
+    public let cabinGrid: AnyView
+    /// The passenger-assignment rail (initials pills, active traveller);
+    /// `nil` unless the component was given `SeatMap.passengers(_:assignment:)`.
+    public let passengerRail: AnyView?
+    /// The deck-switch pill row; `nil` for single-deck cabins.
+    public let deckSelector: AnyView?
+    /// The fare-tier legend, already matched to the map's seat shape and
+    /// palette; `nil` unless `SeatMap.legend()` is on and
+    /// ``legendPlacement`` isn't `.hidden`.
+    public let legend: AnyView?
+    /// The seat-detail + running-total bar — the `SeatMap.summaryBar { }`
+    /// slot when provided, else the built-in bar; `nil` unless
+    /// `SeatMap.showsSeatInfo()` or a custom summary slot was set.
+    public let summaryBar: AnyView?
+
+    // Typed signals for arrangement decisions.
+    /// How many seats are currently selected (or assigned, in passenger mode).
+    public let selectedCount: Int
+    /// Accent for the rail's/deck selector's active pill
+    /// (`SeatMap.accent(_:)`), or `nil` for the theme's hero default.
+    public let accent: SemanticColor?
+    /// Explicit surface fill (`SeatMap.surface(_:)`), or `nil` to let the
+    /// style choose its own default (resolve via ``surface(default:)``).
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// The silhouette every seat in ``cabinGrid`` is drawn with — forwarded
+    /// so a custom style building its own legend keeps swatches matching.
+    public let seatShape: SeatShape
+    /// Where ``legend`` belongs relative to ``cabinGrid``
+    /// (`SeatMap.legendPlacement(_:)`) — `.cabin`/`.schematic` read this to
+    /// place it top or bottom; `.hidden` already renders as `legend == nil`.
+    public let legendPlacement: LegendPlacement
+    /// The environment's component density, captured by the component —
+    /// scale chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — pass through to
+    /// any locale-sensitive content a custom style adds of its own.
+    public let locale: Locale
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out the arrangement.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+}
+
+// MARK: - Protocol
+
+/// Defines a `SeatMap`'s entire presentation. Implement `makeBody` to arrange
+/// the configuration's pre-wired units. Set one with `.seatMapStyle(_:)`; the
+/// default is ``CabinSeatMapStyle``.
+public protocol SeatMapStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: SeatMapConfiguration) -> Body
+}
+
+// MARK: - .cabin (default)
+
+/// Today's arrangement, extracted verbatim: passenger rail, deck selector,
+/// the legend (top or bottom per ``SeatMapConfiguration/legendPlacement``),
+/// the cabin grid, and the summary bar.
+public struct CabinSeatMapStyle: SeatMapStyle {
+    public init() {}
+    public func makeBody(configuration: SeatMapConfiguration) -> some View {
+        VStack(spacing: configuration.spacing(.md)) {
+            if let passengerRail = configuration.passengerRail { passengerRail }
+            if let deckSelector = configuration.deckSelector { deckSelector }
+            if let legend = configuration.legend, configuration.legendPlacement == .top { legend }
+            configuration.cabinGrid
+            if let legend = configuration.legend, configuration.legendPlacement == .bottom { legend }
+            if let summaryBar = configuration.summaryBar { summaryBar }
+        }
+    }
+}
+
+// MARK: - .grid
+
+/// The bare seat grid, chrome-less — no rail, deck selector, legend or
+/// summary bar, even when the component built them. A venue-picker style:
+/// drop a `SeatMap` into a sheet, a form field or a larger layout that
+/// supplies its own surrounding chrome.
+public struct GridSeatMapStyle: SeatMapStyle {
+    public init() {}
+    public func makeBody(configuration: SeatMapConfiguration) -> some View {
+        configuration.cabinGrid
+    }
+}
+
+// MARK: - .schematic
+
+/// The grid framed in the fuselage silhouette shared with
+/// `SeatMap.fuselage()`, plus wing and exit-door markers along its sides —
+/// still arranges rail/deck selector/legend/summary around it, so it stays a
+/// drop-in replacement for `.cabin`.
+public struct SchematicSeatMapStyle: SeatMapStyle {
+    public init() {}
+    public func makeBody(configuration: SeatMapConfiguration) -> some View {
+        SchematicSeatMapChrome(configuration: configuration)
+    }
+}
+
+private struct SchematicSeatMapChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: SeatMapConfiguration
+
+    var body: some View {
+        VStack(spacing: configuration.spacing(.md)) {
+            if let passengerRail = configuration.passengerRail { passengerRail }
+            if let deckSelector = configuration.deckSelector { deckSelector }
+            if let legend = configuration.legend, configuration.legendPlacement == .top { legend }
+            silhouette
+            if let legend = configuration.legend, configuration.legendPlacement == .bottom { legend }
+            if let summaryBar = configuration.summaryBar { summaryBar }
+        }
+    }
+
+    /// The cabin grid framed in ``FuselageView`` (shared with
+    /// `SeatMap.fuselage()`) plus wing and exit-door markers — a schematic
+    /// illustration, not a functional exit map (the real exit rows already
+    /// draw their own `EXIT` band inside the grid).
+    private var silhouette: some View {
+        configuration.cabinGrid
+            .padding(Self.fuselageInsets)
+            .background { FuselageView(surfaceKey: configuration.surface(default: .bgSecondaryLight)) }
+            .overlay(alignment: .leading) { wing(pointsLeading: true) }
+            .overlay(alignment: .trailing) { wing(pointsLeading: false) }
+            .overlay(alignment: .topLeading) { exitMarker.padding(.top, Self.exitInset).padding(.leading, Self.exitInset) }
+            .overlay(alignment: .topTrailing) { exitMarker.padding(.top, Self.exitInset).padding(.trailing, Self.exitInset) }
+    }
+
+    /// A small triangular wing blade pointing away from the fuselage. Purely
+    /// illustrative — the offset that pushes it outward is applied *before*
+    /// `.flipsForRightToLeftLayoutDirection(true)` so the whole picture
+    /// (shape + offset) mirrors together, keeping it pointing outward when
+    /// `.leading`/`.trailing` swap physical sides under RTL.
+    private func wing(pointsLeading: Bool) -> some View {
+        FuselageWingShape(pointsLeading: pointsLeading)
+            .fill(theme.background(configuration.surface(default: .bgSecondaryLight)))
+            .overlay(FuselageWingShape(pointsLeading: pointsLeading).stroke(theme.border(.borderPrimary), lineWidth: 1.5))
+            .frame(width: Self.wingSpan, height: Self.wingChord)
+            .offset(x: pointsLeading ? -Self.wingSpan * 0.55 : Self.wingSpan * 0.55)
+            .flipsForRightToLeftLayoutDirection(true)
+            .accessibilityHidden(true)
+    }
+
+    /// A small forward exit-door glyph — decorative, echoing `SeatTier.exit`'s
+    /// glyph so the schematic reads as an aircraft at a glance.
+    private var exitMarker: some View {
+        Image(systemName: "door.left.hand.open")
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(theme.foreground(.systemcolorsFgSuccess))
+            .padding(4)
+            .background(theme.background(.bgWhite), in: Circle())
+            .overlay(Circle().strokeBorder(theme.border(.borderPrimary), lineWidth: 1))
+            .accessibilityHidden(true)
+    }
+
+    private static let fuselageInsets = EdgeInsets(top: 46, leading: 18, bottom: 26, trailing: 18)
+    private static let wingSpan: CGFloat = 30
+    private static let wingChord: CGFloat = 44
+    private static let exitInset: CGFloat = 10
+}
+
+/// A small triangular wing blade for ``SchematicSeatMapStyle`` — points away
+/// from the fuselage. `pointsLeading` selects which way it tapers; the host
+/// view applies `.flipsForRightToLeftLayoutDirection(true)` (the SKILL's
+/// Path rule) so it still points outward once RTL swaps which physical side
+/// `.leading`/`.trailing` land on.
+private struct FuselageWingShape: Shape {
+    var pointsLeading: Bool
+
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        if pointsLeading {
+            p.move(to: CGPoint(x: rect.maxX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.midY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        } else {
+            p.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            p.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+            p.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        }
+        p.closeSubpath()
+        return p
+    }
+}
+
+// MARK: - Static accessors
+
+public extension SeatMapStyle where Self == CabinSeatMapStyle {
+    /// Rail + deck selector + grid + legend + summary — today's arrangement. The default.
+    static var cabin: CabinSeatMapStyle { CabinSeatMapStyle() }
+}
+public extension SeatMapStyle where Self == GridSeatMapStyle {
+    /// The bare seat grid, chrome-less — a venue-picker style.
+    static var grid: GridSeatMapStyle { GridSeatMapStyle() }
+}
+public extension SeatMapStyle where Self == SchematicSeatMapStyle {
+    /// The grid framed in a fuselage silhouette with wing and exit-door markers.
+    static var schematic: SchematicSeatMapStyle { SchematicSeatMapStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnySeatMapStyle: SeatMapStyle {
+    private let _makeBody: @MainActor (SeatMapConfiguration) -> AnyView
+    init<S: SeatMapStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: SeatMapConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct SeatMapStyleKey: EnvironmentKey {
+    static let defaultValue = AnySeatMapStyle(CabinSeatMapStyle())
+}
+
+extension EnvironmentValues {
+    var seatMapStyle: AnySeatMapStyle {
+        get { self[SeatMapStyleKey.self] }
+        set { self[SeatMapStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``SeatMapStyle`` for `SeatMap`s in this view and its
+    /// descendants — a compact review sheet can run `.grid` while the
+    /// booking flow keeps `.schematic`.
+    func seatMapStyle<S: SeatMapStyle>(_ style: sending S) -> some View {
+        environment(\.seatMapStyle, AnySeatMapStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — a minimal "N selected"
+/// caption above the bare grid, no rail/deck/legend/summary chrome at all.
+/// Proves external implementability.
+private struct CaptionedSeatMapStyle: SeatMapStyle {
+    func makeBody(configuration: SeatMapConfiguration) -> some View {
+        CaptionedSeatMapChrome(configuration: configuration)
+    }
+
+    private struct CaptionedSeatMapChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: SeatMapConfiguration
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
+                Text(configuration.selectedCount == 1
+                     ? String(themeKitTravel: "1 seat selected")
+                     : String(themeKitTravel: "\(configuration.selectedCount) seats selected"))
+                    .textStyle(.labelSm600)
+                    .foregroundStyle(configuration.accent?.base ?? theme.text(.textSecondary))
+                configuration.cabinGrid
+            }
+        }
+    }
+}
+
+/// Preview-only harness: owns the `@State` selection each interactive case binds to.
+private struct SeatMapStyleHarness<Content: View>: View {
+    @State private var selection: Set<String>
+    private let content: (Binding<Set<String>>) -> Content
+
+    init(_ initial: Set<String> = [], @ViewBuilder content: @escaping (Binding<Set<String>>) -> Content) {
+        self._selection = State(initialValue: initial)
+        self.content = content
+    }
+
+    var body: some View { content($selection) }
+}
+
+private func styleSections() -> [SeatSection] {
+    [SeatSection(nil, columns: "ABC DEF", rows: Array(1...6)) { id, row, _ in
+        SeatInfo(available: !["3B", "4E"].contains(id),
+                 price: row <= 2 ? 220 : 90,
+                 tier: row == 1 ? .business : .standard)
+    }]
+}
+
+#Preview("SeatMapStyle — presets × light/dark") {
+    PreviewMatrix("SeatMapStyle") {
+        PreviewCase(".cabin (default)") {
+            SeatMapStyleHarness(["3C"]) { selection in
+                SeatMap(sections: styleSections(), selection: selection)
+                    .showsLabels().legend().showsSeatInfo()
+            }
+        }
+        PreviewCase(".grid — bare, chrome-less") {
+            SeatMapStyleHarness(["3C"]) { selection in
+                SeatMap(sections: styleSections(), selection: selection)
+                    .showsLabels().legend().showsSeatInfo()
+                    .seatMapStyle(.grid)
+            }
+        }
+        PreviewCase(".schematic — fuselage silhouette") {
+            SeatMapStyleHarness(["3C"]) { selection in
+                SeatMap(sections: styleSections(), selection: selection)
+                    .showsLabels().legend().showsSeatInfo()
+                    .seatMapStyle(.schematic)
+            }
+        }
+        PreviewCase(".schematic — custom surface") {
+            SeatMapStyleHarness([]) { selection in
+                SeatMap(sections: styleSections(), selection: selection)
+                    .surface(.bgWhite)
+                    .seatMapStyle(.schematic)
+            }
+        }
+        PreviewCase("Custom (in-preview)") {
+            SeatMapStyleHarness(["3C"]) { selection in
+                SeatMap(sections: styleSections(), selection: selection)
+                    .seatMapStyle(CaptionedSeatMapStyle())
+            }
+        }
+    }
+}
+
+#Preview("SeatMapStyle — .schematic RTL (wing/exit markers mirror)") {
+    PreviewMatrix(".schematic", schemes: [.light], rtl: true) {
+        PreviewCase(".schematic") {
+            SeatMapStyleHarness(["3C"]) { selection in
+                SeatMap(sections: styleSections(), selection: selection)
+                    .legend()
+                    .seatMapStyle(.schematic)
+            }
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCard.swift
@@ -4,20 +4,22 @@
 //
 //  Edition organism (F3.2 · ADR §9.8). "No flights? Take the bus/train" —
 //  a cross-sell for an alternative transport mode: mode glyph, route,
-//  price-from, optional CTA. Two archetypes: `.ribbon` (default) is a
-//  full-width notched strip that borrows TicketStub's coupon chrome — a
-//  `destinationOut` notch cut plus a dashed perforation — rotated to a
-//  *vertical* tear line between the glyph and the content; `.inline` is a
-//  flat ListRow-anatomy row for embedding between flight results.
+//  price-from, optional CTA. Presentation is style-driven
+//  (``TransportCrossSellCardStyle``, ADR-0004) — set once per screen via
+//  `.transportCrossSellCardStyle(_:)`: `.ribbon` (default, a notched
+//  TicketStub-technique coupon strip), `.inline` (a flat ListRow-anatomy
+//  row), `.tile` (a compact vertical card for grids) or `.banner` (a
+//  full-bleed, mode-tinted promo strip). Token-bound.
 //
-//  CardStyle exception (same as TicketStub): the notched tear-line shell *is*
-//  the ribbon's identity, so it deliberately does not route through CardStyle.
-//
-//  RTL: the strip is an `HStack`, so the sections mirror automatically. The
-//  tear line's x is *measured after layout* via an anchor preference (the
-//  TicketStub technique), so the notches and the dashed perforation are cut
-//  at the mirrored position by construction — no manual flip of the drawn
-//  geometry is needed (flipping the anchor-resolved path would double-mirror).
+//  ```swift
+//  TransportCrossSellCard(.bus, from: "Riverton", to: "Lakeside")
+//      .price(19)                       // currency via the §10 env chain
+//      .duration("6h 30m")
+//      .departures("Every 30 min from Central Station")
+//      .badge("Cheapest")
+//      .onSelect { showBusOptions() }
+//      .transportCrossSellCardStyle(.tile)
+//  ```
 //
 //  Currency: the plain `price(_:caption:)` overload resolves the code through
 //  the §10 chain inside `PriceTag` (`\.formatDefaults` > locale > "USD");
@@ -29,6 +31,11 @@ import ThemeKit
 
 /// Layout archetype of a ``TransportCrossSellCard``: notched strip (`.ribbon`),
 /// flat row (`.inline`), or a compact vertical card for grids (`.tile`).
+///
+/// Superseded by ``TransportCrossSellCardStyle`` (each case maps 1:1 to a
+/// preset — `.ribbon`/`.inline`/`.tile`, joined by the new `.banner` strip);
+/// kept for source compatibility until the next major, together with the
+/// deprecated ``TransportCrossSellCard/variant(_:)`` modifier.
 public enum TransportCrossSellVariant: Sendable { case ribbon, inline, tile }
 
 /// Size ramp of a ``TransportCrossSellCard`` — scales the mode glyph, the
@@ -85,7 +92,9 @@ public struct TransportCrossSellCard: View {
         }
     }
 
-    @Environment(\.theme) private var theme
+    @Environment(\.transportCrossSellCardStyle) private var envStyle
+    @Environment(\.componentDensity) private var density
+    @Environment(\.locale) private var locale
     @Environment(\.isReadOnly) private var isReadOnly
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -108,21 +117,22 @@ public struct TransportCrossSellCard: View {
     private var badgeText: String?
     private var ctaTitle: String?
     private var ctaAction: (() -> Void)?
-    private var variantValue: TransportCrossSellVariant = .ribbon
     private var accentOverride: SemanticColor?
     private var logoSlot: AnyView?
-    private var surfaceKey: Theme.BackgroundColorKey = .bgBase
+    /// `nil` lets the active style pick its own default surface (`.bgBase`
+    /// for `.ribbon`/`.tile`; `.banner` always uses the mode's soft tint).
+    private var surfaceKey: Theme.BackgroundColorKey?
     private var sizeValue: TransportCrossSellSize = .medium
     private var tearStyleValue: TearStyle = .notched
     private var badgeFillValue: FillVariant = .soft
-    /// Replaces the ribbon CTA button's built-in label (action preserved).
+    /// Replaces a preset's built-in CTA label/indicator (action preserved).
     private var ctaLabelSlot: AnyView?
     private var shadowStyleValue: ThemeKitCore.ShadowStyle = .soft
-
-    /// Bespoke coupon geometry (TicketStub-class chrome) — fixed constants,
-    /// not knobs: the notch cut radius and the dash inset past the notch.
-    private let notchRadius: CGFloat = 8
-    private let dashInset: CGFloat = 6
+    /// Set by the deprecated ``variant(_:)`` modifier — an explicitly chosen
+    /// per-instance style wins over an ancestor's
+    /// `.transportCrossSellCardStyle(_:)` (source-behavior stability during
+    /// the enum's deprecation window, ADR-0004 §5).
+    private var explicitStyle: AnyTransportCrossSellCardStyle?
 
     /// R1 — mode + route endpoints (display strings; cross-sell has no FlightLeg).
     public init(_ mode: Mode, from: String, to: String) {
@@ -151,290 +161,39 @@ public struct TransportCrossSellCard: View {
         MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion)
     }
 
-    /// The size ramp, resolved once (token-fed paddings; Icon/PriceTag enums).
-    private var glyphIconSize: IconSize { sizeValue == .small ? .md : .lg }
-    private var sectionPad: CGFloat {
-        sizeValue == .small ? Theme.SpacingKey.sm.value : Theme.SpacingKey.md.value
-    }
-    private var ribbonPriceSize: PriceSize { sizeValue == .small ? .small : .medium }
-
     public var body: some View {
-        Group {
-            switch variantValue {
-            case .ribbon: ribbon
-            case .inline: inline
-            case .tile: tile
-            }
-        }
-        .animation(motion, value: priceAmount)
-        .animation(motion, value: badgeText)
-    }
-
-    // MARK: - Ribbon variant — notched coupon strip (TicketStub chrome, vertical tear)
-
-    private var ribbon: some View {
-        HStack(spacing: 0) {
-            glyphSection
-                .padding(sectionPad)
-            // A zero-width marker whose center is the tear line, reported up so
-            // the background carves its notches at exactly this x (mirrors under
-            // RTL by construction — the anchor resolves after layout).
-            Color.clear.frame(width: 0)
-                .anchorPreference(key: TearXAnchorKey.self, value: .center) { $0 }
-            contentSection
-                .padding(sectionPad)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .backgroundPreferenceValue(TearXAnchorKey.self) { anchor in
-            GeometryReader { proxy in
-                ribbonSurface(tearX: anchor.map { proxy[$0].x }, size: proxy.size)
-            }
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(accessibilityText)
-    }
-
-    private var glyphSection: some View {
-        VStack(spacing: Theme.SpacingKey.xs.value) {
-            Group {
-                if let logoSlot {
-                    logoSlot
-                } else {
-                    Icon(systemName: modeGlyph)
-                        .size(glyphIconSize)
-                        .accent(accent)
-                }
-            }
-            .padding(Theme.SpacingKey.sm.value)
-            .background(Circle().fill(accent.soft))
-            Text(modeLabel)
-                .textStyle(.labelSm600)
-                .foregroundStyle(theme.text(.textSecondary))
-        }
-        .accessibilityHidden(true)   // announced by the container label
-    }
-
-    private var contentSection: some View {
-        VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
-            HStack(spacing: Theme.SpacingKey.xs.value) {
-                routeLine
-                if let badgeText {
-                    Badge(badgeText).badgeStyle(badgeStyle).variant(badgeFillValue).size(.small)
-                }
-            }
-            if let metaLine {
-                Text(metaLine)
-                    .textStyle(.bodySm400)
-                    .foregroundStyle(theme.text(.textSecondary))
-            }
-            if priceAmount != nil || ctaAction != nil {
-                HStack(spacing: Theme.SpacingKey.sm.value) {
-                    if priceAmount != nil { priceTag(size: ribbonPriceSize) }
-                    Spacer(minLength: 0)
-                    if ctaAction != nil {
-                        ctaControl
-                    }
-                }
-            }
-        }
-    }
-
-    /// The ribbon CTA: the caller's `.ctaLabel { }` content wrapped in the
-    /// same select action, or the stock `ThemeButton`.
-    @ViewBuilder
-    private var ctaControl: some View {
-        if let ctaLabelSlot {
-            Button { select() } label: {
-                ctaLabelSlot.contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityAddTraits(.isButton)
-        } else if let ctaTitle {
-            ThemeButton(ctaTitle) { select() }
-                .color(accent)
-                .size(sizeValue == .small ? .xsmall : .small)
-        }
-    }
-
-    private var routeLine: some View {
-        HStack(spacing: Theme.SpacingKey.xs.value) {
-            Text(from).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
-            // arrow.forward is direction-aware — it mirrors under RTL.
-            Icon(systemName: "arrow.forward")
-                .size(.xs)
-                .color(theme.text(.textTertiary))
-            Text(to).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
-        }
-    }
-
-    /// The coupon surface: rounded fill, two `destinationOut` semicircular
-    /// notches on the top/bottom edges at the tear x, and a vertical dashed
-    /// perforation between them (TicketStub's drawing approach, rotated 90°).
-    /// `.tearStyle(.plain)` skips the cut and the perforation entirely.
-    private func ribbonSurface(tearX: CGFloat?, size: CGSize) -> some View {
-        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
-        let notched = tearStyleValue == .notched
-        return ZStack {
-            shape
-                .fill(theme.background(surfaceKey))
-                .overlay { if notched, let tearX { notches(tearX: tearX, height: size.height) } }
-                .compositingGroup()                       // scope the destinationOut cut
-                .themeShadow(shadowStyleValue)
-            if notched, let tearX {
-                dashedLine(x: tearX, height: size.height)
-            }
-        }
-    }
-
-    /// Two circles centered on the top/bottom edges — half of each sits outside
-    /// the card, so `destinationOut` erases a clean semicircular notch.
-    private func notches(tearX: CGFloat, height: CGFloat) -> some View {
-        ZStack {
-            Circle().frame(width: notchRadius * 2, height: notchRadius * 2).position(x: tearX, y: 0)
-            Circle().frame(width: notchRadius * 2, height: notchRadius * 2).position(x: tearX, y: height)
-        }
-        .blendMode(.destinationOut)
-    }
-
-    private func dashedLine(x: CGFloat, height: CGFloat) -> some View {
-        Path { p in
-            p.move(to: CGPoint(x: x, y: notchRadius + dashInset))
-            p.addLine(to: CGPoint(x: x, y: height - notchRadius - dashInset))
-        }
-        .stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
-    }
-
-    // MARK: - Inline variant — flat ListRow anatomy
-
-    private var inline: some View {
-        // En dash between endpoints is direction-neutral; the full route is
-        // spelled out in the accessibility label.
-        ListRow("\(from) – \(to)", action: ctaAction == nil || isReadOnly ? nil : { select() })
-            .subtitle(metaLine)
-            .leading {
-                Group {
-                    if let logoSlot {
-                        logoSlot
-                    } else {
-                        Icon(systemName: modeGlyph)
-                            .size(sizeValue == .small ? .sm : .md)
-                            .accent(accent)
-                    }
-                }
-            }
-            .badge(badgeText)
-            .trailing {
-                HStack(spacing: Theme.SpacingKey.xs.value) {
-                    if priceAmount != nil { priceTag(size: .small) }
-                    if ctaAction != nil {
-                        // chevron.forward mirrors under RTL.
-                        Icon(systemName: "chevron.forward")
-                            .size(.xs)
-                            .color(theme.text(.textTertiary))
-                    }
-                }
-            }
-            .accessibilityElement(children: .contain)
-            .accessibilityLabel(accessibilityText)
-    }
-
-    // MARK: - Tile variant — compact vertical card for grids
-
-    private var tile: some View {
-        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
-        let face = VStack(spacing: Theme.SpacingKey.xs.value) {
-            Group {
-                if let logoSlot {
-                    logoSlot
-                } else {
-                    Icon(systemName: modeGlyph)
-                        .size(glyphIconSize)
-                        .accent(accent)
-                }
-            }
-            .padding(Theme.SpacingKey.sm.value)
-            .background(Circle().fill(accent.soft))
-            Text(modeLabel)
-                .textStyle(.labelSm600)
-                .foregroundStyle(theme.text(.textSecondary))
-            Text("\(from) – \(to)")   // en dash — direction-neutral under RTL
-                .textStyle(sizeValue == .small ? .labelSm600 : .labelBase600)
-                .foregroundStyle(theme.text(.textPrimary))
-                .multilineTextAlignment(.center)
-                .lineLimit(2)
-            if let badgeText {
-                Badge(badgeText).badgeStyle(badgeStyle).variant(badgeFillValue).size(.small)
-            }
-            if priceAmount != nil {
-                priceTag(size: sizeValue == .small ? .small : .medium)
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .padding(sectionPad)
-        .background(theme.background(surfaceKey), in: shape)
-        .themeShadow(shadowStyleValue)
-
-        return Group {
-            if ctaAction != nil {
-                Button { select() } label: {
-                    face.contentShape(shape)
-                }
-                .buttonStyle(.plain)
-                .allowsHitTesting(!isReadOnly)
-                .accessibilityAddTraits(.isButton)
-            } else {
-                face
-            }
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityText)
-    }
-
-    // MARK: - Shared pieces
-
-    @ViewBuilder
-    private func priceTag(size: PriceSize) -> some View {
-        // No explicit code → PriceTag's omitted-currency init resolves it via
-        // the §10 chain (formatDefaults > locale currency > "USD").
-        let base = priceCurrencyCode.map { PriceTag(priceAmount ?? 0, currencyCode: $0) }
-            ?? PriceTag(priceAmount ?? 0)
-        let captioned = priceCaption.map { base.prefix($0) } ?? base.from()
-        captioned.size(size).emphasis(.hero)
-    }
-
-    /// "duration · departures" — the middle-dot separator is direction-neutral.
-    private var metaLine: String? {
-        let parts = [durationText, departuresNote].compactMap(\.self)
-        return parts.isEmpty ? nil : parts.joined(separator: " · ")
-    }
-
-    private var badgeStyle: BadgeStyle {
-        switch accent {
-        case .info: return .info
-        case .success: return .success
-        case .warning: return .warning
-        case .error: return .error
-        case .turquoise: return .turquoise
-        case .orange: return .orange
-        case .purple: return .purple
-        case .pink: return .pink
-        default: return .neutral
-        }
-    }
-
-    private var accessibilityText: String {
-        var parts: [String] = [
-            String(themeKitTravel: "\(modeLabel) from \(from) to \(to)")
-        ]
-        if let durationText { parts.append(durationText) }
-        if let departuresNote { parts.append(departuresNote) }
-        if let badgeText { parts.append(badgeText) }
-        return parts.joined(separator: ", ")
-    }
-
-    private func select() {
-        guard !isReadOnly else { return }
-        ctaAction?()
+        // The active `TransportCrossSellCardStyle` owns the entire
+        // presentation — built-ins and custom styles go through the same
+        // gate. The default `.ribbon` reproduces the classic notched-coupon
+        // look verbatim. Motion is resolved *here* (ADR-0004 §4): styles
+        // never read the motion environment themselves.
+        let configuration = TransportCrossSellCardConfiguration(
+            modeGlyph: modeGlyph,
+            modeLabel: modeLabel,
+            from: from,
+            to: to,
+            priceAmount: priceAmount,
+            priceCurrencyCode: priceCurrencyCode,
+            priceCaption: priceCaption,
+            durationText: durationText,
+            departuresNote: departuresNote,
+            badgeText: badgeText,
+            badgeFillVariant: badgeFillValue,
+            logo: logoSlot,
+            ctaTitle: ctaTitle,
+            ctaLabel: ctaLabelSlot,
+            onSelect: ctaAction,
+            isReadOnly: isReadOnly,
+            size: sizeValue,
+            tearStyle: tearStyleValue,
+            accent: accent,
+            surfaceKey: surfaceKey,
+            shadowStyle: shadowStyleValue,
+            density: density,
+            locale: locale)
+        (explicitStyle ?? envStyle).makeBody(configuration: configuration)
+            .animation(motion, value: priceAmount)
+            .animation(motion, value: badgeText)
     }
 }
 
@@ -457,35 +216,50 @@ public extension TransportCrossSellCard {
     func departures(_ note: String?) -> Self { copy { $0.departuresNote = note } }
     /// A short accent-tinted flag, e.g. `"Cheapest"`.
     func badge(_ text: String?) -> Self { copy { $0.badgeText = text } }
-    /// The call to action. In `.ribbon` it renders a button; in `.inline` the
-    /// whole row becomes tappable (with a mirrored chevron). No-op when the
-    /// subtree is `.readOnly(true)`.
+    /// The call to action. `.ribbon` renders a button; `.inline`/`.tile`/
+    /// `.banner` make the whole surface tappable (with a mirrored trailing
+    /// indicator). No-op when the subtree is `.readOnly(true)`.
     func onSelect(
         _ title: String = String(themeKitTravel: "See options"),
         perform action: @escaping () -> Void
     ) -> Self {
         copy { $0.ctaTitle = title; $0.ctaAction = action }
     }
-    /// Layout archetype: `.ribbon` (default, notched strip), `.inline` (flat
-    /// row), or `.tile` (compact vertical card for grids).
-    func variant(_ v: TransportCrossSellVariant) -> Self { copy { $0.variantValue = v } }
+    /// Layout archetype — superseded by the style axis: prefer
+    /// `.transportCrossSellCardStyle(.ribbon/.inline/.tile)`, settable once
+    /// per list via the environment (and joined by the new `.banner`
+    /// full-bleed strip). This modifier keeps working and, when called,
+    /// wins over an ancestor's environment style.
+    @available(*, deprecated, message: "Use .transportCrossSellCardStyle(.ribbon/.inline/.tile) instead")
+    func variant(_ v: TransportCrossSellVariant) -> Self {
+        copy {
+            switch v {
+            case .ribbon: $0.explicitStyle = AnyTransportCrossSellCardStyle(RibbonTransportCrossSellCardStyle())
+            case .inline: $0.explicitStyle = AnyTransportCrossSellCardStyle(InlineTransportCrossSellCardStyle())
+            case .tile: $0.explicitStyle = AnyTransportCrossSellCardStyle(TileTransportCrossSellCardStyle())
+            }
+        }
+    }
     /// Size ramp: `.medium` (default) or `.small` — scales the mode glyph,
     /// the `PriceTag` and the paddings together.
     func size(_ s: TransportCrossSellSize) -> Self { copy { $0.sizeValue = s } }
     /// Ribbon tear-line chrome: `.notched` (default — the TicketStub cut +
-    /// dashed perforation) or `.plain` (an uncut rounded strip).
+    /// dashed perforation) or `.plain` (an uncut rounded strip). Ignored by
+    /// every preset except `.ribbon`.
     func tearStyle(_ t: TearStyle) -> Self { copy { $0.tearStyleValue = t } }
     /// Fill variant of the badge (`.soft` default, `.solid`, `.outline`,
     /// `.ghost`); its color keeps following the accent→style mapping.
     func badgeVariant(_ v: FillVariant) -> Self { copy { $0.badgeFillValue = v } }
-    /// Replaces the ribbon CTA button's label with caller content — the
-    /// select action, accent gating and read-only behavior are preserved.
-    /// `.inline` and `.tile` draw no CTA button, so they ignore this slot
-    /// (documented no-op).
+    /// Replaces a preset's built-in CTA button/indicator with caller
+    /// content — the select action, accent gating and read-only behavior
+    /// are preserved. `.inline` and `.tile` draw no CTA button, so they
+    /// ignore this slot (documented no-op); `.banner` renders it as the
+    /// trailing tap indicator (replacing the default chevron) since its
+    /// whole strip is the tap target.
     func ctaLabel<V: View>(@ViewBuilder _ content: () -> V) -> Self {
         copy { $0.ctaLabelSlot = AnyView(content()) }
     }
-    /// Shadow token under the ribbon/tile surface (default `.soft`).
+    /// Shadow token under a preset's drawn surface (default `.soft`).
     func shadow(_ style: ThemeKitCore.ShadowStyle) -> Self { copy { $0.shadowStyleValue = style } }
     /// Overrides the mode-tinted accent (bus `.warning`, train `.info`,
     /// ferry `.turquoise`, car `.neutral`); `nil` restores the default.
@@ -494,24 +268,16 @@ public extension TransportCrossSellCard {
     func logo<L: View>(@ViewBuilder _ content: () -> L) -> Self {
         copy { $0.logoSlot = AnyView(content()) }
     }
-    /// Surface token for the ribbon's coupon fill (default `.bgBase`); the
-    /// notch cut and dashed perforation are unaffected. `.inline` draws no
-    /// surface of its own, so the key applies to the `.ribbon` variant.
+    /// Surface token for `.ribbon`/`.tile`'s drawn fill (default `.bgBase`);
+    /// the ribbon's notch cut and dashed perforation are unaffected.
+    /// `.inline` draws no surface of its own, and `.banner` always uses the
+    /// mode's soft accent tint — both ignore this key.
     func surface(_ key: Theme.BackgroundColorKey) -> Self { copy { $0.surfaceKey = key } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
         mutate(&c)
         return c
-    }
-}
-
-/// Reports the vertical tear-line x up to the surface so the notches align to
-/// the boundary between the glyph section and the content, whatever their widths.
-private struct TearXAnchorKey: PreferenceKey {
-    static let defaultValue: Anchor<CGPoint>? = nil
-    static func reduce(value: inout Anchor<CGPoint>?, nextValue: () -> Anchor<CGPoint>?) {
-        value = value ?? nextValue()
     }
 }
 
@@ -555,13 +321,13 @@ private struct TearXAnchorKey: PreferenceKey {
             .price(34)
             .duration("4h 15m")
             .badge("Fastest")
-            .variant(.inline)
             .onSelect {}
+            .transportCrossSellCardStyle(.inline)
         TransportCrossSellCard(.bus, from: "Riverton", to: "Lakeside")
             .price(19)
             .duration("6h 30m")
-            .variant(.inline)
             .onSelect {}
+            .transportCrossSellCardStyle(.inline)
             .readOnly()
         TransportCrossSellCard(.bus, from: "Riverton", to: "Lakeside")
             .price(19)
@@ -571,25 +337,25 @@ private struct TearXAnchorKey: PreferenceKey {
     .padding()
 }
 
-#Preview("Tiles · custom mode · sizes · tear/badge/shadow/ctaLabel") {
+#Preview("Tiles · banner · custom mode · sizes · tear/badge/shadow/ctaLabel") {
     ScrollView {
         VStack(spacing: Theme.SpacingKey.md.value) {
             // Tile grid — including a custom mode beyond the 4-case enum.
             HStack(alignment: .top, spacing: Theme.SpacingKey.sm.value) {
                 TransportCrossSellCard(.train, from: "Riverton", to: "Lakeside")
-                    .variant(.tile)
                     .price(34)
                     .badge("Fastest")
                     .onSelect {}
+                    .transportCrossSellCardStyle(.tile)
                 TransportCrossSellCard(customMode: "figure.wave", label: "Shuttle",
                                        accent: .purple, from: "Airport", to: "Center")
-                    .variant(.tile)
                     .price(9)
                     .onSelect {}
+                    .transportCrossSellCardStyle(.tile)
                 TransportCrossSellCard(.ferry, from: "Harbor", to: "North Isle")
-                    .variant(.tile)
                     .size(.small)
                     .price(12)
+                    .transportCrossSellCardStyle(.tile)
             }
             // Plain tear + solid badge + elevated shadow + custom CTA label.
             TransportCrossSellCard(.bus, from: "Riverton", to: "Lakeside")
@@ -612,6 +378,12 @@ private struct TearXAnchorKey: PreferenceKey {
                 .price(28)
                 .duration("3h 40m")
                 .onSelect {}
+            // Full-bleed promo strip, mode-tinted.
+            TransportCrossSellCard(.ferry, from: "Harbor City", to: "North Isle")
+                .price(12)
+                .departures("3 sailings daily")
+                .onSelect("See sailings") {}
+                .transportCrossSellCardStyle(.banner)
         }
         .padding()
     }
@@ -627,17 +399,20 @@ private struct TearXAnchorKey: PreferenceKey {
             .onSelect {}
         TransportCrossSellCard(.train, from: "Riverton", to: "Lakeside")
             .price(34)
-            .variant(.inline)
             .onSelect {}
+            .transportCrossSellCardStyle(.inline)
     }
     .padding()
     .environment(\.layoutDirection, .rightToLeft)
 }
 
 #Preview("Dark") {
-    let dark = Theme()
-    dark.loadTheme(named: Theme.defaultThemeName, dark: true)
-    return VStack(spacing: Theme.SpacingKey.md.value) {
+    let dark: Theme = {
+        let t = Theme()
+        t.loadTheme(named: Theme.defaultThemeName, dark: true)
+        return t
+    }()
+    VStack(spacing: Theme.SpacingKey.md.value) {
         TransportCrossSellCard(.ferry, from: "Harbor City", to: "North Isle")
             .price(12)
             .departures("3 sailings daily")

--- a/Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCardStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCardStyle.swift
@@ -1,0 +1,691 @@
+//
+//  TransportCrossSellCardStyle.swift
+//  ThemeKit
+//
+//  The styling hook for ``TransportCrossSellCard`` (ADR-0004): the configuration
+//  hands styles the *typed cross-sell data* (mode glyph/label, route, price,
+//  meta, CTA…), not pre-laid content, so a style owns the entire arrangement.
+//  Four built-ins — the first three map 1:1 to the former
+//  ``TransportCrossSellVariant`` cases:
+//
+//    .ribbon   notched TicketStub-technique coupon strip — today's default.
+//    .inline   flat ListRow-anatomy row for embedding between flight results.
+//    .tile     compact vertical card for grids/carousels.
+//    .banner   full-bleed, mode-tinted promo strip (new).
+//
+//      TransportCrossSellCard(.bus, from: "Riverton", to: "Lakeside")
+//          .price(19).duration("6h 30m").onSelect { showBusOptions() }
+//          .transportCrossSellCardStyle(.tile)
+//
+//  TicketStub-chrome exception (ADR-0004 §4, same as ``TicketStub`` itself):
+//  `.ribbon`'s notched, perforated tear-line shell *is* that preset's
+//  identity, so `.ribbon` owns the chrome directly inside `makeBody` — it
+//  borrows TicketStub's `destinationOut`-notch + dashed-perforation drawing
+//  technique, rotated 90° to a *vertical* tear between the glyph and the
+//  content, and deliberately does not route through `CardStyle`. `.tile` and
+//  `.banner` also draw their own surface (a plain rounded card / an edge-to-
+//  edge tinted strip) rather than delegating to `CardStyle`, matching their
+//  pre-ADR behaviour. One law (ADR-0004 §6): the component style arranges
+//  *content*; token theme colors everything. The component resolves
+//  MicroMotion / Reduce Motion *before* calling a style — styles never read
+//  the motion environment themselves.
+//
+//  RTL: every preset composes from `HStack`/`VStack` (they mirror
+//  automatically); `.ribbon`'s tear x is measured after layout via an anchor
+//  preference (the TicketStub technique), so the notch cut and the dashed
+//  perforation land at the mirrored position by construction.
+//
+
+import SwiftUI
+import ThemeKit
+
+// MARK: - Configuration
+
+/// The typed inputs a ``TransportCrossSellCardStyle`` lays out. Fields a given
+/// style doesn't use are simply ignored — every built-in degrades gracefully
+/// when optional data is absent (no price → no price block, no CTA → no tap
+/// affordance, no badge → no chip).
+public struct TransportCrossSellCardConfiguration {
+    /// The resolved mode glyph (SF Symbol) — the stock `Mode.systemImage` or
+    /// the `customMode` override. Ignored by presets when ``logo`` is set.
+    public let modeGlyph: String
+    /// The resolved, localized mode label ("Bus", "Train"…), or the
+    /// `customMode` override.
+    public let modeLabel: String
+    /// Departure endpoint (city/airport display string).
+    public let from: String
+    /// Arrival endpoint.
+    public let to: String
+    /// Lead-in fare; `nil` hides every preset's price block.
+    public let priceAmount: Decimal?
+    /// Explicit ISO-4217 code, or `nil` to resolve through the §10
+    /// environment chain inside the shared price-tag helper.
+    public let priceCurrencyCode: String?
+    /// Overrides the default "from" lead-in text.
+    public let priceCaption: String?
+    /// Journey duration, e.g. "6h 30m".
+    public let durationText: String?
+    /// Frequency/terminal note, e.g. "Every 30 min from Central Station".
+    public let departuresNote: String?
+    /// A short accent-tinted flag, e.g. "Cheapest".
+    public let badgeText: String?
+    /// Fill variant of the badge (`.soft` default).
+    public let badgeFillVariant: FillVariant
+    /// Custom brand mark replacing the mode glyph; `nil` falls back to
+    /// ``modeGlyph``.
+    public let logo: AnyView?
+    /// The CTA button's title (localized, re-resolved every body pass).
+    /// `nil` exactly when ``onSelect`` is `nil`. Only `.ribbon` renders it as
+    /// visible text — row/tile/banner presets use the whole surface as the
+    /// tap target and show a trailing indicator instead.
+    public let ctaTitle: String?
+    /// Replaces a preset's built-in CTA affordance with caller content; the
+    /// select action, accent gating and read-only behaviour stay wired by
+    /// the style, not the slot.
+    public let ctaLabel: AnyView?
+    /// The select action; `nil` hides every preset's CTA affordance.
+    public let onSelect: (() -> Void)?
+    /// The read-only environment, captured by the component — presets gate
+    /// their tap targets on it through ``select()``.
+    public let isReadOnly: Bool
+    /// Size ramp — scales the mode glyph, the price tag and the paddings.
+    public let size: TransportCrossSellSize
+    /// Ribbon tear-line chrome (`.ribbon` only; other presets ignore it).
+    public let tearStyle: TearStyle
+    /// The resolved brand accent — the mode default, the `customMode`
+    /// override, or the explicit `.accent(_:)` override; never `nil`.
+    public let accent: SemanticColor
+    /// Explicit surface fill, or `nil` to let the style choose its own
+    /// default (resolve via ``surface(default:)``). `.banner` ignores this —
+    /// its fill is always the mode's soft accent tint.
+    public let surfaceKey: Theme.BackgroundColorKey?
+    /// Shadow token under a preset's drawn surface (default `.soft`).
+    public let shadowStyle: ThemeKitCore.ShadowStyle
+    /// The environment's component density, captured by the component —
+    /// scale chrome padding/gaps with ``spacing(_:)``.
+    public let density: ComponentDensity
+    /// The environment locale, captured by the component — the built-ins
+    /// render preformatted strings, but a custom style formatting its own
+    /// dates/numbers must use it so injected locales (and RTL demos) render
+    /// correctly.
+    public let locale: Locale
+
+    /// The explicit `surface(_:)` override, or the style's own default.
+    public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
+        surfaceKey ?? fallback
+    }
+
+    /// Density-scaled spacing — use for chrome padding/gaps so
+    /// `.componentDensity` compacts or airs out a preset.
+    public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
+
+    /// "duration · departures" — the middle-dot separator is direction-neutral.
+    public var metaLine: String? {
+        let parts = [durationText, departuresNote].compactMap(\.self)
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// ``accent`` mapped to its matching `BadgeStyle` (falls back to
+    /// `.neutral` for accents with no 1:1 badge hue).
+    public var badgeStyle: BadgeStyle {
+        switch accent {
+        case .info: return .info
+        case .success: return .success
+        case .warning: return .warning
+        case .error: return .error
+        case .turquoise: return .turquoise
+        case .orange: return .orange
+        case .purple: return .purple
+        case .pink: return .pink
+        default: return .neutral
+        }
+    }
+
+    /// The spoken summary — route, duration, departures, badge. Every preset
+    /// applies this as its container's accessibility label.
+    public var accessibilityText: String {
+        var parts: [String] = [
+            String(themeKitTravel: "\(modeLabel) from \(from) to \(to)")
+        ]
+        if let durationText { parts.append(durationText) }
+        if let departuresNote { parts.append(departuresNote) }
+        if let badgeText { parts.append(badgeText) }
+        return parts.joined(separator: ", ")
+    }
+
+    /// Fires ``onSelect``, no-oping under `.readOnly(true)` — every preset's
+    /// tap targets call this instead of ``onSelect`` directly.
+    public func select() {
+        guard !isReadOnly else { return }
+        onSelect?()
+    }
+}
+
+// MARK: - Protocol
+
+/// Defines a `TransportCrossSellCard`'s entire presentation. Implement
+/// `makeBody` to lay out the configuration's cross-sell data. Set one with
+/// `.transportCrossSellCardStyle(_:)`; the default is
+/// ``RibbonTransportCrossSellCardStyle``.
+public protocol TransportCrossSellCardStyle {
+    associatedtype Body: View
+    @ViewBuilder @MainActor func makeBody(configuration: TransportCrossSellCardConfiguration) -> Body
+}
+
+// MARK: - Shared building blocks (private to the built-ins)
+
+/// The mode glyph in a soft accent-tinted circle, with the mode label below —
+/// shared by `.ribbon` and `.tile` (today's identical glyph block).
+private struct TransportCrossSellGlyphBadge: View {
+    @Environment(\.theme) private var theme
+    let configuration: TransportCrossSellCardConfiguration
+    var iconSize: IconSize
+
+    var body: some View {
+        VStack(spacing: configuration.spacing(.xs)) {
+            Group {
+                if let logo = configuration.logo {
+                    logo
+                } else {
+                    Icon(systemName: configuration.modeGlyph)
+                        .size(iconSize)
+                        .accent(configuration.accent)
+                }
+            }
+            .padding(configuration.spacing(.sm))
+            .background(Circle().fill(configuration.accent.soft))
+            Text(configuration.modeLabel)
+                .textStyle(.labelSm600)
+                .foregroundStyle(theme.text(.textSecondary))
+        }
+    }
+}
+
+/// The "from → to" route line with a direction-aware arrow — shared by
+/// `.ribbon` and `.banner`.
+private struct TransportCrossSellRouteLine: View {
+    @Environment(\.theme) private var theme
+    let configuration: TransportCrossSellCardConfiguration
+
+    var body: some View {
+        HStack(spacing: Theme.SpacingKey.xs.value) {
+            Text(configuration.from).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+            // arrow.forward is direction-aware — it mirrors under RTL.
+            Icon(systemName: "arrow.forward")
+                .size(.xs)
+                .color(theme.text(.textTertiary))
+            Text(configuration.to).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
+        }
+    }
+}
+
+/// The lead-in price tag — currency, prefix, size — shared by every preset.
+/// No explicit code → `PriceTag`'s omitted-currency init resolves it via the
+/// §10 chain (`formatDefaults` → `locale.currency` → `"USD"`).
+private struct TransportCrossSellPriceTag: View {
+    let configuration: TransportCrossSellCardConfiguration
+    let size: PriceSize
+
+    var body: some View {
+        let base = configuration.priceCurrencyCode.map { PriceTag(configuration.priceAmount ?? 0, currencyCode: $0) }
+            ?? PriceTag(configuration.priceAmount ?? 0)
+        let captioned = configuration.priceCaption.map { base.prefix($0) } ?? base.from()
+        captioned.size(size).emphasis(.hero)
+    }
+}
+
+// MARK: - .ribbon
+
+/// Reports the vertical tear-line x up to the surface so the notches align to
+/// the boundary between the glyph section and the content, whatever their widths.
+private struct TransportCrossSellTearXAnchorKey: PreferenceKey {
+    static let defaultValue: Anchor<CGPoint>? = nil
+    static func reduce(value: inout Anchor<CGPoint>?, nextValue: () -> Anchor<CGPoint>?) {
+        value = value ?? nextValue()
+    }
+}
+
+/// Today's ``TransportCrossSellCard`` look, extracted verbatim: a notched
+/// coupon strip — mode glyph leading, route/badge/meta/price/CTA content
+/// trailing, split by a vertical tear line (the ``TicketStub`` notch +
+/// perforation technique, rotated 90°, drawn locally). Owns the tear chrome
+/// (fill, notch cut, perforation, shadow are one unit), so `.cardStyle(_:)`
+/// is a no-op on this preset — the default.
+public struct RibbonTransportCrossSellCardStyle: TransportCrossSellCardStyle {
+    public init() {}
+    public func makeBody(configuration: TransportCrossSellCardConfiguration) -> some View {
+        RibbonTransportCrossSellChrome(configuration: configuration)
+    }
+}
+
+private struct RibbonTransportCrossSellChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: TransportCrossSellCardConfiguration
+
+    /// Bespoke coupon geometry (TicketStub-class chrome) — fixed constants,
+    /// not knobs: the notch cut radius and the dash inset past the notch.
+    private let notchRadius: CGFloat = 8
+    private let dashInset: CGFloat = 6
+
+    private var sectionPad: CGFloat {
+        configuration.size == .small ? configuration.spacing(.sm) : configuration.spacing(.md)
+    }
+    private var priceSize: PriceSize { configuration.size == .small ? .small : .medium }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            TransportCrossSellGlyphBadge(configuration: configuration,
+                                          iconSize: configuration.size == .small ? .md : .lg)
+                .padding(sectionPad)
+                .accessibilityHidden(true)   // announced by the container label
+            // A zero-width marker whose center is the tear line, reported up so
+            // the background carves its notches at exactly this x (mirrors under
+            // RTL by construction — the anchor resolves after layout).
+            Color.clear.frame(width: 0)
+                .anchorPreference(key: TransportCrossSellTearXAnchorKey.self, value: .center) { $0 }
+            contentSection
+                .padding(sectionPad)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .backgroundPreferenceValue(TransportCrossSellTearXAnchorKey.self) { anchor in
+            GeometryReader { proxy in
+                ribbonSurface(tearX: anchor.map { proxy[$0].x }, size: proxy.size)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(configuration.accessibilityText)
+    }
+
+    private var contentSection: some View {
+        VStack(alignment: .leading, spacing: configuration.spacing(.xs)) {
+            HStack(spacing: configuration.spacing(.xs)) {
+                TransportCrossSellRouteLine(configuration: configuration)
+                if let badgeText = configuration.badgeText {
+                    Badge(badgeText).badgeStyle(configuration.badgeStyle)
+                        .variant(configuration.badgeFillVariant).size(.small)
+                }
+            }
+            if let metaLine = configuration.metaLine {
+                Text(metaLine)
+                    .textStyle(.bodySm400)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+            if configuration.priceAmount != nil || configuration.onSelect != nil {
+                HStack(spacing: configuration.spacing(.sm)) {
+                    if configuration.priceAmount != nil {
+                        TransportCrossSellPriceTag(configuration: configuration, size: priceSize)
+                    }
+                    Spacer(minLength: 0)
+                    if configuration.onSelect != nil { ctaControl }
+                }
+            }
+        }
+    }
+
+    /// The ribbon CTA: the caller's `.ctaLabel { }` content wrapped in the
+    /// same select action, or the stock `ThemeButton`.
+    @ViewBuilder
+    private var ctaControl: some View {
+        if let ctaLabel = configuration.ctaLabel {
+            Button { configuration.select() } label: {
+                ctaLabel.contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityAddTraits(.isButton)
+        } else if let ctaTitle = configuration.ctaTitle {
+            ThemeButton(ctaTitle) { configuration.select() }
+                .color(configuration.accent)
+                .size(configuration.size == .small ? .xsmall : .small)
+        }
+    }
+
+    /// The coupon surface: rounded fill, two `destinationOut` semicircular
+    /// notches on the top/bottom edges at the tear x, and a vertical dashed
+    /// perforation between them (TicketStub's drawing approach, rotated 90°).
+    /// `.tearStyle(.plain)` skips the cut and the perforation entirely.
+    private func ribbonSurface(tearX: CGFloat?, size: CGSize) -> some View {
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+        let notched = configuration.tearStyle == .notched
+        return ZStack {
+            shape
+                .fill(theme.background(configuration.surface(default: .bgBase)))
+                .overlay { if notched, let tearX { notches(tearX: tearX, height: size.height) } }
+                .compositingGroup()                       // scope the destinationOut cut
+                .themeShadow(configuration.shadowStyle)
+            if notched, let tearX {
+                dashedLine(x: tearX, height: size.height)
+            }
+        }
+    }
+
+    /// Two circles centered on the top/bottom edges — half of each sits outside
+    /// the card, so `destinationOut` erases a clean semicircular notch.
+    private func notches(tearX: CGFloat, height: CGFloat) -> some View {
+        ZStack {
+            Circle().frame(width: notchRadius * 2, height: notchRadius * 2).position(x: tearX, y: 0)
+            Circle().frame(width: notchRadius * 2, height: notchRadius * 2).position(x: tearX, y: height)
+        }
+        .blendMode(.destinationOut)
+    }
+
+    private func dashedLine(x: CGFloat, height: CGFloat) -> some View {
+        Path { p in
+            p.move(to: CGPoint(x: x, y: notchRadius + dashInset))
+            p.addLine(to: CGPoint(x: x, y: height - notchRadius - dashInset))
+        }
+        .stroke(theme.border(.borderPrimary), style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
+    }
+}
+
+// MARK: - .inline
+
+/// A flat `ListRow`-anatomy row for embedding between flight results —
+/// today's `.inline` look, extracted verbatim.
+public struct InlineTransportCrossSellCardStyle: TransportCrossSellCardStyle {
+    public init() {}
+    public func makeBody(configuration: TransportCrossSellCardConfiguration) -> some View {
+        InlineTransportCrossSellChrome(configuration: configuration)
+    }
+}
+
+private struct InlineTransportCrossSellChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: TransportCrossSellCardConfiguration
+
+    var body: some View {
+        // En dash between endpoints is direction-neutral; the full route is
+        // spelled out in the accessibility label.
+        ListRow(
+            "\(configuration.from) – \(configuration.to)",
+            action: configuration.onSelect == nil || configuration.isReadOnly ? nil : { configuration.select() }
+        )
+        .subtitle(configuration.metaLine)
+        .leading {
+            Group {
+                if let logo = configuration.logo {
+                    logo
+                } else {
+                    Icon(systemName: configuration.modeGlyph)
+                        .size(configuration.size == .small ? .sm : .md)
+                        .accent(configuration.accent)
+                }
+            }
+        }
+        .badge(configuration.badgeText)
+        .trailing {
+            HStack(spacing: configuration.spacing(.xs)) {
+                if configuration.priceAmount != nil {
+                    TransportCrossSellPriceTag(configuration: configuration, size: .small)
+                }
+                if configuration.onSelect != nil {
+                    // chevron.forward mirrors under RTL.
+                    Icon(systemName: "chevron.forward")
+                        .size(.xs)
+                        .color(theme.text(.textTertiary))
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(configuration.accessibilityText)
+    }
+}
+
+// MARK: - .tile
+
+/// A compact vertical card for grids/carousels — today's `.tile` look,
+/// extracted verbatim.
+public struct TileTransportCrossSellCardStyle: TransportCrossSellCardStyle {
+    public init() {}
+    public func makeBody(configuration: TransportCrossSellCardConfiguration) -> some View {
+        TileTransportCrossSellChrome(configuration: configuration)
+    }
+}
+
+private struct TileTransportCrossSellChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: TransportCrossSellCardConfiguration
+
+    private var sectionPad: CGFloat {
+        configuration.size == .small ? configuration.spacing(.sm) : configuration.spacing(.md)
+    }
+
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous)
+        Group {
+            if configuration.onSelect != nil {
+                Button { configuration.select() } label: {
+                    face(shape).contentShape(shape)
+                }
+                .buttonStyle(.plain)
+                .allowsHitTesting(!configuration.isReadOnly)
+                .accessibilityAddTraits(.isButton)
+            } else {
+                face(shape)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(configuration.accessibilityText)
+    }
+
+    private func face(_ shape: RoundedRectangle) -> some View {
+        VStack(spacing: configuration.spacing(.xs)) {
+            TransportCrossSellGlyphBadge(configuration: configuration,
+                                          iconSize: configuration.size == .small ? .md : .lg)
+            Text("\(configuration.from) – \(configuration.to)")   // en dash — direction-neutral under RTL
+                .textStyle(configuration.size == .small ? .labelSm600 : .labelBase600)
+                .foregroundStyle(theme.text(.textPrimary))
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+            if let badgeText = configuration.badgeText {
+                Badge(badgeText).badgeStyle(configuration.badgeStyle)
+                    .variant(configuration.badgeFillVariant).size(.small)
+            }
+            if configuration.priceAmount != nil {
+                TransportCrossSellPriceTag(configuration: configuration,
+                                            size: configuration.size == .small ? .small : .medium)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(sectionPad)
+        .background(theme.background(configuration.surface(default: .bgBase)), in: shape)
+        .themeShadow(configuration.shadowStyle)
+    }
+}
+
+// MARK: - .banner
+
+/// A full-bleed, mode-tinted promo strip: glyph, route + badge, meta line,
+/// trailing price + tap indicator — on the mode's soft accent fill, edge-to-
+/// edge (no card shell, no border). For a cross-sell slotted flush between
+/// search results or atop a results list. The whole strip is the tap target
+/// when `onSelect` is set (like `.tile`), so ``ctaLabel`` renders as the
+/// trailing indicator and ``ctaTitle`` is a documented no-op here.
+public struct BannerTransportCrossSellCardStyle: TransportCrossSellCardStyle {
+    public init() {}
+    public func makeBody(configuration: TransportCrossSellCardConfiguration) -> some View {
+        BannerTransportCrossSellChrome(configuration: configuration)
+    }
+}
+
+private struct BannerTransportCrossSellChrome: View {
+    @Environment(\.theme) private var theme
+    let configuration: TransportCrossSellCardConfiguration
+
+    var body: some View {
+        Group {
+            if configuration.onSelect != nil {
+                Button { configuration.select() } label: { content }
+                    .buttonStyle(.plain)
+                    .allowsHitTesting(!configuration.isReadOnly)
+                    .accessibilityAddTraits(.isButton)
+            } else {
+                content
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(configuration.accessibilityText)
+    }
+
+    private var content: some View {
+        HStack(spacing: configuration.spacing(.sm)) {
+            Group {
+                if let logo = configuration.logo {
+                    logo
+                } else {
+                    Icon(systemName: configuration.modeGlyph)
+                        .size(configuration.size == .small ? .md : .lg)
+                        .accent(configuration.accent)
+                }
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: configuration.spacing(.xs)) {
+                    TransportCrossSellRouteLine(configuration: configuration)
+                    if let badgeText = configuration.badgeText {
+                        Badge(badgeText).badgeStyle(configuration.badgeStyle)
+                            .variant(configuration.badgeFillVariant).size(.small)
+                    }
+                }
+                if let metaLine = configuration.metaLine {
+                    Text(metaLine)
+                        .textStyle(.bodySm400)
+                        .foregroundStyle(theme.text(.textSecondary))
+                }
+            }
+            Spacer(minLength: configuration.spacing(.sm))
+            trailingBlock
+        }
+        .padding(configuration.spacing(.md))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(configuration.accent.soft)
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private var trailingBlock: some View {
+        HStack(spacing: configuration.spacing(.sm)) {
+            if configuration.priceAmount != nil {
+                TransportCrossSellPriceTag(configuration: configuration,
+                                            size: configuration.size == .small ? .small : .medium)
+            }
+            if let ctaLabel = configuration.ctaLabel {
+                ctaLabel
+            } else if configuration.onSelect != nil {
+                Icon(systemName: "chevron.forward").size(.xs).color(configuration.accent.base)
+            }
+        }
+    }
+}
+
+// MARK: - Static accessors
+
+public extension TransportCrossSellCardStyle where Self == RibbonTransportCrossSellCardStyle {
+    /// Notched TicketStub-technique coupon strip. The default.
+    static var ribbon: RibbonTransportCrossSellCardStyle { RibbonTransportCrossSellCardStyle() }
+}
+public extension TransportCrossSellCardStyle where Self == InlineTransportCrossSellCardStyle {
+    /// Flat `ListRow`-anatomy row for embedding between flight results.
+    static var inline: InlineTransportCrossSellCardStyle { InlineTransportCrossSellCardStyle() }
+}
+public extension TransportCrossSellCardStyle where Self == TileTransportCrossSellCardStyle {
+    /// Compact vertical card for grids/carousels.
+    static var tile: TileTransportCrossSellCardStyle { TileTransportCrossSellCardStyle() }
+}
+public extension TransportCrossSellCardStyle where Self == BannerTransportCrossSellCardStyle {
+    /// Full-bleed, mode-tinted promo strip.
+    static var banner: BannerTransportCrossSellCardStyle { BannerTransportCrossSellCardStyle() }
+}
+
+// MARK: - Type erasure + environment plumbing
+
+struct AnyTransportCrossSellCardStyle: TransportCrossSellCardStyle {
+    private let _makeBody: @MainActor (TransportCrossSellCardConfiguration) -> AnyView
+    init<S: TransportCrossSellCardStyle>(_ style: sending S) {
+        _makeBody = { AnyView(style.makeBody(configuration: $0)) }
+    }
+    func makeBody(configuration: TransportCrossSellCardConfiguration) -> AnyView { _makeBody(configuration) }
+}
+
+private struct TransportCrossSellCardStyleKey: EnvironmentKey {
+    static let defaultValue = AnyTransportCrossSellCardStyle(RibbonTransportCrossSellCardStyle())
+}
+
+extension EnvironmentValues {
+    var transportCrossSellCardStyle: AnyTransportCrossSellCardStyle {
+        get { self[TransportCrossSellCardStyleKey.self] }
+        set { self[TransportCrossSellCardStyleKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set the ``TransportCrossSellCardStyle`` for `TransportCrossSellCard`s
+    /// in this view and its descendants — a results list sets it once.
+    func transportCrossSellCardStyle<S: TransportCrossSellCardStyle>(_ style: sending S) -> some View {
+        environment(\.transportCrossSellCardStyle, AnyTransportCrossSellCardStyle(style))
+    }
+}
+
+// MARK: - Previews
+
+/// A custom style built purely on the public API — what an app target would
+/// write: a leading accent rail + route + price, no card shell at all.
+private struct AccentRailTransportCrossSellCardStyle: TransportCrossSellCardStyle {
+    func makeBody(configuration: TransportCrossSellCardConfiguration) -> some View {
+        AccentRailChrome(configuration: configuration)
+    }
+
+    private struct AccentRailChrome: View {
+        @Environment(\.theme) private var theme
+        let configuration: TransportCrossSellCardConfiguration
+
+        var body: some View {
+            HStack(spacing: configuration.spacing(.sm)) {
+                RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value)
+                    .fill(configuration.accent.base)
+                    .frame(width: 4)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(configuration.modeLabel)
+                        .textStyle(.labelSm600).foregroundStyle(theme.text(.textSecondary))
+                    Text("\(configuration.from) – \(configuration.to)")
+                        .textStyle(.labelMd700).foregroundStyle(theme.text(.textPrimary))
+                }
+                Spacer()
+                if configuration.priceAmount != nil {
+                    TransportCrossSellPriceTag(configuration: configuration, size: .medium)
+                }
+            }
+            .padding(configuration.spacing(.sm))
+            .background(
+                theme.background(.bgSecondaryLight),
+                in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
+        }
+    }
+}
+
+#Preview("TransportCrossSellCardStyle — presets × light/dark") {
+    let ribbonCard = TransportCrossSellCard(.bus, from: "Riverton", to: "Lakeside")
+        .price(19)
+        .duration("6h 30m")
+        .departures("Every 30 min from Central Station")
+        .badge("Cheapest")
+        .onSelect {}
+    let plainCard = TransportCrossSellCard(.train, from: "Riverton", to: "Lakeside")
+        .price(34, currencyCode: "EUR")
+        .duration("4h 15m")
+        .onSelect("View timetable") {}
+    PreviewMatrix("TransportCrossSellCardStyle") {
+        PreviewCase("Ribbon (default)") { ribbonCard }
+        PreviewCase("Inline") { plainCard.transportCrossSellCardStyle(.inline) }
+        PreviewCase("Tile") {
+            plainCard.transportCrossSellCardStyle(.tile).frame(width: 220)
+        }
+        PreviewCase("Banner") {
+            TransportCrossSellCard(.ferry, from: "Harbor City", to: "North Isle")
+                .price(12).departures("3 sailings daily")
+                .onSelect("See sailings") {}
+                .transportCrossSellCardStyle(.banner)
+        }
+        PreviewCase("Custom (in-preview)") {
+            plainCard.transportCrossSellCardStyle(AccentRailTransportCrossSellCardStyle())
+        }
+    }
+}

--- a/Sources/ThemeKitTravel/Resources/Localizable.xcstrings
+++ b/Sources/ThemeKitTravel/Resources/Localizable.xcstrings
@@ -29,6 +29,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "%@ seats selected": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "%@ to %@": {
       "extractionState": "manual",
       "generatesSymbol": false
@@ -50,6 +54,10 @@
       "generatesSymbol": false
     },
     "1 infant": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "1 seat selected": {
       "extractionState": "manual",
       "generatesSymbol": false
     },

--- a/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
+++ b/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
@@ -43,7 +43,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) from \(d) to \(d)",
             "%@ from %@ to %@", 3,
-            site: "Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCard.swift:427")
+            site: "Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCardStyle.swift:148")
         assertKey(
             "\(d) infants",
             "%@ infants", 1,
@@ -91,11 +91,15 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) seats",
             "%@ seats", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:526")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:554")
         assertKey(
             "\(d) seats left",
             "%@ seats left", 1,
             site: "Sources/ThemeKitTravel/Components/Organisms/FlightCardStyle.swift:179")
+        assertKey(
+            "\(d) seats selected",
+            "%@ seats selected", 1,
+            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMapStyle.swift:299")
         assertKey(
             "\(d) selected",
             "%@ selected", 1,
@@ -120,13 +124,13 @@ final class L10nKeyInvariantTests: XCTestCase {
             "\(d)% off",
             "%@%% off", 1,
             site: "Sources/ThemeKit/Components/Atoms/PriceTag.swift:188")
+    }
+
+    func testInterpolatedKeyShapes2() {
         assertKey(
             "\(d)% saturation, \(d)% brightness",
             "%@%% saturation, %@%% brightness", 2,
             site: "Sources/ThemeKit/Components/Molecules/ColorArea.swift:126")
-    }
-
-    func testInterpolatedKeyShapes2() {
         assertKey(
             "\(d)% to \(d)",
             "%@%% to %@", 2,
@@ -166,7 +170,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Available, \(d)",
             "Available, %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Atoms/SeatCell.swift:254")
+            site: "Sources/ThemeKitTravel/Components/Atoms/SeatCellStyle.swift:132")
         assertKey(
             "Bar chart with series \(d).",
             "Bar chart with series %@.", 1,
@@ -190,7 +194,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Deck \(d)",
             "Deck %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:117")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:136")
         assertKey(
             "Decrease \(d)",
             "Decrease %@", 1,
@@ -223,13 +227,13 @@ final class L10nKeyInvariantTests: XCTestCase {
             "Move to \(d)",
             "Move to %@", 1,
             site: "Sources/ThemeKit/Components/Molecules/Transfer.swift:65")
+    }
+
+    func testInterpolatedKeyShapes3() {
         assertKey(
             "Page \(d)",
             "Page %@", 1,
             site: "Sources/ThemeKit/Components/Molecules/Pagination.swift:131")
-    }
-
-    func testInterpolatedKeyShapes3() {
         assertKey(
             "Page \(d) of \(d)",
             "Page %@ of %@", 2,
@@ -237,7 +241,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Passenger \(d), seat \(d)",
             "Passenger %@, seat %@", 2,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:459")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:487")
         assertKey(
             "Payment method, \(d) options",
             "Payment method, %@ options", 1,
@@ -273,7 +277,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Seat \(d)",
             "Seat %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Atoms/SeatCell.swift:245")
+            site: "Sources/ThemeKitTravel/Components/Atoms/SeatCellStyle.swift:122")
         assertKey(
             "Show \(d) more",
             "Show %@ more", 1,

--- a/docs/templates/ThemeKit.xcstrings
+++ b/docs/templates/ThemeKit.xcstrings
@@ -80,6 +80,10 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
+    "%@ seats selected": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
     "%@ selected": {
       "comment": "MultiSelect accessibility value: number of selected options.",
       "extractionState": "manual",
@@ -173,6 +177,10 @@
       "generatesSymbol": false
     },
     "1 seat left": {
+      "extractionState": "manual",
+      "generatesSymbol": false
+    },
+    "1 seat selected": {
       "extractionState": "manual",
       "generatesSymbol": false
     },


### PR DESCRIPTION
**The final wave — completes ADR-0004.** Five Seats-&-filters components each gain their own full Style protocol; with this merge **every one of the 28 ThemeKitTravel components owns a per-component Style protocol**. Default presets reproduce today's render pixel-for-pixel; additive.

| Component | Protocol → modifier | Presets | Class |
|---|---|---|---|
| SeatMap | `.seatMapStyle(_:)` | `.cabin` · `.grid` · `.schematic` | B |
| SeatCell | `.seatCellStyle(_:)` | `.rounded` · `.circle` · `.seatback` | Atom |
| SeatLegend | `.seatLegendStyle(_:)` | `.rows(perRow:)` · `.vertical` · `.inline` | Molecule |
| FilterBar | `.filterBarStyle(_:)` | `.chips` · `.segmented` · `.stacked` | A |
| TransportCrossSellCard | `.transportCrossSellCardStyle(_:)` | `.ribbon` · `.inline` · `.tile` · `.banner` | A |

**16 presets** across 5 protocols.

## Notes
- **SeatMap (Class B):** hands styles the pre-wired cabin-grid / rail / deck-selector / legend / summary units; selection/zoom/deck wiring stays in the component.
- **SeatCell (atom):** promotes `SeatShape` to presets; selected/occupied colors stay **palette-driven** (no free accent). The `shape:` init param deprecate-forwards (documented — Swift has no per-parameter `@available`).
- **SeatLegend:** parameterized preset `.rows(perRow:)`.
- **TransportCrossSellCard:** `.ribbon` owns the notch/tear technique per-preset (TicketStub exemption dissolved).
- **l10n** catalogs regenerated (drift gate green, 616 keys).

## ADR-0004 — DONE
| Wave | Cluster | PR |
|---|---|---|
| 1 | Flight results | #286 |
| 2 | Search | #288 |
| 3 | Booking & payment | #289 |
| 4 | Passenger & day-of-travel | #291 |
| 5 | **Seats & filters (this)** | — |

**28/28 components · ~109 presets** suite-wide, all default-preset pixel-parity, fully additive; every existing variant/layout/knob enum deprecate-forwards (removed at the next major).

## Verification
`swift build` **0 errors** · **312 tests pass** (incl. l10n gate) · **Demo BUILD SUCCEEDED** (iOS Simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)