### PR TITLE
feat(chip): HeroUI V3 status axes — type × variant + onClose

### DIFF
--- a/Demo/Demo/Gallery/Demos/AtomDemos.swift
+++ b/Demo/Demo/Gallery/Demos/AtomDemos.swift
@@ -129,24 +129,58 @@ struct ChipDemo: View {
     @State private var rating = false
     @State private var exists = true
     @State private var expands = false
+    // HeroUI V3 status mode.
+    @State private var statusMode = false
+    @State private var typeIdx = 0   // accent/neutral/success/warning/danger
+    @State private var variantIdx = 0 // primary/secondary/tertiary/soft
+    @State private var closable = false
+
+    private let types: [ChipType] = [.accent, .neutral, .success, .warning, .danger]
+    private let variants: [ChipVariant] = [.primary, .secondary, .tertiary, .soft]
+    private var type: ChipType { types[typeIdx] }
+    private var variant: ChipVariant { variants[variantIdx] }
 
     var body: some View {
-        ComponentStage("Chip", inspector: [
-            ("isSelected", "\(selected)"), ("size", "\(size)"), ("isExist", "\(exists)"), ("isEnabled", "\(enabled)"),
-        ]) {
-            Chip(exists ? "Recommended" : "Sold out", isSelected: $selected)
+        ComponentStage("Chip", inspector: statusMode
+            ? [("mode", "status"), ("type", "\(type)"), ("variant", "\(variant)"), ("size", "\(size)")]
+            : [("isSelected", "\(selected)"), ("size", "\(size)"), ("isExist", "\(exists)"), ("isEnabled", "\(enabled)")]
+        ) {
+            if statusMode {
+                Chip(exists ? "Recommended" : "Sold out")
+                    .type(type)
+                    .variant(variant)
+                    .size(size)
+                    .icon(rating ? "sparkles" : nil)
+                    .onClose(closable ? {} : nil)
+                    .disabled(!enabled)
+            } else {
+                Chip(exists ? "Recommended" : "Sold out", isSelected: $selected)
                     .size(size)
                     .chipStyle(solid ? .solid : .tonal)
                     .rating(rating ? 4.6 : nil)
                     .exists(exists)
                     .fullWidth(expands)
                     .disabled(!enabled)
+            }
         } knobs: {
-            Toggle("Selected", isOn: $selected)
-            Toggle("Embedded rating", isOn: $rating)
-            Toggle("isExist (strike-through when off)", isOn: $exists)
-            Toggle("Expands horizontally", isOn: $expands)
-            Toggle("Solid style", isOn: $solid)
+            Toggle("Status mode (HeroUI type × variant)", isOn: $statusMode)
+            if statusMode {
+                Picker("Type", selection: $typeIdx) {
+                    Text("Accent").tag(0); Text("Default").tag(1); Text("Success").tag(2)
+                    Text("Warning").tag(3); Text("Danger").tag(4)
+                }.pickerStyle(.segmented)
+                Picker("Variant", selection: $variantIdx) {
+                    Text("Primary").tag(0); Text("Secondary").tag(1); Text("Tertiary").tag(2); Text("Soft").tag(3)
+                }.pickerStyle(.segmented)
+                Toggle("Prefix icon", isOn: $rating)
+                Toggle("Closable (× suffix)", isOn: $closable)
+            } else {
+                Toggle("Selected", isOn: $selected)
+                Toggle("Embedded rating", isOn: $rating)
+                Toggle("isExist (strike-through when off)", isOn: $exists)
+                Toggle("Expands horizontally", isOn: $expands)
+                Toggle("Solid style", isOn: $solid)
+            }
             Picker("Size", selection: $size) {
                 Text("Small").tag(ChipSize.small); Text("Medium").tag(ChipSize.medium); Text("Large").tag(ChipSize.large)
             }.pickerStyle(.segmented)

--- a/Sources/ThemeKit/Components/Atoms/Chip.swift
+++ b/Sources/ThemeKit/Components/Atoms/Chip.swift
@@ -42,6 +42,38 @@ public enum ChipSelectionStyle {
     case solid   // hero fill + white text
 }
 
+/// The chip's semantic hue — the HeroUI V3 Chip **Type** axis. Maps onto the
+/// kit's ``SemanticColor`` so an injected `.theme(_:)` re-skins it. Set with
+/// ``Chip/type(_:)``; pair with ``ChipVariant`` for the emphasis level. When
+/// unset the chip keeps its selection-based tonal/solid look.
+public enum ChipType: Sendable {
+    case accent    // HeroUI "accent"  → SemanticColor.primary (brand hero)
+    case neutral   // HeroUI "default" → SemanticColor.neutral
+    case success   // → .success
+    case warning   // → .warning
+    case danger    // HeroUI "danger"  → SemanticColor.error
+
+    /// The kit ``SemanticColor`` this type resolves through.
+    var semantic: SemanticColor {
+        switch self {
+        case .accent: return .primary
+        case .neutral: return .neutral
+        case .success: return .success
+        case .warning: return .warning
+        case .danger: return .error
+        }
+    }
+}
+
+/// The emphasis level of a semantic chip — the HeroUI V3 Chip **Variant** axis.
+/// Only takes effect once a ``ChipType`` is set (see ``Chip/type(_:)``).
+public enum ChipVariant: Sendable {
+    case primary     // high emphasis: solid type fill + contrasting text
+    case secondary   // medium: neutral surface + type-accent text
+    case tertiary    // low: transparent + type-accent text
+    case soft        // subtle: type-tinted surface + type-accent text
+}
+
 /// Improved, token-bound rewrite of the reference BasicChip — a single clear
 /// selection API (tonal / solid) instead of the reference's nested
 /// status × mode × fullSelect × isExist matrix.
@@ -62,40 +94,71 @@ public struct Chip: View {
     // call site to `Chip("x", isSelected: $on)`.
     private var size: ChipSize = .small
     private var selectionStyle: ChipSelectionStyle? = nil   // nil → environment style
+    private var chipType: ChipType? = nil                   // set → HeroUI semantic chroma
+    private var chipVariant: ChipVariant = .primary
     private var leadingSystemImage: String? = nil
     private var rating: Double? = nil
     private var leadingSlot: SlotContent? = nil
     private var trailingSlot: SlotContent? = nil
+    private var onClose: (() -> Void)? = nil
     private var isExist: Bool = true
     private var isInteractive: Bool = true
     private var expandsHorizontally: Bool = false
+    /// `true` for the selectable filter pill (`init(_:isSelected:)`); `false`
+    /// for the static status/label chip (`init(_:)`), which drops the toggle
+    /// button so a `.onClose` affordance stays independently tappable.
+    private var isSelectable: Bool = true
 
     public init(_ title: String, isSelected: Binding<Bool>) {   // R1
         self.title = title
         self._isSelected = isSelected
     }
 
-    public var body: some View {
-        Button {
-            isSelected.toggle()
-        } label: {
-            resolvedStyle.makeBody(configuration: ChipStyleConfiguration(
-                content: AnyView(labelContent),
-                isSelected: isSelected,
-                isEnabled: isEnabled && isExist,
-                size: size))
-                .opacity(isExist ? 1 : 0.6)
-        }
-        .buttonStyle(PressFeedbackStyle())
-        .disabled(!isEnabled || !isInteractive || !isExist)
-        .allowsHitTesting(isInteractive && isExist)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    /// A static status/label chip (HeroUI V3 badge-style) — no selection state.
+    /// Pair with ``type(_:)`` / ``variant(_:)`` for semantic chroma and
+    /// ``onClose(_:)`` for a trailing dismiss.
+    public init(_ title: String) {   // R1 — status chip, no binding
+        self.title = title
+        self._isSelected = .constant(false)
+        self.isSelectable = false
     }
 
-    /// The enum shorthand resolves to the matching built-in `ChipStyle`;
-    /// otherwise the environment style applies — built-ins and custom styles
-    /// share the same door.
+    public var body: some View {
+        if isSelectable {
+            Button {
+                isSelected.toggle()
+            } label: {
+                styledContent
+            }
+            .buttonStyle(PressFeedbackStyle())
+            .disabled(!isEnabled || !isInteractive || !isExist)
+            .allowsHitTesting(isInteractive && isExist)
+            .accessibilityAddTraits(isSelected ? .isSelected : [])
+        } else {
+            // Status chip: no toggle wrapper — the `.onClose` button (if any)
+            // owns its own hit target inside the capsule.
+            styledContent
+        }
+    }
+
+    /// The chroma-wrapped content, shared by both the selectable and status paths.
+    private var styledContent: some View {
+        resolvedStyle.makeBody(configuration: ChipStyleConfiguration(
+            content: AnyView(labelContent),
+            isSelected: isSelected,
+            isEnabled: isEnabled && isExist,
+            size: size))
+            .opacity(isExist ? 1 : 0.6)
+    }
+
+    /// A ``ChipType`` routes through the semantic HeroUI chroma; otherwise the
+    /// enum shorthand resolves to the matching built-in `ChipStyle`, else the
+    /// environment style applies — all built-ins and custom styles share the
+    /// same door.
     private var resolvedStyle: AnyChipStyle {
+        if let chipType {
+            return AnyChipStyle(SemanticChipStyle(type: chipType, variant: chipVariant))
+        }
         switch selectionStyle {
         case .tonal: return AnyChipStyle(TonalChipStyle())
         case .solid: return AnyChipStyle(SolidChipStyle())
@@ -111,7 +174,7 @@ public struct Chip: View {
                 leadingSlot
             } else {
                 if let leadingSystemImage {
-                    Image(systemName: leadingSystemImage).font(.system(size: 14))
+                    Image(systemName: leadingSystemImage).font(.system(size: iconGlyphSize))
                 }
                 if let rating {
                     HStack(spacing: 2) {
@@ -121,17 +184,57 @@ public struct Chip: View {
                     }
                 }
             }
-            Text(title).textStyle(.labelBase600)
+            Text(title).textStyle(titleTextStyle)
                 .strikethrough(!isExist, color: theme.text(.textTertiary))
             if let trailingSlot {
                 trailingSlot
+            }
+            if let onClose {
+                // HeroUI suffix dismiss (`×`). A nested plain Button keeps its
+                // own hit target even inside the selectable path's toggle button
+                // (same nesting `ChipGroup.removable` already ships).
+                Button { onClose() } label: {
+                    Image(systemName: "xmark").font(.system(size: closeGlyphSize, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(themeKit: "Remove"))
             }
         }
         .frame(maxWidth: expandsHorizontally ? .infinity : nil)
         // Enforce the tier's min-height from inside the style's padding, so the
         // capsule (content + 2 × verticalPadding) lands on the ChipSize ramp
         // (C3) — for custom `ChipStyle`s the content still carries the floor.
+        // The floor is ~20pt across sizes, so `SemanticChipStyle`'s compact
+        // outer padding lands the HeroUI 20/24/28pt heights on top of it.
         .scaledControlHeight(size.minHeight - size.verticalPadding * 2)
+    }
+
+    /// The title's text style. Semantic (status) chips follow the HeroUI ramp
+    /// (12pt on sm/md, 14pt on lg); the selectable filter pill keeps its 14pt
+    /// label unchanged.
+    private var titleTextStyle: TextStyle {
+        guard chipType != nil else { return .labelBase600 }
+        switch size {
+        case .small, .medium: return .labelSm600
+        case .large: return .labelBase600
+        }
+    }
+    /// Leading SF Symbol size — HeroUI icon slots are 12/12/14pt in semantic
+    /// mode; the selectable pill keeps its fixed 14pt glyph.
+    private var iconGlyphSize: CGFloat {
+        guard chipType != nil else { return 14 }
+        switch size {
+        case .small, .medium: return 12
+        case .large: return 14
+        }
+    }
+    /// Trailing dismiss glyph size, scaled to the tier.
+    private var closeGlyphSize: CGFloat {
+        switch size {
+        case .small: return 10
+        case .medium: return 11
+        case .large: return 12
+        }
     }
 }
 
@@ -145,6 +248,17 @@ public extension Chip {
     /// built-in ``TonalChipStyle`` / ``SolidChipStyle`` — it overrides the
     /// environment's ``ChipStyle`` for this chip only.
     func chipStyle(_ s: ChipSelectionStyle) -> Self { copy { $0.selectionStyle = s } }
+    /// Semantic hue — the HeroUI V3 Chip **Type** (accent / neutral / success /
+    /// warning / danger). Setting it switches the chip to the semantic status
+    /// chroma (``SemanticChipStyle``) at the current ``variant(_:)``, overriding
+    /// the tonal/solid selection look and any environment ``ChipStyle``.
+    func type(_ t: ChipType) -> Self { copy { $0.chipType = t } }
+    /// Emphasis level of a semantic chip — the HeroUI V3 Chip **Variant**
+    /// (primary / secondary / tertiary / soft). No effect until ``type(_:)`` is set.
+    func variant(_ v: ChipVariant) -> Self { copy { $0.chipVariant = v } }
+    /// A trailing dismiss (`×`) button (HeroUI suffix remove). The callback
+    /// fires on tap; `nil` removes it.
+    func onClose(_ action: (() -> Void)?) -> Self { copy { $0.onClose = action } }
     /// A leading SF Symbol before the title.
     func icon(_ systemName: String?) -> Self { copy { $0.leadingSystemImage = systemName } }
     /// A leading star + numeric rating before the title.
@@ -218,6 +332,34 @@ public extension Chip {
             HStack {
                 Chip("Sold out", isSelected: .constant(false)).exists(false)
                 Chip("a-very-long-filter-value-here", isSelected: .constant(false))
+            }
+        }
+        // HeroUI V3 status chips: static `Chip("…")`, no binding. The Type axis.
+        PreviewCase("Types (primary)") {
+            HStack {
+                Chip("Accent").type(.accent)
+                Chip("Default").type(.neutral)
+                Chip("Success").type(.success)
+                Chip("Warning").type(.warning)
+                Chip("Danger").type(.danger)
+            }
+        }
+        // The Variant (emphasis) axis, one type across all four levels.
+        PreviewCase("Variants (accent)") {
+            HStack {
+                Chip("Primary").type(.accent).variant(.primary)
+                Chip("Secondary").type(.accent).variant(.secondary)
+                Chip("Tertiary").type(.accent).variant(.tertiary)
+                Chip("Soft").type(.accent).variant(.soft)
+            }
+        }
+        // Compact HeroUI size ramp (20 / 24 / 28pt) + prefix icon + dismiss.
+        PreviewCase("Status: sizes / icon / close") {
+            HStack {
+                Chip("Small").type(.success).variant(.soft).size(.small)
+                Chip("Medium").type(.success).variant(.soft).size(.medium)
+                Chip("Large").type(.success).variant(.soft).size(.large).icon("checkmark")
+                Chip("Dismiss").type(.danger).variant(.soft).onClose {}
             }
         }
     }

--- a/Sources/ThemeKit/Components/Atoms/Chip.swift
+++ b/Sources/ThemeKit/Components/Atoms/Chip.swift
@@ -197,7 +197,10 @@ public struct Chip: View {
                     Image(systemName: "xmark").font(.system(size: closeGlyphSize, weight: .semibold))
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(String(themeKit: "Remove"))
+                // Include the chip title so VoiceOver distinguishes each close
+                // button when several closable chips share a row (matches Tag /
+                // ChipGroup.removable).
+                .accessibilityLabel(String(themeKit: "Remove \(title)"))
             }
         }
         .frame(maxWidth: expandsHorizontally ? .infinity : nil)

--- a/Sources/ThemeKit/Components/Atoms/ChipStyle.swift
+++ b/Sources/ThemeKit/Components/Atoms/ChipStyle.swift
@@ -112,6 +112,78 @@ private struct SolidChipChrome: View {
     }
 }
 
+/// The HeroUI V3 **status** chroma: a semantic ``ChipType`` painted at one of
+/// the four ``ChipVariant`` emphasis levels. Selection-independent (a status
+/// chip isn't a toggle), so it ignores `configuration.isSelected`. Set
+/// indirectly via `Chip.type(_:)` + `.variant(_:)`; reads
+/// ``SemanticColor/Resolved``, so an injected `.theme(_:)` re-skins it.
+public struct SemanticChipStyle: ChipStyle, Sendable {
+    let type: ChipType
+    let variant: ChipVariant
+    public init(type: ChipType, variant: ChipVariant) {
+        self.type = type
+        self.variant = variant
+    }
+    public func makeBody(configuration: ChipStyleConfiguration) -> some View {
+        SemanticChipChrome(type: type, variant: variant, configuration: configuration)
+    }
+}
+
+private struct SemanticChipChrome: View {
+    let type: ChipType
+    let variant: ChipVariant
+    let configuration: ChipStyleConfiguration
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        configuration.content
+            .foregroundStyle(foreground)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(background, in: Capsule())
+    }
+
+    private var resolved: SemanticColor.Resolved { theme.resolve(type.semantic) }
+
+    private var foreground: Color {
+        if !configuration.isEnabled { return theme.text(.textDisabled) }
+        switch variant {
+        // `.neutral` has no vivid solid — its "primary" is a light gray chip with
+        // dark text (HeroUI "default" type), so it reads its own text token.
+        case .primary: return type == .neutral ? theme.text(.textPrimary) : resolved.onSolid
+        case .secondary, .tertiary, .soft: return resolved.accent
+        }
+    }
+    private var background: Color {
+        if !configuration.isEnabled { return theme.background(.bgSecondaryLight) }
+        switch variant {
+        // Vivid solid for the colored types; a light neutral surface for `.neutral`.
+        case .primary: return type == .neutral ? theme.background(.bgSecondaryLight) : resolved.solid
+        // HeroUI "secondary" is a neutral gray surface for every type (the hue
+        // shows only through the accent-colored label).
+        case .secondary: return theme.background(.bgSecondaryLight)
+        case .tertiary: return .clear                        // transparent
+        case .soft: return resolved.soft                     // type-tinted surface
+        }
+    }
+    // HeroUI compact ramp: with `Chip`'s ~20pt scaled content floor these
+    // paddings land the capsule on the 20 / 24 / 28pt sm/md/lg heights.
+    private var horizontalPadding: CGFloat {
+        switch configuration.size {
+        case .small: return Theme.SpacingKey.sm.value    // 8
+        case .medium: return Theme.SpacingKey.sm.value   // 8
+        case .large: return Theme.SpacingKey.sm.value + 4 // 12
+        }
+    }
+    private var verticalPadding: CGFloat {
+        switch configuration.size {
+        case .small: return 0
+        case .medium: return 2                            // no 2pt spacing token
+        case .large: return Theme.SpacingKey.xs.value    // 4
+        }
+    }
+}
+
 public extension ChipStyle where Self == TonalChipStyle {
     /// The stock tonal chroma (light hero surface + hero text when selected).
     static var tonal: TonalChipStyle { TonalChipStyle() }

--- a/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
+++ b/Tests/ThemeKitTests/Generated/L10nKeyInvariantTests.swift
@@ -265,7 +265,7 @@ final class L10nKeyInvariantTests: XCTestCase {
         assertKey(
             "Remove \(d)",
             "Remove %@", 1,
-            site: "Sources/ThemeKit/Components/Atoms/Tag.swift:54")
+            site: "Sources/ThemeKit/Components/Atoms/Chip.swift:203")
         assertKey(
             "Remove card ending \(d)",
             "Remove card ending %@", 1,


### PR DESCRIPTION
Adds HeroUI V3 **status axes** to `Chip`. One of three split PRs from a larger unmerged local branch; Chip-only.

## What
- `ChipType` / `ChipVariant` axes + static `Chip("x")` init.
- `.type(_:)` / `.variant(_:)` / `.onClose(_:)` chainable (COW) modifiers.
- `SemanticChipStyle` routed through the existing `ChipStyle` gate.
- `String(themeKit: "Remove")` a11y label on the dismiss button; previews cover every axis.

## Not a duplicate
Main's `Chip` had only tonal/solid selection — no status axes.

## Verification
- Built on current `main`; `swift build` + `--build-tests` ✅; pre-push gate green.
- `scripts/check-api.sh origin/main` → no public-API breakages (additive); `check-variant-naming` clean.

## Follow-up (non-blocking)
- `ChipVariant` (primary/secondary/tertiary/soft) introduces a third emphasis vocabulary beside `FillVariant` — deliberate HeroUI-parity naming; worth an architect nod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)