### PR TITLE
chore(review): P0-2 confirmed + P1-1 blocking CI gates + ADR-0004 status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,11 +151,13 @@ jobs:
       - name: Check modifier signatures against the variant-matrix contract
         run: |
           scripts/check-variant-naming.sh \
-            || echo "::warning::Variant-matrix naming drift — a color/variant/size axis takes a raw Color/CGFloat. Token-feed it, deprecate-and-forward, or allowlist a documented genuine dimension (scripts/check-variant-naming.sh, ADR-3)."
+            || { echo "::error::Variant-matrix naming drift — a color/variant/size axis takes a raw Color/CGFloat. Token-feed it, deprecate-and-forward, or allowlist a documented genuine dimension (scripts/check-variant-naming.sh, ADR-3)."; exit 1; }
 
   # ---------------------------------------------------------------------------
   # Public-API breakage detection. PR-only (diffs against the PR base) and
-  # informational — a public-API change is often intended. See docs/API-STABILITY.md.
+  # BLOCKING (ADR-review P1-1) — a source-breaking change must be intentional and
+  # recorded in .api-breakage-allowlist.txt. Additions are non-breaking and pass.
+  # See docs/API-STABILITY.md and docs/2.0-removal-epoch.md.
   # ---------------------------------------------------------------------------
   api-breakage:
     name: API breakage check
@@ -172,7 +174,7 @@ jobs:
         run: |
           BASELINE="${{ github.event.pull_request.base.sha || 'origin/main' }}"
           scripts/check-api.sh "$BASELINE" \
-            || echo "::warning::Public API changed vs base — confirm the SemVer bump (see docs/API-STABILITY.md)."
+            || { echo "::error::Un-allowlisted source-breaking public-API change vs base. Confirm the SemVer bump and record it in .api-breakage-allowlist.txt (see docs/API-STABILITY.md, docs/2.0-removal-epoch.md)."; exit 1; }
 
   # ---------------------------------------------------------------------------
   # Brand-neutrality & i18n gate — the catalog is brand-neutral and English-only.

--- a/docs/2.0-removal-epoch.md
+++ b/docs/2.0-removal-epoch.md
@@ -1,0 +1,44 @@
+# The 2.0 removal epoch
+
+ThemeKit's public API grows additively within `1.x` and is guarded by two now-**blocking**
+CI gates (ADR-review P1-1):
+
+- **`api-breakage`** — `swift package diagnose-api-breaking-changes` vs. the PR base.
+  A source-breaking change fails CI unless it is deliberately recorded in
+  [`.api-breakage-allowlist.txt`](../.api-breakage-allowlist.txt). Additions are
+  non-breaking and always pass.
+- **`variant-naming`** — a color/variant/size axis must be token-fed, never a raw
+  `Color`/`CGFloat`, unless allowlisted in
+  [`scripts/variant-naming-allowlist.txt`](../scripts/variant-naming-allowlist.txt).
+
+Two debts accumulate under that additive discipline and are **paid down only at a major
+bump**, so consumers get a single, predictable break window:
+
+| Debt | Where | Cleared at |
+|---|---|---|
+| Allowlisted API breaks | `.api-breakage-allowlist.txt` (~133 entries) | 2.0 |
+| `@available(*, deprecated …)` forwards | ~132 symbols across `Sources/**` | 2.0 |
+
+## The rule (1.x)
+
+1. **Prefer additive.** New behavior ships as a new symbol / modifier / overload. No
+   removals, no signature changes, in a minor.
+2. **When a break is unavoidable**, deprecate-and-forward: keep the old symbol as
+   `@available(*, deprecated, message: "Use …")` delegating to the new one, and — if the
+   API-breakage gate flags it — record it in `.api-breakage-allowlist.txt` with a one-line
+   reason. The old spelling keeps compiling for every `1.x` consumer.
+3. **Never delete a deprecated symbol in a minor.** Deletions are the 2.0 epoch's job.
+
+## The epoch (2.0)
+
+When a `2.0` is cut:
+
+1. Delete every `@available(*, deprecated …)` forward (`grep -rl 'deprecated' Sources/`).
+2. Empty `.api-breakage-allowlist.txt` (the breaks it recorded are now the baseline).
+3. Re-baseline the `api-breakage` gate against the last `1.x` tag.
+4. Note the removals in the changelog under **Breaking changes**, grouped by area.
+
+This keeps `1.x` a safe, additive-only line and concentrates every break into one
+well-advertised release, instead of trickling source-breaking changes through minors.
+
+See also [API-STABILITY.md](API-STABILITY.md).

--- a/docs/ADR-0003-localization-override.md
+++ b/docs/ADR-0003-localization-override.md
@@ -37,7 +37,7 @@ A compiled Foundation spike (hand-built bundle with `en`/`tr`/`ru` `.lproj`s car
 | 5 | BCP-47 → `.lproj` matching ("tr-TR" → `tr`, unknown → source language)? | **Works** via `Bundle.preferredLocalizations(from: bundle.localizations, forPreferences: [code])` — returned `["tr"]` for `tr-TR`, `["en"]` for an unknown code. | Use it; never string-munge language codes. |
 | 6 | Detecting a missing key in the consumer catalog? | **Works** via the `value:` sentinel — `localizedString(forKey:value:"\u{7F}")` returns the sentinel on a miss (with `value: nil` it echoes the key, indistinguishable from a real value). | Sentinel probe gates the fallback to `.module`. |
 
-**Remaining assumption (low risk, verify once on device):** Xcode compiles a consumer's `.xcstrings` into `.strings`/`.stringsdict` files inside `.lproj` directories (Apple-documented build behavior); the spike exercised that compiled form directly, not an Xcode-built app bundle. If a future toolchain moves app catalogs to single-file `.loctable`, the sub-bundle path needs re-verification — `sr-ios-dev` confirms once with a real device/simulator build in the test plan below.
+**Remaining assumption (low risk, verify once on device):** Xcode compiles a consumer's `.xcstrings` into `.strings`/`.stringsdict` files inside `.lproj` directories (Apple-documented build behavior); the spike exercised that compiled form directly, not an Xcode-built app bundle. If a future toolchain moves app catalogs to single-file `.loctable`, the sub-bundle path needs re-verification. **Confirmed 2026-07-13 on a real `xcodebuild` Demo app** (`{en,tr,ar}.lproj/ThemeKit.strings`, live in-app switch) — see §Open questions.
 
 ## Decision
 
@@ -279,6 +279,6 @@ LanguageSwitcher([.init(code: "en"), .init(code: "tr")],
 
 - **D2 overload set:** enumerate the interpolated types across the 71 sites (String, Int, Double, formatted Decimals-as-String, …) and compile-verify; decide whether a `CustomStringConvertible` catch-all (→ `%@`) is safe or too permissive vs. `String.LocalizationValue`'s specifier behavior.
 - **`[CVarArg]` sendability** under Swift 6 language mode for the transient capture type (`@unchecked Sendable` vs. structuring resolution to stay isolation-local).
-- **`.xcstrings` compiled form on device** (spike's stated assumption) — confirm `path(forResource:ofType:"lproj")` finds compiled catalogs in a real Xcode-built app, including per-app-language installs.
+- ~~**`.xcstrings` compiled form on device**~~ — **CONFIRMED (2026-07-13).** A real `xcodebuild` build of the Demo app compiled its `ThemeKit.xcstrings` into `Demo.app/{en,tr,ar}.lproj/ThemeKit.strings`; the sub-bundle path resolved Turkish under a `-AppleLanguages (tr)` install, and a live in-app switch (a `LanguageSwitcher` tap while the device language stayed English) flipped both a View string (`"Promo code:"`→`"Promosyon kodu:"`) and non-View enum strings (`ColorChannel` titles). Zero-config `Bundle.main` path verified end-to-end.
 - Whether `ThemeKitTravel`'s (currently empty) catalog merges into the single consumer template or ships as a second `ThemeKitTravel.xcstrings` table — recommendation: **one merged template**, since the consumer experience is one file.
 - Whether `.themeKitLocalized()` should also refresh `\.calendar`/`\.timeZone`-adjacent formatting environment, or leave those to the consumer.

--- a/docs/ADR-0004-travel-style-protocols.md
+++ b/docs/ADR-0004-travel-style-protocols.md
@@ -1,6 +1,6 @@
 # ADR-0004 — Per-component Style protocols across ThemeKitTravel
 
-- **Status:** **Proposed** (2026-07-12) — supersedes the v1 draft's single-promotion decision
+- **Status:** **IMPLEMENTED** (shipped across waves #286/#288/#289/#291/#292; originally Proposed 2026-07-12) — supersedes the v1 draft's single-promotion decision
 - **Date:** 2026-07-12
 - **Deciders:** user directive (explicit override) + ThemeKit architecture (ios-architect); implementation pressure-test by sr-ios-dev
 - **Context source:** full read of `Sources/ThemeKitTravel/Components/**` (29 components, branch `main`), `THEMEKITTRAVEL_ARCHITECTURE.md` §6 (ADR-F5), `docs/ADR-0001-core-kind-in-init.md`, `.claude/skills/themekit-authoring/SKILL.md`


### PR DESCRIPTION
First remediation batch from the architecture review (docs + CI only, no code).

- **P0-2** — ADR-0003's open question *".xcstrings compiled form on device"* → **CONFIRMED**: a real `xcodebuild` Demo app compiled `ThemeKit.xcstrings` into `{en,tr,ar}.lproj/ThemeKit.strings`; the sub-bundle path resolved `tr`, and a live in-app switch flipped both a View string and non-View enum strings (verified this session).
- **P1-1** — the `api-breakage` + `variant-naming` CI gates are now **blocking** (were advisory `::warning`). They fail only on genuine, un-allowlisted violations — additions pass. Adds `docs/2.0-removal-epoch.md` (burn-down plan for the ~133-entry allowlist + ~132 deprecations at the next major).
- **ADR-0004** status: `Proposed` → **IMPLEMENTED** (shipped in waves #286/#288/#289/#291/#292).

🤖 Generated with [Claude Code](https://claude.com/claude-code)