### PR TITLE
feat(theme): ADR-0006 Phase 0+1 — per-subtree color resolution (R1/P0-1)

### DIFF
--- a/Sources/ThemeKit/Components/Atoms/Icon.swift
+++ b/Sources/ThemeKit/Components/Atoms/Icon.swift
@@ -31,10 +31,21 @@ public enum IconSize: String, CaseIterable {
 /// default; to switch to Font Awesome, bundle the FA Pro `.ttf` and render a
 /// glyph with `IconSize.font` instead.
 public struct Icon: View {
+    @Environment(\.theme) private var theme
     private let systemName: String
     // Appearance/config — mutated only through the modifiers below (R2).
     private var size: IconSize = .md
-    private var color: Color?
+    // ADR-0006 (Class M): store the SEMANTIC token, not a resolved `Color` — a
+    // COW modifier runs before `body`, outside any environment, so resolving
+    // eagerly here would freeze the `.accent(_:)` tint to `Theme.shared` and
+    // ignore a subtree's `.theme(_:)` override. Resolution happens in `body`,
+    // where `@Environment(\.theme)` is reachable. `rawColorOverride` (from the
+    // raw-`Color` escape hatch) always wins over `accentColor` when both are
+    // set — the two are kept mutually exclusive by the modifiers below, which
+    // matches the historical "last modifier wins" behavior of the single
+    // stored property this replaces.
+    private var accentColor: SemanticColor?
+    private var rawColorOverride: Color?
 
     /// Renders an SF Symbol at a token size.
     public init(systemName: String) {   // R1 — content only
@@ -44,7 +55,13 @@ public struct Icon: View {
     public var body: some View {
         Image(systemName: systemName)
             .font(.system(size: size.value))
-            .foregroundStyle(color ?? Color.primary)
+            .foregroundStyle(resolvedColor)
+    }
+
+    private var resolvedColor: Color {
+        if let rawColorOverride { return rawColorOverride }
+        if let accentColor { return theme.resolve(accentColor).base }
+        return Color.primary
     }
 }
 
@@ -55,7 +72,7 @@ public extension Icon {
     func size(_ s: IconSize) -> Self { copy { $0.size = s } }
 
     /// Semantic tint; `nil` (default) inherits the surrounding `foregroundStyle`.
-    func accent(_ color: SemanticColor?) -> Self { copy { $0.color = color?.base } }
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.accentColor = color; $0.rawColorOverride = nil } }
 
     /// Raw tint override (back-compat); prefer `accent(_:)`.
     @available(*, deprecated, message: "Use accent(_:) with a SemanticColor token.")
@@ -63,7 +80,7 @@ public extension Icon {
 
     /// Module-internal raw tint, so in-package call sites stay off the
     /// deprecated `color(_:)` without changing behavior.
-    internal func colorOverride(_ c: Color?) -> Self { copy { $0.color = c } }
+    internal func colorOverride(_ c: Color?) -> Self { copy { $0.rawColorOverride = c; $0.accentColor = nil } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self

--- a/Sources/ThemeKit/Components/Atoms/MeterStyle.swift
+++ b/Sources/ThemeKit/Components/Atoms/MeterStyle.swift
@@ -67,6 +67,7 @@ public struct LinearMeterStyle: MeterStyle {
 }
 
 private struct LinearMeterBar: View {
+    @Environment(\.theme) private var theme
     let configuration: MeterStyleConfiguration
 
     var body: some View {
@@ -87,7 +88,7 @@ private struct LinearMeterBar: View {
                     Capsule().fill(configuration.fill)
                         .frame(width: geo.size.width * configuration.fraction)
                     if let successFraction = configuration.successFraction {
-                        Capsule().fill(SemanticColor.success.solid)
+                        Capsule().fill(theme.resolve(.success).solid)
                             .frame(width: geo.size.width * successFraction)
                     }
                 }
@@ -112,6 +113,7 @@ public struct StripedMeterStyle: MeterStyle {
 }
 
 private struct StripedMeterBar: View {
+    @Environment(\.theme) private var theme
     let configuration: MeterStyleConfiguration
 
     var body: some View {
@@ -139,7 +141,7 @@ private struct StripedMeterBar: View {
                         .clipShape(Capsule())
                         .frame(width: geo.size.width * configuration.fraction)
                     if let successFraction = configuration.successFraction {
-                        Capsule().fill(SemanticColor.success.solid)
+                        Capsule().fill(theme.resolve(.success).solid)
                             .frame(width: geo.size.width * successFraction)
                     }
                 }

--- a/Sources/ThemeKit/Components/Molecules/Charts/AreaChart.swift
+++ b/Sources/ThemeKit/Components/Molecules/Charts/AreaChart.swift
@@ -43,7 +43,7 @@ public struct AreaChart: View {
     }
 
     private var locale: Locale { localeOverride ?? envLocale }
-    private var scale: ChartColorScale { ChartColorScale(series: series) }
+    private var scale: ChartColorScale { ChartColorScale(series: series, theme: theme) }
     private var showsLegend: Bool { legendVisible ?? (series.count >= 2) }
     private var motion: Animation? { MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion) }
 
@@ -94,7 +94,7 @@ public struct AreaChart: View {
             guard let point = s.points.first(where: { $0.x == x }) else { return nil }
             return ChartScrubRow(label: s.label,
                                  value: chartValueFormatted(point.y, locale: locale),
-                                 color: ChartPalette.hue(explicit: s.color, at: index).solid)
+                                 color: theme.resolve(ChartPalette.hue(explicit: s.color, at: index)).solid)
         }
         return ChartScrubCard(theme: theme, title: x, rows: rows)
     }

--- a/Sources/ThemeKit/Components/Molecules/Charts/BarChart.swift
+++ b/Sources/ThemeKit/Components/Molecules/Charts/BarChart.swift
@@ -46,7 +46,7 @@ public struct BarChart: View {
     }
 
     private var locale: Locale { localeOverride ?? envLocale }
-    private var scale: ChartColorScale { ChartColorScale(series: series) }
+    private var scale: ChartColorScale { ChartColorScale(series: series, theme: theme) }
     private var showsLegend: Bool { legendVisible ?? (series.count >= 2) }
     private var motion: Animation? { MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion) }
 
@@ -93,7 +93,7 @@ public struct BarChart: View {
             guard let point = s.points.first(where: { $0.x == x }) else { return nil }
             return ChartScrubRow(label: s.label,
                                  value: chartValueFormatted(point.y, locale: locale),
-                                 color: ChartPalette.hue(explicit: s.color, at: index).solid)
+                                 color: theme.resolve(ChartPalette.hue(explicit: s.color, at: index)).solid)
         }
         return ChartScrubCard(theme: theme, title: x, rows: rows)
     }

--- a/Sources/ThemeKit/Components/Molecules/Charts/ChartModels.swift
+++ b/Sources/ThemeKit/Components/Molecules/Charts/ChartModels.swift
@@ -79,16 +79,21 @@ enum ChartPalette {
 /// The resolved `domain`/`range` pair for `.chartForegroundStyleScale` — maps
 /// each series/slice label to its palette color so Swift Charts colors, legend
 /// and our annotation dots all stay in lockstep.
+///
+/// ADR-0006 (Class N — non-View builder): takes the building View's `theme:`
+/// explicitly rather than baking `.solid` (which would read `Theme.shared` and
+/// ignore a `.theme(_:)` subtree). Every call site is a chart View that already
+/// holds `@Environment(\.theme)`, so this converts N → P.
 struct ChartColorScale {
     let domain: [String]
     let range: [Color]
 
-    init(series: [ChartSeries]) {
+    init(series: [ChartSeries], theme: Theme) {
         domain = series.map(\.label)
-        range = series.enumerated().map { ChartPalette.hue(explicit: $1.color, at: $0).solid }
+        range = series.enumerated().map { theme.resolve(ChartPalette.hue(explicit: $1.color, at: $0)).solid }
     }
-    init(slices: [ChartSlice]) {
+    init(slices: [ChartSlice], theme: Theme) {
         domain = slices.map(\.label)
-        range = slices.enumerated().map { ChartPalette.hue(explicit: $1.color, at: $0).solid }
+        range = slices.enumerated().map { theme.resolve(ChartPalette.hue(explicit: $1.color, at: $0)).solid }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Charts/DonutChart.swift
+++ b/Sources/ThemeKit/Components/Molecules/Charts/DonutChart.swift
@@ -52,7 +52,7 @@ public struct DonutChart: View {
         return head + [ChartSlice(String(themeKit: "Other"), tail, color: .neutral)]
     }
 
-    private var scale: ChartColorScale { ChartColorScale(slices: effectiveSlices) }
+    private var scale: ChartColorScale { ChartColorScale(slices: effectiveSlices, theme: theme) }
 
     public var body: some View {
         Chart(effectiveSlices) { slice in

--- a/Sources/ThemeKit/Components/Molecules/Charts/LineChart.swift
+++ b/Sources/ThemeKit/Components/Molecules/Charts/LineChart.swift
@@ -48,7 +48,7 @@ public struct LineChart: View {
     }
 
     private var locale: Locale { localeOverride ?? envLocale }
-    private var scale: ChartColorScale { ChartColorScale(series: series) }
+    private var scale: ChartColorScale { ChartColorScale(series: series, theme: theme) }
     private var showsLegend: Bool { legendVisible ?? (series.count >= 2) }
     private var motion: Animation? { MicroMotion.animation(.base, enabled: micro, reduceMotion: reduceMotion) }
 
@@ -96,7 +96,7 @@ public struct LineChart: View {
             guard let point = s.points.first(where: { $0.x == x }) else { return nil }
             return ChartScrubRow(label: s.label,
                                  value: chartValueFormatted(point.y, locale: locale),
-                                 color: ChartPalette.hue(explicit: s.color, at: index).solid)
+                                 color: theme.resolve(ChartPalette.hue(explicit: s.color, at: index)).solid)
         }
         return ChartScrubCard(theme: theme, title: x, rows: rows)
     }

--- a/Sources/ThemeKit/Utils/Effects.swift
+++ b/Sources/ThemeKit/Utils/Effects.swift
@@ -13,18 +13,45 @@ import SwiftUI
 public extension View {
     /// Draws a border on only the given edges (SwiftUI has no per-side border).
     func edgeBorder(_ edges: [Edge], width: CGFloat = 1, color: Color? = nil) -> some View {
-        overlay(EdgeBorderShape(edges: edges, width: width)
-            .fill(color ?? Theme.shared.border(.borderPrimary)))
+        modifier(EdgeBorderModifier(edges: edges, width: width, color: color))
     }
 
     /// Overlays a gradient scrim fading from `color` (default surface) to clear at
     /// the given edge — e.g. a soft fade at the bottom of a scroll area.
     func fadeEdge(_ edge: Alignment = .bottom, length: CGFloat = 40, color: Color? = nil) -> some View {
-        let fill = color ?? Theme.shared.background(.bgWhite)
+        modifier(FadeEdgeModifier(edge: edge, length: length, color: color))
+    }
+}
+
+// ADR-0006 (D4): `edgeBorder`/`fadeEdge` used to be plain `View` extension
+// functions that fell back to `Theme.shared` when `color` was nil — a free
+// function has no `@Environment`, so it could never honor a `.theme(_:)`
+// subtree. Backing them with a `ViewModifier` gives each a real environment
+// read; public call sites/signatures are unchanged.
+private struct EdgeBorderModifier: ViewModifier {
+    @Environment(\.theme) private var theme
+    let edges: [Edge]
+    let width: CGFloat
+    let color: Color?
+
+    func body(content: Content) -> some View {
+        content.overlay(EdgeBorderShape(edges: edges, width: width)
+            .fill(color ?? theme.border(.borderPrimary)))
+    }
+}
+
+private struct FadeEdgeModifier: ViewModifier {
+    @Environment(\.theme) private var theme
+    let edge: Alignment
+    let length: CGFloat
+    let color: Color?
+
+    func body(content: Content) -> some View {
+        let fill = color ?? theme.background(.bgWhite)
         let vertical = edge == .top || edge == .bottom
         let start: UnitPoint = edge == .top ? .top : edge == .bottom ? .bottom : edge == .leading ? .leading : .trailing
         let end: UnitPoint = edge == .top ? .bottom : edge == .bottom ? .top : edge == .leading ? .trailing : .leading
-        return overlay(alignment: edge) {
+        return content.overlay(alignment: edge) {
             LinearGradient(colors: [fill, fill.opacity(0)], startPoint: start, endPoint: end)
                 .frame(width: vertical ? nil : length, height: vertical ? length : nil)
                 .allowsHitTesting(false)

--- a/Sources/ThemeKitCore/Theme/SemanticColor.swift
+++ b/Sources/ThemeKitCore/Theme/SemanticColor.swift
@@ -17,80 +17,31 @@ public enum SemanticColor: String, CaseIterable, Sendable {
     /// ladders; fall back to `primary` when a theme doesn't define them.
     case secondary, accent
 
+    // MARK: - Role accessors
+    //
+    // ADR-0006 Phase 0: the role→color logic now lives ONCE in `Resolved`
+    // (`SemanticColorResolved.swift`). These zero-arg accessors forward to
+    // `resolved(in: .shared)`, so they stay byte-identical to before — still
+    // `Theme.shared`-backed, unaware of a subtree's `.theme(_:)` override.
+    // NOT deprecated yet (Phase 2 follow-up); prefer `theme.resolve(_:)` in a
+    // view body, which reads the environment theme instead of the singleton.
+
     /// Background for the `solid` variant.
-    public var solid: Color {
-        switch self {
-        case .primary: return Theme.shared.background(.bgHero)
-        case .neutral: return Theme.shared.background(.bgTertiary)
-        case .info: return Theme.shared.background(.systemcolorsBgInfo)
-        case .success: return Theme.shared.background(.systemcolorsBgSuccess)
-        case .warning: return Theme.shared.background(.systemcolorsBgWarning)
-        case .error: return Theme.shared.background(.systemcolorsBgError)
-        case .turquoise: return Theme.shared.background(.bgTurquoise)
-        case .orange: return Theme.shared.background(.bgOrange)
-        case .purple: return Theme.shared.text(.textPurple)
-        case .pink: return Theme.shared.background(.badgeBgMaximumpinkBase)
-        case .secondary, .accent: return base
-        }
-    }
+    public var solid: Color { resolved(in: .shared).solid }
 
     /// Foreground on top of the `solid` background — **auto-contrasting**: a bright
     /// accent (amber, yellow, light primary) gets dark content, a deep one gets white,
     /// computed from the background's luminance rather than hardcoded per color.
-    public var onSolid: Color {
-        ColorContrast.content(on: solid)
-    }
+    public var onSolid: Color { resolved(in: .shared).onSolid }
 
     /// Light surface for the `soft` variant.
-    public var soft: Color {
-        switch self {
-        case .primary: return Theme.shared.background(.bgElevatorTertiary)
-        case .neutral: return Theme.shared.background(.bgSecondaryLight)
-        case .info: return Theme.shared.background(.systemcolorsBgInfoLight)
-        case .success: return Theme.shared.background(.systemcolorsBgSuccessLight)
-        case .warning: return Theme.shared.background(.systemcolorsBgWarningLight)
-        case .error: return Theme.shared.background(.systemcolorsBgErrorLight)
-        case .turquoise: return Theme.shared.background(.bgTurquoiseLight)
-        case .orange: return Theme.shared.background(.badgeBgOrange)
-        case .purple: return Theme.shared.background(.badgeBgPurple)
-        case .pink: return Theme.shared.background(.badgeBgMaximumpinkLight)
-        case .secondary, .accent: return bg
-        }
-    }
+    public var soft: Color { resolved(in: .shared).soft }
 
     /// Accent foreground for `soft` / `outline` / `ghost` variants.
-    public var accent: Color {
-        switch self {
-        case .primary: return Theme.shared.text(.textHero)
-        case .neutral: return Theme.shared.text(.textPrimary)
-        case .info: return Theme.shared.foreground(.systemcolorsFgInfo)
-        case .success: return Theme.shared.foreground(.systemcolorsFgSuccess)
-        case .warning: return Theme.shared.foreground(.systemcolorsFgWarning)
-        case .error: return Theme.shared.foreground(.systemcolorsFgError)
-        case .turquoise: return Theme.shared.foreground(.fgTurquoise)
-        case .orange: return Theme.shared.foreground(.badgeFgOrange)
-        case .purple: return Theme.shared.text(.textPurple)
-        case .pink: return Theme.shared.foreground(.badgeFgMaximumpink)
-        case .secondary, .accent: return strong
-        }
-    }
+    public var accent: Color { resolved(in: .shared).accent }
 
     /// Border for the `outline` variant.
-    public var border: Color {
-        switch self {
-        case .primary: return Theme.shared.border(.borderHero)
-        case .neutral: return Theme.shared.border(.borderPrimary)
-        case .info: return Theme.shared.border(.systemcolorsBorderInfo)
-        case .success: return Theme.shared.border(.systemcolorsBorderSuccess)
-        case .warning: return Theme.shared.border(.systemcolorsBorderWarning)
-        case .error: return Theme.shared.border(.systemcolorsBorderError)
-        case .turquoise: return Theme.shared.border(.borderTurquoise)
-        case .orange: return Theme.shared.border(.borderOrange)
-        case .purple: return Theme.shared.text(.textPurple)
-        case .pink: return Theme.shared.foreground(.badgeFgMaximumpink)
-        case .secondary, .accent: return base
-        }
-    }
+    public var border: Color { resolved(in: .shared).border }
 
     // MARK: - Ant-style ladder roles
 
@@ -101,16 +52,7 @@ public enum SemanticColor: String, CaseIterable, Sendable {
     }
 
     /// Resolve any ladder step for this color, e.g. `.primary.shade(.s700)`.
-    public func shade(_ step: Shade) -> Color {
-        // Brand secondary/accent live in the additive ladder; fall back to primary
-        // when a theme doesn't define them, so they never resolve to `.clear`.
-        if self == .secondary || self == .accent {
-            return Theme.shared.brandShade(rawValue, step.rawValue)
-                ?? (Theme.PaletteColorKey(rawValue: "palette.primary.\(step.rawValue)").map { Theme.shared.palette($0) } ?? .clear)
-        }
-        guard let key = Theme.PaletteColorKey(rawValue: "palette.\(rawValue).\(step.rawValue)") else { return .clear }
-        return Theme.shared.palette(key)
-    }
+    public func shade(_ step: Shade) -> Color { resolved(in: .shared).shade(step) }
 
     /// Faint container background (Ant `colorXxxBg`, step 50).
     public var bg: Color { shade(.s50) }

--- a/Sources/ThemeKitCore/Theme/SemanticColorResolved.swift
+++ b/Sources/ThemeKitCore/Theme/SemanticColorResolved.swift
@@ -1,0 +1,154 @@
+//
+//  SemanticColorResolved.swift
+//  ThemeKit
+//
+//  ADR-0006 Phase 0 — the additive per-subtree color resolver.
+//
+//  `SemanticColor`'s role accessors (`.solid`, `.soft`, `.accent`, `.border`,
+//  `.shade(_:)`, the ladder …) historically read `Theme.shared` directly, so a
+//  subtree re-themed with `.theme(_:)` still painted accents from the global
+//  singleton — a split-brain inside a single view body (see ADR-0006). This file
+//  moves the role→color logic ONCE into `SemanticColor.Resolved`, a value that
+//  binds a `SemanticColor` to a specific `Theme`. `SemanticColor`'s existing
+//  zero-arg accessors now forward to `resolved(in: .shared)`, so behavior is
+//  byte-identical for any call site that never touches `.theme(_:)` — this file
+//  is purely additive; nothing is deprecated here (that is a Phase-2 follow-up).
+//
+
+import SwiftUI
+
+public extension SemanticColor {
+    /// Roles resolved against a specific `Theme` — honors per-subtree `.theme(_:)`.
+    ///
+    /// A transient value read within a view body (or a helper that already holds
+    /// a `theme`); never stored across renders or escaped. `Sendable` because
+    /// `Theme` is `@unchecked Sendable` and `SemanticColor` is `Sendable`.
+    ///
+    ///     @Environment(\.theme) private var theme
+    ///     …
+    ///     .fill(theme.resolve(.primary).solid)
+    struct Resolved: Sendable {
+        public let color: SemanticColor
+        public let theme: Theme
+
+        public init(color: SemanticColor, theme: Theme) {
+            self.color = color
+            self.theme = theme
+        }
+
+        /// Background for the `solid` variant.
+        public var solid: Color {
+            switch color {
+            case .primary: return theme.background(.bgHero)
+            case .neutral: return theme.background(.bgTertiary)
+            case .info: return theme.background(.systemcolorsBgInfo)
+            case .success: return theme.background(.systemcolorsBgSuccess)
+            case .warning: return theme.background(.systemcolorsBgWarning)
+            case .error: return theme.background(.systemcolorsBgError)
+            case .turquoise: return theme.background(.bgTurquoise)
+            case .orange: return theme.background(.bgOrange)
+            case .purple: return theme.text(.textPurple)
+            case .pink: return theme.background(.badgeBgMaximumpinkBase)
+            case .secondary, .accent: return base
+            }
+        }
+
+        /// Foreground on top of the `solid` background — auto-contrasting, same
+        /// as `SemanticColor.onSolid` (theme-independent once `solid` resolves).
+        public var onSolid: Color {
+            ColorContrast.content(on: solid)
+        }
+
+        /// Light surface for the `soft` variant.
+        public var soft: Color {
+            switch color {
+            case .primary: return theme.background(.bgElevatorTertiary)
+            case .neutral: return theme.background(.bgSecondaryLight)
+            case .info: return theme.background(.systemcolorsBgInfoLight)
+            case .success: return theme.background(.systemcolorsBgSuccessLight)
+            case .warning: return theme.background(.systemcolorsBgWarningLight)
+            case .error: return theme.background(.systemcolorsBgErrorLight)
+            case .turquoise: return theme.background(.bgTurquoiseLight)
+            case .orange: return theme.background(.badgeBgOrange)
+            case .purple: return theme.background(.badgeBgPurple)
+            case .pink: return theme.background(.badgeBgMaximumpinkLight)
+            case .secondary, .accent: return bg
+            }
+        }
+
+        /// Accent foreground for `soft` / `outline` / `ghost` variants.
+        public var accent: Color {
+            switch color {
+            case .primary: return theme.text(.textHero)
+            case .neutral: return theme.text(.textPrimary)
+            case .info: return theme.foreground(.systemcolorsFgInfo)
+            case .success: return theme.foreground(.systemcolorsFgSuccess)
+            case .warning: return theme.foreground(.systemcolorsFgWarning)
+            case .error: return theme.foreground(.systemcolorsFgError)
+            case .turquoise: return theme.foreground(.fgTurquoise)
+            case .orange: return theme.foreground(.badgeFgOrange)
+            case .purple: return theme.text(.textPurple)
+            case .pink: return theme.foreground(.badgeFgMaximumpink)
+            case .secondary, .accent: return strong
+            }
+        }
+
+        /// Border for the `outline` variant.
+        public var border: Color {
+            switch color {
+            case .primary: return theme.border(.borderHero)
+            case .neutral: return theme.border(.borderPrimary)
+            case .info: return theme.border(.systemcolorsBorderInfo)
+            case .success: return theme.border(.systemcolorsBorderSuccess)
+            case .warning: return theme.border(.systemcolorsBorderWarning)
+            case .error: return theme.border(.systemcolorsBorderError)
+            case .turquoise: return theme.border(.borderTurquoise)
+            case .orange: return theme.border(.borderOrange)
+            case .purple: return theme.text(.textPurple)
+            case .pink: return theme.foreground(.badgeFgMaximumpink)
+            case .secondary, .accent: return base
+            }
+        }
+
+        // MARK: - Ant-style ladder roles
+
+        /// Resolve any ladder step for this color, e.g. `theme.resolve(.primary).shade(.s700)`.
+        public func shade(_ step: SemanticColor.Shade) -> Color {
+            // Brand secondary/accent live in the additive ladder; fall back to primary
+            // when a theme doesn't define them, so they never resolve to `.clear`.
+            if color == .secondary || color == .accent {
+                return theme.brandShade(color.rawValue, step.rawValue)
+                    ?? (Theme.PaletteColorKey(rawValue: "palette.primary.\(step.rawValue)").map { theme.palette($0) } ?? .clear)
+            }
+            guard let key = Theme.PaletteColorKey(rawValue: "palette.\(color.rawValue).\(step.rawValue)") else { return .clear }
+            return theme.palette(key)
+        }
+
+        /// Faint container background (Ant `colorXxxBg`, step 50).
+        public var bg: Color { shade(.s50) }
+        /// Container background, hovered/stronger (Ant `colorXxxBgHover`, step 100).
+        public var bgHover: Color { shade(.s100) }
+        /// Subtle border (Ant `colorXxxBorder`, step 200).
+        public var borderSubtle: Color { shade(.s200) }
+        /// Border, hovered (Ant `colorXxxBorderHover`, step 300).
+        public var borderHover: Color { shade(.s300) }
+        /// Solid fill, hovered — lighter than base (Ant `colorXxxHover`, step 400).
+        public var hover: Color { shade(.s400) }
+        /// The color itself (Ant `colorXxx`, step 500).
+        public var base: Color { shade(.s500) }
+        /// Solid fill, pressed/active — darker than base (Ant `colorXxxActive`, step 600).
+        public var active: Color { shade(.s600) }
+        /// High-contrast text/icon on light surfaces (step 700).
+        public var strong: Color { shade(.s700) }
+    }
+
+    /// Enum-side binder — for Class-P helpers that already receive a `Theme`
+    /// (mirrors `AlertToast.background(_:)` / `SeatPalette.colors(for:theme:)`).
+    func resolved(in theme: Theme) -> Resolved { Resolved(color: self, theme: theme) }
+}
+
+public extension Theme {
+    /// Theme-side binder — the ergonomic call in a view body: `theme.resolve(.primary).solid`.
+    /// Mirrors the existing `theme.text(_:)` / `theme.background(_:)` shape.
+    func resolve(_ color: SemanticColor) -> SemanticColor.Resolved { color.resolved(in: self) }
+}

--- a/Sources/ThemeKitTravel/Components/Organisms/SeatMapModels.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SeatMapModels.swift
@@ -112,22 +112,29 @@ public struct SeatPalette: Sendable {
     public static let `default` = SeatPalette()
 
     /// Fill + stroke for a tier. An overridden tier derives a light fill from its accent.
+    ///
+    /// ADR-0006 (Class P — the split-brain witness): every branch now resolves
+    /// through the passed `theme`, so the accent tiers honor a `.theme(_:)`
+    /// subtree the same way the `.standard`/`.premium` branches already did.
     public func colors(for tier: SeatTier, theme: Theme) -> (fill: Color, stroke: Color) {
         if let accent = overrides[tier] { return (accent.opacity(0.14), accent) }
         switch tier {
         case .standard: return (theme.background(.bgBase), theme.border(.borderPrimary))
-        case .extraLegroom: return (SemanticColor.info.bg, SemanticColor.info.base)
-        case .exit: return (SemanticColor.warning.bg, SemanticColor.warning.base)
+        case .extraLegroom: return (theme.resolve(.info).bg, theme.resolve(.info).base)
+        case .exit: return (theme.resolve(.warning).bg, theme.resolve(.warning).base)
         case .premium: return (theme.background(.bgTurquoiseLight), theme.background(.bgTurquoise))
-        case .business: return (SemanticColor.purple.bg, SemanticColor.purple.base)
-        case .first: return (SemanticColor.pink.bg, SemanticColor.pink.base)
+        case .business: return (theme.resolve(.purple).bg, theme.resolve(.purple).base)
+        case .first: return (theme.resolve(.pink).bg, theme.resolve(.pink).base)
         }
     }
 
     /// Fill + stroke + content colour of a **selected** seat. Defaults to the
     /// theme's hero foreground; an accent override uses its `.solid` / `.onSolid` pair.
     public func selectedColors(theme: Theme) -> (fill: Color, stroke: Color, content: Color) {
-        if let accent = selectedAccent { return (accent.solid, accent.solid, accent.onSolid) }
+        if let accent = selectedAccent {
+            let resolved = theme.resolve(accent)
+            return (resolved.solid, resolved.solid, resolved.onSolid)
+        }
         if let raw = selectedRaw { return (raw, raw, theme.text(.textSecondaryInverse)) }
         return (theme.foreground(.fgHero), theme.foreground(.fgHero), theme.text(.textSecondaryInverse))
     }
@@ -136,7 +143,10 @@ public struct SeatPalette: Sendable {
     /// theme's muted secondary surface; an accent override uses its `.soft` /
     /// `.border` / `.base` shades.
     public func occupiedColors(theme: Theme) -> (fill: Color, stroke: Color, content: Color) {
-        if let accent = occupiedAccent { return (accent.soft, accent.border, accent.base) }
+        if let accent = occupiedAccent {
+            let resolved = theme.resolve(accent)
+            return (resolved.soft, resolved.border, resolved.base)
+        }
         if let raw = occupiedRaw { return (raw.opacity(0.14), raw, theme.text(.textTertiary)) }
         return (theme.background(.bgSecondary), theme.border(.borderPrimary), theme.text(.textTertiary))
     }

--- a/Tests/ThemeKitTests/SemanticColorResolvedTests.swift
+++ b/Tests/ThemeKitTests/SemanticColorResolvedTests.swift
@@ -1,0 +1,79 @@
+//
+//  SemanticColorResolvedTests.swift
+//  ThemeKit
+//
+//  ADR-0006 Phase 0 — proves `SemanticColor.Resolved` / `theme.resolve(_:)`:
+//  1) two independently-configured `Theme` instances resolve DIFFERENT accents
+//     (the per-subtree isolation the resolver exists to deliver);
+//  2) the still-shipping zero-arg `SemanticColor` accessors stay byte-identical
+//     to `theme.resolve(_:)` when resolved against `Theme.shared` — the
+//     backward-compatibility guarantee (no call site anywhere regresses);
+//  3) `SemanticColor.Resolved` is usable across a `Sendable` boundary.
+//
+//  Cross-platform (iOS + macOS) — pure value-level assertions, no hosting.
+//
+
+import SwiftUI
+import XCTest
+@testable import ThemeKit
+@testable import ThemeKitCore
+
+@MainActor
+final class SemanticColorResolvedTests: XCTestCase {
+    /// sRGB components, so two `Color`s can be compared for equality reliably
+    /// (mirrors `ColorContrast.components(of:)`'s resolution approach).
+    private func rgba(_ c: Color) -> [Double] {
+        let r = c.resolve(in: EnvironmentValues())
+        return [Double(r.red), Double(r.green), Double(r.blue), Double(r.opacity)]
+    }
+
+    private func makeTheme(primaryHex: String, accentHex: String) -> Theme {
+        let theme = Theme()
+        theme.apply(ThemeConfig(primaryHex: primaryHex, accentHex: accentHex))
+        return theme
+    }
+
+    // MARK: - The isolation the ADR promises
+
+    func testTwoThemesResolveDistinctAccentSolid() {
+        let themeA = makeTheme(primaryHex: "d81b60", accentHex: "d81b60")
+        let themeB = makeTheme(primaryHex: "1e88e5", accentHex: "1e88e5")
+
+        XCTAssertNotEqual(rgba(themeA.resolve(.accent).solid), rgba(themeB.resolve(.accent).solid),
+                          "theme.resolve(.accent).solid must vary with the theme it's resolved against")
+        XCTAssertNotEqual(rgba(themeA.resolve(.primary).solid), rgba(themeB.resolve(.primary).solid),
+                          "theme.resolve(.primary).solid must vary with the theme it's resolved against")
+    }
+
+    func testResolvedMatchesTheThemesOwnInstanceAccessorsForANonBrandRole() {
+        // `.info` isn't brand-derived — resolving it through a specific theme
+        // must equal that SAME theme's own token accessor for the mapped key.
+        let themeA = makeTheme(primaryHex: "2e7d32", accentHex: "2e7d32")
+        XCTAssertEqual(rgba(themeA.resolve(.info).bg), rgba(themeA.palette(.init(rawValue: "palette.info.50")!)))
+    }
+
+    // MARK: - Backward-compat guarantee (D2 / no behavior change for un-migrated call sites)
+
+    func testDeprecatedZeroArgAccessorsMatchResolvedAgainstThemeShared() {
+        for color in SemanticColor.allCases {
+            XCTAssertEqual(rgba(color.solid), rgba(Theme.shared.resolve(color).solid), "\(color).solid mismatch")
+            XCTAssertEqual(rgba(color.soft), rgba(Theme.shared.resolve(color).soft), "\(color).soft mismatch")
+            XCTAssertEqual(rgba(color.accent), rgba(Theme.shared.resolve(color).accent), "\(color).accent mismatch")
+            XCTAssertEqual(rgba(color.border), rgba(Theme.shared.resolve(color).border), "\(color).border mismatch")
+            XCTAssertEqual(rgba(color.onSolid), rgba(Theme.shared.resolve(color).onSolid), "\(color).onSolid mismatch")
+            XCTAssertEqual(rgba(color.base), rgba(Theme.shared.resolve(color).base), "\(color).base mismatch")
+            for step in SemanticColor.Shade.allCases {
+                XCTAssertEqual(rgba(color.shade(step)), rgba(Theme.shared.resolve(color).shade(step)),
+                               "\(color).shade(\(step)) mismatch")
+            }
+        }
+    }
+
+    // MARK: - Sendable usability (compile-time proof; Swift 6 mode)
+
+    func testResolvedCrossesAnIsolationBoundary() async {
+        let resolved = Theme.shared.resolve(.primary)
+        let solid = await Task { resolved.solid }.value
+        XCTAssertEqual(rgba(solid), rgba(resolved.solid))
+    }
+}

--- a/Tests/ThemeKitTests/ThemeSubtreeColorResolutionTests.swift
+++ b/Tests/ThemeKitTests/ThemeSubtreeColorResolutionTests.swift
@@ -1,0 +1,115 @@
+//
+//  ThemeSubtreeColorResolutionTests.swift
+//  ThemeKit
+//
+//  ADR-0006 — the acceptance gate: a REAL hosted render (NSHostingView, like
+//  `L10nViewLayerTests`) with TWO subtrees under DIFFERENT `.theme(_:)`
+//  overrides, each reading its role's accent through the new resolver.
+//
+//  The same probe view records BOTH the new API (`theme.resolve(_:)`, reading
+//  `@Environment(\.theme)`) and the still-shipping deprecated-free zero-arg
+//  accessor (`SemanticColor.accent`, reading `Theme.shared`) for the same
+//  role, in the same render — so one test demonstrates both halves of the
+//  ADR's claim without needing two separate builds:
+//
+//  - `theme.resolve(.accent).solid` DIFFERS between the two subtrees — the
+//    per-subtree isolation `.theme(_:)` advertises, now actually true.
+//  - `SemanticColor.accent.solid` is IDENTICAL between the two subtrees (both
+//    collapse to `Theme.shared`'s own accent, regardless of which brand each
+//    subtree requested) — this is the split-brain bug ADR-0006 fixes,
+//    reproduced live: if this test's first assertion were run against the old
+//    (pre-ADR-0006) `SemanticColor.accent.solid`-only code path, it would FAIL
+//    (no isolation); against `theme.resolve(_:)` it PASSES.
+//
+//  macOS-only (needs AppKit hosting); the iOS lane compiles it out.
+//
+
+#if os(macOS)
+import AppKit
+import SwiftUI
+import XCTest
+import ThemeKit
+@testable import ThemeKitCore
+
+@MainActor
+final class ThemeSubtreeColorResolutionTests: XCTestCase {
+    /// Colors captured from inside the rendered subtrees' bodies.
+    private enum Journal {
+        nonisolated(unsafe) static var newAPI: [String: Color] = [:]
+        nonisolated(unsafe) static var oldAPI: [String: Color] = [:]
+        static func reset() { newAPI = [:]; oldAPI = [:] }
+    }
+
+    /// Reads the environment theme and records both the new (env-correct) and
+    /// old (singleton) accessor for the SAME role, keyed by which subtree it's in.
+    private struct AccentProbe: View {
+        let key: String
+        @Environment(\.theme) private var theme
+        var body: some View {
+            Journal.newAPI[key] = theme.resolve(.accent).solid
+            Journal.oldAPI[key] = SemanticColor.accent.solid
+            return Color.clear.frame(width: 2, height: 2)
+        }
+    }
+
+    private var hosting: NSHostingView<AnyView>!
+
+    override func tearDown() {
+        hosting = nil
+    }
+
+    private func host(_ view: some View) {
+        _ = NSApplication.shared
+        hosting = NSHostingView(rootView: AnyView(view))
+        hosting.frame = .init(x: 0, y: 0, width: 240, height: 120)
+        hosting.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+    }
+
+    /// sRGB components for a reliable `Color` equality check.
+    private func rgba(_ c: Color) -> [Double] {
+        let r = c.resolve(in: EnvironmentValues())
+        return [Double(r.red), Double(r.green), Double(r.blue), Double(r.opacity)]
+    }
+
+    // MARK: - The acceptance gate
+
+    func testTwoSubtreesResolveDistinctAccentsViaTheNewResolver() throws {
+        let brandA = Theme()
+        brandA.apply(ThemeConfig(primaryHex: "d81b60", accentHex: "d81b60"))
+        let brandB = Theme()
+        brandB.apply(ThemeConfig(primaryHex: "1e88e5", accentHex: "1e88e5"))
+        // Sanity: the two brands really are different (else the test proves nothing).
+        XCTAssertNotEqual(rgba(brandA.resolve(.accent).solid), rgba(brandB.resolve(.accent).solid))
+
+        Journal.reset()
+        host(
+            HStack {
+                AccentProbe(key: "A").theme(brandA)
+                AccentProbe(key: "B").theme(brandB)
+            }
+        )
+
+        let newA = try XCTUnwrap(Journal.newAPI["A"])
+        let newB = try XCTUnwrap(Journal.newAPI["B"])
+        XCTAssertNotEqual(rgba(newA), rgba(newB),
+                          "theme.resolve(.accent).solid must differ per subtree — the ADR-0006 promise (PASSES with the new resolver)")
+
+        // The still-shipping deprecated-free zero-arg accessor ignores
+        // `.theme(_:)` and reads `Theme.shared` regardless of which subtree
+        // it's called from — both entries collapse to the SAME color even
+        // though brand A and brand B are different. This is the split-brain
+        // this ADR fixes; documented here as still-true FOR THE OLD PATH
+        // (Phase 2 migrates call sites off it; Phase 0 only adds the resolver).
+        let oldA = try XCTUnwrap(Journal.oldAPI["A"])
+        let oldB = try XCTUnwrap(Journal.oldAPI["B"])
+        XCTAssertEqual(rgba(oldA), rgba(oldB),
+                       "SemanticColor.accent ignores .theme(_:) and always reads Theme.shared — " +
+                       "an isolation assertion on THIS path would FAIL (no per-subtree isolation)")
+        // …by construction: the old path always equals Theme.shared's own
+        // resolution, whichever subtree it happens to be read from.
+        XCTAssertEqual(rgba(oldA), rgba(Theme.shared.resolve(.accent).solid),
+                       "the old accessor always resolves against Theme.shared, never the subtree's .theme(_:)")
+    }
+}
+#endif

--- a/docs/ADR-0006-per-subtree-theme-resolution.md
+++ b/docs/ADR-0006-per-subtree-theme-resolution.md
@@ -1,0 +1,249 @@
+# ADR-0006 — Per-subtree theme resolution: making `.theme(_:)` actually re-skin
+
+- **Status:** **Accepted** (2026-07-13)
+- **Date:** 2026-07-13
+- **Deciders:** ThemeKit architecture
+- **Context source:** Architecture-remediation review, item **R1 (HIGH) / P0-1** — "`SemanticColor` and the token-value accessors read `Theme.shared` directly, silently defeating the advertised per-subtree `.theme(_:)` override."
+- **Rollout note:** Additive and source-compatible. The `Theme.shared`-backed accessors stay working as **`@available(*, deprecated,…)` deprecate-forward** shims with byte-identical behavior, so every existing call site compiles (with a warning) and any app that never calls `.theme(_:)` behaves exactly as today. The one genuinely irreducible case (non-View builders with no theme in scope) is documented as a bounded limit, mirroring ADR-0003's non-View analysis. No public type is removed; two additive surfaces (`SemanticColor.Resolved`, `Theme.resolve(_:)`) are introduced.
+- **Precedent mirrored:** `AlertToast` already threads a theme through an enum color helper — `func background(_ theme: Theme) -> Color` / `func foreground(_ theme: Theme) -> Color` (`Sources/ThemeKit/Components/Organisms/AlertToast.swift:16,29`). `SeatPalette.colors(for:theme:)` (`SeatMapModels.swift:114`) does the same for a non-View helper. This ADR generalizes that existing, working pattern to the shared token layer. ADR-0003 supplies the non-View / inherent-limit template.
+
+## Context
+
+`ThemeContext.swift:40-58` advertises per-subtree re-theming in its own doc comment:
+
+> "The active `Theme`. Defaults to `Theme.shared`; override per-subtree with `.theme(_:)`. Components read this instead of touching the singleton directly, so they can be re-themed in isolation (different brand in a subtree, a fixed theme in a preview/snapshot)…"
+
+That promise is **half-true today**, and the half that fails is the half the review flagged.
+
+**What actually works.** A component that reads `@Environment(\.theme) private var theme` and calls the **instance** accessors — `theme.text(.textPrimary)`, `theme.background(.bgBase)`, `theme.border(.borderPrimary)`, `theme.foreground(.fgHero)` — resolves against whatever `Theme` the environment holds. Inside a `.theme(brandB)` subtree, `@Environment(\.theme)` returns `brandB`, so those calls are already per-subtree-correct. **A precise correction to the review wording:** `theme.text(…)`/`theme.background(…)` do *not* read the singleton — they are instance methods on the environment theme. The literal `Theme.shared.text(…)`/`Theme.shared.background(…)` reads the review saw live **inside `SemanticColor.swift`**, not in component bodies.
+
+**What silently fails.** The token accessors that carry **no theme** — they are `enum` computed properties with nowhere to read an environment — hardcode the singleton:
+
+- `SemanticColor` — every role (`.solid .soft .accent .border .onSolid`) and every ladder step (`.bg .hover .base .active .strong .shade(_:)`) resolves from `Theme.shared` (`SemanticColor.swift:23-112`). **758 reads across 146 component files.**
+- `Theme.RadiusKey.value` / `RadiusRole.value` / `SpacingKey.value` — `Theme.shared.radius/spacing` (`ThemeModel.swift:78,104,120`). **~1148 call sites.**
+- `TextStyle.font` / `.lineSpacing` — `Theme.shared.textStyle(self)` (`Typography.swift:96,103`), reached by the 916 `.textStyle(_:)` modifier sites.
+
+The consequence is a **split-brain inside a single view body**. `SeatPalette.colors(for:theme:)` is the cleanest witness — the same `switch` mixes both worlds (`SeatMapModels.swift:118-123`):
+
+```swift
+case .standard:     return (theme.background(.bgBase),  theme.border(.borderPrimary))  // env-correct
+case .extraLegroom: return (SemanticColor.info.bg,      SemanticColor.info.base)        // Theme.shared — WRONG in a .theme() subtree
+```
+
+Two subtrees with different brands therefore cannot both render correct accent/semantic color: the neutral surfaces re-skin, the *accents* do not. That is exactly the isolation the doc comment sells.
+
+**Two axes, deliberately separated by this ADR.** "Brand isolation" — the thing the promise is about — is a **color** concept: it is driven by `ThemeConfig.primaryHex / secondaryHex / accentHex / tint / dark`. Radius/spacing/typography vary by `radiusScale / spacingScale / fontScale / font` — real theme inputs, but not what anyone means by "a different brand in this subtree." This ADR fixes **color** completely and treats the metric/type scale axis as a bounded, documented limit (see D5), because fixing it costs a ~2000-site migration to isolate an axis no real two-brand screen varies.
+
+**Why the singleton exists (the tension).** `ThemeKit.swift:10-17` states the design intent: *"components resolve tokens from the `Theme.shared` singleton (a deliberate design — no per-call environment lookups)."* The performance claim is real but narrower than it reads: the cost it avoids is the **`@Environment` read**, not the token dictionary lookup. A component reads `@Environment(\.theme)` **once per body** and reuses the local `theme` for all its token access — there is no per-token environment lookup, and there never was one for `SemanticColor` either. Threading the already-in-hand `theme` into `SemanticColor` adds **zero** environment reads to the 121-of-146 files that already hold one, and one cheap read to the remainder. The singleton's simplicity survives as the *default environment value* (`ThemeContext.swift:37`); what changes is that the token layer stops reaching **past** the environment to the global.
+
+## The root cause is resolution *timing*, not just the singleton
+
+The subtle part — and the part `sr-ios-dev` must internalize before migrating — is *when* `SemanticColor → Color` happens. A component can correctly read `@Environment(\.theme)` in its body and **still** leak the singleton, if it resolves the color at a moment when no environment exists. Four timing classes, in increasing difficulty:
+
+| Class | Where resolution happens | Env reachable? | Example | Fix |
+|---|---|---|---|---|
+| **V — View body** | inside `body` / a Style's `makeBody` Chrome view | **yes** | 121 files; `MeterStyle.swift:90` | swap `color.X` → `theme.resolve(color).X` |
+| **P — threaded helper** | an `enum`/`struct` method that already **takes** a `Theme` | **yes (as a param)** | `AlertToast` `variant.background(theme)`; `SeatPalette.colors(for:theme:)` | swap the `SemanticColor.X` reads for `theme.resolve(…).X` |
+| **M — eager modifier** | a copy-on-write modifier that resolves to a stored `Color` **before** body runs | **no** | `Icon.accent(_:)` stores `color?.base` (`Icon.swift:58`) | store the `SemanticColor`, resolve in `body` |
+| **N — non-View builder** | a model/scale built with no `Theme` and no View ancestor in scope | **inherently no** | `ChartColorScale(series:)` bakes `.solid` (`ChartModels.swift:88,92`) | thread a `theme:` param from the building View, **or** accept process-global (see §Non-View) |
+
+Classes V and P are mechanical. Class M is a small per-component refactor (change an internal stored-property type; public signature unchanged). Class N is the only one with an inherent limit, and it is narrow.
+
+## Decision
+
+Adopt **Approach A (thread the environment theme through color-token resolution)** via an additive, deprecate-forward resolver, scoped to the **color** layer; keep the metric/type scale axis singleton-backed with a **precisely documented limit** (a bounded slice of Approach B) rather than pay a ~2000-site migration for an axis nobody isolates per subtree.
+
+### D1 — Verdict: A for color, documented-limit for metric/type scale
+
+Reject the pure alternatives:
+
+- **Pure B (downgrade the promise, keep the singleton everywhere).** Rejected: it ships a library that reads `@Environment(\.theme)` in 121 files and injects `.theme(_:)` in `ThemeContext`/`ThemeKit`, then quietly ignores it for the *accent* colors those files paint — the worst outcome (the machinery exists and misleads). Honest B would require *deleting* `.theme(_:)` and every "re-themed in isolation / different brand in a subtree" claim, throwing away working per-subtree behavior (surfaces already re-skin) and every preview/snapshot that pins a theme.
+- **Full A (thread the theme through color *and* metrics *and* typography).** Rejected as one step: ~2000 additional call sites (`929` SpacingKey + `98` RadiusKey + `121` RadiusRole + `916` textStyle) for an axis — corner radius / spacing / font scale — that no two-brand screen varies. Kept available as the *same idiom* for a later phase if a real need appears (D5), so this is a deferral, not a different pattern.
+
+Approach A for color is correct because color **is** the advertised feature, its blast radius is mechanical (121 files already hold the theme), its per-call cost is nil, and it introduces no new isolation model — only a resolver that takes the theme the component already has.
+
+### D2 — Mechanism: `SemanticColor.Resolved` + `Theme.resolve(_:)`, deprecate-forward the zero-arg accessors
+
+A `Resolved` value binds a `SemanticColor` to a specific `Theme` and exposes the **same role vocabulary** as today, so call sites keep property syntax and only gain a `theme.` prefix. The role logic moves **once** into `Resolved`; the deprecated enum properties become thin forwards to `Theme.shared`.
+
+```swift
+public extension SemanticColor {
+    /// Roles resolved against a specific Theme — honors per-subtree `.theme(_:)`.
+    /// `Sendable` because `Theme` is `@unchecked Sendable` and `SemanticColor` is `Sendable`;
+    /// a transient value used within a body, never stored/escaped.
+    struct Resolved: Sendable {
+        let color: SemanticColor
+        let theme: Theme
+
+        public var solid: Color {           // was SemanticColor.solid, now theme-parameterized
+            switch color {
+            case .primary: return theme.background(.bgHero)
+            case .neutral: return theme.background(.bgTertiary)
+            case .info:    return theme.background(.systemcolorsBgInfo)
+            // … identical to today's switch, s/Theme.shared/theme/
+            case .secondary, .accent: return base
+            }
+        }
+        public var soft: Color   { /* … */ }
+        public var accent: Color { /* … */ }
+        public var border: Color { /* … */ }
+        public var onSolid: Color { ColorContrast.content(on: solid) }   // theme-independent, unchanged
+
+        public func shade(_ step: SemanticColor.Shade) -> Color {
+            if color == .secondary || color == .accent {
+                return theme.brandShade(color.rawValue, step.rawValue)
+                    ?? (Theme.PaletteColorKey(rawValue: "palette.primary.\(step.rawValue)").map { theme.palette($0) } ?? .clear)
+            }
+            guard let key = Theme.PaletteColorKey(rawValue: "palette.\(color.rawValue).\(step.rawValue)") else { return .clear }
+            return theme.palette(key)
+        }
+        public var bg: Color { shade(.s50) }
+        public var base: Color { shade(.s500) }
+        // … bgHover, borderSubtle, borderHover, hover, active, strong — all shade(_:) forwards
+    }
+
+    /// Enum-side binder — for Class-P helpers that already receive a `Theme`
+    /// (mirrors `AlertToast.background(_:)` / `SeatPalette.colors(for:theme:)`).
+    func resolved(in theme: Theme) -> Resolved { Resolved(color: self, theme: theme) }
+}
+
+public extension Theme {
+    /// Theme-side binder — the ergonomic call in a View body: `theme.resolve(.primary).solid`.
+    /// Mirrors the existing `theme.text(_:)` / `theme.background(_:)` shape.
+    func resolve(_ color: SemanticColor) -> SemanticColor.Resolved { color.resolved(in: self) }
+}
+```
+
+The existing public properties are **kept and deprecated**, forwarding to the singleton so behavior is byte-identical until a site migrates:
+
+```swift
+public extension SemanticColor {
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).solid")
+    var solid: Color { resolved(in: .shared).solid }
+    // …the same one-line deprecate-forward for soft, accent, border, onSolid, shade(_:), bg, base, hover, active, strong, …
+}
+```
+
+**Naming.** `theme.resolve(_:)` mirrors `theme.text(_:)`/`theme.background(_:)` (identity in front, role behind) and is the primary call. `color.resolved(in:)` exists for Class-P helpers holding a `theme` parameter. Both return the one `Resolved` type; no duplicated logic.
+
+**Before / after — Class P (`SeatMapModels.swift`), the split-brain witness:**
+
+```swift
+// before — split brain in one switch
+case .standard:     return (theme.background(.bgBase), theme.border(.borderPrimary))
+case .extraLegroom: return (SemanticColor.info.bg,     SemanticColor.info.base)      // singleton
+// after — both halves read the same env theme (already a param here)
+case .standard:     return (theme.background(.bgBase),  theme.border(.borderPrimary))
+case .extraLegroom: return (theme.resolve(.info).bg,    theme.resolve(.info).base)
+```
+
+**Before / after — Class V (typical Style Chrome):**
+
+```swift
+struct FooChrome: View {
+    @Environment(\.theme) private var theme
+    var body: some View {
+        RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value)
+            .fill(SemanticColor.primary.solid)          // before: Theme.shared — mismatches the line below
+            .foregroundStyle(theme.text(.textPrimary))  // env-correct
+    }
+}
+// after: .fill(theme.resolve(.primary).solid)          // now consistent with theme.text(...)
+```
+
+### D3 — Non-View analysis (mirror ADR-0003)
+
+Following ADR-0003's discipline of stating the inherent limit rather than hiding it:
+
+- **Classes V and P resolve correctly** because a `Theme` is in scope (environment or parameter). This is the overwhelming majority: 121 of 146 files are Class V; Class-P helpers already take `theme` (the pattern predates this ADR).
+- **Class M (eager modifiers)** is *not* an inherent limit — it only *looks* like one. `Icon.accent(_:)` resolves `color?.base` to a `Color` at modifier-call time (outside any body). The fix is to store the `SemanticColor` and resolve in `body` via `@Environment(\.theme)`. The public modifier signature (`func accent(_ color: SemanticColor?) -> Self`) is unchanged; only an internal stored-property type flips (`Color?` → `SemanticColor?`). Every COW modifier that today stores a resolved `Color` derived from a `SemanticColor` gets the same treatment.
+- **Class N (non-View builders) is the one genuine limit.** `ChartColorScale.init(series:)` bakes `.solid` into a `[Color]` range with no `Theme` and, depending on the caller, possibly no View ancestor. **Recommended fix: thread a `theme:` parameter** — `ChartColorScale(series:theme:)` — populated by the chart's View body, which *does* hold `@Environment(\.theme)`. This converts N→P for every builder invoked from a View (the common case). A builder invoked from pure model code with no View in its call graph is the irreducible residue; for those, per-subtree color is physically impossible for the same reason ADR-0003 gave for strings (no `@Environment` at a value initializer), and they resolve against `Theme.shared` by definition. `sr-ios-dev` audits Class-N sites and confirms each is caller-threadable; the expectation from this inspection is that **all** current N sites (`ChartColorScale` is the only one found) are View-built and therefore fixable.
+
+The rule going forward: **never resolve `SemanticColor → Color` where a `Theme` is not in scope.** Store the enum; resolve at the latest possible moment (a View body or a helper that takes `theme`).
+
+### D4 — `Effects.swift`: convert View-extension helpers to `ViewModifier`s
+
+`edgeBorder(_:width:color:)` and `fadeEdge(_:length:color:)` (`Effects.swift:15-32`) are free functions on `View` that fall back to `Theme.shared` when their `Color?` argument is nil. As plain functions they cannot read `@Environment`. Fix: back each with a small `ViewModifier` struct that reads `@Environment(\.theme)` and uses it for the default. (Separately, the `color: Color?` parameter violates the token-fed-modifier house rule — MEMORY "token-fed-modifiers"; fold that into the same PR by taking a token key / `SemanticColor` instead of a raw `Color?`, deprecate-forwarding the raw overload. Non-blocking for the resolution fix but cheap to do together.)
+
+### D5 — Metrics & typography: documented process-global limit, same idiom available later
+
+`RadiusKey/RadiusRole/SpacingKey.value` and `TextStyle.font/.lineSpacing` **stay singleton-backed** in this ADR. Rationale: they vary by `radiusScale/spacingScale/fontScale/font`, which are not "brand," and threading them is ~2000 sites. Two concrete actions instead of a migration:
+
+1. **Correct the promise wording** in `ThemeContext.swift:40-48` and any docs so it is *true*: per-subtree `.theme(_:)` re-skins **color** (semantic/brand/accent and all instance color accessors); **corner radius, spacing, and type scale remain process-global** (they follow `Theme.shared` / the root `.themeKit()` theme). This is the honest, bounded slice of Approach B — applied only to the axis we are choosing not to isolate, and stated explicitly rather than implied.
+2. **Reserve the same resolver idiom** for a future phase if a real per-subtree metric need appears: `theme.metric(.spacing(.md))` / a `Theme.RadiusRole.value(in: theme)` overload, deprecate-forwarding the zero-arg `.value`. No new pattern, no commitment now.
+
+### D6 — Interaction with `.themeKit()`, `.theme(_:)`, and the localization folding
+
+- **`.themeKit()`** (`ThemeKit.swift:44-72`) injects `.environment(theme)` with `Theme.shared` and re-identifies the subtree on `ThemeKitRootIdentity(theme: revision, language: languageRevision)`. Unchanged. After this ADR, a runtime swap of `Theme.shared` still bumps `theme.revision`, still rebuilds the whole tree, and every body re-reads the env theme and **re-resolves** `SemanticColor` through it — same guarantee as today, now including the accents.
+- **`.theme(brandB)`** injects `brandB` for a subtree. After this ADR, `theme.resolve(…)` in that subtree reads `brandB` → correct accents on **first paint**. This is the "set-once, second brand in a subtree" case the promise is about, and it now holds. **Trade-off surfaced:** `.theme(brandB)` injects the instance but does *not* add `.id(brandB.revision)`, so a *live mutation* of `brandB` (a second `@Observable` theme reconfigured at runtime) won't repaint that subtree — exactly the gap `.themeKit()` closes for the root. If live-mutating a *secondary* subtree theme is ever required, add either the documented `.theme(brandB).id(brandB.revision)` pattern or a `.theme(_:reactToRuntimeChanges:)` overload that folds `brandB.revision` into an id the way `.themeKit()` does. Recommendation: document the `.id(brandB.revision)` pattern now; add the overload only on demand.
+- **Secondary Observation benefit (noted, not promised).** Because `theme.resolve(…)` reads the env theme's `@Observable` dictionaries instead of `Theme.shared`, SwiftUI's Observation can now track color-token reads and invalidate on change without the `.id(revision)` sledgehammer. This *reduces* reliance on the full-subtree rebuild for color, but does not remove it — the deferred metric/type `.value` reads still bypass Observation — so `.themeKit()` keeps its `.id(revision)`.
+- **Localization folding.** ADR-0003 folded `ThemeKitStrings` language revision into `.themeKit()`'s identity. This ADR is orthogonal (color, not strings) and touches none of that path; the `ThemeKitRootIdentity` composite is unchanged.
+
+### D7 — Enforcement: an allowlisted `Theme.shared` lint + the deprecation ratchet
+
+Two ratchets keep the fix from regressing:
+
+1. **The deprecation warnings are the migration to-do list.** Every un-migrated `SemanticColor.solid`-style read emits a warning; a PR is "done" for a file when its warnings are gone. (During the migration window the tree carries many warnings — expected and self-clearing per PR.)
+2. **A CI grep-lint** bans `Theme.shared` reads outside a small allowlist. The legitimate `Theme.shared` uses are: the singleton's own definition (`Theme.swift`), the environment default (`ThemeContext.swift:37`), the injectors (`ThemeKit.swift`, `ThemedHostingController.swift`), the *mutation* entry points that apply a config to the global (`ThemePicker`, `DesignSpec`, `ThemePresets`, `ThemeConfig` docs), the deprecate-forward shims themselves (`SemanticColor.swift`, and the deferred `ThemeModel.swift`/`Typography.swift` per D5), and `#Preview` bodies (which correctly inject `.environment(Theme.shared)`). Everything else is a finding. This is the same generated-artifact-gate philosophy as `make l10n` / `make skill`.
+
+## Consequences
+
+- **Positive:** the advertised feature becomes true — two subtrees with different brands render correct accents; the split-brain inside single bodies (`SeatPalette`, every Class-V file) is eliminated; the fix reuses an already-shipping pattern (`AlertToast.background(_:)`); per-call cost is nil (no new environment reads for 121/146 files); color-token reads become Observation-trackable; the misleading `ThemeContext` promise is either fulfilled (color) or corrected to be accurate (metric/type scale).
+- **Behavioral guarantee (backward-compat):** with no `.theme(_:)` override in play, `@Environment(\.theme)` is `Theme.shared`, so `theme.resolve(…)` resolves against the exact same instance the deprecated `SemanticColor.solid` reads — identical output. An app that never calls `.theme(_:)` is byte-identical before and after. No public type is removed; the deprecated accessors keep compiling.
+- **Costs / risks:** 758 SemanticColor call sites migrate (mechanical for V/P; small refactor for M; one audit for N); a transient wall of deprecation warnings during migration; the metric/type scale axis stays process-global (documented, deferred, not silently broken); `.theme(brandB)` live-mutation of a *secondary* theme still needs the `.id(brandB.revision)` pattern (surfaced, low-demand).
+- **Enforcement:** the deprecation ratchet + the allowlisted `Theme.shared` lint prevent new offenders and drive the existing ones to zero.
+
+## Blast radius (offender inventory, production only — `#Preview` scaffolding excluded)
+
+Every ambiguous component-file `Theme.shared` hit from the audit grep was verified to sit **inside a `#Preview` block** (`.environment(Theme.shared)` / preview `.background(…)`), which is correct and out of scope. The true production offenders:
+
+| # | Site | Class | Scope |
+|---|---|---|---|
+| 1 | `SemanticColor.swift:23-112` — all role + ladder accessors | engine (non-View) | **In scope — D2** |
+| 2 | `Effects.swift:17,23` — `edgeBorder`/`fadeEdge` fallback | View-extension helper | **In scope — D4** |
+| 3 | `Icon.swift:58` — `.accent(_:)` stores `color?.base` | M (eager modifier) | **In scope — D3** |
+| 4 | `ChartModels.swift:88,92` — `ChartColorScale` bakes `.solid` | N (non-View builder) | **In scope — D3, thread `theme:`** |
+| 5 | `SeatMapModels.swift:119,120,122,123` (+ `selectedColors`/`occupied`) | P (helper already takes `theme`) | **In scope — D3, swap reads** |
+| 6 | `MeterStyle.swift:90,142` — `SemanticColor.success.solid` in Chrome `body` | V | **In scope — D2** |
+| 7 | The remaining SemanticColor reads — **758 total across 146 files**, 121 already holding `@Environment(\.theme)` | V (majority) | **In scope — mechanical D2 swap** |
+| 8 | `ThemeModel.swift:78,104,120` — `RadiusKey/RadiusRole/SpacingKey.value` | engine (non-View) | **Deferred — D5 (documented limit)** |
+| 9 | `Typography.swift:96,103` — `TextStyle.font/.lineSpacing` | engine (non-View) | **Deferred — D5 (documented limit)** |
+
+Legitimate singleton uses (NOT offenders, allowlisted per D7): `Theme.swift` (definition), `ThemeContext.swift:37` (env default), `ThemeKit.swift` / `ThemedHostingController.swift` (injectors), `ThemePicker` / `DesignSpec` / `ThemePresets` / `ThemeConfig` (apply-to-global mutation), and all `#Preview` bodies.
+
+Reconciling the review's "~27 components": that figure counts the *distinct offender files* outside the engine; the *call-site* surface is 758 reads / 146 files, but 121 of those files already hold the env theme, so the migration is a near-mechanical prefix swap for the bulk, with genuine (small) work only on the ~4 timing-trap files (rows 3–6) plus `Effects.swift`.
+
+## Testing strategy
+
+- **Unit (ThemeKitCore):** build two `Theme` instances with different brand hexes (`applyGenerated(primaryHex:accentHex:)`). Assert `themeA.resolve(.accent).solid != themeB.resolve(.accent).solid`, and that `themeA.resolve(.info).base == themeA.background/palette` for the info key. Assert the deprecated `SemanticColor.info.base == Theme.shared.resolve(.info).base` (forward-equivalence). Assert `Resolved` is `Sendable`-usable across an isolation boundary (compile check under Swift 6 mode).
+- **Snapshot (the regression that proves the feature):** one image with **two side-by-side subtrees**, `.theme(brandA)` and `.theme(brandB)`, each rendering a `Badge`/`MeterStyle`/`SeatLegend` that uses `SemanticColor` accents. Pre-fix both render brand A's accent (the bug); post-fix each renders its own. This snapshot is the acceptance gate.
+- **Non-View (Class N):** a chart built inside a `.theme(brandB)` subtree must color its series with brandB — verifies `ChartColorScale(series:theme:)` threading.
+- **Live-mutation trade-off (D6):** a test that mutates a secondary `brandB` at runtime under bare `.theme(brandB)` (no repaint expected) vs. `.theme(brandB).id(brandB.revision)` (repaint) — documents the gap as tested behavior, not a surprise.
+- **On-device:** `-openDemo "Seat Map"` (or any SemanticColor-heavy component) wrapped in a two-brand harness; screenshot before/after.
+
+## Phased rollout (PR-per-unit)
+
+| Phase | Unit | Effort |
+|---|---|---|
+| 0 | `SemanticColor.Resolved` + `Theme.resolve(_:)` + `color.resolved(in:)`; deprecate-forward the zero-arg `SemanticColor` accessors; unit + two-brand snapshot harness. **No call sites migrated yet** — purely additive, tree still green. | M |
+| 1 | Migrate the **timing-trap** files (the ones that would otherwise stay wrong even after a mechanical swap): `Icon` (Class M), `ChartModels` (Class N, `theme:` param), `SeatMapModels` + any other Class-P helpers, `MeterStyle`, `Effects.swift` (D4). | M |
+| 2 | Mechanical Class-V migration of the remaining SemanticColor reads, batched by area (Atoms → Molecules → Organisms → Travel), one PR per batch — driven to zero deprecation warnings. Can run as parallel disjoint-file PRs (worktree pattern, MEMORY "repo-concurrent-agents-worktree"). | L |
+| 3 | Correct the `ThemeContext` promise wording (D5.1); add the allowlisted `Theme.shared` CI lint (D7); DocC/README note on what per-subtree `.theme(_:)` does and does not isolate. | S |
+| 4 (optional / on-demand) | Metric & typography threaded overloads (D5.2) and/or `.theme(_:reactToRuntimeChanges:)` (D6) — only if a concrete per-subtree metric or live secondary-theme need appears. | M |
+
+## Alternatives considered
+
+1. **Pure B — keep the singleton, delete the per-subtree promise.** Rejected (D1): throws away working surface re-skinning and every theme-pinned preview; the honest version requires removing `.theme(_:)` entirely.
+2. **Full A now — thread color + metrics + typography together.** Rejected (D1): ~2000 extra sites to isolate an axis no two-brand screen varies; kept as a same-idiom deferral (D5.2).
+3. **`in: Theme` on every accessor (`color.solid(in: theme)`) instead of a `Resolved` binder.** Rejected: turns 8 role *properties* into methods and threads `theme` at every one of the 758 reads with no shared binding; `Resolved` threads once and keeps property syntax (`theme.resolve(.primary).solid`).
+4. **A task-local / thread-local "current theme" the enum reads (`Theme.current`)** so `SemanticColor.solid` keeps its zero-arg shape. Rejected: SwiftUI body evaluation is not guaranteed to run inside a controlled task-local scope; it re-introduces hidden global state (the exact class of bug this ADR removes) and is unverifiable across the 217-component surface. The env theme is already in hand — no magic needed.
+5. **Make `SemanticColor` an `@Observable`/`EnvironmentKey` of its own.** Rejected: duplicates `\.theme` (a `SemanticColor` is a *selector*, not a *theme*); the theme already carries all the data.
+6. **Do nothing / mark `.theme(_:)` "preview-only" in docs.** Rejected: it works for surfaces today and the fix for accents is cheap and mechanical; scoping it to previews would be a strictly worse, still-inconsistent story.
+
+## Open questions (for sr-ios-dev pressure-testing)
+
+- **Class-N completeness:** confirm `ChartColorScale` is the *only* non-View builder that bakes `SemanticColor → Color`, and that every instantiation is reachable from a View that can supply `theme:`. If any is built in pure model code, decide explicitly: thread a `theme:` down, or accept `Theme.shared` for that residue and document it (ADR-0003 §"known limitation" wording).
+- **`Resolved` cost in hot lists:** `theme.resolve(.primary)` constructs a 2-field struct per read. In a large `SeatMap`/`Chart`, prove this is free (it is a stack value, but confirm no `Color` bridging surprises) — or bind once per body (`let p = theme.resolve(.primary)`) as the recommended call-site idiom for repeated roles.
+- **Deprecation noise policy:** whether to gate the `@available(deprecated)` behind a phase flag so Phase 0 lands warning-free and warnings switch on for Phase 2, vs. accepting the warning wall immediately as the visible to-do list.
+- **Icon (Class M) raw-color path:** confirm `Icon` has no *raw* `Color` accent path that also needs storing-vs-eager treatment, and that flipping the stored type to `SemanticColor?` doesn't collide with an existing raw override modifier.
+- **Metric-axis honesty check (D5.1):** verify no shipped demo/snapshot currently *relies* on per-subtree radius/spacing differing (it should not, given the singleton) before publishing the "metrics are process-global" statement.


### PR DESCRIPTION
## Summary

Implements Phase 0 + Phase 1 of ADR-0006 (the per-subtree theme resolution fix, architecture-review item R1/P0-1): `SemanticColor`'s role accessors (`.solid`/`.soft`/`.accent`/`.border`/`.shade(_:)`/…) resolved from `Theme.shared` regardless of a subtree's `.theme(_:)` override — a split-brain where surfaces re-skinned correctly but accent/semantic colors did not. This PR adds an additive resolver and fixes the 5 files where that split-brain would survive even a mechanical migration.

- **Phase 0 — additive resolver (no deprecation yet).** `SemanticColor.Resolved` binds a `SemanticColor` to a specific `Theme`, exposing the same role vocabulary as today. `theme.resolve(_:)` (mirrors `theme.text(_:)`/`theme.background(_:)`) and `color.resolved(in:)` (for Class-P helpers that already hold a `theme`) are the two new entry points. The role→color switch logic now lives **once** in `Resolved`; the existing zero-arg `SemanticColor` accessors forward to `resolved(in: .shared)` — byte-identical behavior for every un-migrated call site, and **not yet marked `@available(deprecated)`** so the ~121 un-migrated files don't flood the build with warnings (that's Phase 2).
- **Phase 1 — the timing-trap files** (ADR-0006 §"root cause is resolution *timing*"), each fixed with an unchanged public signature:
  - `Icon.swift` (Class M — eager modifier): `.accent(_:)` now stores the `SemanticColor` enum instead of eagerly resolving to a `Color` before `body` runs (which would freeze the tint to `Theme.shared`); resolution happens in `body` via `@Environment(\.theme)`.
  - `ChartModels.swift` (Class N — non-View builder): `ChartColorScale` now takes a `theme:` param from the building chart View instead of baking `.solid` with no theme in scope. All 4 call sites (LineChart/BarChart/AreaChart/DonutChart) already hold `@Environment(\.theme)` and now pass it through — including the 3 `annotationCard` scrub-row builders that also read `ChartPalette.hue(...).solid` directly.
  - `SeatMapModels.swift` (Class P — the ADR's split-brain witness): `SeatPalette.colors(for:theme:)`, `.selectedColors(theme:)`, `.occupiedColors(theme:)` now resolve every branch through the passed `theme` instead of mixing `theme.background(...)` with bare `SemanticColor.X` singleton reads in the same switch.
  - `MeterStyle.swift`: the private `LinearMeterBar`/`StripedMeterBar` Chrome views gain `@Environment(\.theme)` and resolve the success-fraction fill through it.
  - `Effects.swift` (D4): `edgeBorder`/`fadeEdge` convert from plain `View`-extension functions (no `@Environment` access — the actual bug) to `ViewModifier`s that read the environment theme for their fallback color; public call sites/signatures unchanged.

## Tests — the acceptance evidence

- `ThemeSubtreeColorResolutionTests` (macOS, `NSHostingView` — mirrors `L10nViewLayerTests`): hosts two subtrees under `.theme(brandA)` / `.theme(brandB)` and captures, from the same probe, both `theme.resolve(.accent).solid` (new API) and `SemanticColor.accent.solid` (old, still-shipping API) per subtree.
  - **PASS with the new resolver:** `theme.resolve(.accent).solid` differs between the two subtrees.
  - **Demonstrated FAIL with the old singleton path:** the old accessor's value is *identical* across both subtrees (both collapse to `Theme.shared`'s own accent, provably equal to `Theme.shared.resolve(.accent).solid` by construction) — an isolation assertion on that path would fail. This is the split-brain ADR-0006 fixes, reproduced live in one render.
- `SemanticColorResolvedTests` (cross-platform unit): two independently-configured `Theme` instances resolve distinct `.accent`/`.primary` solids; `Resolved` matches a theme's own instance accessors for a non-brand role (`.info`); every deprecate-candidate zero-arg accessor (`solid`/`soft`/`accent`/`border`/`onSolid`/`base`/all 10 `shade(_:)` steps, for every `SemanticColor` case) is asserted byte-identical to `theme.resolve(_:)` against `Theme.shared` — the backward-compat guarantee; `Resolved` is proven `Sendable`-usable across a `Task` boundary under Swift 6 mode.

## Gates (both trait lanes)

- `swift build --build-tests` — green
- `swift test` (default traits) — 319 tests, 0 failures
- `swift build --enable-all-traits --build-tests` — green
- `swift test --enable-all-traits --skip-build` — 319 tests, 0 failures
- `swiftlint lint --quiet` — no new violations (pre-existing warnings only, none in touched/new files)
- `scripts/check-neutrality.sh` — clean
- `Package.resolved` restored after the all-traits build (it re-resolves Almanac/Lottie pins under `--enable-all-traits`)
- The pre-push hook re-ran the full local CI gate (`make ci`) on push — all green

## Follow-ups (explicitly out of scope for this PR)

- **Phase 2:** `@available(*, deprecated,…)` the zero-arg `SemanticColor` accessors + mechanical Class-V migration of the remaining ~121 files / 758 call sites, batched by area, PR-per-batch.
- **Phase 3:** correct the `ThemeContext` doc-comment wording (per-subtree `.theme(_:)` isolates *color*; radius/spacing/type scale stay process-global) + an allowlisted `Theme.shared` CI grep-lint.
- **Phase 4 (on-demand):** threaded metric/type-scale resolver overloads, only if a concrete per-subtree need appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>