### PR TITLE
fix(review): address Codex review findings on the Ant-parity PRs (#312–#326)

### DIFF
--- a/Sources/ThemeKit/Components/Molecules/CalendarView.swift
+++ b/Sources/ThemeKit/Components/Molecules/CalendarView.swift
@@ -210,7 +210,7 @@ public struct CalendarView: View {
                 .textStyle(.bodyBase400)
                 .foregroundStyle(dayColor(isSelected: isSelected, isToday: isToday, disabled: disabled))
                 .frame(width: 36, height: 36)
-                .background(isSelected ? selectedFill : .clear, in: Circle())
+                .background((isSelected && !disabled) ? selectedFill : .clear, in: Circle())   // disabled greys, even if selected
                 .overlay { if isToday && !isSelected && !disabled { Circle().stroke(todayRing, lineWidth: 1) } }
                 .frame(maxWidth: .infinity, minHeight: 44)   // A11y: ≥44pt tap target (circle stays 36)
                 .contentShape(Rectangle())
@@ -221,8 +221,8 @@ public struct CalendarView: View {
     }
 
     private func dayColor(isSelected: Bool, isToday: Bool, disabled: Bool) -> Color {
+        if disabled { return theme.text(.textDisabled) }   // disabled wins, even when selected
         if isSelected { return selectedContent }
-        if disabled { return theme.text(.textDisabled) }
         if isToday { return todayText }
         return theme.text(.textPrimary)
     }

--- a/Sources/ThemeKit/Components/Molecules/Cascader.swift
+++ b/Sources/ThemeKit/Components/Molecules/Cascader.swift
@@ -113,7 +113,7 @@ public struct Cascader: View {
             switch multiPaths.count {
             case 0: return placeholder
             case 1: return pathLabel(multiPaths[0]) ?? placeholder
-            default: return "\(multiPaths.count) " + String(themeKit: "selected")
+            default: return String(themeKit: "\(multiPaths.count) selected")   // count-aware localized phrase
             }
         }
         return pathLabel(singlePath) ?? placeholder

--- a/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
+++ b/Sources/ThemeKit/Components/Molecules/MultiSelect.swift
@@ -292,7 +292,7 @@ public struct MultiSelect<Option: Hashable>: View {
         Button { commitTag() } label: {
             HStack(spacing: Theme.SpacingKey.sm.value) {
                 Icon(systemName: "plus.circle").size(.sm).color(theme.foreground(.fgHero))
-                Text(String(themeKit: "Create") + " \u{201C}\(trimmedQuery)\u{201D}")
+                Text(String(themeKit: "Create \(trimmedQuery)"))   // one interpolated key — fully localizable
                     .textStyle(.bodyBase400)
                     .foregroundStyle(theme.text(.textPrimary))
                 Spacer()
@@ -302,7 +302,7 @@ public struct MultiSelect<Option: Hashable>: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(RowPressStyle())
-        .accessibilityLabel(String(themeKit: "Create") + " " + trimmedQuery)
+        .accessibilityLabel(String(themeKit: "Create \(trimmedQuery)"))
     }
 }
 

--- a/Sources/ThemeKit/Components/Molecules/Steps.swift
+++ b/Sources/ThemeKit/Components/Molecules/Steps.swift
@@ -31,7 +31,7 @@ public struct Steps: View {
     @Environment(\.layoutDirection) private var layoutDirection
 
     public struct Step: Identifiable {
-        public let id = UUID()
+        public let id: UUID
         let title: String
         /// Secondary title shown next to the main title in a lighter tone (Ant `subTitle`).
         let subTitle: String?
@@ -45,6 +45,17 @@ public struct Steps: View {
         public init(_ title: String, subTitle: String? = nil, description: String? = nil,
                     systemImage: String? = nil, state: StepState = .todo,
                     disabled: Bool = false, percent: Double? = nil) {
+            self.id = UUID()
+            self.title = title; self.subTitle = subTitle; self.description = description
+            self.systemImage = systemImage; self.state = state
+            self.disabled = disabled; self.percent = percent
+        }
+
+        /// Copy with an explicit id — lets `with(state:)` preserve identity so a
+        /// controlled step doesn't get a fresh UUID (and re-render) each pass.
+        fileprivate init(id: UUID, title: String, subTitle: String?, description: String?,
+                         systemImage: String?, state: StepState, disabled: Bool, percent: Double?) {
+            self.id = id
             self.title = title; self.subTitle = subTitle; self.description = description
             self.systemImage = systemImage; self.state = state
             self.disabled = disabled; self.percent = percent
@@ -161,8 +172,10 @@ public struct Steps: View {
                 // Custom marker replaces the stock circle/number (and the
                 // progress-dot variant), centered in the same dotSize slot so
                 // connectors and layout are unchanged. The Ant `percent` ring
-                // is still drawn around it.
-                markerBuilder(step, index)
+                // is still drawn around it. Pass the *resolved* state (so a
+                // controlled `.current(_:)` step reaches `step.state`-reading
+                // marker closures, not the declared/default state).
+                markerBuilder(step.with(state: state), index)
                 percentRing(step, state: state)
             } else if progressDot {
                 Circle().fill(dotFill(state)).frame(width: 10, height: 10)
@@ -319,8 +332,9 @@ public extension Steps.Step {
     /// `CheckInFlow`) derive header states from a selection index without
     /// re-declaring the steps.
     func with(state: StepState) -> Steps.Step {
-        Steps.Step(title, subTitle: subTitle, description: description, systemImage: systemImage,
-                   state: state, disabled: disabled, percent: percent)
+        // Preserve `id` so identity-sensitive custom markers don't re-render each pass.
+        Steps.Step(id: id, title: title, subTitle: subTitle, description: description,
+                   systemImage: systemImage, state: state, disabled: disabled, percent: percent)
     }
 }
 

--- a/Sources/ThemeKit/Components/Organisms/DataTable.swift
+++ b/Sources/ThemeKit/Components/Organisms/DataTable.swift
@@ -176,7 +176,10 @@ public struct DataTable<Row: Identifiable>: View {
         return sortAscending ? sorted : sorted.reversed()
     }
 
-    private var isInteractive: Bool { selection != nil || onRowTap != nil }
+    // In checkbox-column mode the checkbox owns selection, so a row is only an
+    // interactive button when it has an `onRowTap` (navigation). Otherwise a row
+    // tap toggles selection (legacy), so any `selection` binding makes it interactive.
+    private var isInteractive: Bool { onRowTap != nil || (selection != nil && !hasSelectionColumn) }
 
     private var pageCount: Int { Self.pageCount(rowCount: displayRows.count, pageSize: pageSize) }
     private var pagedRows: [Row] {

--- a/Sources/ThemeKit/Components/Organisms/Dialog.swift
+++ b/Sources/ThemeKit/Components/Organisms/Dialog.swift
@@ -383,7 +383,23 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
 
                         // HeroUI ScrollShadow: frost the clipped scroll edges so
                         // long content visibly fades into the header / footer.
-                        ScrollShadow {
+                        // Only on OSes where ScrollShadow can OBSERVE the scroll
+                        // (iOS 18 / macOS 15+) — below that its `.auto` degrades to
+                        // always-on scrims, which would paint permanent top+bottom
+                        // gradients over a short, non-scrollable body. There, fall
+                        // back to the plain ScrollView (the pre-scroll-shadow look).
+                        if #available(iOS 18.0, macOS 15.0, *) {
+                            ScrollShadow {
+                                ScrollView {
+                                    dialogContent()
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.horizontal, Theme.SpacingKey.lg.value)
+                                        .padding(.bottom, Theme.SpacingKey.md.value)
+                                }
+                                .frame(maxHeight: maxContentHeight)
+                            }
+                            .fadeColor(.bgWhite)
+                        } else {
                             ScrollView {
                                 dialogContent()
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -392,7 +408,6 @@ private struct CustomDialogModifier<DialogContent: View, Footer: View>: ViewModi
                             }
                             .frame(maxHeight: maxContentHeight)
                         }
-                        .fadeColor(.bgWhite)
 
                         DividerView().size(.small)
 

--- a/Sources/ThemeKit/Components/Organisms/Upload.swift
+++ b/Sources/ThemeKit/Components/Organisms/Upload.swift
@@ -142,53 +142,67 @@ public struct Upload: View {
     }
 
     private func pictureCardCell(for file: UploadFile) -> some View {
-        let tile = RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
-            .fill(theme.background(.bgElevatorTertiary))
-            .frame(width: cardSide, height: cardSide)
-            .overlay { cardStatus(for: file) }
+        // The preview tap covers the tile *background* only; the remove / retry /
+        // download controls are overlaid ABOVE it (not nested inside the preview
+        // button), so their taps reach the intended action.
+        previewBase(for: file)
             .overlay(alignment: .topTrailing) {
                 if showsRemoveIcon {
-                    Button { onRemove(file) } label: {
-                        Icon(systemName: "xmark.circle.fill").size(.sm)
-                            .color(theme.text(.textTertiary))
-                            .padding(4)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(String(themeKit: "Remove \(file.name)"))
+                    cardControl("xmark.circle.fill", label: String(themeKit: "Remove \(file.name)")) { onRemove(file) }
+                }
+            }
+            .overlay(alignment: .bottomTrailing) {
+                // Only for completed files with a download handler (parity with list mode).
+                if onDownload != nil, case .done = file.status {
+                    cardControl("arrow.down.circle.fill", label: String(themeKit: "Download \(file.name)")) { onDownload?(file) }
+                }
+            }
+            .overlay(alignment: .bottom) {
+                // Retry only when a handler exists (no dead control), like list mode.
+                if onRetry != nil, case .failed = file.status {
+                    cardControl("arrow.clockwise", label: String(themeKit: "Retry"), error: true) { onRetry?(file) }
                 }
             }
             .overlay(RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
                 .strokeBorder(cardBorder(for: file.status), lineWidth: 1))
-        return Group {
-            if let onPreview {
-                Button { onPreview(file) } label: { tile.contentShape(Rectangle()) }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(String(themeKit: "Preview \(file.name)"))
-            } else {
-                tile
+    }
+
+    /// The preview-tappable tile: photo glyph + upload progress, and nothing
+    /// interactive nested inside (the action controls are separate overlays).
+    @ViewBuilder
+    private func previewBase(for file: UploadFile) -> some View {
+        let tile = RoundedRectangle(cornerRadius: Theme.RadiusKey.sm.value, style: .continuous)
+            .fill(theme.background(.bgElevatorTertiary))
+            .frame(width: cardSide, height: cardSide)
+            .overlay {
+                VStack(spacing: Theme.SpacingKey.xs.value) {
+                    Icon(systemName: "photo").size(.md).color(theme.foreground(.fgHero))
+                    if case .uploading(let progress) = file.status {
+                        ProgressBar(value: progress).barHeight(3).frame(width: cardSide - 24)
+                    }
+                }
+                .padding(.horizontal, Theme.SpacingKey.xs.value)
             }
+        if let onPreview {
+            Button { onPreview(file) } label: { tile.contentShape(Rectangle()) }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(themeKit: "Preview \(file.name)"))
+        } else {
+            tile
         }
     }
 
-    /// The card interior: a thumbnail glyph plus a status hint (progress / retry).
-    @ViewBuilder
-    private func cardStatus(for file: UploadFile) -> some View {
-        VStack(spacing: Theme.SpacingKey.xs.value) {
-            Icon(systemName: "photo").size(.md).color(theme.foreground(.fgHero))
-            switch file.status {
-            case .uploading(let progress):
-                ProgressBar(value: progress).barHeight(3).frame(width: cardSide - 24)
-            case .done:
-                EmptyView()
-            case .failed:
-                Button { onRetry?(file) } label: {
-                    Icon(systemName: "arrow.clockwise").size(.xs).color(theme.foreground(.systemcolorsFgError))
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(themeKit: "Retry"))
-            }
+    /// A small overlaid card action button (remove / download / retry).
+    private func cardControl(_ systemImage: String, label: String, error: Bool = false,
+                             action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Icon(systemName: systemImage).size(.sm)
+                .color(error ? theme.foreground(.systemcolorsFgError) : theme.text(.textTertiary))
+                .padding(4)
+                .contentShape(Rectangle())
         }
-        .padding(.horizontal, Theme.SpacingKey.xs.value)
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
     }
 
     private func cardBorder(for status: UploadStatus) -> Color {
@@ -252,9 +266,12 @@ public struct Upload: View {
             .frame(width: 36, height: 36)
             .overlay(Icon(systemName: "photo").size(.sm).color(theme.foreground(.fgHero)))
         if let onPreview {
-            Button { onPreview(file) } label: { tile.contentShape(Rectangle()) }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(themeKit: "Preview \(file.name)"))
+            Button { onPreview(file) } label: {
+                // >=44pt hit area (WCAG 2.5.5) while the visual thumbnail stays 36pt.
+                tile.frame(minWidth: 44, minHeight: 44).contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(themeKit: "Preview \(file.name)"))
         } else {
             tile.accessibilityHidden(true)   // decorative thumbnail placeholder
         }

--- a/Sources/ThemeKitCore/Resources/Localizable.xcstrings
+++ b/Sources/ThemeKitCore/Resources/Localizable.xcstrings
@@ -378,7 +378,7 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
-    "Create": {
+    "Create %@": {
       "extractionState": "manual",
       "generatesSymbol": false
     },

--- a/Templates/ThemeKit.xcstrings
+++ b/Templates/ThemeKit.xcstrings
@@ -510,7 +510,7 @@
       "extractionState": "manual",
       "generatesSymbol": false
     },
-    "Create": {
+    "Create %@": {
       "extractionState": "manual",
       "generatesSymbol": false
     },

--- a/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
+++ b/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
@@ -103,7 +103,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "\(d) selected",
             "%@ selected", 1,
-            site: "Sources/ThemeKit/Components/Molecules/MultiSelect.swift:169")
+            site: "Sources/ThemeKit/Components/Molecules/Cascader.swift:116")
         assertKey(
             "\(d) stops",
             "%@ stops", 1,
@@ -192,6 +192,10 @@ final class L10nKeyInvariantTests: XCTestCase {
             "Close %@", 1,
             site: "Sources/ThemeKit/Components/Organisms/SegmentedTabBar.swift:264")
         assertKey(
+            "Create \(d)",
+            "Create %@", 1,
+            site: "Sources/ThemeKit/Components/Molecules/MultiSelect.swift:295")
+        assertKey(
             "Deck \(d)",
             "Deck %@", 1,
             site: "Sources/ThemeKitTravel/Components/Organisms/SeatMap.swift:144")
@@ -210,7 +214,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Download \(d)",
             "Download %@", 1,
-            site: "Sources/ThemeKit/Components/Organisms/Upload.swift:230")
+            site: "Sources/ThemeKit/Components/Organisms/Upload.swift:157")
         assertKey(
             "Expires \(d)",
             "Expires %@", 1,
@@ -223,13 +227,13 @@ final class L10nKeyInvariantTests: XCTestCase {
             "Line chart with series \(d).",
             "Line chart with series %@.", 1,
             site: "Sources/ThemeKit/Components/Molecules/Charts/LineChart.swift:107")
+    }
+
+    func testInterpolatedKeyShapes3() {
         assertKey(
             "More about \(d)",
             "More about %@", 1,
             site: "Sources/ThemeKitTravel/Components/Organisms/FareSummaryStyle.swift:154")
-    }
-
-    func testInterpolatedKeyShapes3() {
         assertKey(
             "Move to \(d)",
             "Move to %@", 1,
@@ -253,7 +257,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Preview \(d)",
             "Preview %@", 1,
-            site: "Sources/ThemeKit/Components/Organisms/Upload.swift:166")
+            site: "Sources/ThemeKit/Components/Organisms/Upload.swift:189")
         assertKey(
             "React with \(d), \(d) reactions",
             "React with %@, %@ reactions", 2,
@@ -326,13 +330,13 @@ final class L10nKeyInvariantTests: XCTestCase {
             "seat \(d)",
             "seat %@", 1,
             site: "Sources/ThemeKitTravel/Components/Molecules/PassengerRowStyle.swift:113")
+    }
+
+    func testInterpolatedKeyShapes4() {
         assertKey(
             "up \(d)",
             "up %@", 1,
             site: "Sources/ThemeKit/Components/Molecules/Stat.swift:17")
-    }
-
-    func testInterpolatedKeyShapes4() {
         assertKey(
             "via \(d)",
             "via %@", 1,


### PR DESCRIPTION
## What & why
The Codex review bot left **10 P2 findings** across the merged Ant-parity PRs (they were merged before the review comments were read). This addresses all of them.

| Source PR | Fix |
|---|---|
| #312 Dialog | Gate `content:footer:` ScrollShadow on iOS 18 / macOS 15+ (where it observes scroll); plain ScrollView below — no permanent scrims on short bodies |
| #314 Calendar | A disabled-AND-selected day greys out (disabled takes precedence over the selected fill/text) |
| #315 Steps | Custom `.marker` closures receive the resolved controlled-`.current` state (`step.with(state:)`) |
| #320 Upload | `onPreview` thumbnail button gets a ≥44pt hit area (tile stays 36pt) |
| #323 Cascader | Multi-select summary uses the count-aware `"%@ selected"` localized phrase |
| #324 DataTable | `.selectionColumn()` rows without `onRowTap` are no longer dead buttons (`isInteractive` gates on `onRowTap`) |
| #325 MultiSelect | "Create" tag row emits one interpolated `"Create %@"` key (fully localizable) |
| #326 Upload picture-card | remove/retry/download controls overlaid ABOVE the preview button (reliable taps); retry only when `onRetry` exists; `onDownload` affordance restored on `.done` cells |

## Verification
- ✅ `swift build` — **Build complete!**; SwiftLint clean (no new warnings)
- ✅ Full pre-push CI gate green; new `"Create %@"` via make l10n

🤖 Generated with [Claude Code](https://claude.com/claude-code)