### PR TITLE
feat(review): ADR-0006 Phase 2+3 — migrate consumers, deprecate singleton accessors, guard R1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,25 @@ jobs:
             || { echo "::error::Variant-matrix naming drift — a color/variant/size axis takes a raw Color/CGFloat. Token-feed it, deprecate-and-forward, or allowlist a documented genuine dimension (scripts/check-variant-naming.sh, ADR-3)."; exit 1; }
 
   # ---------------------------------------------------------------------------
+  # Per-subtree theme resolution gate (ADR-0006 §D7): `Theme.shared` reads
+  # outside the allowlist (scripts/theme-shared-allowlist.txt) silently defeat
+  # per-subtree `.theme(_:)` re-theming (the R1 bug the ADR fixed) — pure grep
+  # → Linux (1× minutes), and BLOCKING (unlike variant-naming's informational
+  # policy): a regression here means the advertised feature quietly breaks
+  # again for the offending component.
+  # ---------------------------------------------------------------------------
+  theme-shared:
+    name: Theme.shared allowlist (ADR-0006)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for un-allowlisted Theme.shared reads
+        run: |
+          scripts/check-theme-shared.sh \
+            || { echo "::error::Un-allowlisted Theme.shared read — it defeats per-subtree .theme() (ADR-0006 §D7). Resolve against @Environment(\\.theme) / thread a theme: param, or document a genuine engine site in scripts/theme-shared-allowlist.txt."; exit 1; }
+
+  # ---------------------------------------------------------------------------
   # Public-API breakage detection. PR-only (diffs against the PR base) and
   # BLOCKING (ADR-review P1-1) — a source-breaking change must be intentional and
   # recorded in .api-breakage-allowlist.txt. Additions are non-breaking and pass.

--- a/Sources/ThemeKit/Components/Atoms/Aura.swift
+++ b/Sources/ThemeKit/Components/Atoms/Aura.swift
@@ -35,7 +35,7 @@ public struct Aura: View {
         Circle()
             .fill(
                 RadialGradient(
-                    colors: [color.base.opacity(intensity), color.base.opacity(0)],
+                    colors: [theme.resolve(color).base.opacity(intensity), theme.resolve(color).base.opacity(0)],
                     center: .center,
                     startRadius: 0,
                     endRadius: diameter / 2
@@ -103,6 +103,7 @@ private struct AuraModifier: ViewModifier {
     let radius: CGFloat
     let intensity: Double
 
+    @Environment(\.theme) private var theme
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var breathing = false
@@ -115,7 +116,7 @@ private struct AuraModifier: ViewModifier {
                 // Two ladder steps of the same semantic color give the halo a
                 // subtle direction without introducing a second color knob.
                 LinearGradient(
-                    colors: [color.base, color.hover],
+                    colors: [theme.resolve(color).base, theme.resolve(color).hover],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
                 )

--- a/Sources/ThemeKit/Components/Atoms/Avatar.swift
+++ b/Sources/ThemeKit/Components/Atoms/Avatar.swift
@@ -115,11 +115,13 @@ public struct Avatar: View {
     /// every other `FillVariant` resolves like `.solid` (documented on `fill(_:)`).
     private var surfaceFill: Color {
         guard let accent = effectiveAccent else { return background.fill(theme) }
-        return fillVariant == .soft ? accent.soft : accent.solid
+        let resolved = theme.resolve(accent)
+        return fillVariant == .soft ? resolved.soft : resolved.solid
     }
     private var contentColor: Color {
         guard let accent = effectiveAccent else { return background.foreground(theme) }
-        return fillVariant == .soft ? accent.accent : accent.onSolid
+        let resolved = theme.resolve(accent)
+        return fillVariant == .soft ? resolved.accent : resolved.onSolid
     }
 
     public var body: some View {
@@ -137,7 +139,7 @@ public struct Avatar: View {
         // set, else the primary border token.
         .overlay {
             if isBordered {
-                clip.stroke(borderAccent?.solid ?? theme.border(.borderPrimary), lineWidth: 2)
+                clip.stroke(borderAccent.map { theme.resolve($0).solid } ?? theme.border(.borderPrimary), lineWidth: 2)
             }
         }
         .overlay(alignment: .bottomTrailing) { presenceDot }

--- a/Sources/ThemeKit/Components/Atoms/Badge.swift
+++ b/Sources/ThemeKit/Components/Atoms/Badge.swift
@@ -119,7 +119,12 @@ public struct Badge: View {
     private var shape: BadgeShape = .pill
     private var trailingSystemImage: String?
     private var textColor: Color?
-    private var gradient: [Color]?
+    // ADR-0006: stored as `SemanticColor` (not a resolved `Color`) so the
+    // gradient is re-resolved from the environment theme in `body`, honoring
+    // per-subtree `.theme(_:)`; `rawGradient` is the raw-`Color` escape hatch
+    // (deprecated `gradient(_: [Color]?)`), which has no theme to resolve.
+    private var semanticGradient: [SemanticColor]?
+    private var rawGradient: [Color]?
     private var highlighted: Bool = false
 
     public init(_ text: String, action: (() -> Void)? = nil) {   // R1 — content + action
@@ -157,15 +162,21 @@ public struct Badge: View {
         if let textColor { return textColor }
         switch variant {
         case .soft: return style.foreground(theme)
-        case .solid: return style.semantic.onSolid
-        case .outline, .ghost: return style.semantic.accent
+        case .solid: return theme.resolve(style.semantic).onSolid
+        case .outline, .ghost: return theme.resolve(style.semantic).accent
         }
     }
     private var backgroundStyle: AnyShapeStyle {
-        if let gradient { return AnyShapeStyle(LinearGradient(colors: gradient, startPoint: .leading, endPoint: .trailing)) }
+        if let semanticGradient {
+            let colors = semanticGradient.map { theme.resolve($0).solid }
+            return AnyShapeStyle(LinearGradient(colors: colors, startPoint: .leading, endPoint: .trailing))
+        }
+        if let rawGradient {
+            return AnyShapeStyle(LinearGradient(colors: rawGradient, startPoint: .leading, endPoint: .trailing))
+        }
         switch variant {
         case .soft: return AnyShapeStyle(style.background(theme))
-        case .solid: return AnyShapeStyle(style.semantic.solid)
+        case .solid: return AnyShapeStyle(theme.resolve(style.semantic).solid)
         case .outline, .ghost: return AnyShapeStyle(Color.clear)
         }
     }
@@ -173,7 +184,7 @@ public struct Badge: View {
         switch variant {
         case .soft: return style.border(theme)
         case .solid: return .clear
-        case .outline: return style.semantic.border
+        case .outline: return theme.resolve(style.semantic).border
         case .ghost: return .clear
         }
     }
@@ -207,14 +218,14 @@ public extension Badge {
     func badgeColor(_ color: Color?) -> Self { copy { $0.textColor = color } }
     /// Fills the badge with a horizontal gradient of semantic tokens (each
     /// hue's solid shade) instead of the style background; `nil` restores it.
-    func gradient(_ colors: [SemanticColor]?) -> Self { copy { $0.gradient = colors?.map(\.solid) } }
+    func gradient(_ colors: [SemanticColor]?) -> Self { copy { $0.semanticGradient = colors; $0.rawGradient = nil } }
     /// Raw-color gradient (back-compat); prefer the token-bound overload.
     /// Disfavored so member-shorthand literals like `[.purple, .pink]` —
     /// valid as both `[Color]` and `[SemanticColor]` — resolve to the token
     /// overload instead of being ambiguous.
     @_disfavoredOverload
     @available(*, deprecated, message: "Use gradient(_: [SemanticColor]?) — the token-bound overload.")
-    func gradient(_ colors: [Color]?) -> Self { copy { $0.gradient = colors } }
+    func gradient(_ colors: [Color]?) -> Self { copy { $0.rawGradient = colors; $0.semanticGradient = nil } }
     /// Lifts the badge off the surface with a subtle drop shadow.
     func highlighted(_ on: Bool = true) -> Self { copy { $0.highlighted = on } }
 

--- a/Sources/ThemeKit/Components/Atoms/BorderBeam.swift
+++ b/Sources/ThemeKit/Components/Atoms/BorderBeam.swift
@@ -90,7 +90,7 @@ private struct BorderBeamModifier: ViewModifier {
     private var beamInset: CGFloat { lineWidth / 2 - outset }
 
     private var palette: [Color] {
-        colors ?? [theme.background(.bgHero), SemanticColor.turquoise.base]
+        colors ?? [theme.background(.bgHero), theme.resolve(.turquoise).base]
     }
 
     func body(content: Content) -> some View {

--- a/Sources/ThemeKit/Components/Atoms/CloseButton.swift
+++ b/Sources/ThemeKit/Components/Atoms/CloseButton.swift
@@ -81,7 +81,7 @@ public struct CloseButton: View {
     /// Disabled always wins; then the semantic tint; else the muted default.
     private var glyphColor: Color {
         guard isEnabled else { return theme.text(.textDisabled) }
-        if let tint { return tint.accent }
+        if let tint { return theme.resolve(tint).accent }
         return theme.text(.textTertiary)
     }
 }

--- a/Sources/ThemeKit/Components/Atoms/CodeBlock.swift
+++ b/Sources/ThemeKit/Components/Atoms/CodeBlock.swift
@@ -69,7 +69,7 @@ public struct CodeBlock: View {
             .padding(.vertical, Theme.SpacingKey.md.value)
             .padding(.trailing, showsCopyButton ? 36 : 0)
         }
-        .background(SemanticColor.neutral.shade(.s900))
+        .background(theme.resolve(.neutral).shade(.s900))
         .clipShape(shape)
         .overlay(alignment: .topTrailing) {
             if showsCopyButton { copyButton }
@@ -81,24 +81,24 @@ public struct CodeBlock: View {
         HStack(alignment: .firstTextBaseline, spacing: Theme.SpacingKey.sm.value) {
             Text(line.prefix ?? "")
                 .frame(minWidth: 18, alignment: .trailing)
-                .foregroundStyle(line.highlight.map { $0.onSolid.opacity(0.7) }
-                                 ?? SemanticColor.neutral.shade(.s500))
+                .foregroundStyle(line.highlight.map { theme.resolve($0).onSolid.opacity(0.7) }
+                                 ?? theme.resolve(.neutral).shade(.s500))
             Text(line.text)
-                .foregroundStyle(line.highlight.map { $0.onSolid }
-                                 ?? SemanticColor.neutral.shade(.s100))
+                .foregroundStyle(line.highlight.map { theme.resolve($0).onSolid }
+                                 ?? theme.resolve(.neutral).shade(.s100))
         }
         .font(.system(.footnote, design: .monospaced))
         .padding(.horizontal, Theme.SpacingKey.md.value)
         .padding(.vertical, 3)
-        .background(line.highlight.map { $0.solid } ?? .clear)
+        .background(line.highlight.map { theme.resolve($0).solid } ?? .clear)
     }
 
     private var copyButton: some View {
         Button(action: copyAll) {
             Image(systemName: copied ? "checkmark" : "doc.on.doc")
                 .font(.footnote.weight(.semibold))
-                .foregroundStyle(copied ? SemanticColor.success.base
-                                        : SemanticColor.neutral.shade(.s400))
+                .foregroundStyle(copied ? theme.resolve(.success).base
+                                        : theme.resolve(.neutral).shade(.s400))
                 .frame(width: 28, height: 28)
                 .contentShape(Rectangle())
         }

--- a/Sources/ThemeKit/Components/Atoms/Confetti.swift
+++ b/Sources/ThemeKit/Components/Atoms/Confetti.swift
@@ -20,6 +20,7 @@ import SwiftUI
 /// content.confetti(trigger: submissionCount)
 /// ```
 public struct Confetti: View {
+    @Environment(\.theme) private var theme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Appearance — mutated only through the modifiers below (R2).
@@ -33,9 +34,9 @@ public struct Confetti: View {
     public init() {}
 
     private var palette: [Color] {
-        colorsOverride.map { $0.map(\.base) } ?? [
-            SemanticColor.primary.base, SemanticColor.purple.base, SemanticColor.pink.base,
-            SemanticColor.orange.base, SemanticColor.success.base, SemanticColor.warning.base,
+        colorsOverride.map { $0.map { theme.resolve($0).base } } ?? [
+            theme.resolve(.primary).base, theme.resolve(.purple).base, theme.resolve(.pink).base,
+            theme.resolve(.orange).base, theme.resolve(.success).base, theme.resolve(.warning).base,
         ]
     }
 
@@ -75,7 +76,7 @@ public struct Confetti: View {
             ConfettiPiece(
                 startX: CGFloat.random(in: 0.05...0.95),
                 drift: CGFloat.random(in: -0.25...0.25),
-                color: palette.randomElement() ?? SemanticColor.primary.base,
+                color: palette.randomElement() ?? theme.resolve(.primary).base,
                 spin: Double.random(in: 240...900) * (Bool.random() ? 1 : -1),
                 delay: reduceMotion ? 0 : CGFloat.random(in: 0...0.25),
                 size: CGFloat.random(in: 6...11)

--- a/Sources/ThemeKit/Components/Atoms/CountBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/CountBadge.swift
@@ -42,10 +42,10 @@ private struct CountBubble: View {
                 ? "\(overflowCount.formatted(.number.locale(locale)))+"
                 : count.formatted(.number.locale(locale)))
                 .font(.system(size: 11, weight: .bold))
-                .foregroundStyle(color.onSolid)
+                .foregroundStyle(theme.resolve(color).onSolid)
                 .padding(.horizontal, 5)
                 .frame(minWidth: 18, minHeight: 18)
-                .background(color.solid, in: Capsule())
+                .background(theme.resolve(color).solid, in: Capsule())
                 .overlay(Capsule().strokeBorder(theme.background(.bgWhite), lineWidth: 1.5))
                 .offset(x: 9, y: -9)
         }
@@ -57,7 +57,7 @@ private struct DotBadge: View {
     @Environment(\.theme) private var theme
 
     var body: some View {
-        Circle().fill(color.solid).frame(width: 10, height: 10)
+        Circle().fill(theme.resolve(color).solid).frame(width: 10, height: 10)
             .overlay(Circle().strokeBorder(theme.background(.bgWhite), lineWidth: 1.5))
             .offset(x: 4, y: -4)
             // Color-only status dot — decorative to VoiceOver; the host view
@@ -78,14 +78,16 @@ public struct Ribbon<Content: View>: View {
         self.content = content()
     }
 
+    @Environment(\.theme) private var theme
+
     public var body: some View {
         content.overlay(alignment: .topTrailing) {
             Text(text)
                 .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(color.onSolid)
+                .foregroundStyle(theme.resolve(color).onSolid)
                 .padding(.horizontal, Theme.SpacingKey.sm.value)
                 .padding(.vertical, 3)
-                .background(color.solid)
+                .background(theme.resolve(color).solid)
                 .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
                 .offset(x: 6, y: 8)
                 .themeShadow(.soft)

--- a/Sources/ThemeKit/Components/Atoms/FareFeatureRow.swift
+++ b/Sources/ThemeKit/Components/Atoms/FareFeatureRow.swift
@@ -41,7 +41,7 @@ public struct FareFeatureRow: View {
     }
 
     private var iconColor: Color {
-        if let accent { return accent.accent }
+        if let accent { return theme.resolve(accent).accent }
         switch feature.status {
         case .included: return theme.foreground(.systemcolorsFgSuccess)
         case .excluded: return theme.text(.textTertiary)

--- a/Sources/ThemeKit/Components/Atoms/IconTile.swift
+++ b/Sources/ThemeKit/Components/Atoms/IconTile.swift
@@ -28,8 +28,8 @@ public struct IconTile: View {
 
     public init(_ systemImage: String) { self.systemImage = systemImage }   // R1
 
-    private var bg: Color { accent.map { $0.bg } ?? theme.background(backgroundKey) }
-    private var fg: Color { accent.map { $0.base } ?? iconColorKey.map { theme.text($0) } ?? theme.text(.textSecondary) }
+    private var bg: Color { accent.map { theme.resolve($0).bg } ?? theme.background(backgroundKey) }
+    private var fg: Color { accent.map { theme.resolve($0).base } ?? iconColorKey.map { theme.text($0) } ?? theme.text(.textSecondary) }
 
     public var body: some View {
         Image(systemName: systemImage)

--- a/Sources/ThemeKit/Components/Atoms/Indicator.swift
+++ b/Sources/ThemeKit/Components/Atoms/Indicator.swift
@@ -41,20 +41,20 @@ public extension View {
     /// Overlays a small status dot at a corner, in the error token — the
     /// classic notification dot.
     func indicatorDot(position: IndicatorPosition = .topTrailing) -> some View {
-        indicator(position) { IndicatorDot(color: nil) }
+        indicator(position) { IndicatorDot(semantic: nil, rawColor: nil) }
     }
 
     /// Overlays a small status dot at a corner, tinted by a semantic color
     /// (e.g. `.success` for an online dot).
     func indicatorDot(_ accent: SemanticColor, position: IndicatorPosition = .topTrailing) -> some View {
-        indicator(position) { IndicatorDot(color: accent.base) }
+        indicator(position) { IndicatorDot(semantic: accent, rawColor: nil) }
     }
 
     /// Raw dot tint (back-compat); prefer the `SemanticColor` overload —
     /// or `indicatorDot(position:)` for the error-token default.
     @available(*, deprecated, message: "Use indicatorDot(_: SemanticColor, position:) — the token-fed overload.")
     func indicatorDot(_ color: Color? = nil, position: IndicatorPosition = .topTrailing) -> some View {
-        indicator(position) { IndicatorDot(color: color) }
+        indicator(position) { IndicatorDot(semantic: nil, rawColor: color) }
     }
 }
 
@@ -72,13 +72,17 @@ private struct IndicatorNudge: ViewModifier {
 }
 
 // Extracted into a View so the dot + halo resolve the injected `\.theme`.
+// `semantic` is resolved here (in `body`), not at modifier-call time, so it
+// honors per-subtree `.theme(_:)` (ADR-0006); `rawColor` is the raw-`Color`
+// escape hatch (deprecated `indicatorDot(_: Color?, position:)`).
 private struct IndicatorDot: View {
-    let color: Color?
+    let semantic: SemanticColor?
+    let rawColor: Color?
     @Environment(\.theme) private var theme
 
     var body: some View {
         Circle()
-            .fill(color ?? theme.foreground(.systemcolorsFgError))
+            .fill(semantic.map { theme.resolve($0).base } ?? rawColor ?? theme.foreground(.systemcolorsFgError))
             .frame(width: 10, height: 10)
             .overlay(Circle().stroke(theme.background(.bgWhite), lineWidth: 2))
             // Color-only status dot — decorative to VoiceOver; the host view

--- a/Sources/ThemeKit/Components/Atoms/InlineText.swift
+++ b/Sources/ThemeKit/Components/Atoms/InlineText.swift
@@ -17,6 +17,9 @@ public struct InlineText: View {
 
     // Appearance/config — mutated only through the modifiers below (R2).
     private var baseColor: Color? = nil
+    // ADR-0006: the token overload stores the `SemanticColor` (not a resolved
+    // `Color`) so it re-resolves against the environment theme in `body`.
+    private var semanticColor: SemanticColor? = nil
     private var style: TextStyle = .bodySm400
 
     public init(_ text: String, links: [(substring: String, action: () -> Void)] = []) {   // R1
@@ -38,7 +41,7 @@ public struct InlineText: View {
     private var attributed: AttributedString {
         var string = AttributedString(text)
         string.font = style.font
-        string.foregroundColor = baseColor ?? theme.text(.textSecondary)
+        string.foregroundColor = semanticColor.map { theme.resolve($0).base } ?? baseColor ?? theme.text(.textSecondary)
         for (index, link) in links.enumerated() {
             if let range = string.range(of: link.substring) {
                 string[range].foregroundColor = theme.text(.textHero)
@@ -54,11 +57,11 @@ public struct InlineText: View {
 
 public extension InlineText {
     /// Semantic base text color; `nil` (default) uses the theme's secondary text color.
-    func accent(_ color: SemanticColor?) -> Self { copy { $0.baseColor = color?.base } }
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.semanticColor = color; $0.baseColor = nil } }
 
     /// Raw base text color (back-compat); prefer `accent(_:)`.
     @available(*, deprecated, message: "Use accent(_:) with a SemanticColor token.")
-    func color(_ color: Color?) -> Self { copy { $0.baseColor = color } }
+    func color(_ color: Color?) -> Self { copy { $0.baseColor = color; $0.semanticColor = nil } }
 
     /// Typography token for the body text. Named `inlineStyle` so it doesn't
     /// shadow the kit-wide `.textStyle(_:)` view modifier.

--- a/Sources/ThemeKit/Components/Atoms/ProgressBar.swift
+++ b/Sources/ThemeKit/Components/Atoms/ProgressBar.swift
@@ -45,6 +45,9 @@ public struct ProgressBar: View {
     private var gradient: Bool = false
     private var steps: Int? = nil
     private var strokeColor: Color? = nil
+    // ADR-0006: the token overload stores the `SemanticColor` (not a resolved
+    // `Color`) so it re-resolves against the environment theme in `body`.
+    private var semanticFill: SemanticColor? = nil
     private var trailColor: Color? = nil
     private var successSegment: Double? = nil
     private var format: ((Double) -> String)? = nil
@@ -110,7 +113,7 @@ public struct ProgressBar: View {
     private var labelView: AnyView? {
         if status == .success && value >= 1 {
             return AnyView(
-                Icon(systemName: "checkmark.circle.fill").size(.sm).colorOverride(status.semantic.accent)
+                Icon(systemName: "checkmark.circle.fill").size(.sm).colorOverride(theme.resolve(status.semantic).accent)
             )
         }
         if showPercentage {
@@ -125,13 +128,17 @@ public struct ProgressBar: View {
     }
 
     private var fillStyle: AnyShapeStyle {
+        if let semanticFill {
+            return AnyShapeStyle(theme.resolve(semanticFill).base)
+        }
         if let strokeColor {
             return AnyShapeStyle(strokeColor)
         }
         if gradient {
-            return AnyShapeStyle(LinearGradient(colors: [status.semantic.base, status.semantic.hover], startPoint: .leading, endPoint: .trailing))
+            let resolved = theme.resolve(status.semantic)
+            return AnyShapeStyle(LinearGradient(colors: [resolved.base, resolved.hover], startPoint: .leading, endPoint: .trailing))
         }
-        return AnyShapeStyle(status.semantic.solid)
+        return AnyShapeStyle(theme.resolve(status.semantic).solid)
     }
 }
 
@@ -148,12 +155,12 @@ public extension ProgressBar {
     func steps(_ count: Int?) -> Self { copy { $0.steps = count } }
     /// Semantic fill override; `nil` (default) keeps the status-derived fill.
     /// Drives only the fill — the track keeps its token default.
-    func accent(_ color: SemanticColor?) -> Self { copy { $0.strokeColor = color?.base } }
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.semanticFill = color; $0.strokeColor = nil } }
     /// Raw fill/track overrides (back-compat); prefer `accent(_:)` for the fill.
     @available(*, deprecated, message: "Use accent(_:) with a SemanticColor token.")
     func colors(fill: Color? = nil, track: Color? = nil) -> Self {
         copy {
-            if let fill { $0.strokeColor = fill }
+            if let fill { $0.strokeColor = fill; $0.semanticFill = nil }
             if let track { $0.trailColor = track }
         }
     }

--- a/Sources/ThemeKit/Components/Atoms/RadialProgress.swift
+++ b/Sources/ThemeKit/Components/Atoms/RadialProgress.swift
@@ -56,7 +56,7 @@ public struct RadialProgress: View {
     }
 
     // Raw override wins, then the semantic accent, then the status color.
-    private var color: Color { tint ?? semantic?.solid ?? status.semantic.solid }
+    private var color: Color { tint ?? semantic.map { theme.resolve($0).solid } ?? theme.resolve(status.semantic).solid }
     /// Semantic driving the success / exception glyph tint (accent-aware).
     private var glyphSemantic: SemanticColor { semantic ?? status.semantic }
 
@@ -108,12 +108,12 @@ public struct RadialProgress: View {
         guard showLabel else { return nil }
         if status == .success && value >= 1 {
             return AnyView(
-                Image(systemName: "checkmark").font(.system(size: size * 0.3, weight: .bold)).foregroundStyle(glyphSemantic.accent)
+                Image(systemName: "checkmark").font(.system(size: size * 0.3, weight: .bold)).foregroundStyle(theme.resolve(glyphSemantic).accent)
             )
         }
         if status == .exception {
             return AnyView(
-                Image(systemName: "xmark").font(.system(size: size * 0.3, weight: .bold)).foregroundStyle(glyphSemantic.accent)
+                Image(systemName: "xmark").font(.system(size: size * 0.3, weight: .bold)).foregroundStyle(theme.resolve(glyphSemantic).accent)
             )
         }
         return AnyView(

--- a/Sources/ThemeKit/Components/Atoms/RollingNumber.swift
+++ b/Sources/ThemeKit/Components/Atoms/RollingNumber.swift
@@ -14,6 +14,9 @@ public struct RollingNumber: View {
     private var size: CGFloat = 28
     private var weight: Font.Weight = .bold
     private var color: Color?
+    // ADR-0006: the token overload stores the `SemanticColor` (not a resolved
+    // `Color`) so it re-resolves against the environment theme in `body`.
+    private var semanticColor: SemanticColor?
 
     private let value: Int
 
@@ -26,11 +29,15 @@ public struct RollingNumber: View {
 
     private var digits: [Int] { String(abs(value)).compactMap(\.wholeNumberValue) }
 
+    /// Resolved against the environment theme in `body` — never stored eagerly
+    /// at modifier-call time (ADR-0006).
+    private var resolvedColor: Color? { semanticColor.map { theme.resolve($0).base } ?? color }
+
     public var body: some View {
         HStack(spacing: 0) {
-            if value < 0 { Text("-").rollingFont(size, weight, color ?? theme.text(.textPrimary)) }
+            if value < 0 { Text("-").rollingFont(size, weight, resolvedColor ?? theme.text(.textPrimary)) }
             ForEach(Array(digits.enumerated()), id: \.offset) { _, digit in
-                DigitColumn(digit: digit, size: size, weight: weight, color: color)
+                DigitColumn(digit: digit, size: size, weight: weight, color: resolvedColor)
             }
         }
         // Numbers always read left-to-right — pin only the digit row so an
@@ -53,7 +60,7 @@ public extension RollingNumber {
     func weight(_ w: Font.Weight) -> Self { copy { $0.weight = w } }
 
     /// Semantic digit color; `nil` (default) uses `textPrimary`.
-    func accent(_ color: SemanticColor?) -> Self { copy { $0.color = color?.base } }
+    func accent(_ color: SemanticColor?) -> Self { copy { $0.semanticColor = color; $0.color = nil } }
 
     /// Raw digit color override (back-compat); prefer `accent(_:)`.
     @available(*, deprecated, message: "Use accent(_:) with a SemanticColor token.")
@@ -62,7 +69,7 @@ public extension RollingNumber {
     /// Module-internal raw digit color (mirrors `Icon.colorOverride`), so
     /// in-package call sites needing a theme-token `Color` stay off the
     /// deprecated `color(_:)` without changing behavior.
-    internal func colorOverride(_ c: Color?) -> Self { copy { $0.color = c } }
+    internal func colorOverride(_ c: Color?) -> Self { copy { $0.color = c; $0.semanticColor = nil } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self

--- a/Sources/ThemeKit/Components/Atoms/ScoreBadge.swift
+++ b/Sources/ThemeKit/Components/Atoms/ScoreBadge.swift
@@ -28,9 +28,9 @@ public struct ScoreBadge: View {
     }
 
     /// Fill — the accent's solid role when set, else the stock turquoise token.
-    private var fill: Color { accent.map { $0.solid } ?? theme.background(.bgTurquoise) }
+    private var fill: Color { accent.map { theme.resolve($0).solid } ?? theme.background(.bgTurquoise) }
     /// Content on the fill — auto-contrasting on a custom accent.
-    private var content: Color { accent.map { $0.onSolid } ?? theme.foreground(.fgSecondary) }
+    private var content: Color { accent.map { theme.resolve($0).onSolid } ?? theme.foreground(.fgSecondary) }
 
     private var isLarge: Bool { size == .large }
 

--- a/Sources/ThemeKit/Components/Atoms/ShareButton.swift
+++ b/Sources/ThemeKit/Components/Atoms/ShareButton.swift
@@ -29,8 +29,8 @@ public struct ShareButton: View {
                 .textStyle(size?.textStyle ?? .labelBase600)
                 .padding(.horizontal, size?.horizontalPadding ?? Theme.SpacingKey.md.value)
                 .frame(height: size?.height ?? 44)
-                .foregroundStyle(accent.map { $0.onSolid } ?? theme.foreground(.fgSecondary))
-                .background(accent.map { $0.solid } ?? theme.foreground(.fgHero),
+                .foregroundStyle(accent.map { theme.resolve($0).onSolid } ?? theme.foreground(.fgSecondary))
+                .background(accent.map { theme.resolve($0).solid } ?? theme.foreground(.fgHero),
                             in: RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous))
         }
     }

--- a/Sources/ThemeKit/Components/Atoms/Skeleton.swift
+++ b/Sources/ThemeKit/Components/Atoms/Skeleton.swift
@@ -68,7 +68,7 @@ struct SkeletonShimmer: View {
     /// The sweep's tint — a semantic color's soft shade when set, else the
     /// token default.
     private var highlightColor: Color {
-        highlight?.soft ?? theme.background(.bgWhite).opacity(0.7)
+        highlight.map { theme.resolve($0).soft } ?? theme.background(.bgWhite).opacity(0.7)
     }
 
     /// Pulse breathes the fill; shimmer / `none` / Reduce Motion keep it solid.

--- a/Sources/ThemeKit/Components/Atoms/Spinner.swift
+++ b/Sources/ThemeKit/Components/Atoms/Spinner.swift
@@ -63,7 +63,7 @@ public struct Spinner: View {
     public init() {}   // R1
 
     /// Raw override wins, then the semantic accent, then the theme hero foreground.
-    private var tint: Color { color ?? semantic?.accent ?? theme.foreground(.fgHero) }
+    private var tint: Color { color ?? semantic.map { theme.resolve($0).accent } ?? theme.foreground(.fgHero) }
 
     /// Explicit override wins; else the `.controlSize(_:)` preset.
     private var resolvedSize: CGFloat { size ?? controlSize.spinnerDiameter }

--- a/Sources/ThemeKit/Components/Atoms/Tag.swift
+++ b/Sources/ThemeKit/Components/Atoms/Tag.swift
@@ -94,31 +94,33 @@ public struct Tag: View {
 
     private var foreground: Color {
         if let semantic {
+            let resolved = theme.resolve(semantic)
             switch variant {
-            case .soft, .outline, .ghost: return semantic.accent
-            case .solid: return semantic.onSolid
+            case .soft, .outline, .ghost: return resolved.accent
+            case .solid: return resolved.onSolid
             }
         }
         guard let style else { return theme.text(.textHero) }
         switch variant {
         case .soft: return style.foreground(theme)
-        case .solid: return style.semantic.onSolid
-        case .outline, .ghost: return style.semantic.accent
+        case .solid: return theme.resolve(style.semantic).onSolid
+        case .outline, .ghost: return theme.resolve(style.semantic).accent
         }
     }
 
     private var background: Color {
         if let semantic {
+            let resolved = theme.resolve(semantic)
             switch variant {
-            case .soft: return semantic.soft
-            case .solid: return semantic.solid
+            case .soft: return resolved.soft
+            case .solid: return resolved.solid
             case .outline, .ghost: return .clear
             }
         }
         guard let style else { return theme.background(.bgElevatorTertiary) }
         switch variant {
         case .soft: return style.background(theme)
-        case .solid: return style.semantic.solid
+        case .solid: return theme.resolve(style.semantic).solid
         case .outline, .ghost: return .clear
         }
     }
@@ -127,8 +129,9 @@ public struct Tag: View {
     private var border: Color {
         let hue = semantic ?? style?.semantic
         guard let hue else { return bordered ? theme.border(.borderPrimary) : .clear }
-        if variant == .outline { return hue.border }
-        return bordered ? hue.border : .clear
+        let resolved = theme.resolve(hue)
+        if variant == .outline { return resolved.border }
+        return bordered ? resolved.border : .clear
     }
 }
 
@@ -208,10 +211,10 @@ public struct CheckableTag: View {
                 }
                 Text(text).textStyle(.labelSm600)
             }
-            .foregroundStyle(isChecked ? color.onSolid : theme.text(.textSecondary))
+            .foregroundStyle(isChecked ? theme.resolve(color).onSolid : theme.text(.textSecondary))
             .padding(.horizontal, Theme.SpacingKey.sm.value)
             .padding(.vertical, Theme.SpacingKey.xs.value)   // padding-derived height — Dynamic Type never clips
-            .background(isChecked ? color.solid : theme.background(.bgElevatorTertiary), in: Capsule())
+            .background(isChecked ? theme.resolve(color).solid : theme.background(.bgElevatorTertiary), in: Capsule())
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)

--- a/Sources/ThemeKit/Components/Atoms/TextLink.swift
+++ b/Sources/ThemeKit/Components/Atoms/TextLink.swift
@@ -27,7 +27,7 @@ public struct TextLink: View {
             Text(title)
                 .textStyle(.linkBase)
                 .underline(underline)
-                .foregroundStyle(accent?.accent ?? theme.text(.textHero))
+                .foregroundStyle(accent.map { theme.resolve($0).accent } ?? theme.text(.textHero))
         }
         .buttonStyle(.plain)
     }

--- a/Sources/ThemeKit/Components/Atoms/TextRotate.swift
+++ b/Sources/ThemeKit/Components/Atoms/TextRotate.swift
@@ -32,7 +32,7 @@ public struct TextRotate: View {
     public var body: some View {
         Text(current)
             .textStyle(style)
-            .foregroundStyle(accent.map { $0.accent } ?? theme.text(.textHero))
+            .foregroundStyle(accent.map { theme.resolve($0).accent } ?? theme.text(.textHero))
             .contentTransition(.opacity)
             .animation(.easeInOut(duration: 0.4), value: index)
             .onReceive(Timer.publish(every: interval, on: .main, in: .common).autoconnect()) { _ in

--- a/Sources/ThemeKit/Components/Molecules/AmenityGrid.swift
+++ b/Sources/ThemeKit/Components/Molecules/AmenityGrid.swift
@@ -59,6 +59,9 @@ public struct AmenityGrid: View {
     private var columns: Int = 2
     private var size: AmenitySize = .medium
     private var tint: Color?
+    // ADR-0006: the token overload stores the `SemanticColor` (not a resolved
+    // `Color`) so it re-resolves against the environment theme in `body`.
+    private var semanticTint: SemanticColor?
     private var limit: Int?
     private var highlighted: Set<String> = []
 
@@ -99,7 +102,7 @@ public struct AmenityGrid: View {
         return HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
             Image(systemName: amenity.systemImage)
                 .font(size.textStyle.font)
-                .foregroundStyle(tint ?? theme.foreground(.fgHero))
+                .foregroundStyle(semanticTint.map { theme.resolve($0).base } ?? tint ?? theme.foreground(.fgHero))
                 .frame(width: size.iconSize + 4)
             Text(amenity.label)
                 .textStyle(size.textStyle)
@@ -126,9 +129,9 @@ public extension AmenityGrid {
     func size(_ s: AmenitySize) -> Self { copy { $0.size = s } }
     /// Overrides the icon tint (otherwise the theme accent).
     @available(*, deprecated, message: "Use tint(_:) with a SemanticColor token.")
-    func tint(_ color: Color?) -> Self { copy { $0.tint = color } }
+    func tint(_ color: Color?) -> Self { copy { $0.tint = color; $0.semanticTint = nil } }
     /// Token-bound overload — icons use the semantic colour's base.
-    func tint(_ color: SemanticColor) -> Self { copy { $0.tint = color.base } }
+    func tint(_ color: SemanticColor) -> Self { copy { $0.semanticTint = color; $0.tint = nil } }
     /// Shows only the first `count`, with a "+N more" expander for the rest.
     func limit(_ count: Int) -> Self { copy { $0.limit = max(1, count) } }
     /// Amenities (by label) to emphasise in the accent colour.

--- a/Sources/ThemeKit/Components/Molecules/Breadcrumbs.swift
+++ b/Sources/ThemeKit/Components/Molecules/Breadcrumbs.swift
@@ -82,7 +82,7 @@ public struct Breadcrumbs: View {
     /// The current (last) crumb's tint — the accent token when set, else the
     /// primary text token.
     private var currentColor: Color {
-        accent.map { $0.accent } ?? theme.text(.textPrimary)
+        accent.map { theme.resolve($0).accent } ?? theme.text(.textPrimary)
     }
 
     private var separator: some View {

--- a/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
@@ -121,7 +121,7 @@ private struct ThemedButton: View {
     private var foreground: Color {
         guard isEnabled else { return theme.text(.textDisabled) }
         switch style {
-        case .primary: return SemanticColor.primary.onSolid   // auto-contrast on the primary fill
+        case .primary: return theme.resolve(.primary).onSolid   // auto-contrast on the primary fill
         case .secondary, .outline, .ghost, .link: return theme.text(.textHero)
         }
     }

--- a/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
@@ -50,6 +50,9 @@ public struct ThemeButton: View {
     /// The resolved semantic color: explicit modifier ?? subtree
     /// `componentDefaults.accent` ?? `.primary`.
     private var color: SemanticColor { explicitColor ?? componentDefaults.accent ?? .primary }
+    /// Bound once per body read — resolves `color` against the environment
+    /// theme (ADR-0006), honoring per-subtree `.theme(_:)`.
+    private var resolvedColor: SemanticColor.Resolved { theme.resolve(color) }
 
     private let title: String?
     private let action: () -> Void
@@ -113,7 +116,7 @@ public struct ThemeButton: View {
             shape: shapeStyle,
             resting: background,
             pressed: pressedBackground,
-            stroke: variant == .outline ? (isEnabled ? color.border : theme.border(.borderPrimary)) : nil
+            stroke: variant == .outline ? (isEnabled ? resolvedColor.border : theme.border(.borderPrimary)) : nil
         ))
         .disabled(!isEnabled)
         .a11y(A11yElement.Action.button, in: accessibilityID)
@@ -182,16 +185,16 @@ public struct ThemeButton: View {
     private var foreground: Color {
         guard isEnabled else { return theme.text(.textDisabled) }
         switch variant {
-        case .solid: return color.onSolid
-        case .soft, .outline, .ghost, .link: return color.accent
+        case .solid: return resolvedColor.onSolid
+        case .soft, .outline, .ghost, .link: return resolvedColor.accent
         }
     }
 
     private var background: Color {
         guard isEnabled else { return variant == .solid ? theme.background(.bgSecondary) : .clear }
         switch variant {
-        case .solid: return color.solid
-        case .soft: return color.soft
+        case .solid: return resolvedColor.solid
+        case .soft: return resolvedColor.soft
         case .outline, .ghost, .link: return .clear
         }
     }
@@ -202,9 +205,9 @@ public struct ThemeButton: View {
     private var pressedBackground: Color {
         guard isEnabled else { return background }
         switch variant {
-        case .solid: return color == .neutral ? background : color.active
-        case .soft: return color.bgHover
-        case .outline, .ghost, .link: return color.bg
+        case .solid: return color == .neutral ? background : resolvedColor.active
+        case .soft: return resolvedColor.bgHover
+        case .outline, .ghost, .link: return resolvedColor.bg
         }
     }
 
@@ -372,7 +375,7 @@ private struct SurfacePressBody: View {
     /// used by the button-sized styles above.
     private static let pressedScale: CGFloat = 0.985
 
-    private var wash: Color { tint?.soft ?? theme.background(.bgElevatorTertiary) }
+    private var wash: Color { tint.map { theme.resolve($0).soft } ?? theme.background(.bgElevatorTertiary) }
 
     var body: some View {
         configuration.label

--- a/Sources/ThemeKit/Components/Molecules/CalendarView.swift
+++ b/Sources/ThemeKit/Components/Molecules/CalendarView.swift
@@ -198,10 +198,10 @@ public struct CalendarView: View {
 
     // MARK: - Accent resolution (defaults keep the hero tokens, R4)
 
-    private var selectedFill: Color { accent?.solid ?? theme.background(.bgHero) }
-    private var selectedContent: Color { accent?.onSolid ?? theme.foreground(.fgSecondary) }
-    private var todayText: Color { accent?.accent ?? theme.text(.textHero) }
-    private var todayRing: Color { accent?.border ?? theme.border(.borderHero) }
+    private var selectedFill: Color { accent.map { theme.resolve($0).solid } ?? theme.background(.bgHero) }
+    private var selectedContent: Color { accent.map { theme.resolve($0).onSolid } ?? theme.foreground(.fgSecondary) }
+    private var todayText: Color { accent.map { theme.resolve($0).accent } ?? theme.text(.textHero) }
+    private var todayRing: Color { accent.map { theme.resolve($0).border } ?? theme.border(.borderHero) }
 
     // MARK: - Year / month stages (opt-in via .yearPicker())
 

--- a/Sources/ThemeKit/Components/Molecules/CalendarYearPicker.swift
+++ b/Sources/ThemeKit/Components/Molecules/CalendarYearPicker.swift
@@ -118,10 +118,10 @@ public struct CalendarYearPicker: View {
 
     // MARK: - Accent resolution (defaults keep the hero tokens, R4 — CalendarView parity)
 
-    private var selectedFill: Color { accent?.solid ?? theme.background(.bgHero) }
-    private var selectedContent: Color { accent?.onSolid ?? theme.foreground(.fgSecondary) }
-    private var todayText: Color { accent?.accent ?? theme.text(.textHero) }
-    private var todayRing: Color { accent?.border ?? theme.border(.borderHero) }
+    private var selectedFill: Color { accent.map { theme.resolve($0).solid } ?? theme.background(.bgHero) }
+    private var selectedContent: Color { accent.map { theme.resolve($0).onSolid } ?? theme.foreground(.fgSecondary) }
+    private var todayText: Color { accent.map { theme.resolve($0).accent } ?? theme.text(.textHero) }
+    private var todayRing: Color { accent.map { theme.resolve($0).border } ?? theme.border(.borderHero) }
 
     // MARK: - Paging math
 

--- a/Sources/ThemeKit/Components/Molecules/Cascader.swift
+++ b/Sources/ThemeKit/Components/Molecules/Cascader.swift
@@ -188,7 +188,7 @@ public struct Cascader: View {
                         .padding(.horizontal, Theme.SpacingKey.sm.value)
                         .frame(height: 36)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(onPath ? SemanticColor.primary.soft : .clear)
+                        .background(onPath ? theme.resolve(.primary).soft : .clear)
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)

--- a/Sources/ThemeKit/Components/Molecules/Checkbox.swift
+++ b/Sources/ThemeKit/Components/Molecules/Checkbox.swift
@@ -55,6 +55,11 @@ public struct Checkbox: View {
     private var isIndeterminate: Bool = false
     private var alignment: VerticalAlignment = .center
     private var accent: SemanticColor?
+    // ADR-0006: the token-bound `customInner(_:)` overload stores the
+    // `SemanticColor` here (not baked into `type`'s `.customInner(color:)`
+    // at modifier-call time), so it re-resolves against the environment
+    // theme in `body`; `type` keeps a `.clear` placeholder as the discriminant.
+    private var semanticSwatch: SemanticColor?
     private var accessibilityID: String?
     private var controlPlacement: HorizontalEdge = .leading   // A2
     private var customLabel: SlotContent?                     // D1 — `.label { }` slot
@@ -79,12 +84,12 @@ public struct Checkbox: View {
 
     /// Selected fill — the semantic accent when set (and enabled), else the hero token.
     private var selectedFill: Color {
-        if isEnabled, let accent { return accent.solid }
+        if isEnabled, let accent { return theme.resolve(accent).solid }
         return theme.background(isEnabled ? .bgHero : .bgSecondary)
     }
     /// Glyph tint on top of the selected fill (auto-contrasts against an accent).
     private var glyphColor: Color {
-        if isEnabled, let accent { return accent.onSolid }
+        if isEnabled, let accent { return theme.resolve(accent).onSolid }
         return theme.foreground(.fgSecondary)
     }
 
@@ -148,6 +153,7 @@ public struct Checkbox: View {
     }
 
     private var fill: Color {
+        if let semanticSwatch { return theme.resolve(semanticSwatch).solid }
         switch type {
         case .customInner(let color):
             return color
@@ -165,7 +171,7 @@ public struct Checkbox: View {
         if dominant == .error { return theme.border(.systemcolorsBorderError) }
         if dominant == .warning { return theme.border(.systemcolorsBorderWarning) }
         guard selected else { return theme.border(.borderPrimary) }
-        return accent?.border ?? theme.border(.borderHero)
+        return accent.map { theme.resolve($0).border } ?? theme.border(.borderHero)
     }
 
     @ViewBuilder
@@ -200,13 +206,13 @@ public extension Checkbox {
     /// Always fills the box with a semantic swatch (the `.customInner` type),
     /// resolved from the token's solid role — the token-bound path.
     func customInner(_ color: SemanticColor) -> Self {
-        copy { $0.type = .customInner(color: color.solid) }
+        copy { $0.type = .customInner(color: .clear); $0.semanticSwatch = color }
     }
 
     /// Raw swatch fill (back-compat); prefer the token-bound `customInner(_:)`.
     @available(*, deprecated, message: "Use customInner(_:) with a SemanticColor token.")
     func customInner(color: Color) -> Self {
-        copy { $0.type = .customInner(color: color) }
+        copy { $0.type = .customInner(color: color); $0.semanticSwatch = nil }
     }
 
     /// Renders the indeterminate (mixed) state instead of a checkmark.

--- a/Sources/ThemeKit/Components/Molecules/Chips.swift
+++ b/Sources/ThemeKit/Components/Molecules/Chips.swift
@@ -303,7 +303,7 @@ public struct ChoseChip: View {
             .foregroundStyle(theme.foreground(.fgSecondary))
             .padding(.vertical, 2).padding(.horizontal, Theme.SpacingKey.xs.value)
             .background(
-                LinearGradient(colors: [SemanticColor.primary.base, SemanticColor.purple.base],
+                LinearGradient(colors: [theme.resolve(.primary).base, theme.resolve(.purple).base],
                                startPoint: .topLeading, endPoint: .bottomTrailing),
                 in: RoundedRectangle(cornerRadius: Theme.RadiusKey.xs.value, style: .continuous)
             )

--- a/Sources/ThemeKit/Components/Molecules/Dropdown.swift
+++ b/Sources/ThemeKit/Components/Molecules/Dropdown.swift
@@ -364,8 +364,8 @@ public struct Dropdown<Trigger: View>: View {
     @MainActor
     private func row(_ item: DropdownItem, reservesIndicator: Bool, indented: Bool = false) -> some View {
         let destructive = item.role == .destructive
-        let titleColor = destructive ? SemanticColor.error.accent : theme.text(.textPrimary)
-        let iconColor = destructive ? SemanticColor.error.accent : theme.text(.textSecondary)
+        let titleColor = destructive ? theme.resolve(.error).accent : theme.text(.textPrimary)
+        let iconColor = destructive ? theme.resolve(.error).accent : theme.text(.textSecondary)
 
         return Button {
             if closesOnSelect { open = false }
@@ -397,7 +397,7 @@ public struct Dropdown<Trigger: View>: View {
             .padding(.vertical, Theme.SpacingKey.sm.value)
             .contentShape(Rectangle())
         }
-        .buttonStyle(DropdownRowPressStyle(tint: destructive ? SemanticColor.error.soft : accentColor.soft))
+        .buttonStyle(DropdownRowPressStyle(tint: destructive ? theme.resolve(.error).soft : theme.resolve(accentColor).soft))
         .disabled(item.isDisabled)
         .opacity(item.isDisabled ? 0.4 : 1)
         .accessibilityAddTraits(item.isSelected ? .isSelected : [])
@@ -436,7 +436,7 @@ public struct Dropdown<Trigger: View>: View {
             .padding(.vertical, Theme.SpacingKey.sm.value)
             .contentShape(Rectangle())
         }
-        .buttonStyle(DropdownRowPressStyle(tint: accentColor.soft))
+        .buttonStyle(DropdownRowPressStyle(tint: theme.resolve(accentColor).soft))
         .disabled(item.isDisabled)
         .opacity(item.isDisabled ? 0.4 : 1)
         .accessibilityValue(expanded ? Text(String(themeKit: "Expanded")) : Text(String(themeKit: "Collapsed")))

--- a/Sources/ThemeKit/Components/Molecules/EmojiReactionButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/EmojiReactionButton.swift
@@ -73,9 +73,9 @@ public struct EmojiReactionButton: View {
 
     /// Chroma when reacted — the semantic accent when set, else the stock hero
     /// treatment (unchanged default).
-    private var reactedFill: Color { accent?.soft ?? SemanticColor.primary.soft }
-    private var reactedBorder: Color { accent?.border ?? theme.border(.borderHero) }
-    private var reactedCount: Color { accent?.accent ?? theme.text(.textHero) }
+    private var reactedFill: Color { accent.map { theme.resolve($0).soft } ?? theme.resolve(.primary).soft }
+    private var reactedBorder: Color { accent.map { theme.resolve($0).border } ?? theme.border(.borderHero) }
+    private var reactedCount: Color { accent.map { theme.resolve($0).accent } ?? theme.text(.textHero) }
 
     public var body: some View {
         Button(action: toggle) {

--- a/Sources/ThemeKit/Components/Molecules/InstallmentPicker.swift
+++ b/Sources/ThemeKit/Components/Molecules/InstallmentPicker.swift
@@ -51,7 +51,7 @@ public struct InstallmentPicker: View {
     private var resolvedCurrency: String {
         currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
-    private var accentBase: Color { (accent ?? .primary).base }
+    private var accentBase: Color { theme.resolve(accent ?? .primary).base }
     private func money(_ d: Decimal) -> String { d.formatted(.currency(code: resolvedCurrency).precision(.fractionLength(0)).locale(locale)) }
     private func title(_ o: InstallmentOption) -> String { o.label ?? (o.count <= 1 ? String(themeKit: "Single payment") : String(themeKit: "\(o.count) installments")) }
 
@@ -79,7 +79,7 @@ public struct InstallmentPicker: View {
             }
             .padding(.horizontal, density.scale(Theme.SpacingKey.md.value))
             .frame(minHeight: 56)
-            .background(isOn ? (accent ?? .primary).bg : theme.background(.bgBase), in: shape)
+            .background(isOn ? theme.resolve(accent ?? .primary).bg : theme.background(.bgBase), in: shape)
             .overlay(shape.stroke(isOn ? accentBase : theme.border(.borderPrimary), lineWidth: isOn ? 1.5 : 1))
             .contentShape(shape)
         }

--- a/Sources/ThemeKit/Components/Molecules/LanguageSwitcher.swift
+++ b/Sources/ThemeKit/Components/Molecules/LanguageSwitcher.swift
@@ -117,7 +117,7 @@ public struct LanguageSwitcher: View {
     // MARK: Resolution
 
     private var resolvedAccent: SemanticColor? { accentColor ?? componentDefaults.accent }
-    private var checkColor: Color { resolvedAccent?.accent ?? theme.foreground(.fgHero) }
+    private var checkColor: Color { resolvedAccent.map { theme.resolve($0).accent } ?? theme.foreground(.fgHero) }
     private var selected: AppLanguage? { languages.first { $0.code == selection } }
 
     /// Primary display name per the `nativeNames` axis.

--- a/Sources/ThemeKit/Components/Molecules/MapPriceMarker.swift
+++ b/Sources/ThemeKit/Components/Molecules/MapPriceMarker.swift
@@ -34,8 +34,8 @@ public struct MapPriceMarker: View {
 
     public init(_ text: String) { self.text = text }   // R1
 
-    private var accentBg: Color { (accent ?? .primary).solid }
-    private var accentFg: Color { (accent ?? .primary).onSolid }
+    private var accentBg: Color { theme.resolve(accent ?? .primary).solid }
+    private var accentFg: Color { theme.resolve(accent ?? .primary).onSolid }
     private var bg: Color { isSelected ? accentBg : theme.background(.bgWhite) }
     private var fg: Color { isSelected ? accentFg : theme.text(.textPrimary) }
 

--- a/Sources/ThemeKit/Components/Molecules/PaymentCardField.swift
+++ b/Sources/ThemeKit/Components/Molecules/PaymentCardField.swift
@@ -87,7 +87,7 @@ public struct PaymentCardField: View {
     }
 
     private var brand: CardBrand { CardBrand.detect(number) }
-    private var accentBase: Color { (accent ?? .primary).base }
+    private var accentBase: Color { theme.resolve(accent ?? .primary).base }
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous) }
     /// Explicit `.size(_:)` → subtree `FieldDefaults.size` → the classic 52pt rows.
     private var effectiveSize: TextInputSize? { explicitSize ?? fieldDefaults.size }

--- a/Sources/ThemeKit/Components/Molecules/PriceHistogram.swift
+++ b/Sources/ThemeKit/Components/Molecules/PriceHistogram.swift
@@ -31,6 +31,9 @@ public struct PriceHistogram: View {
     // Appearance/state — mutated only through the modifiers below (R2).
     private var barHeight: CGFloat = 56
     private var accent: Color?
+    // ADR-0006: the token overload stores the `SemanticColor` (not a resolved
+    // `Color`) so it re-resolves against the environment theme in `body`.
+    private var semanticAccent: SemanticColor?
     private var currencyCode: String?
     private var resultCount: Int?
     private var showsBounds: Bool = false
@@ -78,7 +81,7 @@ public struct PriceHistogram: View {
         }
     }
 
-    private var selectedColor: Color { accent ?? theme.foreground(.fgHero) }
+    private var selectedColor: Color { semanticAccent.map { theme.resolve($0).base } ?? accent ?? theme.foreground(.fgHero) }
 
     /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
     private var resolvedCurrency: String {
@@ -110,9 +113,9 @@ public extension PriceHistogram {
     func barHeight(_ height: CGFloat) -> Self { copy { $0.barHeight = height } }
     /// Overrides the selected-bar colour (otherwise the theme accent).
     @available(*, deprecated, message: "Use accent(_:) with a SemanticColor token.")
-    func accent(_ color: Color?) -> Self { copy { $0.accent = color } }
+    func accent(_ color: Color?) -> Self { copy { $0.accent = color; $0.semanticAccent = nil } }
     /// Token-bound overload — selected bars use the semantic colour's base.
-    func accent(_ color: SemanticColor) -> Self { copy { $0.accent = color.base } }
+    func accent(_ color: SemanticColor) -> Self { copy { $0.semanticAccent = color; $0.accent = nil } }
     /// Currency for the range / bound labels. Unset, it resolves from
     /// `\.formatDefaults`, then the locale's currency, then "USD".
     func currency(_ code: String) -> Self { copy { $0.currencyCode = code } }

--- a/Sources/ThemeKit/Components/Molecules/PriceTrendChart.swift
+++ b/Sources/ThemeKit/Components/Molecules/PriceTrendChart.swift
@@ -57,7 +57,7 @@ public struct PriceTrendChart: View {
     // MARK: Derived
 
     private var visiblePoints: [PriceTrendPoint] { maxDays.map { Array(points.prefix(max(1, $0))) } ?? points }
-    private var accent: Color { accentColor?.base ?? theme.foreground(.fgHero) }
+    private var accent: Color { accentColor.map { theme.resolve($0).base } ?? theme.foreground(.fgHero) }
     private var maxPrice: Decimal { visiblePoints.map(\.price).max() ?? 1 }
     private var minPrice: Decimal { visiblePoints.map(\.price).min() ?? 0 }
     private var minFraction: CGFloat { maxPrice > 0 ? CGFloat(NSDecimalNumber(decimal: minPrice / maxPrice).doubleValue) : 0 }
@@ -67,8 +67,8 @@ public struct PriceTrendChart: View {
     private var barFill: AnyShapeStyle {
         useGradient ? AnyShapeStyle(LinearGradient(colors: [accent, accent.opacity(0.5)], startPoint: .bottom, endPoint: .top)) : AnyShapeStyle(accent)
     }
-    private var selectionBg: Color { selectionColorToken?.base ?? theme.text(.textPrimary) }
-    private var selectionFg: Color { selectionColorToken?.onSolid ?? theme.text(.textSecondaryInverse) }
+    private var selectionBg: Color { selectionColorToken.map { theme.resolve($0).base } ?? theme.text(.textPrimary) }
+    private var selectionFg: Color { selectionColorToken.map { theme.resolve($0).onSolid } ?? theme.text(.textSecondaryInverse) }
     /// Explicit `.currency(_:)` > `\.formatDefaults` > locale currency > "USD" (§10).
     private var resolvedCurrency: String {
         currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"

--- a/Sources/ThemeKit/Components/Molecules/RadioButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/RadioButton.swift
@@ -83,7 +83,7 @@ public struct RadioButton: View {
     /// Raw override wins, then the semantic accent (enabled only), then the hero token.
     private var fillColor: Color {
         if let backgroundColor { return backgroundColor }
-        if isEnabled, let accent { return accent.solid }
+        if isEnabled, let accent { return theme.resolve(accent).solid }
         return theme.background(isEnabled ? .bgHero : .bgSecondary)
     }
 
@@ -144,7 +144,7 @@ public struct RadioButton: View {
         if dominant == .error { return theme.border(.systemcolorsBorderError) }
         if dominant == .warning { return theme.border(.systemcolorsBorderWarning) }
         guard isSelected else { return theme.border(.borderPrimary) }
-        return accent?.border ?? theme.border(.borderHero)
+        return accent.map { theme.resolve($0).border } ?? theme.border(.borderHero)
     }
 
     @ViewBuilder
@@ -156,7 +156,7 @@ public struct RadioButton: View {
             case (.check, .plain):
                 Image(systemName: "checkmark")
                     .font(.system(size: controlSize.checkboxSide * 0.55, weight: .bold))
-                    .foregroundStyle((isEnabled && backgroundColor == nil) ? (accent?.onSolid ?? theme.foreground(.fgSecondary)) : theme.foreground(.fgSecondary))
+                    .foregroundStyle((isEnabled && backgroundColor == nil) ? (accent.map { theme.resolve($0).onSolid } ?? theme.foreground(.fgSecondary)) : theme.foreground(.fgSecondary))
             case (.check, .inner):
                 ZStack {
                     Circle().fill(theme.background(.bgWhite))

--- a/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
+++ b/Sources/ThemeKit/Components/Molecules/RangeSlider.swift
@@ -183,13 +183,13 @@ public struct RangeSlider: View {
     /// Track-fill shade — the accent's solid shade when set, else the hero token.
     private var fillColor: Color {
         guard isEnabled else { return theme.background(.bgSecondaryLight) }
-        return accent?.solid ?? theme.background(.bgHero)
+        return accent.map { theme.resolve($0).solid } ?? theme.background(.bgHero)
     }
 
     /// Thumb-ring shade — the accent's solid shade when set, else the hero border.
     private var thumbRingColor: Color {
         guard isEnabled else { return theme.border(.borderPrimary) }
-        return accent?.solid ?? theme.border(.borderHero)
+        return accent.map { theme.resolve($0).solid } ?? theme.border(.borderHero)
     }
 
     // MARK: Marks

--- a/Sources/ThemeKit/Components/Molecules/ScrubGallery.swift
+++ b/Sources/ThemeKit/Components/Molecules/ScrubGallery.swift
@@ -89,7 +89,7 @@ public struct ScrubGallery<Content: View>: View {
         HStack(spacing: Theme.SpacingKey.xs.value) {
             ForEach(0..<pageCount, id: \.self) { i in
                 Capsule()
-                    .fill(i == index ? accentColor.solid : MediaScrim.onContentSecondary)
+                    .fill(i == index ? theme.resolve(accentColor).solid : MediaScrim.onContentSecondary)
                     .frame(height: 4)
                     .frame(maxWidth: .infinity)
             }

--- a/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
+++ b/Sources/ThemeKit/Components/Molecules/SegmentedControl.swift
@@ -120,7 +120,7 @@ public struct SegmentedControl: View {
 
     /// The track fill — the tint's soft wash for `.tinted`, else the neutral base.
     private var trackFill: Color {
-        selectionStyle == .tinted ? resolvedTint.soft : theme.background(.bgBase)
+        selectionStyle == .tinted ? theme.resolve(resolvedTint).soft : theme.background(.bgBase)
     }
 
     public var body: some View {
@@ -200,8 +200,8 @@ public struct SegmentedControl: View {
             case .outline:
                 // Stock hue keeps the historical hero-border chroma exactly;
                 // an explicit/provider accent re-tints the pill + stroke.
-                thumbShape.fill(resolvedTint.soft)
-                    .overlay(thumbShape.stroke(usesStockTint ? theme.border(.borderHero) : resolvedTint.border, lineWidth: 2))
+                thumbShape.fill(theme.resolve(resolvedTint).soft)
+                    .overlay(thumbShape.stroke(usesStockTint ? theme.border(.borderHero) : theme.resolve(resolvedTint).border, lineWidth: 2))
                     .matchedGeometryEffect(id: "pill", in: pill)
             case .tinted:
                 EmptyView()   // no thumb — the soft track + hero foreground carry selection
@@ -219,7 +219,7 @@ public struct SegmentedControl: View {
         guard enabled else { return theme.text(.textDisabled) }
         guard isActive else { return theme.text(.textSecondary) }
         // The tinted style follows its base color's accent; others use the hero.
-        return selectionStyle == .tinted ? resolvedTint.accent : theme.text(.textHero)
+        return selectionStyle == .tinted ? theme.resolve(resolvedTint).accent : theme.text(.textHero)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/Slider.swift
+++ b/Sources/ThemeKit/Components/Molecules/Slider.swift
@@ -212,7 +212,7 @@ public struct Slider: View {
 
     private var fillColor: Color {
         guard isEnabled else { return theme.background(.bgSecondary) }
-        return accent?.solid ?? theme.background(.bgHero)
+        return accent.map { theme.resolve($0).solid } ?? theme.background(.bgHero)
     }
 
     /// Attached to the whole track (minimumDistance 0), so a tap anywhere sets

--- a/Sources/ThemeKit/Components/Molecules/SmartSuggestion.swift
+++ b/Sources/ThemeKit/Components/Molecules/SmartSuggestion.swift
@@ -31,13 +31,16 @@ public struct SmartSuggestion: View {
     public init(_ message: String) { self.message = message }   // R1
 
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous) }
+    /// Bound once per body read — resolves `tint` against the environment
+    /// theme (ADR-0006), honoring per-subtree `.theme(_:)`.
+    private var resolvedTint: SemanticColor.Resolved { theme.resolve(tint) }
 
     public var body: some View {
         content
             .padding(density.scale(Theme.SpacingKey.md.value))
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(tint.bg, in: shape)
-            .overlay { if bordered { shape.stroke(tint.base.opacity(0.35), lineWidth: 1) } }
+            .background(resolvedTint.bg, in: shape)
+            .overlay { if bordered { shape.stroke(resolvedTint.base.opacity(0.35), lineWidth: 1) } }
             .contentShape(shape)
             .onTapGesture { onTap?() }
             .accessibilityElement(children: .combine)
@@ -46,16 +49,16 @@ public struct SmartSuggestion: View {
 
     private var content: some View {
         HStack(alignment: .top, spacing: density.scale(Theme.SpacingKey.sm.value)) {
-            Image(systemName: systemImage).font(.system(size: 15, weight: .semibold)).foregroundStyle(tint.base)
+            Image(systemName: systemImage).font(.system(size: 15, weight: .semibold)).foregroundStyle(resolvedTint.base)
             (labelText + messageText)
                 .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 4)
             if let actionTitle, let onAction {
                 Button { onAction() } label: {
-                    Text(actionTitle).textStyle(.labelSm700).foregroundStyle(tint.strong).fixedSize()
+                    Text(actionTitle).textStyle(.labelSm700).foregroundStyle(resolvedTint.strong).fixedSize()
                 }.buttonStyle(.plain)
             } else if onTap != nil {
-                Image(systemName: "chevron.right").font(.system(size: 12, weight: .semibold)).foregroundStyle(tint.base).mirrorsInRTL()
+                Image(systemName: "chevron.right").font(.system(size: 12, weight: .semibold)).foregroundStyle(resolvedTint.base).mirrorsInRTL()
             }
         }
     }
@@ -65,7 +68,7 @@ public struct SmartSuggestion: View {
     // raw system font here is a justified constraint, not an oversight.
     private var labelText: Text {
         guard let label else { return Text("") }
-        return Text(label + ": ").font(.system(size: 14, weight: .semibold)).foregroundColor(tint.strong)
+        return Text(label + ": ").font(.system(size: 14, weight: .semibold)).foregroundColor(resolvedTint.strong)
     }
     private var messageText: Text {
         Text(message).font(.system(size: 14, weight: .semibold)).foregroundColor(theme.text(.textPrimary))

--- a/Sources/ThemeKit/Components/Molecules/SortSummaryBar.swift
+++ b/Sources/ThemeKit/Components/Molecules/SortSummaryBar.swift
@@ -42,9 +42,9 @@ public struct SortTab: View {
     }
 
     /// Selected underline/icon tint — semantic accent when set, else the hero token (R4).
-    private var selectionTint: Color { accent?.accent ?? theme.foreground(.fgHero) }
+    private var selectionTint: Color { accent.map { theme.resolve($0).accent } ?? theme.foreground(.fgHero) }
     /// Selected title color — follows the accent when set, else primary text.
-    private var selectedTitle: Color { accent?.accent ?? theme.text(.textPrimary) }
+    private var selectedTitle: Color { accent.map { theme.resolve($0).accent } ?? theme.text(.textPrimary) }
 
     public var body: some View {
         Button(action: action) {

--- a/Sources/ThemeKit/Components/Molecules/StepperRow.swift
+++ b/Sources/ThemeKit/Components/Molecules/StepperRow.swift
@@ -31,7 +31,7 @@ public struct StepperRow: View {
         self._value = value
     }
 
-    private var accentBase: Color { (accent ?? .primary).base }
+    private var accentBase: Color { theme.resolve(accent ?? .primary).base }
 
     public var body: some View {
         HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {

--- a/Sources/ThemeKit/Components/Molecules/SuggestionRow.swift
+++ b/Sources/ThemeKit/Components/Molecules/SuggestionRow.swift
@@ -43,7 +43,7 @@ public struct SuggestionRow: View {
         self.action = action
     }
 
-    private var accentBase: Color { (accent ?? .primary).base }
+    private var accentBase: Color { theme.resolve(accent ?? .primary).base }
     private var rowShape: RoundedRectangle { RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous) }
     private var tileShape: RoundedRectangle { RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous) }
 
@@ -68,7 +68,7 @@ public struct SuggestionRow: View {
             .padding(.horizontal, density.scale(Theme.SpacingKey.sm.value))
             .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isSelected ? (accent ?? .primary).bg : .clear, in: rowShape)
+            .background(isSelected ? theme.resolve(accent ?? .primary).bg : .clear, in: rowShape)
             .contentShape(rowShape)
         }
         .buttonStyle(.plain)

--- a/Sources/ThemeKit/Components/Molecules/ThemeController.swift
+++ b/Sources/ThemeKit/Components/Molecules/ThemeController.swift
@@ -30,7 +30,7 @@ public struct ThemeController: View {
     }
 
     /// Active-label tint — semantic accent when set, else the hero token (R4).
-    private var activeText: Color { accent?.accent ?? theme.text(.textHero) }
+    private var activeText: Color { accent.map { theme.resolve($0).accent } ?? theme.text(.textHero) }
 
     public var body: some View {
         HStack(spacing: 4) {

--- a/Sources/ThemeKit/Components/Molecules/ThemeToggle.swift
+++ b/Sources/ThemeKit/Components/Molecules/ThemeToggle.swift
@@ -108,13 +108,13 @@ public struct ThemeToggle: View {
     /// the secondary background.
     private var trackSymbolColor: Color {
         guard isOn, isEnabled else { return theme.text(.textTertiary) }
-        return accent?.onSolid ?? theme.text(.textHero)
+        return accent.map { theme.resolve($0).onSolid } ?? theme.text(.textHero)
     }
 
     private var track: Color {
         guard isEnabled else { return theme.background(.bgSecondary) }
         guard isOn else { return theme.background(.bgSecondary) }
-        return accent?.solid ?? theme.background(.bgHero)
+        return accent.map { theme.resolve($0).solid } ?? theme.background(.bgHero)
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/Tooltip.swift
+++ b/Sources/ThemeKit/Components/Molecules/Tooltip.swift
@@ -132,7 +132,7 @@ private struct TooltipBubble: View {
 
     // `color` (full semantic palette, incl. primary/secondary/accent) wins over
     // the badge-style shorthand; nil-nil keeps the dark default.
-    private var bubbleColor: Color { color?.solid ?? style?.semantic.solid ?? theme.background(.bgTertiary) }
+    private var bubbleColor: Color { color.map { theme.resolve($0).solid } ?? style.map { theme.resolve($0.semantic).solid } ?? theme.background(.bgTertiary) }
     // Auto-contrast against whatever bubble is shown (styled solid or the dark default).
     private var textColor: Color { ColorContrast.content(on: bubbleColor) }
 

--- a/Sources/ThemeKit/Components/Molecules/Transfer.swift
+++ b/Sources/ThemeKit/Components/Molecules/Transfer.swift
@@ -125,7 +125,7 @@ public struct Transfer: View {
             .padding(.horizontal, Theme.SpacingKey.sm.value)
             .frame(height: 34)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isOn && enabled ? SemanticColor.primary.soft.opacity(0.5) : .clear)
+            .background(isOn && enabled ? theme.resolve(.primary).soft.opacity(0.5) : .clear)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -137,9 +137,9 @@ public struct Transfer: View {
         Button(action: action) {
             Image(systemName: systemImage)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(enabled ? SemanticColor.primary.onSolid : theme.text(.textDisabled))
+                .foregroundStyle(enabled ? theme.resolve(.primary).onSolid : theme.text(.textDisabled))
                 .frame(width: 32, height: 32)
-                .background(enabled ? SemanticColor.primary.solid : theme.background(.bgElevatorTertiary),
+                .background(enabled ? theme.resolve(.primary).solid : theme.background(.bgElevatorTertiary),
                             in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
                 .frame(minWidth: 44, minHeight: 44)
                 .contentShape(Rectangle())

--- a/Sources/ThemeKit/Components/Organisms/Agenda.swift
+++ b/Sources/ThemeKit/Components/Organisms/Agenda.swift
@@ -98,7 +98,7 @@ public struct Agenda: View {
                 timeColumn(event)
                     .frame(width: 60, alignment: .leading)
                 RoundedRectangle(cornerRadius: 1.5)
-                    .fill(event.accent?.solid ?? SemanticColor.primary.solid)
+                    .fill(event.accent.map { theme.resolve($0).solid } ?? theme.resolve(.primary).solid)
                     .frame(width: 3)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(event.title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))

--- a/Sources/ThemeKit/Components/Organisms/AgentPriceRow.swift
+++ b/Sources/ThemeKit/Components/Organisms/AgentPriceRow.swift
@@ -85,7 +85,7 @@ public struct AgentPriceRow: View {
         }
         .padding(density.scale(Theme.SpacingKey.md.value))
         .background(theme.background(surfaceKey), in: shape)
-        .overlay(shape.stroke(recommended ? accentSemantic.base : theme.border(.borderPrimary), lineWidth: recommended ? 1.5 : 1))
+        .overlay(shape.stroke(recommended ? theme.resolve(accentSemantic).base : theme.border(.borderPrimary), lineWidth: recommended ? 1.5 : 1))
         .contentShape(shape)
     }
 

--- a/Sources/ThemeKit/Components/Organisms/AlertToast.swift
+++ b/Sources/ThemeKit/Components/Organisms/AlertToast.swift
@@ -20,7 +20,7 @@ public enum AlertToastType {
         case .danger: return theme.background(.systemcolorsBgError)
         case .info: return theme.background(.systemcolorsBgInfo)
         case .neutral: return theme.background(.bgTertiary)
-        case .accent: return SemanticColor.primary.solid
+        case .accent: return theme.resolve(.primary).solid
         }
     }
 
@@ -30,7 +30,7 @@ public enum AlertToastType {
         switch self {
         case .warning: return theme.text(.textPrimary)
         case .success, .danger, .info, .neutral: return theme.foreground(.fgSecondary)
-        case .accent: return SemanticColor.primary.onSolid
+        case .accent: return theme.resolve(.primary).onSolid
         }
     }
 

--- a/Sources/ThemeKit/Components/Organisms/BrowserFrame.swift
+++ b/Sources/ThemeKit/Components/Organisms/BrowserFrame.swift
@@ -60,13 +60,13 @@ public struct BrowserFrame<Content: View>: View {
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
         .padding(.vertical, Theme.SpacingKey.sm.value)
-        .background(accent.map { $0.soft } ?? theme.background(.bgSecondary))
+        .background(accent.map { theme.resolve($0).soft } ?? theme.background(.bgSecondary))
     }
 
     private var urlPill: some View {
         Text(url)
             .font(.system(.footnote, design: .monospaced))
-            .foregroundStyle(accent.map { $0.accent } ?? theme.text(.textSecondary))
+            .foregroundStyle(accent.map { theme.resolve($0).accent } ?? theme.text(.textSecondary))
             .lineLimit(1)
             .truncationMode(.middle)
             .padding(.horizontal, Theme.SpacingKey.sm.value)

--- a/Sources/ThemeKit/Components/Organisms/Callout.swift
+++ b/Sources/ThemeKit/Components/Organisms/Callout.swift
@@ -18,7 +18,7 @@ public enum CalloutType {
         case .success: return theme.foreground(.systemcolorsFgSuccess)
         case .warning: return theme.foreground(.systemcolorsFgWarning)
         case .error: return theme.foreground(.systemcolorsFgError)
-        case .accent: return SemanticColor.primary.base
+        case .accent: return theme.resolve(.primary).base
         }
     }
     func soft(_ theme: Theme) -> Color {
@@ -28,7 +28,7 @@ public enum CalloutType {
         case .success: return theme.background(.systemcolorsBgSuccessLight)
         case .warning: return theme.background(.systemcolorsBgWarningLight)
         case .error: return theme.background(.systemcolorsBgErrorLight)
-        case .accent: return SemanticColor.primary.soft
+        case .accent: return theme.resolve(.primary).soft
         }
     }
     var systemImage: String {

--- a/Sources/ThemeKit/Components/Organisms/ChatBubble.swift
+++ b/Sources/ThemeKit/Components/Organisms/ChatBubble.swift
@@ -58,11 +58,11 @@ public struct ChatBubble: View {
 
     /// Accent tint wins over the side defaults (daisyUI `chat-bubble-{color}`).
     private var bubbleFill: Color {
-        if let accent { return accent.solid }
+        if let accent { return theme.resolve(accent).solid }
         return side == .incoming ? theme.background(.bgElevatorTertiary) : theme.background(.bgHero)
     }
     private var bubbleForeground: Color {
-        if let accent { return accent.onSolid }
+        if let accent { return theme.resolve(accent).onSolid }
         return side == .incoming ? theme.text(.textPrimary) : theme.foreground(.fgSecondary)
     }
 

--- a/Sources/ThemeKit/Components/Organisms/CommandPalette.swift
+++ b/Sources/ThemeKit/Components/Organisms/CommandPalette.swift
@@ -163,7 +163,7 @@ private struct CommandPaletteView: View {
             .padding(.horizontal, Theme.SpacingKey.md.value)
             .padding(.vertical, Theme.SpacingKey.sm.value)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isHighlighted ? SemanticColor.primary.soft : .clear)
+            .background(isHighlighted ? theme.resolve(.primary).soft : .clear)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Sources/ThemeKit/Components/Organisms/Counter.swift
+++ b/Sources/ThemeKit/Components/Organisms/Counter.swift
@@ -62,7 +62,7 @@ public struct Counter: View {
     }
 
     /// Digit tint — semantic accent when set, else primary text (R4).
-    private var valueColor: Color { accent?.accent ?? theme.text(.textPrimary) }
+    private var valueColor: Color { accent.map { theme.resolve($0).accent } ?? theme.text(.textPrimary) }
 
     public var body: some View {
         HStack(spacing: Theme.SpacingKey.xs.value) {

--- a/Sources/ThemeKit/Components/Organisms/DestinationCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/DestinationCard.swift
@@ -118,10 +118,10 @@ public struct DestinationCard: View {
     private func ribbonTag(_ text: String) -> some View {
         Text(text)
             .textStyle(.labelSm700)
-            .foregroundStyle(ribbonColor.onSolid)
+            .foregroundStyle(theme.resolve(ribbonColor).onSolid)
             .padding(.horizontal, Theme.SpacingKey.sm.value)
             .padding(.vertical, 4)
-            .background(ribbonColor.solid, in: Capsule())
+            .background(theme.resolve(ribbonColor).solid, in: Capsule())
             .padding(Theme.SpacingKey.sm.value)
             .themeShadow(.soft)
     }

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -107,7 +107,7 @@ struct DialogCard: View {
     var body: some View {
         VStack(spacing: Theme.SpacingKey.md.value) {
             if let kind {
-                Icon(systemName: kind.systemImage).size(.xl).color(kind.semanticColor.accent)
+                Icon(systemName: kind.systemImage).size(.xl).color(theme.resolve(kind.semanticColor).accent)
             }
             VStack(spacing: Theme.SpacingKey.sm.value) {
                 Text(title)

--- a/Sources/ThemeKit/Components/Organisms/Feedback.swift
+++ b/Sources/ThemeKit/Components/Organisms/Feedback.swift
@@ -530,7 +530,7 @@ private struct FeedbackHostModifier: ViewModifier {
                 if let custom = note.custom {
                     custom
                 } else {
-                    Icon(systemName: note.kind.systemImage).size(.md).color(note.kind.semanticColor.accent)
+                    Icon(systemName: note.kind.systemImage).size(.md).color(theme.resolve(note.kind.semanticColor).accent)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(note.title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
                         if let message = note.message {

--- a/Sources/ThemeKit/Components/Organisms/FloatingActionButton.swift
+++ b/Sources/ThemeKit/Components/Organisms/FloatingActionButton.swift
@@ -85,9 +85,9 @@ public struct FloatingActionButton: View {
             } label: {
                 Image(systemName: systemImage)
                     .font(.system(size: 22, weight: .semibold))
-                    .foregroundStyle(color.onSolid)
+                    .foregroundStyle(theme.resolve(color).onSolid)
                     .frame(width: 56, height: 56)
-                    .background(color.solid, in: mainShape)
+                    .background(theme.resolve(color).solid, in: mainShape)
                     .themeShadow(.elevated)
                     .rotationEffect(.degrees(expanded && !actions.isEmpty ? 45 : 0))
                     .countBadge(badge ?? 0)

--- a/Sources/ThemeKit/Components/Organisms/HotelResultCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/HotelResultCard.swift
@@ -65,7 +65,7 @@ public struct HotelResultCard: View {
     public init(name: String) { self.name = name }   // R1
 
     private var shape: RoundedRectangle { RoundedRectangle(cornerRadius: radiusRole.value, style: .continuous) }
-    private var accentColor: Color { accent.map { $0.base } ?? theme.foreground(.fgHero) }
+    private var accentColor: Color { accent.map { theme.resolve($0).base } ?? theme.foreground(.fgHero) }
 
     /// Explicit `price(_:currencyCode:)` > `\.formatDefaults` > locale currency > "USD" (§10).
     private var resolvedCurrency: String {
@@ -108,9 +108,9 @@ public struct HotelResultCard: View {
 
             HStack(alignment: .top) {
                 if let cornerBadge {
-                    Text(cornerBadge).textStyle(.labelSm700).foregroundStyle(accent.map { $0.onSolid } ?? theme.text(.textSecondaryInverse))
+                    Text(cornerBadge).textStyle(.labelSm700).foregroundStyle(accent.map { theme.resolve($0).onSolid } ?? theme.text(.textSecondaryInverse))
                         .padding(.horizontal, 10).padding(.vertical, 5)
-                        .background(accent.map { $0.solid } ?? theme.foreground(.fgHero), in: Capsule())
+                        .background(accent.map { theme.resolve($0).solid } ?? theme.foreground(.fgHero), in: Capsule())
                 }
                 Spacer()
                 if let favorite { heart(favorite) }
@@ -200,7 +200,8 @@ public struct HotelResultCard: View {
                 ForEach(Array(promos.enumerated()), id: \.offset) { _, promo in
                     Text(promo).textStyle(.labelSm600).foregroundStyle(accentColor)
                         .padding(.horizontal, 10).padding(.vertical, 6)
-                        .background(accent.map { $0.bg } ?? theme.background(.bgElevatorTertiary), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
+                        .background(accent.map { theme.resolve($0).bg } ?? theme.background(.bgElevatorTertiary),
+                                    in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
                         .overlay(RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous).stroke(accentColor.opacity(0.5), lineWidth: 1))
                 }
             }
@@ -233,7 +234,7 @@ public struct HotelResultCard: View {
             }
         }
         .padding(density.scale(Theme.SpacingKey.sm.value))
-        .background(accent.map { $0.bg } ?? theme.background(.bgSecondary), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
+        .background(accent.map { theme.resolve($0).bg } ?? theme.background(.bgSecondary), in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
@@ -18,7 +18,7 @@ public enum InfoBannerType {
         case .success: return theme.background(.systemcolorsBgSuccessLight)
         case .warning: return theme.background(.systemcolorsBgWarningLight)
         case .error: return theme.background(.systemcolorsBgErrorLight)
-        case .accent: return SemanticColor.primary.soft
+        case .accent: return theme.resolve(.primary).soft
         }
     }
 
@@ -29,7 +29,7 @@ public enum InfoBannerType {
         case .success: return theme.foreground(.systemcolorsFgSuccess)
         case .warning: return theme.foreground(.systemcolorsFgWarning)
         case .error: return theme.foreground(.systemcolorsFgError)
-        case .accent: return SemanticColor.primary.base
+        case .accent: return theme.resolve(.primary).base
         }
     }
 
@@ -40,7 +40,7 @@ public enum InfoBannerType {
         case .success: return theme.border(.systemcolorsBorderSuccessLight)
         case .warning: return theme.border(.systemcolorsBorderWarningLight)
         case .error: return theme.border(.systemcolorsBorderErrorLight)
-        case .accent: return SemanticColor.primary.border
+        case .accent: return theme.resolve(.primary).border
         }
     }
 

--- a/Sources/ThemeKit/Components/Organisms/KanbanBoard.swift
+++ b/Sources/ThemeKit/Components/Organisms/KanbanBoard.swift
@@ -81,7 +81,7 @@ public struct KanbanBoard<Item: Identifiable & Equatable, CardContent: View>: Vi
         let isOverLimit = column.limit.map { column.items.count > $0 } ?? false
         return VStack(alignment: .leading, spacing: Theme.SpacingKey.sm.value) {
             HStack(spacing: Theme.SpacingKey.xs.value) {
-                Circle().fill(column.accent?.solid ?? SemanticColor.primary.solid).frame(width: 8, height: 8)
+                Circle().fill(column.accent.map { theme.resolve($0).solid } ?? theme.resolve(.primary).solid).frame(width: 8, height: 8)
                 Text(column.title).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
                 Text(countText(column))
                     .textStyle(.labelSm600)

--- a/Sources/ThemeKit/Components/Organisms/ListRow.swift
+++ b/Sources/ThemeKit/Components/Organisms/ListRow.swift
@@ -417,7 +417,7 @@ public struct ListSectionHeader: View {
         HStack(spacing: Theme.SpacingKey.sm.value) {
             Text(title.uppercased())
                 .textStyle(textStyle)
-                .foregroundStyle(accent?.accent ?? theme.text(.textTertiary))
+                .foregroundStyle(accent.map { theme.resolve($0).accent } ?? theme.text(.textTertiary))
                 .frame(maxWidth: .infinity, alignment: .leading)
             if let trailingSlot { trailingSlot }
         }

--- a/Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift
@@ -51,7 +51,11 @@ public struct LoyaltyCard: View {
     private var progress: Double?
     private var nextTier: String?
     private var systemImage: String = "seal.fill"
-    private var gradientOverride: [Color]?
+    // ADR-0006: the token overload stores `SemanticColor`s (not resolved
+    // `Color`s) so the gradient re-resolves against the environment theme in
+    // `body`; `rawGradientOverride` is the raw-`Color` escape hatch.
+    private var semanticGradientOverride: [SemanticColor]?
+    private var rawGradientOverride: [Color]?
     private var animatesValue: Bool = false
     private var logoSlot: AnyView?
     private var membership: MembershipCode?
@@ -174,7 +178,9 @@ public struct LoyaltyCard: View {
     }
 
     private var gradient: LinearGradient {
-        let colors = gradientOverride ?? [theme.palette(.primary600), theme.palette(.primary900)]
+        let colors = semanticGradientOverride?.map { theme.resolve($0).solid }
+            ?? rawGradientOverride
+            ?? [theme.palette(.primary600), theme.palette(.primary900)]
         return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
     }
 
@@ -198,14 +204,14 @@ public extension LoyaltyCard {
     func icon(_ systemName: String) -> Self { copy { $0.systemImage = systemName } }
     /// Overrides the brand gradient with semantic tokens (each hue's solid
     /// shade); `nil` restores the theme's primary 600→900 gradient.
-    func gradient(_ colors: [SemanticColor]?) -> Self { copy { $0.gradientOverride = colors?.map(\.solid) } }
+    func gradient(_ colors: [SemanticColor]?) -> Self { copy { $0.semanticGradientOverride = colors; $0.rawGradientOverride = nil } }
     /// Raw-color gradient override (back-compat); prefer the token-bound
     /// overload. Disfavored so member-shorthand literals like
     /// `[.purple, .pink]` — valid as both `[Color]` and `[SemanticColor]` —
     /// resolve to the token overload instead of being ambiguous.
     @_disfavoredOverload
     @available(*, deprecated, message: "Use gradient(_: [SemanticColor]?) — the token-bound overload.")
-    func gradient(_ colors: [Color]?) -> Self { copy { $0.gradientOverride = colors } }
+    func gradient(_ colors: [Color]?) -> Self { copy { $0.rawGradientOverride = colors; $0.semanticGradientOverride = nil } }
     /// A brand logo slot in the top-trailing corner (replaces the tier icon).
     func logo<V: View>(@ViewBuilder _ content: () -> V) -> Self { copy { $0.logoSlot = AnyView(content()) } }
     /// Animates the points balance on change (numeric-text; no-op under Reduce Motion).

--- a/Sources/ThemeKit/Components/Organisms/MapCallout.swift
+++ b/Sources/ThemeKit/Components/Organisms/MapCallout.swift
@@ -75,7 +75,7 @@ public struct MapCallout: View {
                 surfaceKey: surfaceKey,
                 radius: .box))
                 .overlay {
-                    if let accent { shape.stroke(accent.base, lineWidth: 1.5) }
+                    if let accent { shape.stroke(theme.resolve(accent).base, lineWidth: 1.5) }
                 }
                 .contentShape(shape)
         }
@@ -101,7 +101,7 @@ public struct MapCallout: View {
             }
             Spacer(minLength: 4)
             if onSelect != nil {
-                Image(systemName: "chevron.right").font(.system(size: 13, weight: .semibold)).foregroundStyle(accent.map { $0.base } ?? theme.text(.textTertiary)).mirrorsInRTL()
+                Image(systemName: "chevron.right").font(.system(size: 13, weight: .semibold)).foregroundStyle(accent.map { theme.resolve($0).base } ?? theme.text(.textTertiary)).mirrorsInRTL()
             }
         }
         .padding(density.scale(Theme.SpacingKey.sm.value))

--- a/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/NotificationCard.swift
@@ -45,7 +45,7 @@ public struct NotificationCard<Actions: View>: View {
     }
 
     private var iconName: String { type?.systemImage ?? "bell" }
-    private var iconColor: Color { type?.semanticColor.accent ?? theme.foreground(.fgHero) }
+    private var iconColor: Color { type.map { theme.resolve($0.semanticColor).accent } ?? theme.foreground(.fgHero) }
 
     public var body: some View {
         // The shell (fill, corner clipping, border, shadow) is drawn by the active

--- a/Sources/ThemeKit/Components/Organisms/PageHeaderStyle.swift
+++ b/Sources/ThemeKit/Components/Organisms/PageHeaderStyle.swift
@@ -116,9 +116,9 @@ struct PHFilterButton: View {
 
     var body: some View {
         Button(action: action) {
-            Icon(systemName: systemImage).size(.sm).colorOverride(SemanticColor.primary.onSolid)
+            Icon(systemName: systemImage).size(.sm).colorOverride(theme.resolve(.primary).onSolid)
                 .frame(width: PHMetrics.slot, height: PHMetrics.slot)
-                .background(SemanticColor.primary.solid,
+                .background(theme.resolve(.primary).solid,
                             in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous))
         }
         .buttonStyle(.plain)
@@ -242,7 +242,7 @@ struct PHAccessory: View {
         HStack(spacing: Theme.SpacingKey.xs.value) {
             ForEach(0..<max(total, 1), id: \.self) { index in
                 Capsule()
-                    .fill(index < current ? SemanticColor.primary.active : theme.background(.bgSecondaryLight))
+                    .fill(index < current ? theme.resolve(.primary).active : theme.background(.bgSecondaryLight))
                     .frame(height: PHMetrics.track)
             }
         }
@@ -399,11 +399,11 @@ private struct BrandChrome: View {
     let color: SemanticColor
     let filled: Bool
 
-    private var foreground: Color { filled ? color.onSolid : theme.text(.textPrimary) }
+    private var foreground: Color { filled ? theme.resolve(color).onSolid : theme.text(.textPrimary) }
 
     var body: some View {
         PHBarRow(configuration: configuration, foreground: foreground)
-            .background(filled ? color.solid : theme.background(.bgWhite))
+            .background(filled ? theme.resolve(color).solid : theme.background(.bgWhite))
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/PhoneFrame.swift
+++ b/Sources/ThemeKit/Components/Organisms/PhoneFrame.swift
@@ -46,7 +46,7 @@ public struct PhoneFrame<Content: View>: View {
     private let bezelWidth: CGFloat = 10
     private let aspectRatio: CGFloat = 9.0 / 19.5
 
-    private var bezelColor: Color { bezel.shade(.s900) }
+    private var bezelColor: Color { theme.resolve(bezel).shade(.s900) }
 
     private var screenShape: RoundedRectangle {
         RoundedRectangle(cornerRadius: outerRadius - bezelWidth, style: .continuous)
@@ -85,7 +85,7 @@ public struct PhoneFrame<Content: View>: View {
 
     private var homeIndicator: some View {
         Capsule()
-            .fill(bezel.shade(.s300))
+            .fill(theme.resolve(bezel).shade(.s300))
             .frame(width: 96, height: 4)
             .padding(.bottom, 8)
             .accessibilityHidden(true)

--- a/Sources/ThemeKit/Components/Organisms/PriceAlertCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/PriceAlertCard.swift
@@ -90,7 +90,7 @@ public struct PriceAlertCard: View {
             Spacer(minLength: 6)
             // The Toggle is the card's one VoiceOver element (label = card texts) — a
             // `.combine` on the container would flatten it into a static element.
-            Toggle("", isOn: $isOn).labelsHidden().tint(accentSemantic.base)
+            Toggle("", isOn: $isOn).labelsHidden().tint(theme.resolve(accentSemantic).base)
                 .accessibilityLabel([title, subtitle].compactMap { $0 }.joined(separator: ", "))
         }
         .padding(density.scale(Theme.SpacingKey.md.value))

--- a/Sources/ThemeKit/Components/Organisms/ResultView.swift
+++ b/Sources/ThemeKit/Components/Organisms/ResultView.swift
@@ -109,17 +109,17 @@ public struct ResultView: View {
         if let code = status.code {
             Text(code)
                 .font(.system(size: 72, weight: .heavy, design: .rounded))
-                .foregroundStyle(status.color.base)
+                .foregroundStyle(theme.resolve(status.color).base)
                 .overlay(alignment: .bottomTrailing) {
-                    Icon(systemName: status.systemImage).size(.md).colorOverride(status.color.base)
+                    Icon(systemName: status.systemImage).size(.md).colorOverride(theme.resolve(status.color).base)
                         .padding(6)   // intentional: 6pt, no token — small emblem badge inset
                         .background(theme.background(.bgWhite), in: Circle())
                         .offset(x: 10, y: 4)
                 }
         } else {
             ZStack {
-                Circle().fill(status.color.bg).frame(width: 88, height: 88)
-                Icon(systemName: status.systemImage).size(.xl).colorOverride(status.color.base)
+                Circle().fill(theme.resolve(status.color).bg).frame(width: 88, height: 88)
+                Icon(systemName: status.systemImage).size(.xl).colorOverride(theme.resolve(status.color).base)
             }
         }
     }

--- a/Sources/ThemeKit/Components/Organisms/RoomCard.swift
+++ b/Sources/ThemeKit/Components/Organisms/RoomCard.swift
@@ -140,7 +140,7 @@ public struct RoomCard: View {
         if let selection {
             Button { selection.wrappedValue.toggle() } label: {
                 Image(systemName: selection.wrappedValue ? "largecircle.fill.circle" : "circle")
-                    .font(.system(size: 22)).foregroundStyle(selection.wrappedValue ? accentSemantic.base : theme.text(.textTertiary))
+                    .font(.system(size: 22)).foregroundStyle(selection.wrappedValue ? theme.resolve(accentSemantic).base : theme.text(.textTertiary))
             }.buttonStyle(.plain).accessibilityLabel(name)
                 .accessibilityAddTraits(selection.wrappedValue ? .isSelected : [])
         } else if let onSelect {

--- a/Sources/ThemeKit/Components/Organisms/SheetHeader.swift
+++ b/Sources/ThemeKit/Components/Organisms/SheetHeader.swift
@@ -40,7 +40,7 @@ public struct SheetHeader: View {
 
     public init(_ title: String) { self.title = title }   // R1
 
-    private var accentBase: Color { (accent ?? .primary).base }
+    private var accentBase: Color { theme.resolve(accent ?? .primary).base }
 
     public var body: some View {
         // `surface(_:)` / `showsDivider(_:)` must beat whatever fill/hairline

--- a/Sources/ThemeKit/Components/Organisms/Timeline.swift
+++ b/Sources/ThemeKit/Components/Organisms/Timeline.swift
@@ -185,7 +185,7 @@ public struct Timeline: View {
     }
 
     private func railColor(_ item: Item) -> Color {
-        item.state == .done ? (item.color?.solid ?? theme.background(.bgHero)) : theme.border(.borderPrimary)
+        item.state == .done ? (item.color.map { theme.resolve($0).solid } ?? theme.background(.bgHero)) : theme.border(.borderPrimary)
     }
 
     @ViewBuilder
@@ -204,7 +204,7 @@ public struct Timeline: View {
     private func stockMarker(_ item: Item) -> some View {
         let dotColor = item.state == .error
             ? theme.background(.systemcolorsBgError)
-            : (item.color?.solid ?? theme.background(.bgHero))
+            : (item.color.map { theme.resolve($0).solid } ?? theme.background(.bgHero))
         ZStack {
             Circle().fill(item.state == .todo ? theme.background(.bgWhite) : dotColor).frame(width: 28, height: 28)
             Circle().strokeBorder(item.state == .todo ? theme.border(.borderPrimary) : dotColor, lineWidth: 1.5).frame(width: 28, height: 28)

--- a/Sources/ThemeKit/Components/Organisms/WindowFrame.swift
+++ b/Sources/ThemeKit/Components/Organisms/WindowFrame.swift
@@ -12,11 +12,13 @@ import SwiftUI
 /// The three macOS-style window control dots (decorative, token-tinted).
 /// Shared by ``WindowFrame`` and ``BrowserFrame``.
 struct TrafficLights: View {
+    @Environment(\.theme) private var theme
+
     var body: some View {
         HStack(spacing: 6) {
-            Circle().fill(SemanticColor.error.base).frame(width: 10, height: 10)
-            Circle().fill(SemanticColor.warning.base).frame(width: 10, height: 10)
-            Circle().fill(SemanticColor.success.base).frame(width: 10, height: 10)
+            Circle().fill(theme.resolve(.error).base).frame(width: 10, height: 10)
+            Circle().fill(theme.resolve(.warning).base).frame(width: 10, height: 10)
+            Circle().fill(theme.resolve(.success).base).frame(width: 10, height: 10)
         }
         .accessibilityHidden(true)
     }
@@ -70,7 +72,7 @@ public struct WindowFrame<Content: View>: View {
             if let title {
                 Text(title)
                     .textStyle(.labelSm600)
-                    .foregroundStyle(accent.map { $0.accent } ?? theme.text(.textSecondary))
+                    .foregroundStyle(accent.map { theme.resolve($0).accent } ?? theme.text(.textSecondary))
                     .lineLimit(1)
             }
             HStack {
@@ -80,7 +82,7 @@ public struct WindowFrame<Content: View>: View {
         }
         .padding(.horizontal, Theme.SpacingKey.md.value)
         .padding(.vertical, Theme.SpacingKey.sm.value)
-        .background(accent.map { $0.soft } ?? theme.background(.bgSecondary))
+        .background(accent.map { theme.resolve($0).soft } ?? theme.background(.bgSecondary))
     }
 }
 

--- a/Sources/ThemeKitCalendar/DateRangePicker.swift
+++ b/Sources/ThemeKitCalendar/DateRangePicker.swift
@@ -47,6 +47,10 @@ public struct DateRangePicker: View {
     private var accent: SemanticColor?
     private var daySelection: DaySelection = .circle
     private var styleTransform: ((inout CalendarStyle) -> Void)?
+    // ADR-0006: token holidays are queued as `SemanticColor` (not a resolved
+    // ARGB) so the fill re-themes; baked into `HolidayEntry`s against the
+    // environment theme in `resolvedConfiguration`, not at modifier-call time.
+    private var pendingTokenHolidays: [(dates: [ETSCalendarDate], color: SemanticColor, name: String)] = []
     // Composition overrides (bring-your-own views).
     private var dayContent: ((CalendarDayContext) -> AnyView)?
     private var selectedAccessoryContent: ((Date) -> AnyView)?
@@ -84,14 +88,14 @@ public struct DateRangePicker: View {
         switch display {
         case .picker:
             switch purpose {
-            case .range:    CalendarRangePickerView.rangeSelector(configuration: configuration, onApply: onApply, onCancel: onCancel)
-            case .hotel:    CalendarRangePickerView.hotel(configuration: configuration, onApply: onApply, onCancel: onCancel)
-            case .rentACar: CalendarRangePickerView.rentACar(configuration: configuration, onApply: onApply, onCancel: onCancel)
+            case .range:    CalendarRangePickerView.rangeSelector(configuration: resolvedConfiguration, onApply: onApply, onCancel: onCancel)
+            case .hotel:    CalendarRangePickerView.hotel(configuration: resolvedConfiguration, onApply: onApply, onCancel: onCancel)
+            case .rentACar: CalendarRangePickerView.rentACar(configuration: resolvedConfiguration, onApply: onApply, onCancel: onCancel)
             }
         case .month:
-            CalendarGridView(configuration: configuration, onSelectionChange: onApply)
+            CalendarGridView(configuration: resolvedConfiguration, onSelectionChange: onApply)
         case .week:
-            CalendarWeekView(configuration: configuration,
+            CalendarWeekView(configuration: resolvedConfiguration,
                              showsTitle: configuration.chrome.showsTitleBar,
                              showsWeekdayHeader: configuration.chrome.showsWeekdayHeader,
                              onSelectionChange: onApply)
@@ -99,20 +103,34 @@ public struct DateRangePicker: View {
             CalendarYearView(year: configuration.calendar.component(.year, from: Date()),
                              calendar: configuration.calendar, locale: configuration.locale)
         case .browse:
-            CalendarBrowseView(configuration: configuration, onSelectionChange: onApply)
+            CalendarBrowseView(configuration: resolvedConfiguration, onSelectionChange: onApply)
         }
     }
 
     // MARK: Style (ThemeKit tokens + overrides)
 
+    /// `configuration` with any `.holiday(on:color:name:)` token entries baked
+    /// into `HolidayEntry`s against the environment theme — resolved here (in
+    /// `body`'s scope) rather than at modifier-call time, so it honors a
+    /// per-subtree `.theme(_:)` override (ADR-0006).
+    private var resolvedConfiguration: CalendarPickerConfiguration {
+        guard !pendingTokenHolidays.isEmpty else { return configuration }
+        var c = configuration
+        c.holidays += pendingTokenHolidays.map { entry in
+            HolidayEntry(dates: entry.dates, colorARGB: Self.argb(theme.resolve(entry.color).base), description: entry.name)
+        }
+        return c
+    }
+
     private var resolvedStyle: CalendarStyle {
         var s = CalendarStyle.themeKit(theme)
         s.metrics.daySelectionShape = resolvedDayShape
         if let accent {                                  // token-fed brand override (re-themes)
-            s.theme.ink = accent.strong
-            s.theme.onInk = accent.onSolid
-            s.theme.todayRing = accent.base
-            s.theme.inBetweenFill = accent.bg
+            let resolved = theme.resolve(accent)
+            s.theme.ink = resolved.strong
+            s.theme.onInk = resolved.onSolid
+            s.theme.todayRing = resolved.base
+            s.theme.inBetweenFill = resolved.bg
         }
         styleTransform?(&s)
         return s
@@ -200,7 +218,7 @@ public extension DateRangePicker {
     func holidays(_ entries: [HolidayEntry]) -> Self { copy { $0.configuration.holidays = entries } }
     /// Append a token-coloured holiday for the given days.
     func holiday(on dates: [ETSCalendarDate], color: SemanticColor, name: String) -> Self {
-        copy { $0.configuration.holidays.append(HolidayEntry(dates: dates, colorARGB: Self.argb(color.base), description: name)) }
+        copy { $0.pendingTokenHolidays.append((dates: dates, color: color, name: name)) }
     }
     /// BCP-47 locale tag (e.g. "tr", "en-US", "ar" for RTL). nil ⇒ system.
     func locale(_ tag: String?) -> Self { copy { $0.configuration.localeTag = tag } }

--- a/Sources/ThemeKitCore/Theme/SemanticColor.swift
+++ b/Sources/ThemeKitCore/Theme/SemanticColor.swift
@@ -19,28 +19,34 @@ public enum SemanticColor: String, CaseIterable, Sendable {
 
     // MARK: - Role accessors
     //
-    // ADR-0006 Phase 0: the role→color logic now lives ONCE in `Resolved`
+    // ADR-0006 Phase 0/2: the role→color logic lives ONCE in `Resolved`
     // (`SemanticColorResolved.swift`). These zero-arg accessors forward to
-    // `resolved(in: .shared)`, so they stay byte-identical to before — still
-    // `Theme.shared`-backed, unaware of a subtree's `.theme(_:)` override.
-    // NOT deprecated yet (Phase 2 follow-up); prefer `theme.resolve(_:)` in a
-    // view body, which reads the environment theme instead of the singleton.
+    // `resolved(in: .shared)`, so they stay byte-identical to before — but
+    // they are `Theme.shared`-backed and unaware of a subtree's `.theme(_:)`
+    // override. Deprecated in favor of `theme.resolve(color)` (a View body,
+    // reads `@Environment(\.theme)`) or `color.resolved(in: theme)` (a helper
+    // that already holds a `theme`) — either honors per-subtree re-theming.
 
     /// Background for the `solid` variant.
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).solid")
     public var solid: Color { resolved(in: .shared).solid }
 
     /// Foreground on top of the `solid` background — **auto-contrasting**: a bright
     /// accent (amber, yellow, light primary) gets dark content, a deep one gets white,
     /// computed from the background's luminance rather than hardcoded per color.
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).onSolid")
     public var onSolid: Color { resolved(in: .shared).onSolid }
 
     /// Light surface for the `soft` variant.
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).soft")
     public var soft: Color { resolved(in: .shared).soft }
 
     /// Accent foreground for `soft` / `outline` / `ghost` variants.
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).accent")
     public var accent: Color { resolved(in: .shared).accent }
 
     /// Border for the `outline` variant.
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).border")
     public var border: Color { resolved(in: .shared).border }
 
     // MARK: - Ant-style ladder roles
@@ -52,24 +58,33 @@ public enum SemanticColor: String, CaseIterable, Sendable {
     }
 
     /// Resolve any ladder step for this color, e.g. `.primary.shade(.s700)`.
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).shade(_:)")
     public func shade(_ step: Shade) -> Color { resolved(in: .shared).shade(step) }
 
     /// Faint container background (Ant `colorXxxBg`, step 50).
-    public var bg: Color { shade(.s50) }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).bg")
+    public var bg: Color { resolved(in: .shared).bg }
     /// Container background, hovered/stronger (Ant `colorXxxBgHover`, step 100).
-    public var bgHover: Color { shade(.s100) }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).bgHover")
+    public var bgHover: Color { resolved(in: .shared).bgHover }
     /// Subtle border (Ant `colorXxxBorder`, step 200).
-    public var borderSubtle: Color { shade(.s200) }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).borderSubtle")
+    public var borderSubtle: Color { resolved(in: .shared).borderSubtle }
     /// Border, hovered (Ant `colorXxxBorderHover`, step 300).
-    public var borderHover: Color { shade(.s300) }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).borderHover")
+    public var borderHover: Color { resolved(in: .shared).borderHover }
     /// Solid fill, hovered — lighter than base (Ant `colorXxxHover`, step 400).
-    public var hover: Color { shade(.s400) }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).hover")
+    public var hover: Color { resolved(in: .shared).hover }
     /// The color itself (Ant `colorXxx`, step 500).
-    public var base: Color { shade(.s500) }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).base")
+    public var base: Color { resolved(in: .shared).base }
     /// Solid fill, pressed/active — darker than base (Ant `colorXxxActive`, step 600).
-    public var active: Color { shade(.s600) }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).active")
+    public var active: Color { resolved(in: .shared).active }
     /// High-contrast text/icon on light surfaces (step 700).
-    public var strong: Color { shade(.s700) }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use theme.resolve(color).strong")
+    public var strong: Color { resolved(in: .shared).strong }
 }
 
 /// Fill style shared by configurable components (daisyUI: solid / soft / outline / ghost).

--- a/Sources/ThemeKitCore/Theme/ThemeContext.swift
+++ b/Sources/ThemeKitCore/Theme/ThemeContext.swift
@@ -42,6 +42,22 @@ public extension EnvironmentValues {
     /// `.theme(_:)`. Components read this instead of touching the singleton directly,
     /// so they can be re-themed in isolation (different brand in a subtree, a fixed
     /// theme in a preview/snapshot) without mutating global state.
+    ///
+    /// **What "re-themed in isolation" covers (ADR-0006).** Per-subtree `.theme(_:)`
+    /// re-skins **color** completely: `theme.text(_:)` / `.background(_:)` /
+    /// `.border(_:)` / `.foreground(_:)` and `theme.resolve(_:)` (the `SemanticColor`
+    /// role/ladder resolver — `.solid .soft .accent .border .onSolid` and the
+    /// 50…900 shade steps) all read *this* environment value, so two subtrees with
+    /// different brands render correct, independent colors — including accents.
+    /// **What it does not (yet) cover:** corner radius (`Theme.RadiusRole` /
+    /// `RadiusKey`), spacing (`Theme.SpacingKey`), and the type scale
+    /// (`TextStyle.font` / `.lineSpacing`) stay **process-global** — they resolve
+    /// from `Theme.shared` regardless of a subtree override, because no shipped
+    /// two-brand screen varies those per subtree and isolating them would cost a
+    /// ~2000-call-site migration for a real but currently theoretical need. This is
+    /// a documented, bounded limit (ADR-0006 §D5), not a silent gap: if a genuine
+    /// per-subtree metric/type need appears, the same `theme.resolve(_:)`-style
+    /// idiom is reserved for it.
     var theme: Theme {
         get { self[ThemeEnvironmentKey.self] }
         set { self[ThemeEnvironmentKey.self] = newValue }
@@ -49,9 +65,18 @@ public extension EnvironmentValues {
 }
 
 public extension View {
-    /// Re-theme this view and its descendants with a specific `Theme` instance.
+    /// Re-theme this view and its descendants with a specific `Theme` instance —
+    /// **color only** re-skins per subtree (semantic/brand/accent colors and every
+    /// instance color accessor); corner radius, spacing, and the type scale stay
+    /// process-global (they follow `Theme.shared` / the root `.themeKit()` theme).
+    /// See `EnvironmentValues.theme` for the full scope (ADR-0006).
     /// At the app root prefer `.themeKit()`; use this to scope a different theme to
     /// a branch, or to pin a theme in a preview/test.
+    ///
+    /// A live *mutation* of `theme` after it's injected (a second `@Observable`
+    /// theme reconfigured at runtime) won't repaint the subtree on its own — add
+    /// `.id(theme.revision)` alongside `.theme(theme)` if that's a real need;
+    /// `.themeKit()` already does this for the root.
     func theme(_ theme: Theme) -> some View {
         environment(\.theme, theme)
     }

--- a/Sources/ThemeKitTravel/Components/Atoms/FlightStatusBadgeStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Atoms/FlightStatusBadgeStyle.swift
@@ -119,6 +119,7 @@ public protocol FlightStatusBadgeStyle {
 
 /// The dot-or-glyph + label + time content row every built-in shares.
 private struct StatusContent: View {
+    @Environment(\.theme) private var theme
     let configuration: FlightStatusBadgeConfiguration
     /// `.dot` swaps the glyph for a small plain status dot.
     var showsDot = false
@@ -126,7 +127,7 @@ private struct StatusContent: View {
     var body: some View {
         HStack(spacing: 4) {
             if showsDot {
-                Circle().fill(configuration.tone.base).frame(width: 6, height: 6)
+                Circle().fill(theme.resolve(configuration.tone).base).frame(width: 6, height: 6)
             } else if let icon = configuration.icon {
                 Image(systemName: icon).textStyle(configuration.iconTextStyle)
             }
@@ -138,13 +139,35 @@ private struct StatusContent: View {
     }
 }
 
+/// The `StatusPill` fill/foreground/stroke treatment — a role, not a resolved
+/// `Color`, so the pill can resolve `configuration.tone` against its own
+/// environment theme in `body` (ADR-0006) instead of the caller baking colors
+/// at `makeBody`-call time (`FlightStatusBadgeStyle` conformers are plain
+/// structs with no `@Environment` access of their own).
+private enum PillTreatment { case soft, solid, outline }
+
 /// The pill chrome shared by `.soft`/`.solid`/`.outline`: content row, side
 /// padding, fixed control height, shaped fill and optional hairline stroke.
 private struct StatusPill: View {
+    @Environment(\.theme) private var theme
     let configuration: FlightStatusBadgeConfiguration
-    let fill: Color
-    let foreground: Color
-    var stroke: Color?
+    let treatment: PillTreatment
+
+    private var resolved: SemanticColor.Resolved { theme.resolve(configuration.tone) }
+    private var fill: Color {
+        switch treatment {
+        case .soft: return resolved.bg
+        case .solid: return resolved.solid
+        case .outline: return .clear
+        }
+    }
+    private var foreground: Color {
+        switch treatment {
+        case .soft, .outline: return resolved.base
+        case .solid: return resolved.onSolid
+        }
+    }
+    private var stroke: Color? { treatment == .outline ? resolved.border : nil }
 
     var body: some View {
         StatusContent(configuration: configuration)
@@ -164,9 +187,7 @@ private struct StatusPill: View {
 public struct SoftFlightStatusBadgeStyle: FlightStatusBadgeStyle {
     public init() {}
     public func makeBody(configuration: FlightStatusBadgeConfiguration) -> some View {
-        StatusPill(configuration: configuration,
-                   fill: configuration.tone.bg,
-                   foreground: configuration.tone.base)
+        StatusPill(configuration: configuration, treatment: .soft)
     }
 }
 
@@ -177,9 +198,7 @@ public struct SoftFlightStatusBadgeStyle: FlightStatusBadgeStyle {
 public struct SolidFlightStatusBadgeStyle: FlightStatusBadgeStyle {
     public init() {}
     public func makeBody(configuration: FlightStatusBadgeConfiguration) -> some View {
-        StatusPill(configuration: configuration,
-                   fill: configuration.tone.solid,
-                   foreground: configuration.tone.onSolid)
+        StatusPill(configuration: configuration, treatment: .solid)
     }
 }
 
@@ -189,10 +208,7 @@ public struct SolidFlightStatusBadgeStyle: FlightStatusBadgeStyle {
 public struct OutlineFlightStatusBadgeStyle: FlightStatusBadgeStyle {
     public init() {}
     public func makeBody(configuration: FlightStatusBadgeConfiguration) -> some View {
-        StatusPill(configuration: configuration,
-                   fill: .clear,
-                   foreground: configuration.tone.base,
-                   stroke: configuration.tone.border)
+        StatusPill(configuration: configuration, treatment: .outline)
     }
 }
 

--- a/Sources/ThemeKitTravel/Components/Molecules/CabinClassSelectorStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/CabinClassSelectorStyle.swift
@@ -246,7 +246,7 @@ private struct CabinClassCard: View {
 
     var body: some View {
         let isOn = configuration.isSelected(cabin)
-        let tint = configuration.resolvedAccent
+        let tint = theme.resolve(configuration.resolvedAccent)
         let description = configuration.descriptionProvider(cabin)
         let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value, style: .continuous)
         Button { configuration.select(cabin) } label: {
@@ -346,7 +346,7 @@ private struct ChecklistCabinClassSelectorStyle: CabinClassSelectorStyle {
                         HStack(spacing: configuration.spacing(.sm)) {
                             Image(systemName: isOn ? "checkmark.circle.fill" : "circle")
                                 .textStyle(.labelBase600)
-                                .foregroundStyle(isOn ? configuration.resolvedAccent.base : theme.text(.textTertiary))
+                                .foregroundStyle(isOn ? theme.resolve(configuration.resolvedAccent).base : theme.text(.textTertiary))
                             Text(configuration.labelProvider(cabin))
                                 .textStyle(.labelBase600)
                                 .foregroundStyle(theme.text(.textPrimary))

--- a/Sources/ThemeKitTravel/Components/Molecules/DatePriceStrip.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/DatePriceStrip.swift
@@ -99,9 +99,9 @@ public struct DatePriceCard: View {
     }
 
     /// Selected-state foreground — the accent's base shade, or the stock hero.
-    private var selectedColor: Color { accent?.base ?? theme.foreground(.fgHero) }
+    private var selectedColor: Color { accent.map { theme.resolve($0).base } ?? theme.foreground(.fgHero) }
     /// Lowest-fare foreground — the tone's base shade, or the stock success token.
-    private var cheapestColor: Color { cheapestToneOverride?.base ?? theme.foreground(.systemcolorsFgSuccess) }
+    private var cheapestColor: Color { cheapestToneOverride.map { theme.resolve($0).base } ?? theme.foreground(.systemcolorsFgSuccess) }
 
     private var priceColor: Color {
         if item.unavailable { return theme.text(.textDisabled) }
@@ -158,9 +158,9 @@ public struct DatePriceCard: View {
         }
         .padding(.horizontal, Theme.SpacingKey.base.value)
         .frame(height: pillSize.height)
-        .background(isSelected ? (accent ?? .primary).soft : theme.background(.bgWhite), in: shape)
+        .background(isSelected ? theme.resolve(accent ?? .primary).soft : theme.background(.bgWhite), in: shape)
         .overlay {
-            if isSelected { shape.strokeBorder(accent?.base ?? theme.border(.borderHero), lineWidth: 2) }
+            if isSelected { shape.strokeBorder(accent.map { theme.resolve($0).base } ?? theme.border(.borderHero), lineWidth: 2) }
         }
     }
 
@@ -183,7 +183,7 @@ public struct DatePriceCard: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, density.scale(Theme.SpacingKey.sm.value))
         .padding(.horizontal, Theme.SpacingKey.xs.value)
-        .background(isSelected ? (accent ?? .primary).bg : Color.clear)
+        .background(isSelected ? theme.resolve(accent ?? .primary).bg : Color.clear)
     }
 }
 

--- a/Sources/ThemeKitTravel/Components/Molecules/DatePriceStripStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/DatePriceStripStyle.swift
@@ -98,12 +98,12 @@ public struct DatePriceStripConfiguration {
 
     /// The `accent(_:)` override's base, else the theme's hero foreground — the
     /// selected-state chroma every built-in uses.
-    public func accentForeground(_ theme: Theme) -> Color { accent?.base ?? theme.foreground(.fgHero) }
+    public func accentForeground(_ theme: Theme) -> Color { accent.map { theme.resolve($0).base } ?? theme.foreground(.fgHero) }
 
     /// The `cheapestTone(_:)` override's base, else the stock success token —
     /// the lowest-fare chroma every built-in uses.
     public func cheapestForeground(_ theme: Theme) -> Color {
-        cheapestTone?.base ?? theme.foreground(.systemcolorsFgSuccess)
+        cheapestTone.map { theme.resolve($0).base } ?? theme.foreground(.systemcolorsFgSuccess)
     }
 
     /// An item's price, formatted with the strip's resolved currency and the
@@ -387,7 +387,7 @@ private struct ChartDatePriceStripChrome: View {
         if item.unavailable { return theme.background(.bgSecondaryLight) }
         if isSelected { return configuration.accentForeground(theme) }
         if isCheapest { return configuration.cheapestForeground(theme) }
-        return (configuration.accent ?? .primary).soft
+        return theme.resolve(configuration.accent ?? .primary).soft
     }
 
     private func priceColor(_ item: DatePriceItem, isSelected: Bool, isCheapest: Bool) -> Color {
@@ -486,7 +486,7 @@ private struct AgendaDatePriceStripStyle: DatePriceStripStyle {
                 }
                 .padding(configuration.spacing(.sm))
                 .background(
-                    isSelected ? (configuration.accent ?? .primary).soft : theme.background(.bgWhite),
+                    isSelected ? theme.resolve(configuration.accent ?? .primary).soft : theme.background(.bgWhite),
                     in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
             }
             .buttonStyle(.plain)

--- a/Sources/ThemeKitTravel/Components/Molecules/FlightRouteStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/FlightRouteStyle.swift
@@ -94,7 +94,7 @@ public struct FlightRouteConfiguration {
     // Accent resolution — the `accent(_:)` override, else the `pathColor(_:)`
     // token (the value the built-ins used before the accent axis existed).
     /// The route's accent colour — direct-flight track fill, plane glyph, dots.
-    public func pathAccent(_ theme: Theme) -> Color { accent?.base ?? theme.foreground(pathColorKey) }
+    public func pathAccent(_ theme: Theme) -> Color { accent.map { theme.resolve($0).base } ?? theme.foreground(pathColorKey) }
     /// Track-line fill: the accent when direct, a hairline border otherwise.
     public func trackLineColor(_ theme: Theme) -> Color {
         stops == 0 ? pathAccent(theme) : theme.border(.borderPrimary)
@@ -102,7 +102,7 @@ public struct FlightRouteConfiguration {
     /// Stops-label colour: direct keeps the accent, 1+ stops uses ``stopsTone``
     /// (default tertiary).
     public func stopsLabelColor(_ theme: Theme) -> Color {
-        stops == 0 ? pathAccent(theme) : (stopsTone?.base ?? theme.text(.textTertiary))
+        stops == 0 ? pathAccent(theme) : (stopsTone.map { theme.resolve($0).base } ?? theme.text(.textTertiary))
     }
 }
 
@@ -276,7 +276,7 @@ private struct InlineFlightRouteChrome: View {
                 }
                 Text(configuration.stopsText).textStyle(ramp.duration)
                     .foregroundStyle(configuration.stops > 0
-                        ? (configuration.stopsTone?.base ?? theme.text(.textTertiary))
+                        ? (configuration.stopsTone.map { theme.resolve($0).base } ?? theme.text(.textTertiary))
                         : theme.text(.textTertiary))
             }
             .frame(maxWidth: .infinity)

--- a/Sources/ThemeKitTravel/Components/Molecules/LayoverRowStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/LayoverRowStyle.swift
@@ -66,12 +66,12 @@ public struct LayoverRowConfiguration {
     /// foreground (the value the built-ins hardcoded before the tone axis
     /// existed).
     public func warningColor(_ theme: Theme) -> Color {
-        warningTone?.base ?? theme.foreground(.systemcolorsFgWarning)
+        warningTone.map { theme.resolve($0).base } ?? theme.foreground(.systemcolorsFgWarning)
     }
     /// The connector icon/label tint: the warning color while warning, else
     /// the accent's base (neutral by default).
     public func accentColor(_ theme: Theme) -> Color {
-        hasWarning ? warningColor(theme) : (accent ?? .neutral).base
+        hasWarning ? warningColor(theme) : theme.resolve(accent ?? .neutral).base
     }
     /// Semantic tone that tints the pill / banner chrome.
     public var chromeTone: SemanticColor { hasWarning ? (warningTone ?? .warning) : (accent ?? .neutral) }
@@ -197,6 +197,7 @@ public struct PillLayoverRowStyle: LayoverRowStyle {
 }
 
 private struct PillLayoverRowChrome: View {
+    @Environment(\.theme) private var theme
     let configuration: LayoverRowConfiguration
 
     var body: some View {
@@ -206,7 +207,7 @@ private struct PillLayoverRowChrome: View {
                 LayoverRowLabel(configuration: configuration)
                     .padding(.horizontal, configuration.spacing(.sm))
                     .padding(.vertical, Theme.SpacingKey.xs.value)
-                    .background(configuration.chromeTone.soft, in: Capsule(style: .continuous))
+                    .background(theme.resolve(configuration.chromeTone).soft, in: Capsule(style: .continuous))
                 LayoverRowConnectorLine(lineStyle: configuration.lineStyle)
             }
             if configuration.hasWarning { LayoverRowWarningLine(configuration: configuration) }
@@ -225,6 +226,7 @@ public struct BannerLayoverRowStyle: LayoverRowStyle {
 }
 
 private struct BannerLayoverRowChrome: View {
+    @Environment(\.theme) private var theme
     let configuration: LayoverRowConfiguration
 
     var body: some View {
@@ -233,7 +235,7 @@ private struct BannerLayoverRowChrome: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, configuration.spacing(.sm))
                 .padding(.horizontal, Theme.SpacingKey.sm.value)
-                .background(configuration.chromeTone.bg,
+                .background(theme.resolve(configuration.chromeTone).bg,
                             in: RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous))
             if configuration.hasWarning { LayoverRowWarningLine(configuration: configuration) }
         }

--- a/Sources/ThemeKitTravel/Components/Molecules/PassengerRowStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/PassengerRowStyle.swift
@@ -92,7 +92,11 @@ public struct PassengerRowConfiguration {
 
     /// The `accent(_:)` override's base, else the primary semantic's base — the
     /// value the built-ins hardcoded before the accent axis existed.
-    public var accentBase: Color { (accent ?? .primary).base }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use accentBase(_ theme:)")
+    public var accentBase: Color { accentBase(.shared) }
+    /// Theme-parameterized twin of ``accentBase`` — resolves against the
+    /// environment theme (ADR-0006), honoring per-subtree `.theme(_:)`.
+    public func accentBase(_ theme: Theme) -> Color { theme.resolve(accent ?? .primary).base }
 
     /// The explicit `surface(_:)` override, or the style's own default.
     public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
@@ -128,6 +132,7 @@ public protocol PassengerRowStyle {
 /// ``PassengerRowConfiguration/avatar`` when set, else a person-glyph icon
 /// tinted with ``PassengerRowConfiguration/accentBase``.
 private struct PassengerRowAvatar: View {
+    @Environment(\.theme) private var theme
     let configuration: PassengerRowConfiguration
     var size: AvatarSize = .md
 
@@ -137,7 +142,7 @@ private struct PassengerRowAvatar: View {
         } else {
             Image(systemName: configuration.systemImage)
                 .font(.system(size: size.rawValue * 0.75))
-                .foregroundStyle(configuration.accentBase)
+                .foregroundStyle(configuration.accentBase(theme))
         }
     }
 }
@@ -251,7 +256,7 @@ private struct RowPassengerRowChrome: View {
                 custom
             } else if let onEdit = configuration.onEdit {
                 Button { onEdit() } label: {
-                    Image(systemName: "pencil").textStyle(.labelBase600).foregroundStyle(configuration.accentBase)
+                    Image(systemName: "pencil").textStyle(.labelBase600).foregroundStyle(configuration.accentBase(theme))
                         .frame(width: 44, height: 44).contentShape(Rectangle())
                 }.buttonStyle(.plain).accessibilityLabel(String(themeKit: "Edit"))
             } else if let onRemove = configuration.onRemove {
@@ -456,12 +461,12 @@ private struct CapsulePassengerRowStyle: PassengerRowStyle {
                 HStack(spacing: configuration.spacing(.sm)) {
                     Text(configuration.name).textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary))
                     if let seat = configuration.seat {
-                        Text(seat).textStyle(.overline500).foregroundStyle(configuration.accentBase)
+                        Text(seat).textStyle(.overline500).foregroundStyle(configuration.accentBase(theme))
                     }
                 }
                 .padding(.vertical, configuration.spacing(.xs))
                 .padding(.horizontal, configuration.spacing(.sm))
-                .background((configuration.accent ?? .primary).soft, in: Capsule(style: .continuous))
+                .background(theme.resolve(configuration.accent ?? .primary).soft, in: Capsule(style: .continuous))
                 .contentShape(Capsule(style: .continuous))
             }
             .buttonStyle(.plain)

--- a/Sources/ThemeKitTravel/Components/Molecules/RecentSearchRowStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/RecentSearchRowStyle.swift
@@ -395,12 +395,12 @@ private struct ChipRecentSearchRowStyle: RecentSearchRowStyle {
                 HStack(spacing: configuration.spacing(.xs)) {
                     Image(systemName: "clock.arrow.circlepath")
                         .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle((configuration.accent ?? .neutral).base)
+                        .foregroundStyle(theme.resolve(configuration.accent ?? .neutral).base)
                     RecentSearchRowRouteLine(configuration: configuration)
                 }
                 .padding(.vertical, configuration.spacing(.xs))
                 .padding(.horizontal, configuration.spacing(.sm))
-                .background((configuration.accent ?? .neutral).soft, in: Capsule(style: .continuous))
+                .background(theme.resolve(configuration.accent ?? .neutral).soft, in: Capsule(style: .continuous))
                 .contentShape(Capsule(style: .continuous))
             }
             .buttonStyle(.plain)

--- a/Sources/ThemeKitTravel/Components/Molecules/SeatLegendStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/SeatLegendStyle.swift
@@ -108,7 +108,7 @@ public struct SeatLegendConfiguration {
             let c = palette.colors(for: tier, theme: theme)
             return SeatLegendEntry(fill: c.fill, border: c.stroke, label: tier.label)
         }
-        e += customEntries.map { SeatLegendEntry(fill: $0.color.bg, border: $0.color.base, label: $0.label) }
+        e += customEntries.map { SeatLegendEntry(fill: theme.resolve($0.color).bg, border: theme.resolve($0.color).base, label: $0.label) }
         if showsSelected {
             let selected = palette.selectedColors(theme: theme)
             e.append(SeatLegendEntry(fill: selected.fill, border: selected.stroke, label: String(themeKit: "Selected")))

--- a/Sources/ThemeKitTravel/Components/Molecules/TripTypeToggleStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Molecules/TripTypeToggleStyle.swift
@@ -159,11 +159,11 @@ private struct PillTripTypeToggleChrome: View {
             configuration.select(index)
         } label: {
             TripTypeOptionLabel(configuration: configuration, index: index, option: option)
-                .foregroundStyle(isOn ? configuration.resolvedAccent.onSolid : theme.text(.textSecondary))
+                .foregroundStyle(isOn ? theme.resolve(configuration.resolvedAccent).onSolid : theme.text(.textSecondary))
                 .padding(.horizontal, configuration.spacing(.sm))
                 .frame(maxWidth: configuration.fullWidth ? .infinity : nil)
                 .frame(minHeight: configuration.size.minHeight)
-                .background(isOn ? configuration.resolvedAccent.solid : .clear, in: configuration.trackShape)
+                .background(isOn ? theme.resolve(configuration.resolvedAccent).solid : .clear, in: configuration.trackShape)
                 .contentShape(configuration.trackShape)
         }
         .buttonStyle(.plain)
@@ -203,9 +203,9 @@ private struct UnderlineTripTypeToggleChrome: View {
         } label: {
             VStack(spacing: Theme.SpacingKey.xs.value) {
                 TripTypeOptionLabel(configuration: configuration, index: index, option: option)
-                    .foregroundStyle(isOn ? configuration.resolvedAccent.base : theme.text(.textSecondary))
+                    .foregroundStyle(isOn ? theme.resolve(configuration.resolvedAccent).base : theme.text(.textSecondary))
                 Rectangle()
-                    .fill(isOn ? configuration.resolvedAccent.base : Color.clear)
+                    .fill(isOn ? theme.resolve(configuration.resolvedAccent).base : Color.clear)
                     .frame(height: 2)
             }
             .padding(.horizontal, configuration.spacing(.xs))
@@ -256,7 +256,7 @@ private struct MenuTripTypeToggleChrome: View {
             if let symbol = configuration.icon(at: configuration.selectedIndex) {
                 Image(systemName: symbol)
                     .textStyle(configuration.size.iconStyle)
-                    .foregroundStyle(configuration.resolvedAccent.base)
+                    .foregroundStyle(theme.resolve(configuration.resolvedAccent).base)
             }
             Text(configuration.selectedTitle)
                 .textStyle(configuration.size.textStyle)
@@ -349,7 +349,7 @@ private struct RadioListTripTypeToggleStyle: TripTypeToggleStyle {
                 HStack(spacing: configuration.spacing(.sm)) {
                     Image(systemName: isOn ? "largecircle.fill.circle" : "circle")
                         .textStyle(configuration.size.iconStyle)
-                        .foregroundStyle(isOn ? configuration.resolvedAccent.base : theme.text(.textTertiary))
+                        .foregroundStyle(isOn ? theme.resolve(configuration.resolvedAccent).base : theme.text(.textTertiary))
                     Text(option)
                         .textStyle(configuration.size.textStyle)
                         .foregroundStyle(isOn ? theme.text(.textPrimary) : theme.text(.textSecondary))

--- a/Sources/ThemeKitTravel/Components/Organisms/AirportPicker.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/AirportPicker.swift
@@ -345,7 +345,7 @@ public struct AirportPicker: View {
                 Button(action: onClear) {
                     Text(String(themeKitTravel: "Clear"))
                         .textStyle(.labelSm700)
-                        .foregroundStyle(accentColor?.accent ?? theme.foreground(.fgHero))
+                        .foregroundStyle(accentColor.map { theme.resolve($0).accent } ?? theme.foreground(.fgHero))
                 }
                 .buttonStyle(.plain)
                 .disabled(isReadOnly)
@@ -405,7 +405,7 @@ public struct AirportPicker: View {
                 .overlay {
                     if isSelected(airport) {
                         RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
-                            .strokeBorder(accentColor?.accent ?? theme.foreground(.fgHero), lineWidth: 1)
+                            .strokeBorder(accentColor.map { theme.resolve($0).accent } ?? theme.foreground(.fgHero), lineWidth: 1)
                     }
                 }
                 .frame(minWidth: Metrics.chipMinWidth, minHeight: Metrics.chipTapTarget)
@@ -435,7 +435,7 @@ public struct AirportPicker: View {
             if isSelected {
                 Icon(systemName: "checkmark")
                     .size(.sm)
-                    .color(accentColor?.accent ?? theme.foreground(.fgHero))
+                    .color(accentColor.map { theme.resolve($0).accent } ?? theme.foreground(.fgHero))
             }
         }
     }
@@ -443,23 +443,23 @@ public struct AirportPicker: View {
     /// Bold IATA code chip — token-fed fill/foreground, accent-tintable, with
     /// a `FillVariant` axis (`.soft` default, `.solid`, `.outline`, `.ghost`).
     private func codeChip(_ code: String) -> some View {
-        let tone = accentColor ?? .primary
+        let tone = theme.resolve(accentColor ?? .primary)
         let shape = RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
         let fill: Color
         let text: Color
         switch chipVariantValue {
         case .soft:
-            fill = accentColor?.soft ?? theme.background(.bgSecondaryLight)
-            text = accentColor?.accent ?? theme.text(.textPrimary)
+            fill = accentColor.map { theme.resolve($0).soft } ?? theme.background(.bgSecondaryLight)
+            text = accentColor.map { theme.resolve($0).accent } ?? theme.text(.textPrimary)
         case .solid:
             fill = tone.solid
             text = tone.onSolid
         case .outline:
             fill = .clear
-            text = accentColor?.accent ?? theme.text(.textPrimary)
+            text = accentColor.map { theme.resolve($0).accent } ?? theme.text(.textPrimary)
         case .ghost:
             fill = .clear
-            text = accentColor?.accent ?? theme.text(.textSecondary)
+            text = accentColor.map { theme.resolve($0).accent } ?? theme.text(.textSecondary)
         }
         return Text(code)
             .textStyle(.labelSm700)
@@ -469,7 +469,7 @@ public struct AirportPicker: View {
             .background(fill, in: shape)
             .overlay {
                 if chipVariantValue == .outline {
-                    shape.strokeBorder(accentColor?.border ?? theme.border(.borderPrimary), lineWidth: 1)
+                    shape.strokeBorder(accentColor.map { theme.resolve($0).border } ?? theme.border(.borderPrimary), lineWidth: 1)
                 }
             }
     }

--- a/Sources/ThemeKitTravel/Components/Organisms/AirportPickerStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/AirportPickerStyle.swift
@@ -156,7 +156,7 @@ public struct AirportPickerConfiguration {
 
     /// The `accent(_:)` override's tint, else the theme's hero foreground —
     /// the value the stock checkmark and Clear button use.
-    public func accentForeground(_ theme: Theme) -> Color { accent?.accent ?? theme.foreground(.fgHero) }
+    public func accentForeground(_ theme: Theme) -> Color { accent.map { theme.resolve($0).accent } ?? theme.foreground(.fgHero) }
 }
 
 // MARK: - Protocol

--- a/Sources/ThemeKitTravel/Components/Organisms/AncillaryCardStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/AncillaryCardStyle.swift
@@ -242,7 +242,7 @@ private struct AncillaryCardStepper: View {
     private func stepButton(_ icon: String, label: String, enabled: Bool, _ action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: icon).font(.system(size: 13, weight: .bold))
-                .foregroundStyle(enabled ? accentSemantic.base : theme.text(.textDisabled))
+                .foregroundStyle(enabled ? theme.resolve(accentSemantic).base : theme.text(.textDisabled))
                 .frame(width: 32, height: 32)
         }
         .buttonStyle(.plain)
@@ -267,10 +267,10 @@ private struct AncillaryCardAddButton: View {
                 Image(systemName: on ? "checkmark" : "plus").font(.system(size: 12, weight: .bold))
                 Text(on ? configuration.addedTitle : configuration.addTitle).textStyle(.labelSm700)
             }
-            .foregroundStyle(on ? accentSemantic.onSolid : accentSemantic.base)
+            .foregroundStyle(on ? theme.resolve(accentSemantic).onSolid : theme.resolve(accentSemantic).base)
             .padding(.horizontal, configuration.spacing(.md))
             .frame(height: 36)
-            .background(on ? accentSemantic.solid : accentSemantic.bg, in: Capsule())
+            .background(on ? theme.resolve(accentSemantic).solid : theme.resolve(accentSemantic).bg, in: Capsule())
         }
         .buttonStyle(.plain)
         .disabled(isReadOnly)

--- a/Sources/ThemeKitTravel/Components/Organisms/BoardingPassStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/BoardingPassStyle.swift
@@ -126,9 +126,16 @@ public struct BoardingPassConfiguration {
     // deferred: accent-fallback unification — keeps the `.primary` fallback
     // (matching AncillaryCard/StickyBookingBar would be visually breaking here).
     /// Accent for the airline glyph, route plane and duration.
-    public var accentBase: Color { (accent ?? .primary).base }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use accentBase(_ theme:)")
+    public var accentBase: Color { accentBase(.shared) }
+    /// Theme-parameterized twin of ``accentBase`` — resolves against the
+    /// environment theme (ADR-0006), honoring per-subtree `.theme(_:)`.
+    public func accentBase(_ theme: Theme) -> Color { theme.resolve(accent ?? .primary).base }
     /// Content colour on top of a solid accent fill.
-    public var accentOnSolid: Color { (accent ?? .primary).onSolid }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use accentOnSolid(_ theme:)")
+    public var accentOnSolid: Color { accentOnSolid(.shared) }
+    /// Theme-parameterized twin of ``accentOnSolid``.
+    public func accentOnSolid(_ theme: Theme) -> Color { theme.resolve(accent ?? .primary).onSolid }
 
     /// Internal point constants behind the `CodeSize` ramp (token rule: ramp
     /// enums map to private CGFloats; no raw sizes in the public signature).
@@ -162,7 +169,7 @@ private struct BoardingPassHeaderRow: View {
         HStack {
             HStack(spacing: 6) {
                 Image(systemName: configuration.airlineIcon).font(.system(size: 14))
-                    .foregroundStyle(configuration.accentBase)
+                    .foregroundStyle(configuration.accentBase(theme))
                     .accessibilityHidden(true)   // decorative airline glyph
                 if let airline = configuration.airline {
                     Text(airline).textStyle(.labelBase700).foregroundStyle(theme.text(.textPrimary))
@@ -196,7 +203,7 @@ private struct BoardingPassRouteRow: View {
                     Text(date).textStyle(.overline400).foregroundStyle(theme.text(.textTertiary))
                 }
                 Image(systemName: "airplane").font(.system(size: 16))
-                    .foregroundStyle(configuration.accentBase).mirrorsInRTL()
+                    .foregroundStyle(configuration.accentBase(theme)).mirrorsInRTL()
                     .accessibilityHidden(true)   // decorative route glyph
             }
             Spacer(minLength: 8)
@@ -208,7 +215,7 @@ private struct BoardingPassRouteRow: View {
         VStack(alignment: alignment, spacing: 1) {
             Text(code).textStyle(.displaySm).foregroundStyle(theme.text(.textPrimary))
             if let city { Text(city).textStyle(.bodySm400).foregroundStyle(theme.text(.textTertiary)).lineLimit(1) }
-            if let time { Text(time).textStyle(.labelBase700).foregroundStyle(configuration.accentBase) }
+            if let time { Text(time).textStyle(.labelBase700).foregroundStyle(configuration.accentBase(theme)) }
         }
         .fixedSize()
     }
@@ -522,24 +529,25 @@ private struct GateAnnouncementBoardingPassStyle: BoardingPassStyle {
     }
 
     private struct GateAnnouncementChrome: View {
+        @Environment(\.theme) private var theme
         let configuration: BoardingPassConfiguration
 
         var body: some View {
             VStack(alignment: .leading, spacing: configuration.spacing(.sm)) {
                 Text(String(themeKit: "Now boarding")).textStyle(.overline500)
-                    .foregroundStyle(configuration.accentOnSolid)
+                    .foregroundStyle(configuration.accentOnSolid(theme))
                 HStack {
                     Text("\(configuration.from) → \(configuration.to)")
-                        .textStyle(.headingSm).foregroundStyle(configuration.accentOnSolid)
+                        .textStyle(.headingSm).foregroundStyle(configuration.accentOnSolid(theme))
                     Spacer()
                     if let gate = configuration.gate {
-                        Text(gate).textStyle(.labelLg700).foregroundStyle(configuration.accentOnSolid)
+                        Text(gate).textStyle(.labelLg700).foregroundStyle(configuration.accentOnSolid(theme))
                     }
                 }
-                Text(configuration.passenger).textStyle(.bodySm400).foregroundStyle(configuration.accentOnSolid)
+                Text(configuration.passenger).textStyle(.bodySm400).foregroundStyle(configuration.accentOnSolid(theme))
             }
             .padding(configuration.spacing(.md))
-            .background((configuration.accent ?? .primary).solid,
+            .background(theme.resolve(configuration.accent ?? .primary).solid,
                         in: RoundedRectangle(cornerRadius: configuration.radiusRole.value, style: .continuous))
         }
     }

--- a/Sources/ThemeKitTravel/Components/Organisms/CheckInFlow.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/CheckInFlow.swift
@@ -227,20 +227,21 @@ public struct CheckInFlow<Page: View>: View {
     private func accentMarker(index: Int, color: SemanticColor) -> some View {
         let isDone = index < currentIndex
         let isCurrent = index == currentIndex
+        let resolved = theme.resolve(color)
         return ZStack {
-            Circle().fill(isDone || isCurrent ? color.solid : theme.background(.bgWhite))
+            Circle().fill(isDone || isCurrent ? resolved.solid : theme.background(.bgWhite))
             Circle().strokeBorder(
-                isDone || isCurrent ? color.solid : theme.border(.borderPrimary),
+                isDone || isCurrent ? resolved.solid : theme.border(.borderPrimary),
                 lineWidth: 1.5
             )
             if isDone {
                 Image(systemName: "checkmark")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(color.onSolid)
+                    .foregroundStyle(resolved.onSolid)
             } else {
                 Text("\(index + 1)")
                     .textStyle(.labelSm700)
-                    .foregroundStyle(isCurrent ? color.onSolid : theme.text(.textTertiary))
+                    .foregroundStyle(isCurrent ? resolved.onSolid : theme.text(.textTertiary))
             }
         }
     }

--- a/Sources/ThemeKitTravel/Components/Organisms/CheckInFlowStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/CheckInFlowStyle.swift
@@ -292,7 +292,7 @@ private struct LabelCheckInFlowStyle: CheckInFlowStyle {
                 if configuration.showsStepper {
                     Text("Step \(configuration.currentIndex + 1) of \(configuration.stepCount)")
                         .textStyle(.overline500)
-                        .foregroundStyle(configuration.accent?.base ?? theme.text(.textSecondary))
+                        .foregroundStyle(configuration.accent.map { theme.resolve($0).base } ?? theme.text(.textSecondary))
                         .padding(.vertical, configuration.spacing(.sm))
                 }
                 configuration.page

--- a/Sources/ThemeKitTravel/Components/Organisms/FareFamilyCardStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FareFamilyCardStyle.swift
@@ -132,7 +132,10 @@ public protocol FareFamilyCardStyle {
 /// The tier name chip, rendered per ``FillVariant`` on the accent's ladder —
 /// shared by every built-in preset (`.header { }` replaces it).
 private struct FareFamilyTierChip: View {
+    @Environment(\.theme) private var theme
     let configuration: FareFamilyCardConfiguration
+
+    private var resolvedAccent: SemanticColor.Resolved { theme.resolve(configuration.accent) }
 
     var body: some View {
         Text(configuration.name.uppercased())
@@ -144,21 +147,21 @@ private struct FareFamilyTierChip: View {
             .overlay {
                 if configuration.badgeVariant == .outline {
                     RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value, style: .continuous)
-                        .strokeBorder(configuration.accent.border, lineWidth: 1)
+                        .strokeBorder(resolvedAccent.border, lineWidth: 1)
                 }
             }
     }
 
     private var foreground: Color {
         switch configuration.badgeVariant {
-        case .solid: return configuration.accent.onSolid
-        case .soft, .outline, .ghost: return configuration.accent.accent
+        case .solid: return resolvedAccent.onSolid
+        case .soft, .outline, .ghost: return resolvedAccent.accent
         }
     }
     private var background: Color {
         switch configuration.badgeVariant {
-        case .solid: return configuration.accent.solid
-        case .soft: return configuration.accent.soft
+        case .solid: return resolvedAccent.solid
+        case .soft: return resolvedAccent.soft
         case .outline, .ghost: return .clear
         }
     }
@@ -500,7 +503,7 @@ private struct PillFareFamilyCardStyle: FareFamilyCardStyle {
 
         var body: some View {
             HStack(spacing: configuration.spacing(.sm)) {
-                Circle().fill(configuration.accent.base).frame(width: 8, height: 8)
+                Circle().fill(theme.resolve(configuration.accent).base).frame(width: 8, height: 8)
                 Text(configuration.name).textStyle(.labelMd700).foregroundStyle(theme.text(.textPrimary))
                 Spacer()
                 PriceTag(configuration.priceAmount, currencyCode: configuration.currencyCode).size(.small)

--- a/Sources/ThemeKitTravel/Components/Organisms/FilterBarStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FilterBarStyle.swift
@@ -111,14 +111,14 @@ public struct FilterBarConfiguration {
 
     /// The solid accent fill for a selected `.solid` chip / leading action —
     /// the explicit `accent(_:)` override, else the theme's hero background.
-    public func accentFill(_ theme: Theme) -> Color { accent.map { $0.solid } ?? theme.background(.bgHero) }
+    public func accentFill(_ theme: Theme) -> Color { accent.map { theme.resolve($0).solid } ?? theme.background(.bgHero) }
     /// The foreground atop ``accentFill(_:)`` — contrast-safe on the solid fill.
     public func onAccentFill(_ theme: Theme) -> Color {
-        accent.map { $0.onSolid } ?? theme.text(.textSecondaryInverse)
+        accent.map { theme.resolve($0).onSolid } ?? theme.text(.textSecondaryInverse)
     }
     /// Accent used as a plain text/icon tint on a neutral surface (unselected
     /// `.solid` chip text, the `.ghost` fallback, the Clear affordance).
-    public func accentTint(_ theme: Theme) -> Color { accent.map { $0.base } ?? theme.foreground(.fgHero) }
+    public func accentTint(_ theme: Theme) -> Color { accent.map { theme.resolve($0).base } ?? theme.foreground(.fgHero) }
 
     /// A count formatted with the captured locale (grouping separators honor
     /// injected locales) — shared by every preset's trailing count pill.
@@ -170,12 +170,12 @@ private struct FilterChipPalette {
         switch configuration.chipStyle {
         case .outlined:
             text = theme.text(.textPrimary)
-            fill = isOn ? (accent?.soft ?? SemanticColor.primary.soft) : theme.background(configuration.chipSurfaceKey)
-            border = isOn ? (accent?.border ?? theme.border(.borderHero)) : theme.background(.bgElevatorTertiary)
+            fill = isOn ? (accent.map { theme.resolve($0).soft } ?? theme.resolve(.primary).soft) : theme.background(configuration.chipSurfaceKey)
+            border = isOn ? (accent.map { theme.resolve($0).border } ?? theme.border(.borderHero)) : theme.background(.bgElevatorTertiary)
             borderWidth = isOn ? 2 : 1
         case .ghost:
-            text = isOn ? (accent?.strong ?? theme.foreground(.fgHero)) : theme.text(.textSecondary)
-            fill = isOn ? (accent ?? .primary).soft : .clear
+            text = isOn ? (accent.map { theme.resolve($0).strong } ?? theme.foreground(.fgHero)) : theme.text(.textSecondary)
+            fill = isOn ? theme.resolve(accent ?? .primary).soft : .clear
             border = .clear
             borderWidth = 1
         case .solid:
@@ -190,12 +190,13 @@ private struct FilterChipPalette {
 /// The trailing count pill on a chip, e.g. "Seafront · 12". Shared across
 /// presets — `SemanticColor` ladder steps, no raw colors.
 private struct FilterCountPill: View {
+    @Environment(\.theme) private var theme
     let count: Int
     let isOn: Bool
     let configuration: FilterBarConfiguration
 
     var body: some View {
-        let tone = configuration.accent ?? .primary
+        let tone = theme.resolve(configuration.accent ?? .primary)
         let solidSelected = configuration.chipStyle == .solid && isOn
         Text(configuration.formattedCount(count))
             .textStyle(.labelSm600)

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightCardStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightCardStyle.swift
@@ -112,7 +112,7 @@ public struct FlightCardConfiguration {
 
     /// The `accent(_:)` override's base, else the theme's hero foreground — the
     /// value the built-ins hardcoded before the accent axis existed.
-    public func accentForeground(_ theme: Theme) -> Color { accent?.base ?? theme.foreground(.fgHero) }
+    public func accentForeground(_ theme: Theme) -> Color { accent.map { theme.resolve($0).base } ?? theme.foreground(.fgHero) }
 
     // Shared formatting, so all styles speak one language.
     public func time(_ date: Date) -> String {

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightListItemStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightListItemStyle.swift
@@ -132,13 +132,13 @@ public struct FlightListItemConfiguration {
     // Accent resolution — the `accent(_:)` override, else the theme's hero tokens
     // (the values the built-ins hardcoded before the accent axis existed).
     /// Selected-state border tint.
-    public func accentBorder(_ theme: Theme) -> Color { accent?.base ?? theme.border(.borderHero) }
+    public func accentBorder(_ theme: Theme) -> Color { accent.map { theme.resolve($0).base } ?? theme.border(.borderHero) }
     /// Emphasized foreground tint (selected text/icons).
-    public func accentForeground(_ theme: Theme) -> Color { accent?.base ?? theme.foreground(.fgHero) }
+    public func accentForeground(_ theme: Theme) -> Color { accent.map { theme.resolve($0).base } ?? theme.foreground(.fgHero) }
     /// Selected-chip fill.
-    public func accentFill(_ theme: Theme) -> Color { accent?.solid ?? theme.background(.bgHero) }
+    public func accentFill(_ theme: Theme) -> Color { accent.map { theme.resolve($0).solid } ?? theme.background(.bgHero) }
     /// Content colour on top of ``accentFill(_:)``.
-    public func accentOnFill(_ theme: Theme) -> Color { accent?.onSolid ?? theme.foreground(.fgSecondary) }
+    public func accentOnFill(_ theme: Theme) -> Color { accent.map { theme.resolve($0).onSolid } ?? theme.foreground(.fgSecondary) }
 
     // Shared formatting, so all styles speak one language.
     public func time(_ date: Date) -> String {
@@ -312,7 +312,7 @@ private struct Sparkline: View {
                     i == 0 ? p.move(to: CGPoint(x: x, y: y)) : p.addLine(to: CGPoint(x: x, y: y))
                 }
             }
-            .stroke(tone.base, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
+            .stroke(theme.resolve(tone).base, style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
         }
         .flipsForRightToLeftLayoutDirection(true)
     }
@@ -557,12 +557,12 @@ private struct DealChrome: View {
             if let deal = configuration.dealText {
                 HStack(spacing: Theme.SpacingKey.xs.value) {
                     Icon(systemName: "chart.line.downtrend.xyaxis").size(.xs).accent(configuration.dealTone)
-                    Text(deal).textStyle(.labelSm700).foregroundStyle(configuration.dealTone.base)
+                    Text(deal).textStyle(.labelSm700).foregroundStyle(theme.resolve(configuration.dealTone).base)
                     Spacer()
                 }
                 .padding(.horizontal, Theme.SpacingKey.md.value)
                 .padding(.vertical, Theme.SpacingKey.xs.value)
-                .background(configuration.dealTone.soft)
+                .background(theme.resolve(configuration.dealTone).soft)
             }
             HStack(spacing: Theme.SpacingKey.md.value) {
                 VStack(alignment: .leading, spacing: Theme.SpacingKey.xs.value) {
@@ -1124,12 +1124,12 @@ private struct HeroChrome: View {
             if let deal = configuration.dealText {
                 HStack(spacing: Theme.SpacingKey.xs.value) {
                     Icon(systemName: "flame.fill").size(.xs).accent(configuration.dealTone)
-                    Text(deal).textStyle(.labelSm700).foregroundStyle(configuration.dealTone.base)
+                    Text(deal).textStyle(.labelSm700).foregroundStyle(theme.resolve(configuration.dealTone).base)
                     Spacer()
                 }
                 .padding(.horizontal, configuration.spacing(.md))
                 .padding(.vertical, Theme.SpacingKey.xs.value)
-                .background(configuration.dealTone.soft)
+                .background(theme.resolve(configuration.dealTone).soft)
             }
             VStack(alignment: .leading, spacing: configuration.spacing(.md)) {
                 HStack(spacing: Theme.SpacingKey.sm.value) {

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightResultRowStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightResultRowStyle.swift
@@ -118,7 +118,7 @@ public struct FlightResultRowConfiguration {
 
     /// The brand-chrome tint: the `accent(_:)` override's base, else the theme's
     /// hero foreground — `nil` reproduces the classic rendering exactly.
-    public func accentForeground(_ theme: Theme) -> Color { accent?.base ?? theme.foreground(.fgHero) }
+    public func accentForeground(_ theme: Theme) -> Color { accent.map { theme.resolve($0).base } ?? theme.foreground(.fgHero) }
 
     /// Whether a leg lands on a different calendar day than it departs
     /// (feeds ``FlightRoute/nextDay(_:)``).

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightTicketCard.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightTicketCard.swift
@@ -215,7 +215,7 @@ public extension FlightTicketCard {
                 .padding(configuration.spacing(.md))
                 .background(
                     RoundedRectangle(cornerRadius: configuration.cornerRadius, style: .continuous)
-                        .fill((configuration.accent ?? .primary).soft)
+                        .fill(theme.resolve(configuration.accent ?? .primary).soft)
                 )
             }
         }

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightTicketCardStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightTicketCardStyle.swift
@@ -110,9 +110,16 @@ public struct FlightTicketCardConfiguration {
     // deferred: accent-fallback unification — keeps the `.primary` fallback
     // (matching AncillaryCard/StickyBookingBar would be visually breaking here).
     /// Accent for the duration, timeline dots/plane and the active heart fill.
-    public var accentBase: Color { (accent ?? .primary).base }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use accentBase(_ theme:)")
+    public var accentBase: Color { accentBase(.shared) }
+    /// Theme-parameterized twin of ``accentBase`` — resolves against the
+    /// environment theme (ADR-0006), honoring per-subtree `.theme(_:)`.
+    public func accentBase(_ theme: Theme) -> Color { theme.resolve(accent ?? .primary).base }
     /// Content colour on top of ``accentBase`` (the heart glyph).
-    public var accentOnSolid: Color { (accent ?? .primary).onSolid }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use accentOnSolid(_ theme:)")
+    public var accentOnSolid: Color { accentOnSolid(.shared) }
+    /// Theme-parameterized twin of ``accentOnSolid``.
+    public func accentOnSolid(_ theme: Theme) -> Color { theme.resolve(accent ?? .primary).onSolid }
 }
 
 // MARK: - Protocol
@@ -147,7 +154,7 @@ private struct TicketRouteHeader: View {
                 }
                 Spacer(minLength: 8)
                 if let duration = configuration.duration {
-                    Text(duration).textStyle(.labelSm700).foregroundStyle(configuration.accentBase)
+                    Text(duration).textStyle(.labelSm700).foregroundStyle(configuration.accentBase(theme))
                 }
                 Spacer(minLength: 8)
                 VStack(alignment: .trailing, spacing: 1) {
@@ -182,7 +189,7 @@ private struct TicketTimeline: View {
                     dot; Spacer(); dot
                 }
                 Image(systemName: configuration.stops == 0 ? "airplane" : "airplane.circle.fill")
-                    .font(.system(size: 14)).foregroundStyle(configuration.accentBase)
+                    .font(.system(size: 14)).foregroundStyle(configuration.accentBase(theme))
                     .padding(.horizontal, 4).background(theme.background(surfaceKey))
                     .mirrorsInRTL()
             }
@@ -195,7 +202,7 @@ private struct TicketTimeline: View {
     }
 
     private var dot: some View {
-        Circle().fill(configuration.accentBase).frame(width: 7, height: 7)
+        Circle().fill(configuration.accentBase(theme)).frame(width: 7, height: 7)
             .overlay(Circle().fill(theme.background(surfaceKey)).frame(width: 3, height: 3))
     }
 }
@@ -244,10 +251,10 @@ private struct TicketFavoriteHeart: View {
             Button { configuration.toggleFavorite?() } label: {
                 Image(systemName: isFavorite ? "heart.fill" : "heart")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(configuration.accentOnSolid)
+                    .foregroundStyle(configuration.accentOnSolid(theme))
                     .symbolEffect(.bounce, value: (micro && !reduceMotion) ? isFavorite : false)
                     .frame(width: 30, height: 30)
-                    .background(isFavorite ? configuration.accentBase : theme.text(.textTertiary), in: Circle())
+                    .background(isFavorite ? configuration.accentBase(theme) : theme.text(.textTertiary), in: Circle())
             }
             .buttonStyle(.plain)
             .disabled(isReadOnly)

--- a/Sources/ThemeKitTravel/Components/Organisms/FlightTrackerStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/FlightTrackerStyle.swift
@@ -305,12 +305,12 @@ private struct RouteProgressTrack: View {
                     .fill(theme.border(.borderPrimary))
                     .frame(height: 3)
                 Capsule()
-                    .fill(tone.solid)
+                    .fill(theme.resolve(tone).solid)
                     .frame(width: max(6, geo.size.width * fraction), height: 3)
                     .overlay(alignment: .trailing) {
                         Image(systemName: "airplane")
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(tone.base)
+                            .foregroundStyle(theme.resolve(tone).base)
                             .flipsForRightToLeftLayoutDirection(true)
                     }
             }
@@ -360,7 +360,7 @@ private struct TrackerEstimateRow: View {
                 Text(configuration.time(scheduled))
                     .textStyle(.bodyBase400).strikethrough().foregroundStyle(theme.text(.textTertiary))
                 Text(configuration.time(estimate))
-                    .textStyle(.labelBase600).foregroundStyle(configuration.tone().base)
+                    .textStyle(.labelBase600).foregroundStyle(theme.resolve(configuration.tone()).base)
             }
         }
         .padding(.vertical, configuration.spacing(.sm))
@@ -406,7 +406,7 @@ private struct TrackerCompactStrip: View {
 
     @ViewBuilder private var trailingTime: some View {
         if configuration.showsEstimates, let estimate = configuration.departureEstimate ?? configuration.arrivalEstimate {
-            Text(configuration.time(estimate)).textStyle(.labelBase600).foregroundStyle(configuration.tone().base)
+            Text(configuration.time(estimate)).textStyle(.labelBase600).foregroundStyle(theme.resolve(configuration.tone()).base)
         } else {
             Text(configuration.time(configuration.statusInfo.leg.departure))
                 .textStyle(.labelBase600).foregroundStyle(theme.text(.textSecondary))
@@ -554,7 +554,7 @@ private struct BannerChrome: View {
             }
         }
         .padding(configuration.spacing(.sm))
-        .background(configuration.tone().soft,
+        .background(theme.resolve(configuration.tone()).soft,
                     in: RoundedRectangle(cornerRadius: Theme.RadiusRole.box.value, style: .continuous))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(configuration.headerSummary())
@@ -562,7 +562,7 @@ private struct BannerChrome: View {
 
     @ViewBuilder private var trailingTime: some View {
         if configuration.showsEstimates, let estimate = configuration.departureEstimate ?? configuration.arrivalEstimate {
-            Text(configuration.time(estimate)).textStyle(.labelBase600).foregroundStyle(configuration.tone().accent)
+            Text(configuration.time(estimate)).textStyle(.labelBase600).foregroundStyle(theme.resolve(configuration.tone()).accent)
         } else {
             Text(configuration.time(configuration.statusInfo.leg.departure))
                 .textStyle(.labelBase600).foregroundStyle(theme.text(.textSecondary))
@@ -633,12 +633,12 @@ private struct DotRowFlightTrackerStyle: FlightTrackerStyle {
 
         var body: some View {
             HStack(spacing: configuration.spacing(.sm)) {
-                Circle().fill(configuration.tone().solid).frame(width: 8, height: 8)
+                Circle().fill(theme.resolve(configuration.tone()).solid).frame(width: 8, height: 8)
                 Text("\(configuration.statusInfo.leg.origin) → \(configuration.statusInfo.leg.destination)")
                     .textStyle(.labelSm600).foregroundStyle(theme.text(.textPrimary))
                 Spacer()
                 Text(configuration.statusInfo.status.label)
-                    .textStyle(.overline500).foregroundStyle(configuration.tone().base)
+                    .textStyle(.overline500).foregroundStyle(theme.resolve(configuration.tone()).base)
             }
             .padding(configuration.spacing(.sm))
             .background(theme.background(configuration.surface(default: .bgSecondaryLight)),

--- a/Sources/ThemeKitTravel/Components/Organisms/PassengerForm.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PassengerForm.swift
@@ -185,7 +185,7 @@ public struct PassengerForm: View {
             locale: locale)
         let style = explicitStyle ?? envStyle   // explicit (deprecated .layout) wins — ADR-0004 §5
         return style.makeBody(configuration: configuration)
-            .tint(accent?.base)
+            .tint(accent.map { theme.resolve($0).base })
             // Live canonical re-validation for the select/date fields (see
             // header note): same gate as `.field(_:in:)` — only once the
             // form has validated the field (a failed submit or a prior

--- a/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelectorStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/PaymentMethodSelectorStyle.swift
@@ -91,7 +91,11 @@ public struct PaymentMethodSelectorConfiguration {
 
     /// The `accent(_:)` override's base color — the value the built-ins use
     /// for the radio, selected icon tint and selected tile stroke.
-    public var accentBase: Color { (accent ?? .primary).base }
+    @available(*, deprecated, message: "Reads Theme.shared and ignores per-subtree .theme(); use accentBase(_ theme:)")
+    public var accentBase: Color { accentBase(.shared) }
+    /// Theme-parameterized twin of ``accentBase`` — resolves against the
+    /// environment theme (ADR-0006), honoring per-subtree `.theme(_:)`.
+    public func accentBase(_ theme: Theme) -> Color { theme.resolve(accent ?? .primary).base }
 
     /// The explicit `surface(_:)` override, or the style's own default.
     public func surface(default fallback: Theme.BackgroundColorKey) -> Theme.BackgroundColorKey {
@@ -224,14 +228,14 @@ private struct PaymentOptionRow: View {
                     }
                     Icon(systemName: option.systemImage)
                         .size(.sm)
-                        .color(isOn ? configuration.accentBase : theme.text(.textSecondary))
+                        .color(isOn ? configuration.accentBase(theme) : theme.text(.textSecondary))
                 }
             }
             .badge(configuration.badges[option.id])
             .selected(isOn)
         if configuration.indicator(default: .radio) == .checkmark, isOn {
             listRow = listRow.trailing {
-                Icon(systemName: "checkmark").size(.sm).color(configuration.accentBase)
+                Icon(systemName: "checkmark").size(.sm).color(configuration.accentBase(theme))
             }
         } else {
             listRow = listRow.trailing(ListRowTrailing.none)
@@ -278,7 +282,7 @@ private struct PaymentOptionCompactRow: View {
             Icon(systemName: option.systemImage)
                 .size(.sm)
                 .color(isDisabled ? theme.text(.textDisabled)
-                       : (isOn ? configuration.accentBase : theme.text(.textSecondary)))
+                       : (isOn ? configuration.accentBase(theme) : theme.text(.textSecondary)))
             Text(option.title)
                 .textStyle(.labelBase600)
                 .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
@@ -288,7 +292,7 @@ private struct PaymentOptionCompactRow: View {
                 Badge(badgeText).badgeStyle(configuration.badgeStyle).variant(.soft).size(.small)
             }
             if configuration.indicator(default: .radio) == .checkmark, isOn {
-                Icon(systemName: "checkmark").size(.sm).color(configuration.accentBase)
+                Icon(systemName: "checkmark").size(.sm).color(configuration.accentBase(theme))
             }
         }
         .padding(.vertical, configuration.spacing(.xs))
@@ -310,8 +314,8 @@ private struct PaymentOptionTile: View {
     /// steps only (`base` / `strong`).
     private var selectedStroke: (color: Color, width: CGFloat) {
         switch configuration.emphasis {
-        case .subtle: return (configuration.accentBase, 1.5)
-        case .strong: return ((configuration.accent ?? .primary).strong, 2)
+        case .subtle: return (configuration.accentBase(theme), 1.5)
+        case .strong: return (theme.resolve(configuration.accent ?? .primary).strong, 2)
         }
     }
 
@@ -327,7 +331,7 @@ private struct PaymentOptionTile: View {
             }
             .frame(maxWidth: .infinity, minHeight: Metrics.tileMinHeight)
             .padding(configuration.spacing(.md))
-            .background(isOn ? (configuration.accent ?? .primary).bg
+            .background(isOn ? theme.resolve(configuration.accent ?? .primary).bg
                         : theme.background(configuration.surface(default: .bgBase)), in: shape)
             .overlay(shape.stroke(isOn ? selectedStroke.color : theme.border(.borderPrimary),
                                   lineWidth: isOn ? selectedStroke.width : 1))
@@ -346,7 +350,7 @@ private struct PaymentOptionTile: View {
             Icon(systemName: option.systemImage)
                 .size(.md)
                 .color(isDisabled ? theme.text(.textDisabled)
-                       : (isOn ? configuration.accentBase : theme.text(.textSecondary)))
+                       : (isOn ? configuration.accentBase(theme) : theme.text(.textSecondary)))
             Text(option.title)
                 .textStyle(.labelSm600)
                 .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
@@ -358,7 +362,7 @@ private struct PaymentOptionTile: View {
                     .multilineTextAlignment(.center)
             }
             if configuration.indicator(default: .checkmark) == .checkmark, isOn {
-                Icon(systemName: "checkmark.circle.fill").size(.sm).color(configuration.accentBase)
+                Icon(systemName: "checkmark.circle.fill").size(.sm).color(configuration.accentBase(theme))
             }
         }
     }
@@ -606,15 +610,15 @@ private struct AccentCardPaymentMethodSelectorStyle: PaymentMethodSelectorStyle 
                     let isOn = configuration.selectedID == option.id
                     Button { configuration.select(option.id) } label: {
                         HStack(spacing: configuration.spacing(.sm)) {
-                            Icon(systemName: option.systemImage).size(.sm).color(configuration.accentBase)
+                            Icon(systemName: option.systemImage).size(.sm).color(configuration.accentBase(theme))
                             Text(option.title).textStyle(.labelBase600).foregroundStyle(theme.text(.textPrimary))
                             Spacer()
                             if isOn {
-                                Icon(systemName: "checkmark.circle.fill").size(.sm).color(configuration.accentBase)
+                                Icon(systemName: "checkmark.circle.fill").size(.sm).color(configuration.accentBase(theme))
                             }
                         }
                         .padding(configuration.spacing(.md))
-                        .background(isOn ? (configuration.accent ?? .primary).bg : theme.background(.bgBase),
+                        .background(isOn ? theme.resolve(configuration.accent ?? .primary).bg : theme.background(.bgBase),
                                     in: RoundedRectangle(cornerRadius: Theme.RadiusRole.field.value))
                     }
                     .buttonStyle(.plain)

--- a/Sources/ThemeKitTravel/Components/Organisms/SavedCardsListStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SavedCardsListStyle.swift
@@ -114,7 +114,7 @@ public struct SavedCardsListConfiguration {
     public func spacing(_ key: Theme.SpacingKey) -> CGFloat { density.scale(key.value) }
     /// The `accent(_:)` override's base, else the theme's primary triad — the
     /// value the built-ins hardcoded before the accent axis existed.
-    public func accentBase(_ theme: Theme) -> Color { (accent ?? .primary).base }
+    public func accentBase(_ theme: Theme) -> Color { theme.resolve(accent ?? .primary).base }
     /// The expired badge's resolved text.
     public func expiredBadgeLabel() -> String { expiredBadgeText ?? String(themeKitTravel: "Expired") }
 

--- a/Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift
@@ -75,7 +75,11 @@ public struct SeatMap: View {
     private var seatDisplay: SeatDisplay = .icon
     private var customContent: ((SeatContext) -> AnyView)?
     private var aisleWidthOverride: CGFloat?
-    private var tierOverrides: [SeatTier: Color] = [:]
+    // ADR-0006: the token overload stores `SemanticColor`s (not resolved
+    // `Color`s) so tier overrides re-resolve against the environment theme in
+    // `palette`; `rawTierOverrides` is the raw-`Color` escape hatch.
+    private var semanticTierOverrides: [SeatTier: SemanticColor] = [:]
+    private var rawTierOverrides: [SeatTier: Color] = [:]
     private var accentOverride: SemanticColor?
     private var seatShape: SeatShape = .rounded
     private var legendPlacement: LegendPlacement = .bottom
@@ -89,7 +93,11 @@ public struct SeatMap: View {
     private let gutter: CGFloat = 22
     private var passengerMode: Bool { !passengers.isEmpty && assignment != nil }
     private var gapWidth: CGFloat { aisleWidthOverride ?? seatSize }
-    private var palette: SeatPalette { SeatPalette(tierOverrides) }
+    private var palette: SeatPalette {
+        var overrides = rawTierOverrides
+        for (tier, color) in semanticTierOverrides { overrides[tier] = theme.resolve(color).base }
+        return SeatPalette(overrides)
+    }
     private var resolvedCurrency: String {
         currencyCode ?? formatDefaults.currencyCode ?? locale.currency?.identifier ?? "USD"
     }
@@ -353,7 +361,7 @@ public extension SeatMap {
     /// with your own palette. Each tier uses the token's base shade, matching
     /// the palette's own tier defaults.
     func tierColors(_ overrides: [SeatTier: SemanticColor]) -> Self {
-        copy { $0.tierOverrides = overrides.mapValues(\.base) }
+        copy { $0.semanticTierOverrides = overrides }
     }
     /// Accent for the passenger rail's and deck selector's **active** pill — the
     /// token's `.solid` shade fills the pill and `.onSolid` colours its text.
@@ -365,7 +373,7 @@ public extension SeatMap {
     /// overload instead of being ambiguous.
     @_disfavoredOverload
     @available(*, deprecated, message: "Use tierColors(_: [SeatTier: SemanticColor]) — the token-bound overload.")
-    func tierColors(_ overrides: [SeatTier: Color]) -> Self { copy { $0.tierOverrides = overrides } }
+    func tierColors(_ overrides: [SeatTier: Color]) -> Self { copy { $0.rawTierOverrides = overrides } }
 
     /// Token-stepped seat size (compact 36 · regular 44 · large 52 · xl 60).
     /// Unlike the raw overload, `.compact` deliberately drops below the 44 pt
@@ -467,8 +475,8 @@ private struct PassengerRail: View {
     @Binding var active: String?
     let accent: SemanticColor?
 
-    private var activeFill: Color { accent?.solid ?? theme.foreground(.fgHero) }
-    private var activeContent: Color { accent?.onSolid ?? theme.text(.textSecondaryInverse) }
+    private var activeFill: Color { accent.map { theme.resolve($0).solid } ?? theme.foreground(.fgHero) }
+    private var activeContent: Color { accent.map { theme.resolve($0).onSolid } ?? theme.text(.textSecondaryInverse) }
 
     var body: some View {
         HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {
@@ -499,8 +507,8 @@ private struct DeckSelector: View {
     /// Pill title per floor — `SeatMap.deckLabel(_:)` or the localized default.
     let label: (Int) -> String
 
-    private var activeFill: Color { accent?.solid ?? theme.foreground(.fgHero) }
-    private var activeContent: Color { accent?.onSolid ?? theme.text(.textSecondaryInverse) }
+    private var activeFill: Color { accent.map { theme.resolve($0).solid } ?? theme.foreground(.fgHero) }
+    private var activeContent: Color { accent.map { theme.resolve($0).onSolid } ?? theme.text(.textSecondaryInverse) }
 
     var body: some View {
         HStack(spacing: density.scale(Theme.SpacingKey.sm.value)) {

--- a/Sources/ThemeKitTravel/Components/Organisms/SeatMapStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/SeatMapStyle.swift
@@ -298,7 +298,7 @@ private struct CaptionedSeatMapStyle: SeatMapStyle {
                      ? String(themeKitTravel: "1 seat selected")
                      : String(themeKitTravel: "\(configuration.selectedCount) seats selected"))
                     .textStyle(.labelSm600)
-                    .foregroundStyle(configuration.accent?.base ?? theme.text(.textSecondary))
+                    .foregroundStyle(configuration.accent.map { theme.resolve($0).base } ?? theme.text(.textSecondary))
                 configuration.cabinGrid
             }
         }

--- a/Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCardStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/TransportCrossSellCardStyle.swift
@@ -193,7 +193,7 @@ private struct TransportCrossSellGlyphBadge: View {
                 }
             }
             .padding(configuration.spacing(.sm))
-            .background(Circle().fill(configuration.accent.soft))
+            .background(Circle().fill(theme.resolve(configuration.accent).soft))
             Text(configuration.modeLabel)
                 .textStyle(.labelSm600)
                 .foregroundStyle(theme.text(.textSecondary))
@@ -556,7 +556,7 @@ private struct BannerTransportCrossSellChrome: View {
         }
         .padding(configuration.spacing(.md))
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(configuration.accent.soft)
+        .background(theme.resolve(configuration.accent).soft)
         .contentShape(Rectangle())
     }
 
@@ -570,7 +570,7 @@ private struct BannerTransportCrossSellChrome: View {
             if let ctaLabel = configuration.ctaLabel {
                 ctaLabel
             } else if configuration.onSelect != nil {
-                Icon(systemName: "chevron.forward").size(.xs).color(configuration.accent.base)
+                Icon(systemName: "chevron.forward").size(.xs).color(theme.resolve(configuration.accent).base)
             }
         }
     }
@@ -640,7 +640,7 @@ private struct AccentRailTransportCrossSellCardStyle: TransportCrossSellCardStyl
         var body: some View {
             HStack(spacing: configuration.spacing(.sm)) {
                 RoundedRectangle(cornerRadius: Theme.RadiusRole.selector.value)
-                    .fill(configuration.accent.base)
+                    .fill(theme.resolve(configuration.accent).base)
                     .frame(width: 4)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(configuration.modeLabel)

--- a/Sources/ThemeKitTravel/Components/Organisms/TripSearchCardStyle.swift
+++ b/Sources/ThemeKitTravel/Components/Organisms/TripSearchCardStyle.swift
@@ -127,9 +127,9 @@ public struct TripSearchCardConfiguration {
     // Accent resolution — the `accent(_:)` override, else the theme's hero
     // tokens (mirrors the FlightListItemConfiguration convention).
     /// Emphasized fill (the pill's search glyph disc).
-    public func accentFill(_ theme: Theme) -> Color { accent?.solid ?? theme.background(.bgHero) }
+    public func accentFill(_ theme: Theme) -> Color { accent.map { theme.resolve($0).solid } ?? theme.background(.bgHero) }
     /// Content color on top of ``accentFill(_:)``.
-    public func accentOnFill(_ theme: Theme) -> Color { accent?.onSolid ?? theme.foreground(.fgSecondary) }
+    public func accentOnFill(_ theme: Theme) -> Color { accent.map { theme.resolve($0).onSolid } ?? theme.foreground(.fgSecondary) }
 
     // Shared summaries, so collapsed styles speak one language.
     /// "Istanbul (IST) – London (LHR)" — an en dash, not an arrow, so the

--- a/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
+++ b/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
@@ -63,11 +63,11 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) more",
             "%@ more", 1,
-            site: "Sources/ThemeKit/Components/Atoms/Avatar.swift:330")
+            site: "Sources/ThemeKit/Components/Atoms/Avatar.swift:332")
         assertKey(
             "\(d) of \(d)",
             "%@ of %@", 2,
-            site: "Sources/ThemeKit/Components/Atoms/ProgressBar.swift:213")
+            site: "Sources/ThemeKit/Components/Atoms/ProgressBar.swift:220")
         assertKey(
             "\(d) out of \(d)",
             "%@ out of %@", 2,
@@ -83,7 +83,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) results",
             "%@ results", 1,
-            site: "Sources/ThemeKit/Components/Molecules/PriceHistogram.swift:53")
+            site: "Sources/ThemeKit/Components/Molecules/PriceHistogram.swift:56")
         assertKey(
             "\(d) reviews",
             "%@ reviews", 1,
@@ -91,7 +91,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) seats",
             "%@ seats", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:554")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:562")
         assertKey(
             "\(d) seats left",
             "%@ seats left", 1,
@@ -134,7 +134,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d)% to \(d)",
             "%@%% to %@", 2,
-            site: "Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift:170")
+            site: "Sources/ThemeKit/Components/Organisms/LoyaltyCard.swift:174")
         assertKey(
             "\(d)/mo",
             "%@/mo", 1,
@@ -154,7 +154,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "+\(d) more",
             "+%@ more", 1,
-            site: "Sources/ThemeKit/Components/Molecules/AmenityGrid.swift:87")
+            site: "Sources/ThemeKit/Components/Molecules/AmenityGrid.swift:90")
         assertKey(
             "Area chart with series \(d).",
             "Area chart with series %@.", 1,
@@ -194,7 +194,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Deck \(d)",
             "Deck %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:136")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:144")
         assertKey(
             "Decrease \(d)",
             "Decrease %@", 1,
@@ -241,7 +241,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Passenger \(d), seat \(d)",
             "Passenger %@, seat %@", 2,
-            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:487")
+            site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:495")
         assertKey(
             "Payment method, \(d) options",
             "Payment method, %@ options", 1,
@@ -281,7 +281,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Show \(d) more",
             "Show %@ more", 1,
-            site: "Sources/ThemeKit/Components/Molecules/AmenityGrid.swift:92")
+            site: "Sources/ThemeKit/Components/Molecules/AmenityGrid.swift:95")
         assertKey(
             "Step \(d) of \(d)",
             "Step %@ of %@", 2,
@@ -317,7 +317,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "seat \(d)",
             "seat %@", 1,
-            site: "Sources/ThemeKitTravel/Components/Molecules/PassengerRowStyle.swift:109")
+            site: "Sources/ThemeKitTravel/Components/Molecules/PassengerRowStyle.swift:113")
         assertKey(
             "up \(d)",
             "up %@", 1,

--- a/Tests/ThemeKitTests/SemanticColorResolvedTests.swift
+++ b/Tests/ThemeKitTests/SemanticColorResolvedTests.swift
@@ -54,6 +54,10 @@ final class SemanticColorResolvedTests: XCTestCase {
 
     // MARK: - Backward-compat guarantee (D2 / no behavior change for un-migrated call sites)
 
+    /// Deliberately exercises the deprecated zero-arg accessors — this IS the
+    /// forward-equivalence guarantee ADR-0006 (D2) promises, so the warnings
+    /// here are expected, not a migration gap.
+    @available(*, deprecated, message: "Intentionally tests the deprecated SemanticColor accessors — see ADR-0006 D2.")
     func testDeprecatedZeroArgAccessorsMatchResolvedAgainstThemeShared() {
         for color in SemanticColor.allCases {
             XCTAssertEqual(rgba(color.solid), rgba(Theme.shared.resolve(color).solid), "\(color).solid mismatch")

--- a/scripts/check-theme-shared.sh
+++ b/scripts/check-theme-shared.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# check-theme-shared.sh — ADR-0006 §D7 enforcement gate.
+#
+# `Theme.shared` is the correct default for the engine (env fallback, root
+# injectors, apply-to-global mutators) and for #Preview scaffolding — but a
+# COMPONENT reaching past its `@Environment(\.theme)` to the singleton is
+# exactly the bug ADR-0006 fixed (R1): it silently defeats per-subtree
+# `.theme(_:)`. This gate keeps a new component from regressing it.
+#
+# HARD FAIL → a `Theme.shared` CODE read under Sources/ that is not:
+#   - in a file listed in scripts/theme-shared-allowlist.txt (the engine/
+#     preset/deprecate-forward/deferred-metric files ADR-0006 §D7 names), or
+#   - a comment (a `//` line, or the trailing `// …` on a code line — ADR-0006
+#     itself is documented in-line and legitimately spells out "Theme.shared"
+#     dozens of times), or
+#   - an `@available(*, deprecated, …)` message string (same reason — the
+#     deprecation prose names the thing it's steering callers away from), or
+#   - inside a `#Preview` body (everything at/after a file's first `#Preview`
+#     line — previews correctly pin `.environment(Theme.shared)`).
+#
+# This is a text heuristic (like check-variant-naming.sh), not a compiler
+# plugin: it can't see `.shared` used via type-inferred shorthand outside a
+# `Theme.` receiver, only the literal spelled-out `Theme.shared` token the
+# ADR's audit was built from.
+#
+# Usage: scripts/check-theme-shared.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+ALLOWLIST="scripts/theme-shared-allowlist.txt"
+red=$'\033[31m'; green=$'\033[32m'; dim=$'\033[2m'; reset=$'\033[0m'
+
+allowed_files=""
+if [[ -f "$ALLOWLIST" ]]; then
+  allowed_files=$(sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//' "$ALLOWLIST" | grep -v '^$')
+fi
+
+is_allowed() {
+  grep -qxF "$1" <<< "$allowed_files"
+}
+
+violations=""
+while IFS= read -r -d '' file; do
+  is_allowed "$file" && continue
+
+  hit=$(awk '
+    /^[[:space:]]*#Preview/ { exit }
+    {
+      line = $0
+      sub(/\/\/.*/, "", line)                              # drop trailing // comment
+      if (line ~ /@available\(\*,[[:space:]]*deprecated/) next   # deprecation message prose
+      if (line ~ /Theme\.shared/) printf "  %d: %s\n", NR, $0
+    }
+  ' "$file")
+
+  if [[ -n "$hit" ]]; then
+    violations+="${file}:"$'\n'"${hit}"$'\n'
+  fi
+done < <(find Sources -name '*.swift' -print0)
+
+if [[ -n "$violations" ]]; then
+  printf '%s✗ Theme.shared read(s) outside the allowlist (ADR-0006 §D7):%s\n' "$red" "$reset"
+  printf '%s\n' "$violations"
+  printf '%sFix: resolve against @Environment(\\.theme) in a View body, thread a `theme:`\n' "$dim"
+  printf 'param through a helper (Class P), or store the SemanticColor and resolve in\n'
+  printf '`body` instead of at modifier-call time (Class M). If this is a genuine new\n'
+  printf 'engine/injector site, document it and add it to %s.%s\n' "$ALLOWLIST" "$reset"
+  exit 1
+fi
+
+printf '%s✓%s no un-allowlisted Theme.shared reads under Sources/\n' "$green" "$reset"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -4,6 +4,8 @@
 # verification never depends on Actions billing. Same checks CI runs:
 #   1. SwiftFormat  (lint mode, if installed)
 #   2. SwiftLint    (if installed)
+#   2.5. Brand neutrality / i18n gate
+#   2.6. Theme.shared allowlist gate (ADR-0006 §D7)
 #   3. swift build --build-tests
 #   4. swift test
 #
@@ -46,6 +48,11 @@ fi
 # 2.5: brand-neutrality & i18n gate (fast grep; hard-fails on brand/Turkish leaks).
 step "Brand neutrality (i18n)"
 if bash scripts/check-neutrality.sh ; then pass "Neutrality"; else die "Neutrality — brand/Turkish leak (see THEMEKIT_COMPONENT_AUDIT.md)"; fi
+
+# 2.6: per-subtree theme resolution gate (ADR-0006 §D7; fast grep; hard-fails
+# on a Theme.shared read outside scripts/theme-shared-allowlist.txt).
+step "Theme.shared allowlist (ADR-0006)"
+if bash scripts/check-theme-shared.sh ; then pass "Theme.shared allowlist"; else die "Theme.shared allowlist — un-allowlisted singleton read defeats per-subtree .theme() (ADR-0006 §D7)"; fi
 
 # 3: build (the package + tests). This is the must-pass gate.
 step "swift build --build-tests"

--- a/scripts/theme-shared-allowlist.txt
+++ b/scripts/theme-shared-allowlist.txt
@@ -1,0 +1,40 @@
+# theme-shared-allowlist.txt — files that legitimately read `Theme.shared`
+# (ADR-0006 §D7). One repo-relative path per line; `#` starts a comment.
+#
+# Everything else under Sources/ is checked by scripts/check-theme-shared.sh,
+# which also ignores comment-only lines, `@available(*, deprecated, …)`
+# message strings (their prose legitimately names "Theme.shared" as the thing
+# being deprecated away from), and #Preview bodies (previews correctly pin
+# `.environment(Theme.shared)` / read the environment default).
+
+# The singleton's own definition.
+Sources/ThemeKitCore/Theme/Theme.swift
+
+# The environment default (`ThemeEnvironmentKey.defaultValue`) — the
+# documented fallback so a component reads a working theme even when nothing
+# injected one; a subtree/preview/test overrides it with `.theme(_:)`.
+Sources/ThemeKitCore/Theme/ThemeContext.swift
+
+# Root injectors: `.themeKit()` seeds `.environment(Theme.shared)` at the app
+# root; `ThemedHostingController` does the UIKit-hosted equivalent.
+Sources/ThemeKitCore/Theme/ThemeKit.swift
+Sources/ThemeKitCore/Theme/ThemedHostingController.swift
+
+# Apply-to-global mutation entry points — by design, these change the
+# singleton itself (a theme picker / imported design / preset applies to the
+# *app*, not a subtree).
+Sources/ThemeKit/Components/Organisms/ThemePicker.swift
+Sources/ThemeKitCore/Theme/DesignMode/DesignSpec.swift
+Sources/ThemeKitCore/Theme/ThemePresets.swift
+Sources/ThemeKitCore/Theme/ThemeConfig.swift
+
+# The deprecate-forward shims themselves (ADR-0006 D2) — the zero-arg
+# `SemanticColor` accessors forward to `resolved(in: .shared)` so un-migrated
+# call sites stay byte-identical; this file is the shim, not an offender.
+Sources/ThemeKitCore/Theme/SemanticColor.swift
+
+# Deferred per D5: corner radius / spacing / type scale stay process-global
+# in this ADR (metric/type isolation is a documented, bounded limit — see
+# ThemeContext.swift's corrected doc comment — not a silent gap).
+Sources/ThemeKitCore/Theme/ThemeModel.swift
+Sources/ThemeKitCore/Theme/Typography.swift


### PR DESCRIPTION
## Summary
Completes ADR-0006 (per-subtree theme resolution) Phase 2 + Phase 3, following Phase 0+1 (`SemanticColor.Resolved` + `theme.resolve(_:)` + the 5 timing-trap files) already on `main`.

- **Phase 2 — migrate the Class-V/P/M consumers.** ~113 component files across ThemeKit / ThemeKitTravel / ThemeKitCalendar now resolve `SemanticColor` role/ladder reads against the environment theme instead of `Theme.shared`, so `.theme(_:)` correctly re-skins accent/semantic color per subtree everywhere in the catalog — not just the 5 files Phase 1 fixed.
  - **Class V** (View body, already or newly holding `@Environment(\.theme)`): mechanical `SemanticColor.X.role` / `optionalColor?.role` → `theme.resolve(...)` swap — the bulk of the diff.
  - **Class P** (helper already/now taking a `theme: Theme` param): mirrors the `AlertToast`/`Callout`/`InfoBanner` precedent from the ADR; adds the same deprecate-forward `accentBase(_:)`/`accentOnSolid(_:)` twins to `PassengerRowStyle`, `PaymentMethodSelectorStyle`, `FlightTicketCardStyle`, `BoardingPassStyle`, `SavedCardsListStyle` — these `Configuration` structs had a `public var accentBase: Color` baked to the singleton with no theme of their own.
  - **Class M** (eager COW modifier resolving before `body`): now stores the `SemanticColor` and resolves lazily — `Badge.gradient`, `LoyaltyCard.gradient`, `AmenityGrid.tint`, `PriceHistogram.accent`, `InlineText.accent`, `ProgressBar.accent`, `RollingNumber.accent`, `Checkbox.customInner`, `Indicator.indicatorDot`, `SeatMap.tierColors`, `DateRangePicker.holiday(on:color:name:)`.
  - **Class N**: none found beyond `ChartColorScale`, which Phase 1 already converted N→P — confirms the ADR's open question (it's the only non-View builder that baked `SemanticColor → Color`).
  - Deprecates the zero-arg `SemanticColor` accessors (`.solid .soft .accent .border .onSolid .shade(_:) .bg .bgHover .borderSubtle .borderHover .hover .base .active .strong`) toward `theme.resolve(color).<role>` — additive, byte-identical `resolved(in: .shared)` forwards.

- **Phase 3 — guard the fix + correct the promise.**
  - `scripts/check-theme-shared.sh` + `scripts/theme-shared-allowlist.txt` — a grep gate that fails on any `Theme.shared` **code** read under `Sources/` outside the allowlisted engine/injector/apply-to-global/deferred-metric files (comment-only mentions, `@available(deprecated)` message prose, and `#Preview` bodies are correctly excluded). Wired into `scripts/ci.sh` (a hard gate, mirrors `check-neutrality.sh`) and `.github/workflows/ci.yml` (a new blocking PR-only job, mirrors `variant-naming`'s structure).
  - `ThemeContext.swift` — corrects the `.theme(_:)` doc comment to say what's actually true post-fix: **color** re-skins completely per subtree; corner radius / spacing / type scale stay **process-global** (ADR-0006 §D5 — a documented, bounded limit, not a silent gap).

## Findings / classification
- **Files migrated:** ~113 `Sources/` files (~90 identified via the ADR's Class-V/P grep inventory + ~23 more found via a broader `.map { $0.role }` / `(x ?? .default).role` / Configuration-struct sweep the initial grep missed).
- **Class-N inherent-limit cases:** none new; `ChartColorScale` (already N→P from Phase 1) remains the only one.
- **Deprecation:** all 14 zero-arg `SemanticColor` role/ladder accessors now `@available(*, deprecated)`, forwarding to `resolved(in: .shared)` — byte-identical, non-breaking.
- **api-breakage-allowlist.txt:** no entry needed — `swift package diagnose-api-breaking-changes` vs `origin/main` reports **no breaking changes** (deprecation isn't removal).

## Test plan
- [x] `swift build` + `swift test` green — default traits
- [x] `swift build --enable-all-traits --build-tests` + `swift test --skip-build --enable-all-traits` green (323 tests, 0 failures)
- [x] `ThemeSubtreeColorResolutionTests` (the two-brand regression test) passes
- [x] `scripts/check-theme-shared.sh` passes on the migrated tree; sanity-checked it actually fails on an injected `Theme.shared` violation
- [x] `scripts/check-neutrality.sh` / `swiftlint lint` clean (0 errors)
- [x] `python3 tools/gen_l10n.py --check` green (regenerated — many touched files shifted `String(themeKit:)` line numbers)
- [x] `Package.resolved` restored after the all-traits build
- [x] `scripts/ci.sh` (full local CI mirror, run automatically by the pre-push hook) — all gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)