### PR TITLE
docs(review): P1-4 — surface ThemeKitCore token API from ThemeKit DocC (R7)

### DIFF
--- a/Sources/ThemeKit/Documentation.docc/ThemeKit.md
+++ b/Sources/ThemeKit/Documentation.docc/ThemeKit.md
@@ -66,15 +66,16 @@ views; the core library stays dependency-free.
 
 ### Theme & Tokens
 
-- `Theme`
-- `ThemeConfig`
-- `ThemeContext`
-- `TextStyle`
-- `SemanticColor`
-- `Theme.SpacingKey`
-- `Theme.RadiusKey`
-- `ShadowStyle`
-- `Motion`
+> The token engine — `Theme`, `SemanticColor`, `TextStyle`, `ThemeConfig`, the
+> spacing/radius/shadow tokens — lives in the token-only **ThemeKitCore** layer, which
+> `ThemeKit` re-exports. Because a re-exported symbol isn't carried into this archive's
+> symbol graph, the full, navigable reference for these types is in the **ThemeKitCore
+> API**: <https://isamercan.github.io/ThemeKit/api-core/documentation/themekitcore/>.
+
+- `Theme` · `ThemeConfig` · `ThemeContext` — the theme + runtime recipe
+- `SemanticColor` · `TextStyle` · `ShadowStyle` — the token vocabulary
+- `Theme.SpacingKey` · `Theme.RadiusKey` — spacing & radius scales
+- `Motion` — motion tokens
 
 ### Buttons
 


### PR DESCRIPTION
The token engine lives in ThemeKitCore (re-exported by ThemeKit), but `@_exported` symbols aren't carried into ThemeKit's DocC symbol graph, so the token types weren't navigable from ThemeKit's `/api` reference (review R7). Adds a prominent cross-reference from the *Theme & Tokens* topic to the ThemeKitCore `/api-core` reference. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)