### PR TITLE
feat(form): onFinishFailed submit callback + getFieldsError introspection (Ant parity)

### DIFF
--- a/Sources/ThemeKit/Validation/FormValidator.swift
+++ b/Sources/ThemeKit/Validation/FormValidator.swift
@@ -65,6 +65,15 @@ public final class FormValidator<Field: Hashable> {
         order.allSatisfy { (messages[$0]?.dominantKind ?? .info) != .error }
     }
 
+    /// Fields currently in an error state, in declaration order (Ant
+    /// `getFieldsError`). Empty when the form is valid.
+    public var errorFields: [Field] {
+        order.filter { messages[$0]?.dominantKind == .error }
+    }
+
+    /// The first field currently in error, in declaration order (nil when valid).
+    public var firstError: Field? { errorFields.first }
+
     public func reset() {
         messages = [:]
         focusedField = nil

--- a/Sources/ThemeKit/Validation/FormWiring.swift
+++ b/Sources/ThemeKit/Validation/FormWiring.swift
@@ -27,14 +27,23 @@ import SwiftUI
 
 public extension FormValidator {
     /// Submission handling: validates every field, focuses the first invalid
-    /// one, and runs `action` only when the form is clean.
+    /// one, runs `action` when the form is clean (Ant `onFinish`), and otherwise
+    /// calls `onInvalid` with the first invalid field (Ant `onFinishFailed`).
     ///
     ///     Button("Pay") { form.submit(values) { pay() } }
+    ///     Button("Pay") {
+    ///         form.submit(values) { pay() } onInvalid: { _ in flash("Check the form") }
+    ///     }
     ///
     /// - Returns: `true` when the form was valid and `action` ran.
     @discardableResult
-    func submit(_ values: [Field: String], onValid action: () -> Void) -> Bool {
-        guard validateAll(values) == nil else { return false }
+    func submit(_ values: [Field: String],
+                onValid action: () -> Void,
+                onInvalid: (Field) -> Void = { _ in }) -> Bool {
+        if let invalid = validateAll(values) {
+            onInvalid(invalid)
+            return false
+        }
         action()
         return true
     }

--- a/Tests/ThemeKitTests/ValidationTests.swift
+++ b/Tests/ThemeKitTests/ValidationTests.swift
@@ -85,4 +85,30 @@ final class ValidationTests: XCTestCase {
         XCTAssertNil(form.focusedField)
         XCTAssertTrue(form.isValid)
     }
+
+    func testFormValidatorOnInvalidAndErrorFields() {
+        enum Field { case email, password }
+        let form = FormValidator<Field>([
+            .email: [.required(), .email()],
+            .password: [.required(), .minLength(8)],
+        ])
+
+        // Invalid: onInvalid fires with the first invalid field; onValid does not.
+        var invalidField: Field?
+        var ran = false
+        let ok = form.submit([.email: "nope", .password: "short"]) { ran = true } onInvalid: { invalidField = $0 }
+        XCTAssertFalse(ok)
+        XCTAssertFalse(ran)
+        XCTAssertEqual(invalidField, .email)               // Ant onFinishFailed → first invalid
+        XCTAssertEqual(form.errorFields, [.email, .password])   // Ant getFieldsError, declaration order
+        XCTAssertEqual(form.firstError, .email)
+
+        // Valid: errorFields empties, onInvalid not called.
+        invalidField = nil
+        let ok2 = form.submit([.email: "a@b.co", .password: "longenough"]) { ran = true } onInvalid: { invalidField = $0 }
+        XCTAssertTrue(ok2)
+        XCTAssertNil(invalidField)
+        XCTAssertTrue(form.errorFields.isEmpty)
+        XCTAssertNil(form.firstError)
+    }
 }


### PR DESCRIPTION
## What & why
The Ant **Form** gaps that fit ThemeKit's value-owned-by-the-caller model (fields keep their own `@State`; `FormValidator` only aggregates rules / messages / focus).

## Changes
- **`submit(_:onValid:onInvalid:)`** — the existing `submit(_:onValid:)` gains a defaulted `onInvalid: (Field) -> Void` that fires with the first invalid field on a failed submit (Ant `onFinish` / `onFinishFailed`). Backward-compatible: existing `submit(values) { … }` calls are unchanged.
- **`FormValidator.errorFields`** — the fields currently in error, in declaration order (Ant `getFieldsError`); **`firstError`** returns the first.

## Intentionally NOT ported
These fight ThemeKit's architecture (fields own their own value + label — there is no value store or wrapping Form container), so they are deliberately out of scope: `Form.useForm` FormInstance value store, `layout` (horizontal / vertical / inline), and `Form.List` dynamic array fields.

## Verification
- ✅ `swift test --filter ValidationTests` — **10/10 pass** (incl. a new onInvalid + errorFields/firstError test); existing `testFormValidatorSubmit` still green (backward-compatible)
- ✅ SwiftLint clean; no L10n drift

## Files
- `Sources/ThemeKit/Validation/FormValidator.swift` · `FormWiring.swift`
- `Tests/ThemeKitTests/ValidationTests.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)