### PR TITLE
feat(button): Figma parity — density, prefix/suffix, iconOnly, focus ring, 7 named variants

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoleculeDemos.swift
@@ -12,7 +12,7 @@ import ThemeKit
 import ThemeKitTravel
 
 struct ButtonDemo: View {
-    enum Style: String, CaseIterable { case primary, secondary, outline, ghost, link }
+    enum Style: String, CaseIterable { case primary, secondary, tertiary, outline, ghost, link, danger, dangerSoft }
     @State private var style: Style = .primary
     @State private var size: ButtonSize = .medium
     @State private var title = "Button"
@@ -39,17 +39,23 @@ struct ButtonDemo: View {
                     switch style {
                     case .primary: PrimaryButton(title, task: work).size(size).fullWidth(fullWidth).helperText(helperText).disabled(!enabled)
                     case .secondary: SecondaryButton(title, task: work).size(size).fullWidth(fullWidth).helperText(helperText).disabled(!enabled)
+                    case .tertiary: TertiaryButton(title, task: work).size(size).fullWidth(fullWidth).helperText(helperText).disabled(!enabled)
                     case .outline: OutlineButton(title, task: work).size(size).fullWidth(fullWidth).helperText(helperText).disabled(!enabled)
                     case .ghost: GhostButton(title, task: work).size(size).fullWidth(fullWidth).helperText(helperText).disabled(!enabled)
                     case .link: LinkButton(title, action: tapped).size(size).disabled(!enabled)
+                    case .danger: DangerButton(title, task: work).size(size).fullWidth(fullWidth).helperText(helperText).disabled(!enabled)
+                    case .dangerSoft: DangerSoftButton(title, task: work).size(size).fullWidth(fullWidth).helperText(helperText).disabled(!enabled)
                     }
                 } else {
                     switch style {
                     case .primary: PrimaryButton(title, action: tapped).size(size).fullWidth(fullWidth).helperText(helperText).loading(loading).disabled(!enabled)
                     case .secondary: SecondaryButton(title, action: tapped).size(size).fullWidth(fullWidth).helperText(helperText).loading(loading).disabled(!enabled)
+                    case .tertiary: TertiaryButton(title, action: tapped).size(size).fullWidth(fullWidth).helperText(helperText).loading(loading).disabled(!enabled)
                     case .outline: OutlineButton(title, action: tapped).size(size).fullWidth(fullWidth).helperText(helperText).loading(loading).disabled(!enabled)
                     case .ghost: GhostButton(title, action: tapped).size(size).fullWidth(fullWidth).helperText(helperText).loading(loading).disabled(!enabled)
                     case .link: LinkButton(title, action: tapped).size(size).disabled(!enabled)
+                    case .danger: DangerButton(title, action: tapped).size(size).fullWidth(fullWidth).helperText(helperText).loading(loading).disabled(!enabled)
+                    case .dangerSoft: DangerSoftButton(title, action: tapped).size(size).fullWidth(fullWidth).helperText(helperText).loading(loading).disabled(!enabled)
                     }
                 }
             }

--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -2056,20 +2056,31 @@ struct ThemeButtonDemo: View {
     @State private var trailingIcon = false
     @State private var loading = false
     @State private var spinnerIdx = 0   // 0 replace label, 1 leading, 2 trailing
+    @State private var compact = false
+    @State private var iconOnlyForce = false
+    @State private var prefixSuffix = false
 
-    private var iconOnly: Bool { shape == .circle || shape == .square }
+    private var iconOnly: Bool { iconOnlyForce || shape == .circle || shape == .square }
 
     var body: some View {
         ComponentStage("ThemeButton", inspector: [
-            ("color", color.rawValue), ("variant", variant.rawValue), ("shape", shape.rawValue), ("size", "\(size)"),
+            ("color", color.rawValue), ("variant", variant.rawValue), ("shape", shape.rawValue), ("size", "\(size)"), ("density", compact ? "compact" : "regular"),
         ]) {
             {
-                let base = ThemeButton(iconOnly ? nil : "Button") { flash("ThemeButton tapped") }
-                    .icon(leading: ((icon || iconOnly) && !trailingIcon) ? "star.fill" : nil,
-                          trailing: ((icon || iconOnly) && trailingIcon) ? "star.fill" : nil)
+                var base = ThemeButton(iconOnly ? nil : "Button") { flash("ThemeButton tapped") }
+                    .icon(leading: ((icon || iconOnly) && !trailingIcon && !prefixSuffix) ? "star.fill" : nil,
+                          trailing: ((icon || iconOnly) && trailingIcon && !prefixSuffix) ? "star.fill" : nil)
                     .color(color).variant(variant).size(size).shape(shape)
+                    .density(compact ? .compact : .regular)
+                    .iconOnly(iconOnlyForce)
                     .fullWidth(block && !iconOnly).loading(loading)
-                return spinnerIdx == 0 ? base : base.spinnerPlacement(spinnerIdx == 1 ? .leading : .trailing)
+                // Prefix/suffix element slots (Figma "Prefix"/"Suffix").
+                if prefixSuffix {
+                    base = base.prefix { Icon(systemName: "sparkles").size(.sm) }
+                        .suffix { Icon(systemName: "arrow.right").size(.sm) }
+                }
+                if spinnerIdx != 0 { base = base.spinnerPlacement(spinnerIdx == 1 ? .leading : .trailing) }
+                return base
             }()
         } knobs: {
             Picker("Color", selection: $color) { ForEach(SemanticColor.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) } }
@@ -2085,6 +2096,9 @@ struct ThemeButtonDemo: View {
             Picker("Spinner placement", selection: $spinnerIdx) {
                 Text("Replace").tag(0); Text("Start").tag(1); Text("End").tag(2)
             }.pickerStyle(.segmented)
+            Toggle("Compact density (sm/md/lg 32·36·40)", isOn: $compact)
+            Toggle("Icon-only (force, rounded)", isOn: $iconOnlyForce)
+            Toggle("Prefix + suffix slots", isOn: $prefixSuffix)
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Buttons/ButtonSize.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/ButtonSize.swift
@@ -3,10 +3,19 @@
 //  ThemeKit
 //  Created by İsa Mercan on 23.06.2026.
 //
-//  Button sizing driven by spacing + typography tokens.
+//  Button sizing driven by spacing + typography tokens. Two density ramps:
+//  the default touch-optimized ramp and a compact web/HeroUI ramp.
 //
 
 import SwiftUI
+
+/// Height/padding density of a button. `.regular` is the touch-optimized
+/// default (44pt-friendly targets); `.compact` is the web/HeroUI density —
+/// HeroUI `sm`/`md`/`lg` == compact `small`/`medium`/`large` — for dense
+/// toolbars, tables, chips and inline actions.
+public enum ButtonDensity: String, CaseIterable {
+    case regular, compact
+}
 
 public enum ButtonSize: CaseIterable {
     case xxsmall
@@ -14,6 +23,8 @@ public enum ButtonSize: CaseIterable {
     case small
     case medium
     case large
+
+    // MARK: - Regular (touch) ramp — the default; unchanged.
 
     var height: CGFloat {
         switch self {
@@ -38,6 +49,52 @@ public enum ButtonSize: CaseIterable {
         case .xxsmall, .xsmall: return .labelSm600
         case .small: return .labelBase600
         case .medium, .large: return .labelMd600
+        }
+    }
+
+    /// SF Symbol point size for a leading/trailing glyph at this size.
+    var fontSize: CGFloat {
+        switch self {
+        case .xxsmall, .xsmall: return 12
+        case .small: return 14
+        case .medium, .large: return 16
+        }
+    }
+
+    // MARK: - Compact (web / HeroUI) ramp — 24 / 28 / 32 / 36 / 40.
+    // HeroUI sm(32) · md(36) · lg(40) map to compact small · medium · large;
+    // xxsmall/xsmall extend the ramp below the Figma's three sizes.
+
+    var compactHeight: CGFloat {
+        switch self {
+        case .xxsmall: return 24
+        case .xsmall: return 28
+        case .small: return 32   // HeroUI sm
+        case .medium: return 36  // HeroUI md
+        case .large: return 40   // HeroUI lg
+        }
+    }
+
+    var compactHorizontalPadding: CGFloat {
+        switch self {
+        case .xxsmall, .xsmall: return Theme.SpacingKey.sm.value        // 8
+        case .small, .medium, .large: return Theme.SpacingKey.md.value  // 16
+        }
+    }
+
+    var compactTextStyle: TextStyle {
+        switch self {
+        case .xxsmall, .xsmall: return .labelSm600
+        case .small, .medium: return .labelBase600
+        case .large: return .labelMd600
+        }
+    }
+
+    var compactFontSize: CGFloat {
+        switch self {
+        case .xxsmall, .xsmall: return 12
+        case .small, .medium: return 14
+        case .large: return 16
         }
     }
 }

--- a/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
@@ -18,22 +18,25 @@
 
 import SwiftUI
 
-/// Preset visual style. Maps 1:1 to the HeroUI Figma Button variants:
-/// `primary` → ``PrimaryButton`` · `secondary` → ``SecondaryButton`` ·
-/// `tertiary` → ``TertiaryButton`` · `outline` → ``OutlineButton`` ·
-/// `ghost` → ``GhostButton`` · `danger` → ``DangerButton`` ·
-/// `dangerSoft` → ``DangerSoftButton``. (`link` is the ThemeKit text-link
-/// preset.) For arbitrary semantic colors use the flexible ``ThemeButton``
-/// (`variant` × `color`).
+/// Preset visual style (source-stable public surface). The full HeroUI variant
+/// set is exposed through the preset types — `primary` → ``PrimaryButton`` ·
+/// `secondary` → ``SecondaryButton`` · tertiary → ``TertiaryButton`` ·
+/// `outline` → ``OutlineButton`` · `ghost` → ``GhostButton`` ·
+/// danger → ``DangerButton`` · dangerSoft → ``DangerSoftButton`` — and, for
+/// arbitrary semantic colors, the flexible ``ThemeButton`` (`variant` × `color`).
 public enum ThemeButtonStyle {
     case primary
     case secondary
-    case tertiary
     case outline
     case ghost
     case link
-    case danger
-    case dangerSoft
+}
+
+/// Internal rendering kind for `ThemedButton` — the full HeroUI variant set.
+/// Kept out of the public API so the source-stable ``ThemeButtonStyle`` enum
+/// needn't grow new cases; consumers pick a variant via the preset types.
+private enum ThemedButtonKind {
+    case primary, secondary, tertiary, outline, ghost, link, danger, dangerSoft
 }
 
 /// Whether a preset button was created with a sync `action` or an async `task`.
@@ -55,7 +58,7 @@ private struct ThemedButton: View {
     let title: String
     let helperText: String?
     let textStyle: TextStyle?
-    let style: ThemeButtonStyle
+    let kind: ThemedButtonKind
     let size: ButtonSize
     let block: Bool
     let confirmsSuccess: Bool
@@ -106,7 +109,7 @@ private struct ThemedButton: View {
                 } else {
                     Text(title)
                         .textStyle(textStyle ?? size.textStyle)
-                        .underline(style == .link)
+                        .underline(kind == .link)
                         .lineLimit(1)              // a button label stays on one line (truncates, never wraps)
                         .transition(.opacity)
                 }
@@ -130,7 +133,7 @@ private struct ThemedButton: View {
 
     private var foreground: Color {
         guard isEnabled else { return theme.text(.textDisabled) }
-        switch style {
+        switch kind {
         case .primary: return theme.resolve(.primary).onSolid   // auto-contrast on the primary fill
         case .danger: return theme.resolve(.error).onSolid      // auto-contrast on the danger fill
         case .dangerSoft: return theme.resolve(.error).accent   // danger text on the soft tint
@@ -139,7 +142,7 @@ private struct ThemedButton: View {
     }
 
     private var background: Color {
-        switch style {
+        switch kind {
         case .primary:
             return theme.background(isEnabled ? .bgHero : .bgSecondary)
         case .danger:
@@ -157,7 +160,7 @@ private struct ThemedButton: View {
 
     @ViewBuilder
     private var border: some View {
-        switch style {
+        switch kind {
         case .primary, .tertiary, .ghost, .link, .danger, .dangerSoft:
             EmptyView()
         case .secondary, .outline:
@@ -200,7 +203,7 @@ public struct PrimaryButton: View {
     public var body: some View {
         ThemedButton(
             title: title, helperText: helperText, textStyle: titleTextStyle,
-            style: .primary, size: size, block: block,
+            kind: .primary, size: size, block: block,
             confirmsSuccess: confirmsSuccess ?? (mode == .task),
             accessibilityID: accessibilityID,
             isLoading: isLoading, run: run
@@ -238,7 +241,7 @@ public struct SecondaryButton: View {
     public var body: some View {
         ThemedButton(
             title: title, helperText: helperText, textStyle: titleTextStyle,
-            style: .secondary, size: size, block: block,
+            kind: .secondary, size: size, block: block,
             confirmsSuccess: confirmsSuccess ?? (mode == .task),
             accessibilityID: accessibilityID,
             isLoading: isLoading, run: run
@@ -276,7 +279,7 @@ public struct OutlineButton: View {
     public var body: some View {
         ThemedButton(
             title: title, helperText: helperText, textStyle: titleTextStyle,
-            style: .outline, size: size, block: block,
+            kind: .outline, size: size, block: block,
             confirmsSuccess: confirmsSuccess ?? (mode == .task),
             accessibilityID: accessibilityID,
             isLoading: isLoading, run: run
@@ -314,7 +317,7 @@ public struct GhostButton: View {
     public var body: some View {
         ThemedButton(
             title: title, helperText: helperText, textStyle: titleTextStyle,
-            style: .ghost, size: size, block: block,
+            kind: .ghost, size: size, block: block,
             confirmsSuccess: confirmsSuccess ?? (mode == .task),
             accessibilityID: accessibilityID,
             isLoading: isLoading, run: run
@@ -338,7 +341,7 @@ public struct LinkButton: View {
     public var body: some View {
         ThemedButton(
             title: title, helperText: nil, textStyle: nil,
-            style: .link, size: size, block: false,
+            kind: .link, size: size, block: false,
             confirmsSuccess: false, accessibilityID: accessibilityID,
             isLoading: false, run: run
         )
@@ -377,7 +380,7 @@ public struct TertiaryButton: View {
     public var body: some View {
         ThemedButton(
             title: title, helperText: helperText, textStyle: titleTextStyle,
-            style: .tertiary, size: size, block: block,
+            kind: .tertiary, size: size, block: block,
             confirmsSuccess: confirmsSuccess ?? (mode == .task),
             accessibilityID: accessibilityID,
             isLoading: isLoading, run: run
@@ -417,7 +420,7 @@ public struct DangerButton: View {
     public var body: some View {
         ThemedButton(
             title: title, helperText: helperText, textStyle: titleTextStyle,
-            style: .danger, size: size, block: block,
+            kind: .danger, size: size, block: block,
             confirmsSuccess: confirmsSuccess ?? (mode == .task),
             accessibilityID: accessibilityID,
             isLoading: isLoading, run: run
@@ -457,7 +460,7 @@ public struct DangerSoftButton: View {
     public var body: some View {
         ThemedButton(
             title: title, helperText: helperText, textStyle: titleTextStyle,
-            style: .dangerSoft, size: size, block: block,
+            kind: .dangerSoft, size: size, block: block,
             confirmsSuccess: confirmsSuccess ?? (mode == .task),
             accessibilityID: accessibilityID,
             isLoading: isLoading, run: run

--- a/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/Buttons.swift
@@ -18,12 +18,22 @@
 
 import SwiftUI
 
+/// Preset visual style. Maps 1:1 to the HeroUI Figma Button variants:
+/// `primary` → ``PrimaryButton`` · `secondary` → ``SecondaryButton`` ·
+/// `tertiary` → ``TertiaryButton`` · `outline` → ``OutlineButton`` ·
+/// `ghost` → ``GhostButton`` · `danger` → ``DangerButton`` ·
+/// `dangerSoft` → ``DangerSoftButton``. (`link` is the ThemeKit text-link
+/// preset.) For arbitrary semantic colors use the flexible ``ThemeButton``
+/// (`variant` × `color`).
 public enum ThemeButtonStyle {
     case primary
     case secondary
+    case tertiary
     case outline
     case ghost
     case link
+    case danger
+    case dangerSoft
 }
 
 /// Whether a preset button was created with a sync `action` or an async `task`.
@@ -122,7 +132,9 @@ private struct ThemedButton: View {
         guard isEnabled else { return theme.text(.textDisabled) }
         switch style {
         case .primary: return theme.resolve(.primary).onSolid   // auto-contrast on the primary fill
-        case .secondary, .outline, .ghost, .link: return theme.text(.textHero)
+        case .danger: return theme.resolve(.error).onSolid      // auto-contrast on the danger fill
+        case .dangerSoft: return theme.resolve(.error).accent   // danger text on the soft tint
+        case .secondary, .tertiary, .outline, .ghost, .link: return theme.text(.textHero)
         }
     }
 
@@ -130,8 +142,14 @@ private struct ThemedButton: View {
         switch style {
         case .primary:
             return theme.background(isEnabled ? .bgHero : .bgSecondary)
+        case .danger:
+            return isEnabled ? theme.resolve(.error).solid : theme.background(.bgSecondary)
+        case .dangerSoft:
+            return isEnabled ? theme.resolve(.error).soft : .clear
         case .secondary:
             return theme.background(.bgWhite)
+        case .tertiary:
+            return isEnabled ? theme.background(.bgTertiary) : .clear
         case .outline, .ghost, .link:
             return .clear
         }
@@ -140,7 +158,7 @@ private struct ThemedButton: View {
     @ViewBuilder
     private var border: some View {
         switch style {
-        case .primary, .ghost, .link:
+        case .primary, .tertiary, .ghost, .link, .danger, .dangerSoft:
             EmptyView()
         case .secondary, .outline:
             RoundedRectangle(cornerRadius: Theme.RadiusKey.base.value, style: .continuous)
@@ -327,6 +345,126 @@ public struct LinkButton: View {
     }
 }
 
+/// Minimal-emphasis button (HeroUI `tertiary`) — a subtle tinted surface,
+/// typically paired alongside a primary or secondary action.
+public struct TertiaryButton: View {
+    private let title: String
+    private let run: () async -> Void
+    private let mode: ButtonRunMode
+
+    // Appearance/config — mutated only through the modifiers below (R2).
+    private var size: ButtonSize = .medium
+    private var block = false
+    private var helperText: String?
+    private var titleTextStyle: TextStyle?
+    private var confirmsSuccess: Bool?   // nil = unset → defaults by run mode (action: false, task: true)
+    private var accessibilityID: String?
+    private var isLoading = false
+
+    public init(_ title: String, action: @escaping () -> Void) {   // R1
+        self.title = title
+        self.run = { action() }
+        self.mode = .action
+    }
+
+    /// Async action with automatic loading + (by default) success confirmation.
+    public init(_ title: String, task: @escaping () async -> Void) {   // R1
+        self.title = title
+        self.run = task
+        self.mode = .task
+    }
+
+    public var body: some View {
+        ThemedButton(
+            title: title, helperText: helperText, textStyle: titleTextStyle,
+            style: .tertiary, size: size, block: block,
+            confirmsSuccess: confirmsSuccess ?? (mode == .task),
+            accessibilityID: accessibilityID,
+            isLoading: isLoading, run: run
+        )
+    }
+}
+
+/// Solid destructive button (HeroUI `danger`) — for irreversible actions
+/// (delete, remove). Pair only with genuinely destructive actions.
+public struct DangerButton: View {
+    private let title: String
+    private let run: () async -> Void
+    private let mode: ButtonRunMode
+
+    // Appearance/config — mutated only through the modifiers below (R2).
+    private var size: ButtonSize = .medium
+    private var block = false
+    private var helperText: String?
+    private var titleTextStyle: TextStyle?
+    private var confirmsSuccess: Bool?   // nil = unset → defaults by run mode (action: false, task: true)
+    private var accessibilityID: String?
+    private var isLoading = false
+
+    public init(_ title: String, action: @escaping () -> Void) {   // R1
+        self.title = title
+        self.run = { action() }
+        self.mode = .action
+    }
+
+    /// Async action with automatic loading + (by default) success confirmation.
+    public init(_ title: String, task: @escaping () async -> Void) {   // R1
+        self.title = title
+        self.run = task
+        self.mode = .task
+    }
+
+    public var body: some View {
+        ThemedButton(
+            title: title, helperText: helperText, textStyle: titleTextStyle,
+            style: .danger, size: size, block: block,
+            confirmsSuccess: confirmsSuccess ?? (mode == .task),
+            accessibilityID: accessibilityID,
+            isLoading: isLoading, run: run
+        )
+    }
+}
+
+/// Lower-emphasis destructive button (HeroUI `dangerSoft`) — a soft red tint
+/// for cautionary actions where urgency is lower than a solid ``DangerButton``.
+public struct DangerSoftButton: View {
+    private let title: String
+    private let run: () async -> Void
+    private let mode: ButtonRunMode
+
+    // Appearance/config — mutated only through the modifiers below (R2).
+    private var size: ButtonSize = .medium
+    private var block = false
+    private var helperText: String?
+    private var titleTextStyle: TextStyle?
+    private var confirmsSuccess: Bool?   // nil = unset → defaults by run mode (action: false, task: true)
+    private var accessibilityID: String?
+    private var isLoading = false
+
+    public init(_ title: String, action: @escaping () -> Void) {   // R1
+        self.title = title
+        self.run = { action() }
+        self.mode = .action
+    }
+
+    /// Async action with automatic loading + (by default) success confirmation.
+    public init(_ title: String, task: @escaping () async -> Void) {   // R1
+        self.title = title
+        self.run = task
+        self.mode = .task
+    }
+
+    public var body: some View {
+        ThemedButton(
+            title: title, helperText: helperText, textStyle: titleTextStyle,
+            style: .dangerSoft, size: size, block: block,
+            confirmsSuccess: confirmsSuccess ?? (mode == .task),
+            accessibilityID: accessibilityID,
+            isLoading: isLoading, run: run
+        )
+    }
+}
+
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
 
 public extension PrimaryButton {
@@ -459,13 +597,86 @@ public extension LinkButton {
     }
 }
 
+public extension TertiaryButton {
+    /// Control size: xxsmall … large.
+    func size(_ size: ButtonSize) -> Self { copy { $0.size = size } }
+    /// Stretch to the available width.
+    func fullWidth(_ on: Bool = true) -> Self { copy { $0.block = on } }
+    /// Caption rendered under the button.
+    func helperText(_ text: String?) -> Self { copy { $0.helperText = text } }
+    /// Override the title's text style (defaults to the size's style).
+    func titleTextStyle(_ style: TextStyle?) -> Self { copy { $0.titleTextStyle = style } }
+    /// Morph the label into a success checkmark after the action completes (default: on for `task:`, off for `action:`).
+    func confirmsSuccess(_ on: Bool = true) -> Self { copy { $0.confirmsSuccess = on } }
+    /// Stable accessibility identifier, forwarded to the kit's a11y infrastructure.
+    func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
+    /// Swap the label for a spinner and block taps while `on`.
+    func loading(_ on: Bool = true) -> Self { copy { $0.isLoading = on } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+public extension DangerButton {
+    /// Control size: xxsmall … large.
+    func size(_ size: ButtonSize) -> Self { copy { $0.size = size } }
+    /// Stretch to the available width.
+    func fullWidth(_ on: Bool = true) -> Self { copy { $0.block = on } }
+    /// Caption rendered under the button.
+    func helperText(_ text: String?) -> Self { copy { $0.helperText = text } }
+    /// Override the title's text style (defaults to the size's style).
+    func titleTextStyle(_ style: TextStyle?) -> Self { copy { $0.titleTextStyle = style } }
+    /// Morph the label into a success checkmark after the action completes (default: on for `task:`, off for `action:`).
+    func confirmsSuccess(_ on: Bool = true) -> Self { copy { $0.confirmsSuccess = on } }
+    /// Stable accessibility identifier, forwarded to the kit's a11y infrastructure.
+    func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
+    /// Swap the label for a spinner and block taps while `on`.
+    func loading(_ on: Bool = true) -> Self { copy { $0.isLoading = on } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
+public extension DangerSoftButton {
+    /// Control size: xxsmall … large.
+    func size(_ size: ButtonSize) -> Self { copy { $0.size = size } }
+    /// Stretch to the available width.
+    func fullWidth(_ on: Bool = true) -> Self { copy { $0.block = on } }
+    /// Caption rendered under the button.
+    func helperText(_ text: String?) -> Self { copy { $0.helperText = text } }
+    /// Override the title's text style (defaults to the size's style).
+    func titleTextStyle(_ style: TextStyle?) -> Self { copy { $0.titleTextStyle = style } }
+    /// Morph the label into a success checkmark after the action completes (default: on for `task:`, off for `action:`).
+    func confirmsSuccess(_ on: Bool = true) -> Self { copy { $0.confirmsSuccess = on } }
+    /// Stable accessibility identifier, forwarded to the kit's a11y infrastructure.
+    func a11yID(_ id: String?) -> Self { copy { $0.accessibilityID = id } }
+    /// Swap the label for a spinner and block taps while `on`.
+    func loading(_ on: Bool = true) -> Self { copy { $0.isLoading = on } }
+
+    private func copy(_ mutate: (inout Self) -> Void) -> Self {   // R2 — single mutation point
+        var c = self
+        mutate(&c)
+        return c
+    }
+}
+
 #Preview {
     PreviewMatrix("Buttons") {
         PreviewCase("Primary") { PrimaryButton("Primary") {} }
         PreviewCase("Secondary") { SecondaryButton("Secondary") {} }
+        PreviewCase("Tertiary") { TertiaryButton("Tertiary") {} }
         PreviewCase("Outline") { OutlineButton("Outline") {} }
         PreviewCase("Ghost") { GhostButton("Ghost") {} }
         PreviewCase("Link") { LinkButton("Link") {} }
+        // HeroUI danger variants — solid + soft.
+        PreviewCase("Danger") { DangerButton("Delete") {} }
+        PreviewCase("Danger soft") { DangerSoftButton("Remove") {} }
         PreviewCase("Disabled") { PrimaryButton("Disabled") {}.disabled(true) }
         PreviewCase("Loading") { PrimaryButton("Loading") {}.loading() }
         PreviewCase("Full-width CTA") { PrimaryButton("Full-width CTA") {}.fullWidth() }

--- a/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
+++ b/Sources/ThemeKit/Components/Molecules/Buttons/ThemeButton.swift
@@ -46,6 +46,17 @@ public struct ThemeButton: View {
     private var leadingSystemImage: String?
     private var trailingSystemImage: String?
     private var accessibilityID: String?
+    /// Web/HeroUI density (compact heights); default is the touch ramp.
+    private var density: ButtonDensity = .regular
+    /// Forces a square-footprint icon button at the current shape's corner —
+    /// decoupled from `.circle`/`.square` (HeroUI `iconOnly` property).
+    private var iconOnlyOverride = false
+    /// Prefix/suffix element slots (Figma "Prefix"/"Suffix" — any view). Each
+    /// wins over the SF-Symbol `icon(leading:trailing:)` on its side.
+    private var prefixView: AnyView?
+    private var suffixView: AnyView?
+    /// Drives the visible focus ring (Figma focus state · accessibility).
+    @FocusState private var isFocused: Bool
 
     /// The resolved semantic color: explicit modifier ?? subtree
     /// `componentDefaults.accent` ?? `.primary`.
@@ -89,7 +100,13 @@ public struct ThemeButton: View {
         self.customLabel = AnyView(label())
     }
 
-    private var isIconOnly: Bool { shape == .circle || shape == .square }
+    private var isIconOnly: Bool { iconOnlyOverride || shape == .circle || shape == .square }
+
+    // Density-aware size resolution (regular touch ramp vs compact web ramp).
+    private var sizeHeight: CGFloat { density == .compact ? size.compactHeight : size.height }
+    private var sizePadding: CGFloat { density == .compact ? size.compactHorizontalPadding : size.horizontalPadding }
+    private var sizeTextStyle: TextStyle { density == .compact ? size.compactTextStyle : size.textStyle }
+    private var sizeFontSize: CGFloat { density == .compact ? size.compactFontSize : size.fontSize }
 
     public var body: some View {
         let button = Button {
@@ -103,12 +120,12 @@ public struct ThemeButton: View {
                 // being clipped. Icon-only buttons pin width == height (min==max)
                 // to keep a square footprint.
                 .frame(
-                    minWidth: isIconOnly ? size.height * typeScale : nil,
-                    maxWidth: isIconOnly ? size.height * typeScale : nil,
-                    minHeight: size.height * typeScale
+                    minWidth: isIconOnly ? sizeHeight * typeScale : nil,
+                    maxWidth: isIconOnly ? sizeHeight * typeScale : nil,
+                    minHeight: sizeHeight * typeScale
                 )
                 .frame(maxWidth: isFullWidth && !isIconOnly ? .infinity : nil)
-                .padding(.horizontal, isIconOnly ? 0 : size.horizontalPadding)
+                .padding(.horizontal, isIconOnly ? 0 : sizePadding)
                 .foregroundStyle(foreground)
                 .contentShape(Rectangle())
         }
@@ -121,6 +138,8 @@ public struct ThemeButton: View {
         .disabled(!isEnabled)
         .a11y(A11yElement.Action.button, in: accessibilityID)
         .accessibilityValue(isLoading ? String(themeKit: "Loading") : "")
+        .focused($isFocused)
+        .overlay { focusRing }
 
         // A custom label speaks for itself — overriding it with the (nil) title
         // would silence the slot's text for VoiceOver.
@@ -153,29 +172,39 @@ public struct ThemeButton: View {
             HStack(spacing: Theme.SpacingKey.xs.value) {
                 if spinnerInline && spinnerEdge == .leading { inlineSpinner }
                 customLabel
-                    .textStyle(size.textStyle)
+                    .textStyle(sizeTextStyle)
                 if spinnerInline && spinnerEdge == .trailing { inlineSpinner }
             }
         } else if isIconOnly {
-            // Icon-only: render the single provided glyph (leading takes
-            // precedence), no label.
-            if let glyph = leadingSystemImage ?? trailingSystemImage {
-                Image(systemName: glyph).font(.system(size: size.fontSize, weight: .semibold))
+            // Icon-only: a single glyph — prefix slot ▸ suffix slot ▸ the
+            // leading/trailing SF Symbol. No label.
+            if let prefixView {
+                prefixView
+            } else if let suffixView {
+                suffixView
+            } else if let glyph = leadingSystemImage ?? trailingSystemImage {
+                Image(systemName: glyph).font(.system(size: sizeFontSize, weight: .semibold))
             }
         } else {
             HStack(spacing: Theme.SpacingKey.xs.value) {
                 if spinnerInline && spinnerEdge == .leading { inlineSpinner }
-                if let leadingSystemImage {
-                    Image(systemName: leadingSystemImage).font(.system(size: size.fontSize, weight: .semibold))
+                // Leading: the prefix element slot wins over the SF-Symbol icon.
+                if let prefixView {
+                    prefixView
+                } else if let leadingSystemImage {
+                    Image(systemName: leadingSystemImage).font(.system(size: sizeFontSize, weight: .semibold))
                 }
                 if let title {
                     Text(title)
-                        .textStyle(size.textStyle)
+                        .textStyle(sizeTextStyle)
                         .underline(variant == .link)
                         .lineLimit(1)              // a single-word label never wraps; a ButtonGroup flows instead
                 }
-                if let trailingSystemImage {
-                    Image(systemName: trailingSystemImage).font(.system(size: size.fontSize, weight: .semibold))
+                // Trailing: the suffix element slot wins over the SF-Symbol icon.
+                if let suffixView {
+                    suffixView
+                } else if let trailingSystemImage {
+                    Image(systemName: trailingSystemImage).font(.system(size: sizeFontSize, weight: .semibold))
                 }
                 if spinnerInline && spinnerEdge == .trailing { inlineSpinner }
             }
@@ -218,6 +247,18 @@ public struct ThemeButton: View {
         case .pill, .circle: return AnyShape(Capsule())
         }
     }
+
+    /// Visible focus ring drawn just outside the button on keyboard / hardware
+    /// focus (Figma focus state · accessibility). Offset outward via negative
+    /// padding so it reads as a ring, tinted with the button's own accent.
+    @ViewBuilder
+    private var focusRing: some View {
+        shapeStyle
+            .stroke(resolvedColor.accent, lineWidth: 2)
+            .padding(-3)
+            .opacity(isFocused && isEnabled ? 1 : 0)
+            .allowsHitTesting(false)
+    }
 }
 
 // MARK: - Modifiers (R2 copy-on-write · R5 standard vocabulary)
@@ -256,6 +297,27 @@ public extension ThemeButton {
     /// glyph (or the trailing one if no leading) becomes the icon.
     func icon(leading: String? = nil, trailing: String? = nil) -> Self {
         copy { $0.leadingSystemImage = leading; $0.trailingSystemImage = trailing }
+    }
+
+    /// Height/padding density: `.regular` (touch, default) or `.compact`
+    /// (web/HeroUI — sm/md/lg == compact small/medium/large). Pair with `.size(_:)`.
+    func density(_ d: ButtonDensity) -> Self { copy { $0.density = d } }
+
+    /// Render as a square-footprint icon-only button at the current shape's
+    /// corner — decoupled from `.circle`/`.square` (HeroUI `iconOnly`). The
+    /// glyph comes from `prefix`/`suffix` or `icon(leading:trailing:)`.
+    func iconOnly(_ on: Bool = true) -> Self { copy { $0.iconOnlyOverride = on } }
+
+    /// Prefix element slot rendered before the label — any view (icon, spinner,
+    /// badge, avatar). Wins over the leading `icon(_:)` symbol (Figma "Prefix").
+    func prefix<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.prefixView = AnyView(content()) }
+    }
+
+    /// Suffix element slot rendered after the label — any view. Wins over the
+    /// trailing `icon(_:)` symbol (Figma "Suffix").
+    func suffix<V: View>(@ViewBuilder _ content: () -> V) -> Self {
+        copy { $0.suffixView = AnyView(content()) }
     }
 
     /// Stable accessibility identifier, forwarded to the kit's a11y infrastructure.
@@ -421,16 +483,6 @@ private struct FillButtonBody: View {
     }
 }
 
-extension ButtonSize {
-    var fontSize: CGFloat {
-        switch self {
-        case .xxsmall, .xsmall: return 12
-        case .small: return 14
-        case .medium, .large: return 16
-        }
-    }
-}
-
 #Preview {
     PreviewMatrix("ThemeButton") {
         PreviewCase("Variants × colors") {
@@ -450,6 +502,34 @@ extension ButtonSize {
                 ThemeButton { }.icon(leading: "plus").color(.primary).shape(.square)
                 ThemeButton("Pill") {}.color(.success).shape(.pill)
                 ThemeButton("Link") {}.variant(.link)
+            }
+        }
+        // Prefix/suffix element slots (Figma "Prefix"/"Suffix" — any view).
+        PreviewCase("Prefix + suffix slots") {
+            VStack(spacing: 12) {
+                ThemeButton("Continue") {}
+                    .color(.primary)
+                    .prefix { Icon(systemName: "sparkles").size(.sm) }
+                    .suffix { Icon(systemName: "arrow.right").size(.sm) }
+                ThemeButton("Cart") {}
+                    .variant(.soft).color(.primary)
+                    .suffix { Badge("3").badgeStyle(.error).size(.small) }
+            }
+        }
+        // Compact (web/HeroUI) density — small/medium/large == 32/36/40.
+        PreviewCase("Compact density") {
+            HStack {
+                ThemeButton("Small") {}.color(.primary).density(.compact).size(.small)
+                ThemeButton("Medium") {}.color(.primary).density(.compact).size(.medium)
+                ThemeButton("Large") {}.color(.primary).density(.compact).size(.large)
+            }
+        }
+        // Icon-only decoupled from shape — a rounded (not circle) icon button.
+        PreviewCase("Icon-only (rounded)") {
+            HStack {
+                ThemeButton { }.icon(leading: "square.and.arrow.up").color(.primary).iconOnly()
+                ThemeButton { }.icon(leading: "trash").color(.error).variant(.soft).iconOnly()
+                ThemeButton { }.icon(leading: "ellipsis").variant(.ghost).iconOnly().density(.compact).size(.small)
             }
         }
         PreviewCase("Full width") { ThemeButton("Block button") {}.color(.primary).fullWidth() }


### PR DESCRIPTION
Completes the Button's **Sizes / Properties / States / Variants** axes against the [HeroUI Figma Kit V3 Button](https://www.figma.com/design/co69sea4jLBX8i3vbvywbR/HeroUI-Figma-Kit-V3--Community---Copy-?node-id=2218-6175) to maximum coverage.

## Sizes — new `ButtonDensity` axis
`.density(.compact)` remaps the size names to a web/HeroUI ramp **24 / 28 / 32 / 36 / 40** (xxsmall→large). HeroUI **sm/md/lg == compact small/medium/large**, with two extra steps below the Figma's three. The touch ramp (32/40/48/56/64) stays the unchanged default.

## Properties (`ThemeButton`)
- **`.prefix { }` / `.suffix { }`** — arbitrary element slots (Figma "Prefix"/"Suffix"), each winning over the SF-Symbol `icon(leading:trailing:)` on its side.
- **`.iconOnly()`** — square-footprint icon button decoupled from `.circle`/`.square` (keeps the shape's corner), matching Figma's `iconOnly` property.
- **`.density(_:)`** compact axis.

## States (`ThemeButton`)
- **`@FocusState`-driven visible focus ring** overlay (Figma focus state · accessibility), tinted with the button's accent. Pressed / disabled / loading already existed.

## Variants (`Buttons.swift`) — the 7 HeroUI named variants
New **`TertiaryButton` / `DangerButton` / `DangerSoftButton`** presets round out `primary · secondary · tertiary · outline · ghost · danger · dangerSoft`. `ThemeButtonStyle` documents the 1:1 mapping. Danger colors resolve from `.error` with the kit's WCAG auto-contrast (`onSolid`) — the same path every solid button uses.

| HeroUI variant | ThemeKit preset | `ThemeButton` equivalent |
|---|---|---|
| primary | `PrimaryButton` | `.variant(.solid).color(.primary)` |
| secondary | `SecondaryButton` | bordered neutral |
| tertiary | `TertiaryButton` | `.variant(.ghost)` subtle surface |
| outline | `OutlineButton` | `.variant(.outline)` |
| ghost | `GhostButton` | `.variant(.ghost)` |
| danger | `DangerButton` | `.variant(.solid).color(.error)` |
| dangerSoft | `DangerSoftButton` | `.variant(.soft).color(.error)` |

## Conventions & verification
- Token-fed, COW-chainable modifiers; `#Preview` cases added for every new axis.
- Demo knobs added: `ThemeButton` (compact density · icon-only · prefix/suffix) and `Button` (tertiary/danger/dangerSoft presets).
- `swift build` + Demo `xcodebuild` green; pre-push gates green (SwiftLint, Neutrality, allowlist, Build, **324 tests**).
- Simulator-verified via `-openDemo`: ThemeButton sparkles-prefix + arrow-suffix on a compact button; the solid Danger preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)