### PR TITLE
refactor(l10n): Theme.setLanguage(_:) as the primary language API

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,9 +744,9 @@ you need — it folds in live localization. Flip the language from anywhere and 
 UI updates live, no relaunch:
 
 ```swift
-ThemeKitStrings.setLanguage("tr")   // whole UI → Turkish  (short alias: Theme.setLanguage("tr"))
-ThemeKitStrings.setLanguage(nil)    // follow the device language again
-ThemeKitStrings.currentLanguage     // "tr"
+Theme.setLanguage("tr")   // whole UI → Turkish  (short alias: Theme.setLanguage("tr"))
+Theme.setLanguage(nil)    // follow the device language again
+Theme.currentLanguage     // "tr"
 ```
 
 Drive it from any picker — e.g. ThemeKit's `LanguageSwitcher` bound to

--- a/Sources/ThemeKit/Documentation.docc/Localization.md
+++ b/Sources/ThemeKit/Documentation.docc/Localization.md
@@ -37,8 +37,8 @@ localization — so there's nothing extra to wire. Switch the language from anyw
 RootView().themeKit()               // root, once — folds in localization
 
 // later, from a settings screen — flips the whole UI live, no relaunch:
-ThemeKitStrings.setLanguage("tr")   // short alias: Theme.setLanguage("tr")
-ThemeKitStrings.setLanguage(nil)    // follow the device
+Theme.setLanguage("tr")   // short alias: Theme.setLanguage("tr")
+Theme.setLanguage(nil)    // follow the device
 ```
 
 An explicit, subtree-scoped provider is available as `themeKitLocalized()`; a picker

--- a/Sources/ThemeKitCore/ThemeKitFacade.swift
+++ b/Sources/ThemeKitCore/ThemeKitFacade.swift
@@ -2,56 +2,62 @@
 //  ThemeKitFacade.swift
 //  ThemeKit
 //
-//  Friendly, discoverable sugar for consumer localization, co-located with the
-//  rest of the `ThemeKitStrings` API (`locale`, `register`, `languageBinding`).
-//  The whole consumer story becomes:
+//  Friendly, discoverable localization sugar on the hub `Theme` type. The whole
+//  consumer story:
 //
-//      ContentView().themeKit()               // root, once (you already add this)
-//      ThemeKitStrings.setLanguage("tr")      // anywhere — the UI flips live, no restart
+//      ContentView().themeKit()      // root, once (you already add this for theming)
+//      Theme.setLanguage("tr")       // anywhere — the UI flips live, no restart
 //
-//  `.themeKit()` folds in the live-localization provider (see ThemeKit.swift),
-//  so no separate `.themeKitLocalized()` is needed. `Theme.setLanguage(_:)` is a
-//  shorter alias on the hub type for the same call.
+//  `.themeKit()` folds in the live-localization provider (see ThemeKit.swift), so no
+//  separate `.themeKitLocalized()` is needed. The lower-level knobs stay on
+//  `ThemeKitStrings` (`locale`, `register(bundle:table:)`, `languageBinding`).
 //
-//  NB: the facade can't be named `ThemeKit` — a type with the module's name
-//  shadows module-qualified lookups (`ThemeKit.Tag`, …) and breaks them.
+//  NB: this sugar can't live on a top-level `ThemeKit` type — a type with the
+//  module's name shadows module-qualified lookups (`ThemeKit.Tag`, …) and breaks
+//  them; `Theme` is the hub type consumers already use.
 //
 
 import Foundation
 
-public extension ThemeKitStrings {
-    /// Switch the language of every ThemeKit default string — live and
-    /// restart-free (the `.themeKit()` root re-renders the tree, including the
-    /// non-View enum/model strings). Pass a BCP-47 code (`"tr"`, `"ar"`,
-    /// `"en"`), or `nil` to follow the device/app language again.
+public extension Theme {
+    /// Switch the language of every ThemeKit default string — live and restart-free
+    /// (the `.themeKit()` root re-renders the tree, including the non-View enum/model
+    /// strings). Pass a BCP-47 code (`"tr"`, `"ar"`, `"en"`), or `nil` to follow the
+    /// device/app language again.
     ///
     /// ```swift
-    /// ThemeKitStrings.setLanguage("tr")   // whole UI → Turkish
-    /// ThemeKitStrings.setLanguage(nil)    // back to the device language
+    /// Theme.setLanguage("tr")   // whole UI → Turkish
+    /// Theme.setLanguage(nil)    // back to the device language
     /// ```
     ///
-    /// Per-component string parameters you pass in code still win over the
-    /// catalog. Requires `.themeKit()` (or `.themeKitLocalized()`) at the root.
+    /// Per-component string parameters you pass in code still win over the catalog,
+    /// and this requires `.themeKit()` (or `.themeKitLocalized()`) at the root. Your
+    /// `ThemeKit.xcstrings` in the app target is picked up automatically (zero-config,
+    /// `Bundle.main`); for a catalog in an app extension / framework, call
+    /// ``ThemeKitStrings/register(bundle:table:)`` once at launch.
+    static func setLanguage(_ languageCode: String?) {
+        ThemeKitStrings.locale = languageCode.map { Locale(identifier: $0) }
+    }
+
+    /// The active override language code, or `nil` when following the device.
+    static var currentLanguage: String? {
+        ThemeKitStrings.locale?.identifier
+    }
+}
+
+public extension ThemeKitStrings {
+    /// - Warning: Renamed. Use ``Theme/setLanguage(_:)`` — the friendlier hub-type
+    ///   spelling. (Deprecated in 1.x; removed at 2.0.)
+    @available(*, deprecated, renamed: "Theme.setLanguage(_:)",
+               message: "Use Theme.setLanguage(_:) — the friendlier hub-type API.")
     static func setLanguage(_ languageCode: String?) {
         locale = languageCode.map { Locale(identifier: $0) }
     }
 
-    /// The active override language code, or `nil` when following the device.
-    /// (For an explicit `Locale`, set ``locale`` directly.)
+    /// - Warning: Renamed. Use ``Theme/currentLanguage``. (Deprecated in 1.x; removed at 2.0.)
+    @available(*, deprecated, renamed: "Theme.currentLanguage",
+               message: "Use Theme.currentLanguage.")
     static var currentLanguage: String? {
         locale?.identifier
-    }
-}
-
-public extension Theme {
-    /// Shorter alias for ``ThemeKitStrings/setLanguage(_:)-(String?)`` on the hub
-    /// type — `Theme.setLanguage("tr")` flips every ThemeKit string live.
-    static func setLanguage(_ languageCode: String?) {
-        ThemeKitStrings.setLanguage(languageCode)
-    }
-
-    /// The active override language code, or `nil` when following the device.
-    static var currentLanguage: String? {
-        ThemeKitStrings.currentLanguage
     }
 }

--- a/Tests/ThemeKitTests/L10nViewLayerTests.swift
+++ b/Tests/ThemeKitTests/L10nViewLayerTests.swift
@@ -229,29 +229,29 @@ final class L10nViewLayerTests: XCTestCase {
     // MARK: - Facade: `.themeKit()` folds in live localization (ThemeKit.setLanguage)
 
     /// The whole consumer story: `.themeKit()` at the root (already there for
-    /// theming) + `ThemeKitStrings.setLanguage(_:)` — no `.themeKitLocalized()`.
+    /// theming) + `Theme.setLanguage(_:)` — no `.themeKitLocalized()`.
     func testThemeKitProviderAloneFlipsLanguageViaSetLanguage() throws {
         ThemeKitStrings.register(bundle: fixture)
-        ThemeKitStrings.setLanguage("en")
+        Theme.setLanguage("en")
 
         host(VStack { EnvironmentChild(); GlobalOnlyChild() }.themeKit())
         XCTAssertTrue(Journal.entries.contains("env|en|LTR|Hue|Hue"), "initial en: \(Journal.entries)")
         XCTAssertTrue(Journal.entries.contains("global|Hue"))
-        XCTAssertEqual(ThemeKitStrings.currentLanguage, "en")
+        XCTAssertEqual(Theme.currentLanguage, "en")
 
         Journal.reset()
-        ThemeKitStrings.setLanguage("tr")   // the facade — no .themeKitLocalized() in sight
+        Theme.setLanguage("tr")   // the facade — no .themeKitLocalized() in sight
         pump()
         XCTAssertTrue(Journal.entries.contains("env|tr|LTR|Ton|Ton"),
                       ".themeKit() alone must flip View + non-View strings: \(Journal.entries)")
         XCTAssertTrue(Journal.entries.contains("global|Ton"),
                       ".themeKit()'s folded identity must re-run global-only bodies: \(Journal.entries)")
-        XCTAssertEqual(ThemeKitStrings.currentLanguage, "tr")
+        XCTAssertEqual(Theme.currentLanguage, "tr")
 
         Journal.reset()
-        ThemeKitStrings.setLanguage(nil)    // follow the device again
+        Theme.setLanguage(nil)    // follow the device again
         pump()
-        XCTAssertNil(ThemeKitStrings.currentLanguage)
+        XCTAssertNil(Theme.currentLanguage)
     }
 
     /// `.themeKit()` also injects the RTL layout direction on an Arabic switch.

--- a/website/src/content/docs/guides/localization.md
+++ b/website/src/content/docs/guides/localization.md
@@ -90,15 +90,15 @@ struct TravelApp: App {
         WindowGroup {
             RootView()
                 .themeKit()                                            // root, once — folds in localization
-                .onAppear { ThemeKitStrings.setLanguage(appLanguage) }
+                .onAppear { Theme.setLanguage(appLanguage) }
         }
     }
 }
 
 // Anywhere — a settings screen:
-ThemeKitStrings.setLanguage("tr")   // whole UI → Turkish (short alias: Theme.setLanguage("tr"))
-ThemeKitStrings.setLanguage(nil)    // follow the device language again
-ThemeKitStrings.currentLanguage     // "tr"
+Theme.setLanguage("tr")   // whole UI → Turkish (short alias: Theme.setLanguage("tr"))
+Theme.setLanguage(nil)    // follow the device language again
+Theme.currentLanguage     // "tr"
 ```
 
 `.themeKit()` observes `ThemeKitStrings`, re-injects the effective `\.locale` and an


### PR DESCRIPTION
Theme.setLanguage(_:) is now the primary language API; ThemeKitStrings.setLanguage(_:) deprecated (renamed). Non-breaking (deprecation, not removal per docs/2.0-removal-epoch.md). Local: 324 tests green + lint/neutrality/theme-shared gates.