### PR TITLE
feat(dialog): HeroUI Modal parity — blur/transparent backdrop, size, placement, header slot, scroll shadow

### DIFF
--- a/Demo/Demo/Gallery/Demos/MoreDemos.swift
+++ b/Demo/Demo/Gallery/Demos/MoreDemos.swift
@@ -2788,8 +2788,13 @@ struct DialogDemo: View {
     @State private var accepted = false
     @State private var showConfirm = false
     @State private var deleted = false
+    @State private var backdrop: BackdropStyle = .dim
+    @State private var size: DialogSize = .md
+    @State private var placement: DialogPlacement = .center
     var body: some View {
-        ComponentStage("Dialog", inspector: [("accepted", "\(accepted)"), ("deleted", "\(deleted)")]) {
+        ComponentStage("Dialog",
+                       inspector: [("backdrop", backdrop.rawValue), ("size", size.rawValue),
+                                   ("placement", placement.rawValue), ("deleted", "\(deleted)")]) {
             VStack(spacing: 12) {
                 PrimaryButton("Open agreement") { show = true; flash("Dialog opened") }
                 OutlineButton("Delete account (async)") { deleted = false; showConfirm = true }
@@ -2802,8 +2807,10 @@ struct DialogDemo: View {
                     primaryTitle: "Delete", onPrimary: {
                         try? await Task.sleep(nanoseconds: 1_200_000_000)   // async work; OK spins
                         deleted = true; flash("Account deleted")
-                    }, secondaryTitle: "Cancel", onSecondary: { flash("Dismissed") }, kind: .error)
-            .dialog(isPresented: $show, title: "Terms of Use", afterClose: {}) {
+                    }, secondaryTitle: "Cancel", onSecondary: { flash("Dismissed") }, kind: .error,
+                    backdrop: backdrop, size: size, placement: placement)
+            .dialog(isPresented: $show, title: "Terms of Use",
+                    backdrop: backdrop, size: size, placement: placement, afterClose: {}) {
                 VStack(alignment: .leading, spacing: 12) {
                     ForEach(1...8, id: \.self) { i in
                         Text("Article \(i)").textStyle(.labelBase700).foregroundStyle(Theme.shared.text(.textPrimary))
@@ -2818,6 +2825,15 @@ struct DialogDemo: View {
                 }
             }
         } knobs: {
+            Picker("Backdrop", selection: $backdrop) {
+                ForEach(BackdropStyle.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) }
+            }.pickerStyle(.segmented)
+            Picker("Size", selection: $size) {
+                ForEach(DialogSize.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+            }.pickerStyle(.segmented)
+            Picker("Placement", selection: $placement) {
+                ForEach(DialogPlacement.allCases, id: \.self) { Text($0.rawValue.capitalized).tag($0) }
+            }.pickerStyle(.segmented)
             Button("Reset") { accepted = false }
         }
     }

--- a/Sources/ThemeKit/Components/Atoms/Backdrop.swift
+++ b/Sources/ThemeKit/Components/Atoms/Backdrop.swift
@@ -11,12 +11,32 @@
 //  the active theme predates the `background.bg-backdrop` token — a consumer
 //  theme can never render an invisible scrim.
 //
+//  Three styles (HeroUI Modal's `backdrop` prop) via `.material(_:)`: `.dim`
+//  (the token fill, default), `.blur` (a translucent `Material` that frosts the
+//  content behind — falls back to `.dim` under Reduce Transparency), and
+//  `.transparent` (no visual dim, still tap-catching so scrim-tap dismissal
+//  keeps working).
+//
 
 import SwiftUI
+
+/// The look of a ``Backdrop`` scrim — HeroUI Modal's `backdrop` prop.
+public enum BackdropStyle: String, CaseIterable, Sendable {
+    /// The `bgBackdrop` token dim (black @ 40% light / 55% dark). The default.
+    case dim
+    /// A translucent `Material` that frosts the content behind the scrim, with a
+    /// light token dim on top for legibility. Degrades to `.dim` under Reduce
+    /// Transparency (no translucency) — the card can never lose contrast.
+    case blur
+    /// No visual dim at all — the card floats over untinted content. The scrim
+    /// still fills the screen and catches taps, so scrim-tap dismissal works.
+    case transparent
+}
 
 /// The standard modal scrim: `bgBackdrop` fill, fade-only, `.ignoresSafeArea()`.
 ///
 /// - `fade` is a 0…1 progress hook (1 = resting dim) for drag-to-dismiss.
+/// - `.material(_:)` picks the `.dim` / `.blur` / `.transparent` style.
 /// - `cutout` optionally punches a spotlight hole through the scrim (Tour);
 ///   it is applied *before* the safe-area expansion so cutout coordinates stay
 ///   in the presenter's own space.
@@ -27,10 +47,13 @@ struct Backdrop<Cutout: View>: View {
     /// Dismiss-drag progress: 1 at rest, toward 0 as the presented surface is
     /// dragged away.
     var fade: Double = 1
+    /// Scrim look (`.dim` by default) — mutate via `.material(_:)`.
+    var style: BackdropStyle = .dim
     /// Shape(s) punched out of the scrim (spotlight). `EmptyView` = solid scrim.
     @ViewBuilder var cutout: () -> Cutout
 
     @Environment(\.theme) private var theme
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     var body: some View {
         if Cutout.self == EmptyView.self {
@@ -42,8 +65,36 @@ struct Backdrop<Cutout: View>: View {
         }
     }
 
-    private var fill: some View {
-        theme.backdrop.opacity(fade)
+    @ViewBuilder private var fill: some View {
+        switch style {
+        case .dim:
+            theme.backdrop.opacity(fade)
+        case .blur:
+            if reduceTransparency {
+                // No translucency permitted — the plain token dim instead.
+                theme.backdrop.opacity(fade)
+            } else {
+                // Frost the content behind, then a light token dim keeps the card
+                // legible over busy imagery. `fade` dims the whole scrim as the
+                // card is dragged away.
+                Rectangle()
+                    .fill(.regularMaterial)
+                    .overlay(theme.backdrop.opacity(0.5))
+                    .opacity(fade)
+            }
+        case .transparent:
+            // Untinted but still full-bleed and hit-testable (scrim-tap dismiss).
+            Color.clear
+        }
+    }
+}
+
+extension Backdrop {
+    /// Selects the scrim style (`.dim` / `.blur` / `.transparent`). Copy-on-write.
+    func material(_ style: BackdropStyle) -> Self {
+        var copy = self
+        copy.style = style
+        return copy
     }
 }
 
@@ -69,6 +120,25 @@ extension Backdrop where Cutout == EmptyView {
             Backdrop {
                 Circle().frame(width: 64, height: 64)
             }
+        }
+    }
+    .frame(height: 220)
+}
+
+#Preview("Backdrop — styles (dim / blur / transparent)") {
+    HStack(spacing: Theme.SpacingKey.md.value) {
+        ForEach(BackdropStyle.allCases, id: \.self) { style in
+            ZStack {
+                VStack(spacing: Theme.SpacingKey.xs.value) {
+                    Icon(systemName: "photo").size(.xl)
+                    Text(style.rawValue).textStyle(.labelSm600)
+                }
+                Backdrop().material(style)
+                Text(verbatim: "Card")
+                    .padding(Theme.SpacingKey.md.value)
+                    .glassChrome(in: RoundedRectangle(cornerRadius: Theme.RadiusKey.md.value, style: .continuous))
+            }
+            .frame(maxWidth: .infinity)
         }
     }
     .frame(height: 220)

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -18,8 +18,68 @@
 //  fade-only scrim, scale+fade card transition, optional swipe-to-dismiss —
 //  all motion gated by `microAnimations` + Reduce Motion.
 //
+//  HeroUI Modal parity axes shared by every overload: `backdrop:` (`.dim` /
+//  `.blur` / `.transparent`), `size:` (a named max-width ramp `.sm…​.xl` + `.full`),
+//  and `placement:` (`.center` / `.top` / `.bottom`). The `content:footer:`
+//  overload also frosts its scroll edges (HeroUI `ScrollShadow`) and takes an
+//  optional custom `header:` slot in place of the plain title string.
+//
 
 import SwiftUI
+
+// MARK: - Modal parity axes (backdrop / size / placement)
+
+/// A named max-width for a dialog card (HeroUI Modal `size`). An explicit
+/// `width:` always overrides this; `.full` stretches the card edge-to-edge
+/// within the presentation insets.
+public enum DialogSize: String, CaseIterable, Sendable {
+    case sm, md, lg, xl, full
+
+    /// Max card width in points; `.full` fills the available width (`.infinity`).
+    var width: CGFloat {
+        switch self {
+        case .sm: return 320
+        case .md: return 400
+        case .lg: return 480
+        case .xl: return 560
+        case .full: return .infinity
+        }
+    }
+}
+
+/// Where a dialog card sits over the scrim (HeroUI Modal `placement`). `.top` /
+/// `.bottom` inset the card off the anchored screen edge and dismiss toward it.
+public enum DialogPlacement: String, CaseIterable, Sendable {
+    case center, top, bottom
+
+    var alignment: Alignment {
+        switch self {
+        case .center: return .center
+        case .top: return .top
+        case .bottom: return .bottom
+        }
+    }
+
+    /// The edge a swipe dismisses toward — up for a top card, down otherwise.
+    var dragEdge: Edge { self == .top ? .top : .bottom }
+
+    /// Which screen edge to inset the card off (none when centered).
+    var edgeInset: Edge.Set {
+        switch self {
+        case .center: return []
+        case .top: return .top
+        case .bottom: return .bottom
+        }
+    }
+}
+
+/// Resolves a card's max width: an explicit `width` wins, then a named `size`,
+/// then the overload's own legacy default. `.full` yields `.infinity`.
+private func dialogMaxWidth(_ width: CGFloat?, _ size: DialogSize?, default legacyDefault: CGFloat) -> CGFloat {
+    if let width { return width }
+    if let size { return size.width }
+    return legacyDefault
+}
 
 // MARK: - Shared presentation chrome (scrim + transitions + swipe-to-dismiss)
 
@@ -35,6 +95,10 @@ private struct DialogPresentation<Card: View>: View {
 
     /// Swipe-down-to-dismiss enabled (callers also gate this on loading state).
     let swipeToDismiss: Bool
+    /// Scrim look (`.dim` / `.blur` / `.transparent`).
+    let backdrop: BackdropStyle
+    /// Where the card sits over the scrim (`.center` / `.top` / `.bottom`).
+    let placement: DialogPlacement
     /// Scrim tap handler; the closure decides whether dismissal applies.
     let onScrimTap: () -> Void
     /// Called when a drag is released past the dismiss threshold.
@@ -48,20 +112,23 @@ private struct DialogPresentation<Card: View>: View {
     private var motionEnabled: Bool { micro && !reduceMotion }
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: placement.alignment) {
             Backdrop(fade: 1 - dragProgress)
+                .material(backdrop)
                 .onTapGesture(perform: onScrimTap)
                 .transition(.opacity)   // Scrim always fades only.
 
             card()
-                // Downward drag offsets the card with the finger; releasing past
-                // a third of the card height dismisses, anything less springs
-                // back (instantly when motion is gated off).
-                .dismissDrag(edge: .bottom,
+                // The drag offsets the card toward the placement edge with the
+                // finger; releasing past a third of the card height dismisses,
+                // anything less springs back (instantly when motion is gated off).
+                .dismissDrag(edge: placement.dragEdge,
                              isEnabled: swipeToDismiss,
                              progress: $dragProgress,
                              onDismiss: onSwipeDismiss)
                 .transition(cardTransition)
+                // Top / bottom placements inset the card off the anchored edge.
+                .padding(placement.edgeInset, Theme.SpacingKey.xl.value)
                 // Modal presenter: VoiceOver ignores the dimmed scrim and the
                 // background content behind the card while the dialog is up.
                 .accessibilityAddTraits(.isModal)
@@ -164,6 +231,9 @@ private struct DialogModifier: ViewModifier {
     let closable: Bool
     let maskClosable: Bool
     let swipeToDismiss: Bool
+    let backdrop: BackdropStyle
+    let size: DialogSize?
+    let placement: DialogPlacement
     let width: CGFloat?
 
     @State private var primaryLoading = false
@@ -176,6 +246,8 @@ private struct DialogModifier: ViewModifier {
             if isPresented {
                 DialogPresentation(
                     swipeToDismiss: swipeToDismiss && !primaryLoading,
+                    backdrop: backdrop,
+                    placement: placement,
                     onScrimTap: { if maskClosable, !primaryLoading { isPresented = false } },
                     onSwipeDismiss: { isPresented = false }
                 ) {
@@ -197,7 +269,7 @@ private struct DialogModifier: ViewModifier {
                         primaryColor: kind?.semanticColor,
                         kind: kind,
                         onClose: (closable && !primaryLoading) ? { isPresented = false } : nil,
-                        width: width,
+                        width: dialogMaxWidth(width, size, default: 320),
                         isPrimaryLoading: primaryLoading
                     )
                     .padding(Theme.SpacingKey.lg.value)
@@ -211,6 +283,10 @@ private struct DialogModifier: ViewModifier {
 public extension View {
     /// `swipeToDismiss` adds a swipe-down-to-dismiss drag on the card
     /// (HeroUI Dialog `isSwipeable`); off by default.
+    ///
+    /// - `backdrop`: scrim style — `.dim` (default), `.blur`, or `.transparent`.
+    /// - `size`: a named max-width ramp (`.sm…​.xl` + `.full`); `width:` overrides it.
+    /// - `placement`: `.center` (default), `.top`, or `.bottom`.
     func dialog(
         isPresented: Binding<Bool>,
         title: String,
@@ -223,6 +299,9 @@ public extension View {
         closable: Bool = false,
         maskClosable: Bool = true,
         swipeToDismiss: Bool = false,
+        backdrop: BackdropStyle = .dim,
+        size: DialogSize? = nil,
+        placement: DialogPlacement = .center,
         width: CGFloat? = nil
     ) -> some View {
         modifier(DialogModifier(
@@ -230,7 +309,8 @@ public extension View {
             primaryTitle: primaryTitle, onPrimary: onPrimary,
             secondaryTitle: secondaryTitle, onSecondary: onSecondary,
             kind: kind, closable: closable, maskClosable: maskClosable,
-            swipeToDismiss: swipeToDismiss, width: width
+            swipeToDismiss: swipeToDismiss, backdrop: backdrop, size: size,
+            placement: placement, width: width
         ))
     }
 }
@@ -242,9 +322,14 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
 
     @Binding var isPresented: Bool
     let title: String?
+    /// Custom header slot; `nil` → the built-in `title` string (or no header).
+    let customHeader: SlotContent?
     let closable: Bool
     let maskClosable: Bool
     let swipeToDismiss: Bool
+    let backdrop: BackdropStyle
+    let size: DialogSize?
+    let placement: DialogPlacement
     let width: CGFloat?
     let maxContentHeight: CGFloat
     let afterClose: (() -> Void)?
@@ -254,6 +339,8 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
     @Environment(\.microAnimations) private var micro
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private var motion: Animation? { MicroMotion.animation(.fast, enabled: micro, reduceMotion: reduceMotion) }
+
+    private var hasHeader: Bool { customHeader != nil || title != nil || closable }
 
     private func close() {
         isPresented = false
@@ -265,13 +352,21 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
             if isPresented {
                 DialogPresentation(
                     swipeToDismiss: swipeToDismiss,
+                    backdrop: backdrop,
+                    placement: placement,
                     onScrimTap: { if maskClosable { close() } },
                     onSwipeDismiss: close
                 ) {
                     VStack(spacing: 0) {
-                        if title != nil || closable {
+                        if hasHeader {
                             HStack {
-                                if let title {
+                                if let customHeader {
+                                    // The slot styles itself, but a bare `Text`
+                                    // header inherits the title's look by default.
+                                    customHeader
+                                        .textStyle(.headingSm)
+                                        .foregroundStyle(theme.text(.textPrimary))
+                                } else if let title {
                                     Text(title).textStyle(.headingSm).foregroundStyle(theme.text(.textPrimary))
                                 }
                                 Spacer(minLength: Theme.SpacingKey.sm.value)
@@ -286,20 +381,25 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
                             .padding(Theme.SpacingKey.lg.value)
                         }
 
-                        ScrollView {
-                            dialogContent()
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, Theme.SpacingKey.lg.value)
-                                .padding(.bottom, Theme.SpacingKey.md.value)
+                        // HeroUI ScrollShadow: frost the clipped scroll edges so
+                        // long content visibly fades into the header / footer.
+                        ScrollShadow {
+                            ScrollView {
+                                dialogContent()
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, Theme.SpacingKey.lg.value)
+                                    .padding(.bottom, Theme.SpacingKey.md.value)
+                            }
+                            .frame(maxHeight: maxContentHeight)
                         }
-                        .frame(maxHeight: maxContentHeight)
+                        .fadeColor(.bgWhite)
 
                         DividerView().size(.small)
 
                         footer()
                             .padding(Theme.SpacingKey.lg.value)
                     }
-                    .frame(maxWidth: width ?? 360)
+                    .frame(maxWidth: dialogMaxWidth(width, size, default: 360))
                     .background(theme.background(.bgWhite),
                                 in: RoundedRectangle(cornerRadius: Theme.RadiusKey.lg.value, style: .continuous))
                     .themeShadow(.elevated)
@@ -313,15 +413,23 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
 
 public extension View {
     /// A modal with custom scrollable content and a pinned footer slot
-    /// (Ant Modal `footer` + long-content scroll + `afterClose`).
+    /// (Ant Modal `footer` + long-content scroll + `afterClose`). The scroll
+    /// edges frost (HeroUI `ScrollShadow`) so long content fades into the chrome.
     /// `swipeToDismiss` adds a swipe-down-to-dismiss drag on the card
     /// (HeroUI Dialog `isSwipeable`); off by default.
+    ///
+    /// - `backdrop`: scrim style — `.dim` (default), `.blur`, or `.transparent`.
+    /// - `size`: a named max-width ramp (`.sm…​.xl` + `.full`); `width:` overrides it.
+    /// - `placement`: `.center` (default), `.top`, or `.bottom`.
     func dialog<DialogContent: View, Footer: View>(
         isPresented: Binding<Bool>,
         title: String? = nil,
         closable: Bool = true,
         maskClosable: Bool = true,
         swipeToDismiss: Bool = false,
+        backdrop: BackdropStyle = .dim,
+        size: DialogSize? = nil,
+        placement: DialogPlacement = .center,
         width: CGFloat? = nil,
         maxContentHeight: CGFloat = 420,
         afterClose: (() -> Void)? = nil,
@@ -329,8 +437,43 @@ public extension View {
         @ViewBuilder footer: @escaping () -> Footer
     ) -> some View {
         modifier(CustomDialogModifier(
-            isPresented: isPresented, title: title, closable: closable, maskClosable: maskClosable,
-            swipeToDismiss: swipeToDismiss, width: width,
+            isPresented: isPresented, title: title, customHeader: nil,
+            closable: closable, maskClosable: maskClosable,
+            swipeToDismiss: swipeToDismiss, backdrop: backdrop, size: size,
+            placement: placement, width: width,
+            maxContentHeight: maxContentHeight, afterClose: afterClose,
+            dialogContent: dialogContent, footer: footer
+        ))
+    }
+
+    /// The same scrollable-content + pinned-footer modal, but with a fully custom
+    /// `header:` slot in place of the plain title string (HeroUI's `ModalHeader`
+    /// slot) — put an icon, a subtitle, a stepper, anything. The close button (if
+    /// `closable`) still floats top-trailing beside the slot.
+    ///
+    /// - `backdrop`: scrim style — `.dim` (default), `.blur`, or `.transparent`.
+    /// - `size`: a named max-width ramp (`.sm…​.xl` + `.full`); `width:` overrides it.
+    /// - `placement`: `.center` (default), `.top`, or `.bottom`.
+    func dialog<Header: View, DialogContent: View, Footer: View>(
+        isPresented: Binding<Bool>,
+        closable: Bool = true,
+        maskClosable: Bool = true,
+        swipeToDismiss: Bool = false,
+        backdrop: BackdropStyle = .dim,
+        size: DialogSize? = nil,
+        placement: DialogPlacement = .center,
+        width: CGFloat? = nil,
+        maxContentHeight: CGFloat = 420,
+        afterClose: (() -> Void)? = nil,
+        @ViewBuilder header: @escaping () -> Header,
+        @ViewBuilder content dialogContent: @escaping () -> DialogContent,
+        @ViewBuilder footer: @escaping () -> Footer
+    ) -> some View {
+        modifier(CustomDialogModifier(
+            isPresented: isPresented, title: nil, customHeader: SlotContent(header),
+            closable: closable, maskClosable: maskClosable,
+            swipeToDismiss: swipeToDismiss, backdrop: backdrop, size: size,
+            placement: placement, width: width,
             maxContentHeight: maxContentHeight, afterClose: afterClose,
             dialogContent: dialogContent, footer: footer
         ))
@@ -346,6 +489,9 @@ private struct FreeformDialogModifier<DialogContent: View>: ViewModifier {
     let closable: Bool
     let maskClosable: Bool
     let swipeToDismiss: Bool
+    let backdrop: BackdropStyle
+    let size: DialogSize?
+    let placement: DialogPlacement
     let width: CGFloat?
     let afterClose: (() -> Void)?
     let dialogContent: () -> DialogContent
@@ -364,12 +510,14 @@ private struct FreeformDialogModifier<DialogContent: View>: ViewModifier {
             if isPresented {
                 DialogPresentation(
                     swipeToDismiss: swipeToDismiss,
+                    backdrop: backdrop,
+                    placement: placement,
                     onScrimTap: { if maskClosable { close() } },
                     onSwipeDismiss: close
                 ) {
                     dialogContent()
                         .padding(Theme.SpacingKey.lg.value)
-                        .frame(maxWidth: width ?? 320)
+                        .frame(maxWidth: dialogMaxWidth(width, size, default: 320))
                         // Same floating modal chrome as `DialogCard`.
                         .glassChrome(in: RoundedRectangle(cornerRadius: Theme.RadiusKey.lg.value, style: .continuous))
                         .overlay(alignment: .topTrailing) {
@@ -399,18 +547,26 @@ public extension View {
     /// `content:footer:` overloads remain unchanged next to this one.
     /// `swipeToDismiss` adds a swipe-down-to-dismiss drag on the card
     /// (HeroUI Dialog `isSwipeable`); off by default.
+    ///
+    /// - `backdrop`: scrim style — `.dim` (default), `.blur`, or `.transparent`.
+    /// - `size`: a named max-width ramp (`.sm…​.xl` + `.full`); `width:` overrides it.
+    /// - `placement`: `.center` (default), `.top`, or `.bottom`.
     func dialog<DialogContent: View>(
         isPresented: Binding<Bool>,
         closable: Bool = false,
         maskClosable: Bool = true,
         swipeToDismiss: Bool = false,
+        backdrop: BackdropStyle = .dim,
+        size: DialogSize? = nil,
+        placement: DialogPlacement = .center,
         width: CGFloat? = nil,
         afterClose: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> DialogContent
     ) -> some View {
         modifier(FreeformDialogModifier(
             isPresented: isPresented, closable: closable, maskClosable: maskClosable,
-            swipeToDismiss: swipeToDismiss, width: width,
+            swipeToDismiss: swipeToDismiss, backdrop: backdrop, size: size,
+            placement: placement, width: width,
             afterClose: afterClose, dialogContent: content
         ))
     }
@@ -443,6 +599,37 @@ public extension View {
                     }
                 } footer: {
                     PrimaryButton("Done") {}
+                }
+        }
+        PreviewCase("Blur backdrop · lg size") {
+            Color.clear.frame(height: 300)
+                .dialog(isPresented: .constant(true), title: "Enable notifications?",
+                        message: "We'll only ping you about gate changes and delays.",
+                        primaryTitle: "Allow", secondaryTitle: "Not now", onSecondary: {},
+                        backdrop: .blur, size: .lg)
+        }
+        PreviewCase("Bottom placement") {
+            Color.clear.frame(height: 340)
+                .dialog(isPresented: .constant(true), title: "Sign out?",
+                        message: "You'll need to log in again next time.",
+                        primaryTitle: "Sign out", secondaryTitle: "Cancel", onSecondary: {},
+                        placement: .bottom)
+        }
+        PreviewCase("Custom header slot") {
+            Color.clear.frame(height: 340)
+                .dialog(isPresented: .constant(true)) {
+                    HStack(spacing: Theme.SpacingKey.sm.value) {
+                        Icon(systemName: "airplane.departure").size(.md)
+                        VStack(alignment: .leading) {
+                            Text("Flight IST → LHR").textStyle(.headingSm)
+                            Text("Today · 14:20").textStyle(.bodySm400)
+                        }
+                    }
+                } content: {
+                    Text("Custom header slots hold icons, subtitles, steppers — anything.")
+                        .textStyle(.bodyBase400)
+                } footer: {
+                    PrimaryButton("Got it") {}
                 }
         }
     }


### PR DESCRIPTION
## What & why

Compared HeroUI **Figma Kit V3 → Modal** ([`5375-77873`](https://www.figma.com/design/co69sea4jLBX8i3vbvywbR/HeroUI-Figma-Kit-V3--Community---Copy-?node-id=5375-77873&m=dev)) against ThemeKit's `Dialog`. The core anatomy (scrim, header/body/footer, close, radius/shadow tokens, light/dark, dismiss paths, loading, destructive color) was already implemented. This PR closes the **5 remaining parity gaps** found in that audit.

## Changes

1. **Backdrop styles** — `Backdrop.material(.dim / .blur / .transparent)` (HeroUI Modal `backdrop` prop).
   - `.blur` frosts content behind via `Material`, with a light token dim for legibility; falls back to `.dim` under **Reduce Transparency** (never loses contrast).
   - `.transparent` floats the card with no dim but stays full-bleed & tap-catching (scrim-tap dismiss keeps working).
   - Default `.dim` → **Drawer / CommandPalette / Feedback / Tour unchanged**.
2. **ScrollShadow** — the `content:footer:` overload now wraps its scroll body in the existing `ScrollShadow` molecule so long content frosts into the chrome (HeroUI `modal-body` behaviour).
3. **`DialogSize`** — named max-width ramp `.sm/.md/.lg/.xl/.full`; explicit `width:` still overrides. `.full` stretches edge-to-edge within the insets.
4. **`DialogPlacement`** — `.center/.top/.bottom`; top/bottom inset off the anchored edge and dismiss toward it (swipe edge follows placement).
5. **Custom header slot** — new `dialog(header:content:footer:)` overload puts an icon/subtitle/stepper where the plain title string used to be (HeroUI `ModalHeader` slot).

The three axes (`backdrop:`, `size:`, `placement:`) are threaded through **every** `.dialog(...)` overload with backward-compatible defaults, so existing call sites are untouched.

## Verification

- ✅ `swift build` (ThemeKit SPM) — **Build complete!**
- ✅ Demo app (`xcodebuild … build`) — **BUILD SUCCEEDED**
- ✅ SwiftLint — **0 new warnings** (7 pre-existing, non-blocking); brand-neutrality + `Theme.shared` allowlist gates green
- ✅ Previews added: blur backdrop, bottom placement, `lg` size, custom header slot
- ✅ Demo gains segmented knobs for backdrop / size / placement

## Files

- `Sources/ThemeKit/Components/Atoms/Backdrop.swift` — `BackdropStyle` + `.material(_:)`
- `Sources/ThemeKit/Components/Organisms/Dialog.swift` — size/placement/header axes + ScrollShadow
- `Demo/Demo/Gallery/Demos/MoreDemos.swift` — knobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)