### PR TITLE
fix(ci): honor .api-breakage-allowlist.txt in check-api.sh (SwiftPM 6.2 plumbing bug)

### DIFF
--- a/scripts/check-api.sh
+++ b/scripts/check-api.sh
@@ -12,6 +12,16 @@
 # source-breaking way versus the baseline. That's allowed — but it MUST come
 # with a MAJOR version bump (see docs/API-STABILITY.md). Intentional breaks can
 # be recorded in .api-breakage-allowlist.txt to keep CI green.
+#
+# NOTE on the allowlist: `swift package diagnose-api-breaking-changes` in the
+# current toolchain (Swift 6.2 / Xcode 26) does NOT forward
+# `--breakage-allowlist-path` to the underlying `swift-api-digester`, so the
+# flag alone no longer suppresses recorded breaks (verified: the digester
+# honours the exact-message allowlist when invoked directly, but SwiftPM drops
+# it). We therefore filter allowlisted breakages here, in the script, matching
+# each `.api-breakage-allowlist.txt` line against the digester's printed
+# `API breakage: …` messages exactly. The flag is still passed so this keeps
+# working automatically if/when SwiftPM fixes the plumbing.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -25,11 +35,53 @@ fi
 
 echo "▸ Comparing public API against baseline: ${BASELINE}"
 
+ALLOWLIST_FILE=".api-breakage-allowlist.txt"
 ALLOWLIST_ARG=()
-if [[ -f .api-breakage-allowlist.txt ]]; then
-  ALLOWLIST_ARG=(--breakage-allowlist-path .api-breakage-allowlist.txt)
+if [[ -f "${ALLOWLIST_FILE}" ]]; then
+  ALLOWLIST_ARG=(--breakage-allowlist-path "${ALLOWLIST_FILE}")
 fi
 
-swift package diagnose-api-breaking-changes "${BASELINE}" \
+# Run the digester. It may exit non-zero when breaks exist (allowlisted or not),
+# so don't let `set -e` abort here — we decide pass/fail from the parsed output.
+set +e
+DIAG_OUTPUT="$(swift package diagnose-api-breaking-changes "${BASELINE}" \
   --products ThemeKit \
-  "${ALLOWLIST_ARG[@]}"
+  "${ALLOWLIST_ARG[@]}" 2>&1)"
+set -e
+
+# Surface the full digester output (build log + breakage list) in CI.
+printf '%s\n' "${DIAG_OUTPUT}"
+
+# Extract the breakage messages the digester reported, normalised to the exact
+# `API breakage: …` text (drops the leading whitespace + 💔 emoji prefix).
+BREAKAGES="$(printf '%s\n' "${DIAG_OUTPUT}" | grep -o 'API breakage:.*' || true)"
+
+if [[ -z "${BREAKAGES}" ]]; then
+  echo "▸ No public-API breakages detected."
+  exit 0
+fi
+
+# Allowlist patterns: every non-comment, non-blank line of the allowlist file.
+ALLOWLIST_PATTERNS=""
+if [[ -f "${ALLOWLIST_FILE}" ]]; then
+  ALLOWLIST_PATTERNS="$(grep -vE '^[[:space:]]*(#|$)' "${ALLOWLIST_FILE}" || true)"
+fi
+
+# Remaining = reported breakages that are NOT in the allowlist (exact, whole-line).
+REMAINING="$(printf '%s\n' "${BREAKAGES}" \
+  | grep -Fxv -f <(printf '%s\n' "${ALLOWLIST_PATTERNS}") || true)"
+
+if [[ -n "${REMAINING}" ]]; then
+  echo ""
+  echo "✗ Un-allowlisted source-breaking public-API change(s) vs ${BASELINE}:"
+  printf '%s\n' "${REMAINING}" | sed 's/^/  💔 /'
+  echo ""
+  echo "  If intentional: add the exact line(s) above to ${ALLOWLIST_FILE}"
+  echo "  together with a MAJOR version bump + CHANGELOG note"
+  echo "  (see docs/API-STABILITY.md, docs/2.0-removal-epoch.md)."
+  exit 1
+fi
+
+echo ""
+echo "▸ All ${BASELINE} API breakages are allowlisted — OK."
+exit 0


### PR DESCRIPTION
## Problem

`swift package diagnose-api-breaking-changes` in the current toolchain (Swift 6.2 / Xcode 26) no longer forwards `--breakage-allowlist-path` to the underlying `swift-api-digester`. As a result, intentional breaks recorded in `.api-breakage-allowlist.txt` stopped being suppressed, and the **API breakage check** gate goes red for *any* allowlisted change — blocking PRs that correctly recorded their breaks (e.g. #308 new `ButtonSize` cases, #311 Drawer `edge` widening).

Verified root cause: invoking `xcrun swift-api-digester -diagnose-sdk … -breakage-allowlist-path <file>` **directly** honors the exact-message allowlist and suppresses the breaks; SwiftPM drops the flag on the way through. The repo's allowlist file format was already correct.

## Fix

Filter allowlisted breakages **script-side** in `scripts/check-api.sh`: parse the digester's printed `API breakage: …` lines and subtract exact whole-line matches from `.api-breakage-allowlist.txt` (comments/blank lines ignored). The `--breakage-allowlist-path` flag is still passed, so behavior reverts to native automatically if/when SwiftPM fixes the plumbing.

## Verification

End-to-end against the Drawer 4-edge branch (2 recorded breaks):
- all breaks allowlisted → **exit 0** ✅
- remove one entry → **exit 1**, naming exactly the un-recorded break ✅

Shell-only change; no library/API surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)