### PR TITLE
feat(components): Accordion prefix/custom-trailing/size + InfoBanner action button (HeroUI/Figma parity)

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -2653,15 +2653,37 @@ struct AccordionGroupDemo: View {
         FAQ(q: "Are pets allowed?", a: "Small-breed pets are allowed for an extra fee."),
     ]
     @State private var multi = false
+    @State private var prefixIdx = 0   // 0 none, 1 icon, 2 number
+    @State private var secondary = true
+    @State private var customTrailing = false
 
     var body: some View {
-        ComponentStage("AccordionGroup", inspector: [("mode", multi ? "multiple" : "single")]) {
-            AccordionGroup(faqs, initiallyExpanded: []) { $0.q } content: {
-                Text($0.a).textStyle(.bodyBase400).foregroundStyle(Theme.shared.text(.textSecondary))
-            }
-            .mode(multi ? .multiple : .single)
+        ComponentStage("AccordionGroup", inspector: [("mode", multi ? "multiple" : "single"), ("variant", secondary ? "secondary" : "default")]) {
+            {
+                var group = AccordionGroup(faqs, initiallyExpanded: []) { $0.q } content: {
+                    Text($0.a).textStyle(.bodyBase400).foregroundStyle(Theme.shared.text(.textSecondary))
+                }
+                .mode(multi ? .multiple : .single)
+                .surface(secondary)   // secondary = surface card · default = flat rows
+                // Leading prefix (Figma "Prefix" instance swap) — icon or number.
+                if prefixIdx == 1 {
+                    group = group.icon { _ in "questionmark.circle" }
+                } else if prefixIdx == 2 {
+                    group = group.number { item in faqs.firstIndex { $0.id == item.id }.map { $0 + 1 } }
+                }
+                // Per-item custom trailing view — replaces the indicator glyph.
+                if customTrailing {
+                    group = group.trailing { _, isOpen in
+                        Icon(systemName: isOpen ? "chevron.up.circle.fill" : "chevron.down.circle").size(.sm).accent(.primary)
+                    }
+                }
+                return group.id("\(multi)\(prefixIdx)\(secondary)\(customTrailing)")
+            }()
         } knobs: {
             Toggle("Multiple open", isOn: $multi)
+            Toggle("Secondary (surface card)", isOn: $secondary)
+            Toggle("Custom trailing", isOn: $customTrailing)
+            Picker("Prefix", selection: $prefixIdx) { Text("None").tag(0); Text("Icon").tag(1); Text("Number").tag(2) }.pickerStyle(.segmented)
             Text("single = opening one closes the others; multiple = independent.").font(.caption).foregroundStyle(.secondary)
         }
     }

--- a/Demo/Demo/Gallery/Demos/OrganismDemos.swift
+++ b/Demo/Demo/Gallery/Demos/OrganismDemos.swift
@@ -12,6 +12,8 @@ import ThemeKit
 struct AccordionDemo: View {
     @State private var expanded = true
     @State private var number = false
+    @State private var leadingIcon = false
+    @State private var customTrailing = false
     @State private var indicatorIdx = 0   // 0 chevron, 1 plusMinus
     @State private var sizeIdx = 1        // 0 large, 1 medium, 2 small
 
@@ -21,17 +23,31 @@ struct AccordionDemo: View {
 
     var body: some View {
         ComponentStage("Accordion", inspector: [("titleSize", sizeIdx == 0 ? "large" : sizeIdx == 2 ? "small" : "medium"), ("indicator", indicatorIdx == 1 ? "plusMinus" : "chevron")]) {
-            Accordion("What is your return policy?", initiallyExpanded: expanded) {
-                Text("You can request a return within 14 days of purchase.")
-            }
-            .number(number ? 1 : nil)
-            .indicator(indicator)
-            .titleSize(titleSize)
-            .density(paddingSize)
-            .id("\(expanded)\(number)\(indicatorIdx)\(sizeIdx)")
+            {
+                var base = Accordion("What is your return policy?", initiallyExpanded: expanded) {
+                    Text("You can request a return within 14 days of purchase.")
+                }
+                .number(number ? 1 : nil)
+                .indicator(indicator)
+                .titleSize(titleSize)
+                .density(paddingSize)
+                // Custom leading (prefix instance swap) — wins over the number.
+                if leadingIcon {
+                    base = base.leading { Icon(systemName: "star.fill").size(.sm).accent(.warning) }
+                }
+                // Custom trailing view — replaces the built-in indicator glyph.
+                if customTrailing {
+                    base = base.trailing { isOpen in
+                        Icon(systemName: isOpen ? "minus.circle.fill" : "plus.circle").size(.sm).accent(.primary)
+                    }
+                }
+                return base.id("\(expanded)\(number)\(leadingIcon)\(customTrailing)\(indicatorIdx)\(sizeIdx)")
+            }()
         } knobs: {
             Toggle("Initially expanded", isOn: $expanded)
             Toggle("Leading number (01)", isOn: $number)
+            Toggle("Leading icon (star)", isOn: $leadingIcon)
+            Toggle("Custom trailing (±)", isOn: $customTrailing)
             Picker("Title/padding size", selection: $sizeIdx) { Text("L").tag(0); Text("M").tag(1); Text("S").tag(2) }.pickerStyle(.segmented)
             Picker("Indicator", selection: $indicatorIdx) { Text("Chevron").tag(0); Text("+/−").tag(1) }.pickerStyle(.segmented)
         }
@@ -107,6 +123,7 @@ struct InfoBannerDemo: View {
     @State private var showIcon = true
     @State private var banner = false
     @State private var action = false
+    @State private var actionBtn = false
     @State private var inlineLink = false
     @State private var tapped = 0
 
@@ -124,6 +141,9 @@ struct InfoBannerDemo: View {
                 .showsIcon(showIcon)
                 .fullWidth(banner)
                 .action(action ? "Undo" : nil, onAction: action ? { flash("InfoBanner: Undo") } : nil)
+                // First-class trailing button — its closure is captured on the
+                // AlertAction (HeroUI Alert parity); wins over the text link.
+                .actionButton(actionBtn ? AlertAction("Refresh", variant: .solid) { flash("InfoBanner: Refresh") } : nil)
                 .onDismiss(dismissable ? { flash("InfoBanner closed") } : nil)
         } knobs: {
             Picker("Type", selection: $type) {
@@ -133,7 +153,8 @@ struct InfoBannerDemo: View {
             Toggle("Title", isOn: $title)
             Toggle("Show icon", isOn: $showIcon)
             Toggle("Banner mode", isOn: $banner)
-            Toggle("Action button", isOn: $action)
+            Toggle("Action link (text)", isOn: $action)
+            Toggle("Action button (real)", isOn: $actionBtn)
             Toggle("Dismissable", isOn: $dismissable)
         }
     }

--- a/Sources/ThemeKit/Components/Organisms/Accordion.swift
+++ b/Sources/ThemeKit/Components/Organisms/Accordion.swift
@@ -53,6 +53,11 @@ public struct Accordion<Content: View>: View {
     private var paddingSize: AccordionPaddingSize = .default
     private var truncateSubtitle: Bool = false
     private var showDivider: Bool = true
+    /// Custom leading accessory (prefix) — wins over `number` / `leadingSystemImage`.
+    /// AnyView slot storage is the house pattern for optional builders.
+    private var leadingView: AnyView? = nil
+    /// Custom trailing accessory (given the expanded state) — wins over `indicator`.
+    private var trailingAccessory: ((Bool) -> AnyView)? = nil
 
     /// Expansion state — uncontrolled (`initiallyExpanded:` seeds @State) or
     /// controlled (the caller's `isExpanded:` binding drives it), unified by
@@ -88,14 +93,18 @@ public struct Accordion<Content: View>: View {
                 withAnimation(motion) { expanded.toggle() }
             } label: {
                 HStack(spacing: Theme.SpacingKey.sm.value) {
-                    if let number {
-                        Text(zeroPad2(number))
-                            .textStyle(titleSize.textStyle)
-                            .foregroundStyle(titleColor)
-                            .monospacedDigit()
-                    }
-                    if let leadingSystemImage {
-                        Icon(systemName: leadingSystemImage).size(.sm).colorOverride(titleColor)
+                    if let leadingView {
+                        leadingView
+                    } else {
+                        if let number {
+                            Text(zeroPad2(number))
+                                .textStyle(titleSize.textStyle)
+                                .foregroundStyle(titleColor)
+                                .monospacedDigit()
+                        }
+                        if let leadingSystemImage {
+                            Icon(systemName: leadingSystemImage).size(.sm).colorOverride(titleColor)
+                        }
                     }
                     VStack(alignment: .leading, spacing: 2) {
                         Text(title)
@@ -109,7 +118,11 @@ public struct Accordion<Content: View>: View {
                         }
                     }
                     Spacer(minLength: Theme.SpacingKey.sm.value)
-                    indicatorIcon
+                    if let trailingAccessory {
+                        trailingAccessory(expanded)
+                    } else {
+                        indicatorIcon
+                    }
                 }
                 .padding(.vertical, paddingSize.value)
                 .contentShape(Rectangle())
@@ -170,6 +183,18 @@ public extension Accordion {
     func truncateSubtitle(_ on: Bool = true) -> Self { copy { $0.truncateSubtitle = on } }
     /// Whether to draw the bottom divider (default true).
     func divider(_ on: Bool) -> Self { copy { $0.showDivider = on } }
+    /// Custom leading accessory (prefix) shown before the title — e.g. an
+    /// avatar, colored badge, or a non-SF-Symbol glyph. Wins over
+    /// `number(_:)` / `icon(_:)` (HeroUI Accordion "Prefix" instance swap).
+    func leading<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.leadingView = AnyView(content()) }
+    }
+    /// Custom trailing accessory, given the expanded state — replaces the
+    /// built-in chevron / plus-minus indicator with a fully custom disclosure
+    /// glyph or control.
+    func trailing<V: View>(@ViewBuilder _ content: @escaping (Bool) -> V) -> Self {
+        copy { $0.trailingAccessory = { AnyView(content($0)) } }
+    }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -204,6 +229,19 @@ public extension Accordion {
                 Text("Expands with a plus/minus glyph.")
             }
             .indicator(.plusMinus)
+        }
+        // Custom leading (prefix instance swap) + custom trailing view slots.
+        PreviewCase("Custom leading + trailing") {
+            Accordion("Priority support") {
+                Text("Included with every Pro plan.")
+            }
+            .leading {
+                Icon(systemName: "star.fill").size(.sm).colorOverride(Theme.shared.resolve(.warning).base)
+            }
+            .trailing { isOpen in
+                Icon(systemName: isOpen ? "chevron.up.circle.fill" : "chevron.down.circle")
+                    .size(.sm).colorOverride(Theme.shared.resolve(.primary).base)
+            }
         }
         // Controlled expansion — the binding drives (and observes) the row.
         PreviewCase("Controlled") {

--- a/Sources/ThemeKit/Components/Organisms/AccordionGroup.swift
+++ b/Sources/ThemeKit/Components/Organisms/AccordionGroup.swift
@@ -28,6 +28,14 @@ public struct AccordionGroup<Item: Identifiable, Content: View>: View {
     private var showDividers: Bool = true
     private var isCollapsible: Bool = true
     private var isItemDisabled: ((Item) -> Bool)? = nil
+    // Per-item leading prefix (Figma "Prefix" instance swap) + custom trailing.
+    private var iconForItem: ((Item) -> String?)? = nil
+    private var numberForItem: ((Item) -> Int?)? = nil
+    private var trailingForItem: ((Item, Bool) -> AnyView)? = nil
+    // Size axis — title text style + header vertical padding. Defaults preserve
+    // the current compact baseline (labelBase600 title, 16pt row padding).
+    private var titleSize: AccordionTitleSize = .small
+    private var paddingSize: AccordionPaddingSize = .large
 
     /// Open-row ids — uncontrolled (`initiallyExpanded:` seeds @State) or
     /// controlled (the caller's `expanded:` binding drives toggling), unified
@@ -98,9 +106,10 @@ public struct AccordionGroup<Item: Identifiable, Content: View>: View {
                     HStack {
                         headerView(for: item, isOpen: isOpen, isDisabled: isDisabled)
                         Spacer()
-                        indicatorIcon(isOpen: isOpen, isDisabled: isDisabled)
+                        indicatorIcon(for: item, isOpen: isOpen, isDisabled: isDisabled)
                     }
-                    .padding(Theme.SpacingKey.md.value)
+                    .padding(.horizontal, Theme.SpacingKey.md.value)
+                    .padding(.vertical, paddingSize.value)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(RowPressStyle())
@@ -137,23 +146,40 @@ public struct AccordionGroup<Item: Identifiable, Content: View>: View {
             header(item, isOpen)
                 .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
         } else {
-            Text(title?(item) ?? "")
-                .textStyle(.labelBase600)
-                .foregroundStyle(isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary))
+            let titleColor = isDisabled ? theme.text(.textDisabled) : theme.text(.textPrimary)
+            HStack(spacing: Theme.SpacingKey.sm.value) {
+                // Leading prefix — number then icon, mirroring the single Accordion.
+                if let number = numberForItem?(item) {
+                    Text(zeroPad2(number))
+                        .textStyle(titleSize.textStyle)
+                        .foregroundStyle(titleColor)
+                        .monospacedDigit()
+                }
+                if let icon = iconForItem?(item) {
+                    Icon(systemName: icon).size(.sm).colorOverride(titleColor)
+                }
+                Text(title?(item) ?? "")
+                    .textStyle(titleSize.textStyle)
+                    .foregroundStyle(titleColor)
+            }
         }
     }
 
     @ViewBuilder
-    private func indicatorIcon(isOpen: Bool, isDisabled: Bool) -> some View {
-        let color = isDisabled ? theme.text(.textDisabled) : theme.text(.textTertiary)
-        switch indicator {
-        case .chevron:
-            Icon(systemName: "chevron.down").size(.sm).colorOverride(color)
-                .rotationEffect(.degrees(isOpen ? 180 : 0))
-        case .plusMinus:
-            Icon(systemName: isOpen ? "minus" : "plus").size(.sm).colorOverride(color)
-        case .custom(let expand, let collapse):
-            Icon(systemName: isOpen ? collapse : expand).size(.sm).colorOverride(color)
+    private func indicatorIcon(for item: Item, isOpen: Bool, isDisabled: Bool) -> some View {
+        if let trailingForItem {
+            trailingForItem(item, isOpen)
+        } else {
+            let color = isDisabled ? theme.text(.textDisabled) : theme.text(.textTertiary)
+            switch indicator {
+            case .chevron:
+                Icon(systemName: "chevron.down").size(.sm).colorOverride(color)
+                    .rotationEffect(.degrees(isOpen ? 180 : 0))
+            case .plusMinus:
+                Icon(systemName: isOpen ? "minus" : "plus").size(.sm).colorOverride(color)
+            case .custom(let expand, let collapse):
+                Icon(systemName: isOpen ? collapse : expand).size(.sm).colorOverride(color)
+            }
         }
     }
 
@@ -189,6 +215,23 @@ public extension AccordionGroup {
     /// Per-item disabled predicate — disabled rows render in the disabled text
     /// token and don't respond to taps.
     func itemDisabled(_ isDisabled: @escaping (Item) -> Bool) -> Self { copy { $0.isItemDisabled = isDisabled } }
+    /// Per-item leading SF Symbol prefix shown before the title (Figma "Prefix"
+    /// icon instance swap). Return `nil` to omit the prefix for a given item.
+    /// Applies to the title-based init; a custom `header:` owns its own leading.
+    func icon(_ systemName: @escaping (Item) -> String?) -> Self { copy { $0.iconForItem = systemName } }
+    /// Per-item leading two-digit number badge shown before the title (numbered
+    /// steps / FAQ). Rendered before `icon(_:)` when both are set.
+    func number(_ value: @escaping (Item) -> Int?) -> Self { copy { $0.numberForItem = value } }
+    /// Per-item custom trailing accessory (item + isExpanded), replacing the
+    /// built-in indicator glyph on every row.
+    func trailing<V: View>(@ViewBuilder _ content: @escaping (Item, Bool) -> V) -> Self {
+        copy { $0.trailingForItem = { AnyView(content($0, $1)) } }
+    }
+    /// Title text size applied to every row (default preserves the compact
+    /// baseline). Pair with `density(_:)` to grow the whole row.
+    func titleSize(_ size: AccordionTitleSize) -> Self { copy { $0.titleSize = size } }
+    /// Header row vertical padding — default / small / large (Figma row height).
+    func density(_ size: AccordionPaddingSize) -> Self { copy { $0.paddingSize = size } }
 
     private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
         var c = self
@@ -218,6 +261,22 @@ public extension AccordionGroup {
                 }
             } content: { Text($0.a).textStyle(.bodyBase400) }
                 .indicator(.plusMinus)
+        }
+        // Leading prefix (number + icon) on the title-based init + a larger size.
+        PreviewCase("Prefix + size") {
+            AccordionGroup(faqs) { $0.q } content: { Text($0.a).textStyle(.bodyBase400) }
+                .number { item in faqs.firstIndex { $0.id == item.id }.map { $0 + 1 } }
+                .icon { _ in "questionmark.circle" }
+                .titleSize(.medium)
+                .density(.large)
+        }
+        // Per-item custom trailing accessory replaces the built-in indicator.
+        PreviewCase("Custom trailing") {
+            AccordionGroup(faqs) { $0.q } content: { Text($0.a).textStyle(.bodyBase400) }
+                .trailing { _, isOpen in
+                    Icon(systemName: isOpen ? "chevron.up.circle.fill" : "chevron.down.circle")
+                        .size(.sm).colorOverride(Theme.shared.resolve(.primary).base)
+                }
         }
         // Plain variant — no card chrome, no dividers.
         PreviewCase("Plain (no chrome)") {

--- a/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
+++ b/Sources/ThemeKit/Components/Organisms/InfoBanner.swift
@@ -63,6 +63,52 @@ public enum InfoBannerType {
         case .error: return String(themeKit: "Error")
         }
     }
+
+    /// The banner's status mapped to a `SemanticColor` — used to tint a
+    /// first-class trailing action button so it matches the alert by default.
+    var semanticColor: SemanticColor {
+        switch self {
+        case .neutral: return .neutral
+        case .info: return .info
+        case .success: return .success
+        case .warning: return .warning
+        case .error: return .error
+        case .accent: return .primary
+        }
+    }
+}
+
+/// A first-class trailing action button for an `InfoBanner` / alert — a real
+/// `ThemeButton` (label + variant + optional semantic color) whose tap handler
+/// is captured as a stored closure. Mirrors HeroUI Native's trailing
+/// `<Button variant onPress>`; richer than the lightweight text-link
+/// `action(_:onAction:)`.
+public struct AlertAction {
+    public let title: String
+    public let variant: ButtonVariant
+    public let color: SemanticColor?
+    public let size: ButtonSize
+    public let handler: () -> Void
+
+    /// - Parameters:
+    ///   - title: Button label.
+    ///   - variant: `ThemeButton` variant (default `.soft`).
+    ///   - color: Semantic color; `nil` inherits the banner's status color.
+    ///   - size: `ThemeButton` size (default `.small`, matching HeroUI `sm`).
+    ///   - handler: Captured tap closure.
+    public init(
+        _ title: String,
+        variant: ButtonVariant = .soft,
+        color: SemanticColor? = nil,
+        size: ButtonSize = .small,
+        handler: @escaping () -> Void
+    ) {
+        self.title = title
+        self.variant = variant
+        self.color = color
+        self.size = size
+        self.handler = handler
+    }
 }
 
 /// Improved, token-bound rewrite of the reference InfoMessage. Semantic types
@@ -80,6 +126,7 @@ public struct InfoBanner: View {
     private var trailingView: AnyView?
     private var actionTitle: String?
     private var onAction: (() -> Void)?
+    private var actionButton: AlertAction?
     private var onDismiss: (() -> Void)?
 
     private let message: String
@@ -128,13 +175,20 @@ public struct InfoBanner: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Custom trailing accessory (e.g. a small ThemeButton) — richer than
-            // the lightweight `action(_:onAction:)` text link below.
+            // Custom trailing accessory (e.g. a small ThemeButton) — the fully
+            // open escape hatch, richer than the options below.
             if let trailingView {
                 trailingView
             }
 
-            if let actionTitle, let onAction {
+            // First-class action button wins over the lightweight text-link;
+            // its color defaults to the banner's status when unspecified.
+            if let actionButton {
+                ThemeButton(actionButton.title, action: actionButton.handler)
+                    .variant(actionButton.variant)
+                    .color(actionButton.color ?? type.semanticColor)
+                    .size(actionButton.size)
+            } else if let actionTitle, let onAction {
                 Button(action: onAction) {
                     Text(actionTitle).textStyle(.labelSm600).foregroundStyle(type.accent(theme))
                 }
@@ -182,6 +236,17 @@ public struct InfoBanner: View {
                 .variant(.info)
                 .trailing { ThemeButton("Install") {}.size(.small).color(.info) }
         }
+        // First-class action button — captured closure, HeroUI Alert parity.
+        PreviewCase("Action button") {
+            InfoBanner("A new version of the app is available.", title: "Update available")
+                .variant(.accent)
+                .actionButton(AlertAction("Refresh", variant: .solid) {})
+        }
+        PreviewCase("Action button · retry") {
+            InfoBanner("Check your internet connection and try again.", title: "Unable to connect")
+                .variant(.error)
+                .actionButton(AlertAction("Retry") {})
+        }
         PreviewCase("Full-width banner") {
             InfoBanner("Scheduled maintenance tonight.").variant(.warning).fullWidth()
         }
@@ -220,10 +285,16 @@ public extension InfoBanner {
     /// rounded corners / border (Ant Alert `banner`).
     func fullWidth(_ on: Bool = true) -> Self { copy { $0.banner = on } }
 
-    /// Trailing inline action button: its label + handler.
+    /// Trailing inline action as a lightweight text link: its label + handler.
     func action(_ title: String?, onAction: (() -> Void)? = nil) -> Self {
         copy { $0.actionTitle = title; $0.onAction = onAction }
     }
+
+    /// A first-class trailing action button (real `ThemeButton`) whose tap
+    /// handler is captured on the `AlertAction`. Matches HeroUI Native's
+    /// trailing `<Button variant onPress>`; wins over the text-link
+    /// `action(_:onAction:)`.
+    func actionButton(_ action: AlertAction?) -> Self { copy { $0.actionButton = action } }
 
     /// Trailing dismiss (×) button handler.
     func onDismiss(_ handler: (() -> Void)?) -> Self { copy { $0.onDismiss = handler } }


### PR DESCRIPTION
Closes the gaps surfaced reviewing the **HeroUI Figma Kit Accordion** and the **HeroUI Native Alert** against ThemeKit.

## Accordion (single) — `Accordion.swift`
- `.leading { }` — fully custom leading accessory (Figma **"Prefix"** icon-instance swap); wins over `.number()` / `.icon()`.
- `.trailing { isExpanded in }` — fully custom trailing view; replaces the built-in chevron / plus-minus indicator.

## AccordionGroup (= the Figma "Accordion" container) — `AccordionGroup.swift`
- `.icon { item }` / `.number { item }` — per-item leading prefix on the **title-based** init (previously only reachable via the custom-header init).
- `.trailing { item, isExpanded in }` — per-item custom trailing view.
- `.titleSize(_:)` + `.density(_:)` — the missing **Size** axis (title text style + row vertical padding). Internal defaults preserve the current compact baseline byte-for-byte (`labelBase600` title, 16pt row padding).

## InfoBanner (ThemeKit's HeroUI **Alert** port) — `InfoBanner.swift`
- New `AlertAction` (title + `ButtonVariant` + optional `SemanticColor` + `ButtonSize` + **captured handler**) and `.actionButton(_:)` — a first-class trailing **`ThemeButton`** whose closure is captured, matching HeroUI's `<Button variant onPress>`. Color defaults to the banner's status; wins over the lightweight text-link `.action()`.

## Figma cross-check
- **Properties** (State / Show-Prefix / Prefix / Title / Description) — covered.
- **Variants** — `default` = `.surface(false)` (flat, divider-separated), `secondary` = `.surface(true)` (surface card) — already covered.
- The real gaps were prefix-on-group, custom-trailing, the size axis, and the Alert action button — all now closed.

## Conventions & verification
- Token-fed modifiers (no raw `Color`/`CGFloat`), COW-chainable, `#Preview` cases added for every new axis.
- Interactive demo knobs added: `AccordionDemo` (leading icon + custom trailing), `AccordionGroupDemo` (prefix picker + secondary/custom-trailing), `InfoBannerDemo` (real action button).
- `swift build` + Demo `xcodebuild` green; pre-push gates green (324 tests).
- Visually verified in the simulator via `-openDemo` (Accordion, AccordionGroup, InfoBanner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)