### PR TITLE
fix(theme): ThemeGenerator byte-exact parity with gen_tokens.py (R8 residual)

### DIFF
--- a/Sources/ThemeKitCore/Theme/ThemeGenerator.swift
+++ b/Sources/ThemeKitCore/Theme/ThemeGenerator.swift
@@ -30,8 +30,13 @@ enum ThemeGenerator {
         return (byte(0), byte(2), byte(4))
     }
 
+    // All rounding here uses `.toNearestOrEven` (banker's rounding) to match Python's
+    // `round()` in `tools/gen_tokens.py` EXACTLY — Swift's default `.rounded()` is
+    // half-away-from-zero and disagreed with the Python source by 1 LSB whenever a
+    // blended channel landed on an `x.5` tie (e.g. seed 5b21b6). Byte-exact parity is
+    // pinned by `ThemeGeneratorGoldenTests`.
     private static func rgbToHex(_ r: Double, _ g: Double, _ b: Double) -> String {
-        String(format: "%02x%02x%02x", Int(r.rounded()), Int(g.rounded()), Int(b.rounded()))
+        String(format: "%02x%02x%02x", Int(r.rounded(.toNearestOrEven)), Int(g.rounded(.toNearestOrEven)), Int(b.rounded(.toNearestOrEven)))
     }
 
     private static func rgbToHSV(_ r0: Double, _ g0: Double, _ b0: Double) -> (Double, Double, Double) {
@@ -64,7 +69,7 @@ enum ThemeGenerator {
     private static let lightCount = 5, darkCount = 4
 
     private static func antHue(_ h0: Double, _ i: Int, _ light: Bool) -> Double {
-        let h = h0.rounded()
+        let h = h0.rounded(.toNearestOrEven)
         let hue: Double
         if h >= 60 && h <= 240 {
             hue = light ? h - hueStep * Double(i) : h + hueStep * Double(i)
@@ -82,12 +87,12 @@ enum ThemeGenerator {
         else { sat = s + satStep2 * Double(i) }
         sat = min(sat, 1)
         if light && i == lightCount && sat > 0.1 { sat = 0.1 }
-        return (max(sat, 0.06) * 100).rounded() / 100
+        return (max(sat, 0.06) * 100).rounded(.toNearestOrEven) / 100
     }
 
     private static func antVal(_ v: Double, _ i: Int, _ light: Bool) -> Double {
         let val = light ? v + briStep1 * Double(i) : v - briStep2 * Double(i)
-        return (min(max(val, 0), 1) * 100).rounded() / 100
+        return (min(max(val, 0), 1) * 100).rounded(.toNearestOrEven) / 100
     }
 
     private static func antGenerate(_ baseHex: String) -> [String] {
@@ -307,15 +312,15 @@ enum ThemeGenerator {
             }
         }
 
-        let radius = radiusBase.map { Theme.AppRadius(name: $0.0, radius: ($0.1 * radiusScale).rounded()) }
-        let spacing = spacingBase.map { Theme.AppSpacing(name: $0.0, spacing: ($0.1 * spacingScale).rounded()) }
+        let radius = radiusBase.map { Theme.AppRadius(name: $0.0, radius: ($0.1 * radiusScale).rounded(.toNearestOrEven)) }
+        let spacing = spacingBase.map { Theme.AppSpacing(name: $0.0, spacing: ($0.1 * spacingScale).rounded(.toNearestOrEven)) }
         let typography = typographyBase.map {
-            Theme.AppTypography(name: $0.0, font: font, size: ($0.1 * fontScale).rounded(),
-                                weight: $0.2, lineHeight: ($0.3 * fontScale).rounded())
+            Theme.AppTypography(name: $0.0, font: font, size: ($0.1 * fontScale).rounded(.toNearestOrEven),
+                                weight: $0.2, lineHeight: ($0.3 * fontScale).rounded(.toNearestOrEven))
         }
         let shadows = shadowBase.map { name, layers in
             Theme.AppShadow(name: name, layers: layers.map {
-                Theme.AppShadowLayer(color: $0.0, radius: ($0.1 * shadowScale).rounded(), x: $0.2, y: ($0.3 * shadowScale).rounded())
+                Theme.AppShadowLayer(color: $0.0, radius: ($0.1 * shadowScale).rounded(.toNearestOrEven), x: $0.2, y: ($0.3 * shadowScale).rounded(.toNearestOrEven))
             })
         }
 

--- a/Tests/ThemeKitTests/ThemeGeneratorGoldenTests.swift
+++ b/Tests/ThemeKitTests/ThemeGeneratorGoldenTests.swift
@@ -84,4 +84,24 @@ final class ThemeGeneratorGoldenTests: XCTestCase {
                            "tinted neutral/\(step) drifted from gen_tokens.py's _tint_neutral()/mix() for seed 5b35ab")
         }
     }
+
+    /// Byte-exact parity on a TIE-hitting seed. `5b21b6` produces an `x.5` blended
+    /// channel on 2 dark-mix steps, where Swift's OLD half-away-from-zero `.rounded()`
+    /// disagreed with Python's half-to-even `round()` by 1 LSB (primary/100 `26173d`
+    /// vs `26173c`; primary/900 `eae2f1` vs `eae2f0`). Now that `ThemeGenerator` uses
+    /// `.toNearestOrEven`, every step matches `gen_tokens.py`'s
+    /// `build_palette("5b21b6", dark=True, tint=0.13)` EXACTLY — this test fails on the
+    /// pre-fix generator and passes after (review R8: byte-exact parity close).
+    func testTieSeedIsByteExactVsGenTokensPy() {
+        let d = ThemeGenerator.generate(primaryHex: "5b21b6", tint: 0.13, dark: true,
+                                        font: "Montserrat", fontScale: 1, radiusScale: 1, spacingScale: 1, shadowScale: 1)
+        let goldenPrimaryDark: [Int: String] = [
+            50: "1a1426", 100: "26173c", 200: "322248", 300: "412962", 400: "543285",
+            500: "683ba8", 600: "895fbc", 700: "ad8bd1", 800: "ceb9e2", 900: "eae2f0",
+        ]
+        for (step, expected) in goldenPrimaryDark.sorted(by: { $0.key < $1.key }) {
+            XCTAssertEqual(hex(d, "palette.primary.\(step)"), expected,
+                           "tie-seed dark primary/\(step) must be byte-exact vs gen_tokens.py (banker's-rounding parity) for 5b21b6")
+        }
+    }
 }


### PR DESCRIPTION
Closes the residual from review R8. ThemeGenerator used Swift's default `.rounded()` (half-away) while `tools/gen_tokens.py` uses Python `round()` (half-to-even), so the two could disagree by 1 LSB on `x.5` ties (the #299 golden test dodged this with a tie-free seed). Switches the color/scale rounding to `.toNearestOrEven` (floors via `.rounded(.down)` untouched) → on-device generation is now byte-exact with the committed Python-generated tokens. New `testTieSeedIsByteExactVsGenTokensPy` pins the tie seed `5b21b6` (fails pre-fix, passes now). 324 tests green (verified locally via scripts/ci.sh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)