### PR TITLE
feat(card): themeable/CSS-settable padding via SpacingRole + demand-minted slot tokens

### DIFF
--- a/Sources/ThemeKit/Components/Organisms/Card.swift
+++ b/Sources/ThemeKit/Components/Organisms/Card.swift
@@ -21,9 +21,32 @@ public enum CardCoverPlacement {
     case fill
 }
 
+// Demand-minted spacing tokens Card reads from the active theme. The naming
+// grammar is `<component>-<slot>-padding` (umbrella `<component>-padding`),
+// resolving down to `Theme.SpacingRole.box`, then `.md` (16). Private on
+// purpose — consumers use the modifiers below; themes/CSS declare these names
+// (`--card-padding`, `--card-header-padding`, …).
+private let cardPaddingToken = "card-padding"
+private let cardHeaderPaddingToken = "card-header-padding"
+private let cardBodyPaddingToken = "card-body-padding"
+private let cardFooterPaddingToken = "card-footer-padding"
+
 /// Organism. A surface container with token padding / radius / elevation. An
 /// optional header (title / subtitle + a trailing `extra` action, divided from
 /// the body) and an `isLoading` skeleton bring it toward Ant Card.
+///
+/// **Padding contract.** Each slot's inner padding resolves through one chain
+/// (first hit wins):
+///
+///     instance modifier (.headerPadding / .footerPadding / .contentPadding)
+///       → deprecated raw CGFloat escape hatch
+///       → slot theme token   ("card-header-padding" / "card-body-padding" / "card-footer-padding")
+///       → umbrella theme token ("card-padding" — CSS `--card-padding`)
+///       → spacing role       (`Theme.SpacingRole.box`, default 16)
+///       → `Theme.SpacingKey.md` (16, bundled themes)
+///
+/// The `sm` (8) gaps between a slot and its divider are deliberately NOT part
+/// of this contract — they are fixed chrome, not themeable padding.
 public struct Card<Content: View>: View {
     private let title: String?
     private let action: (() -> Void)?
@@ -32,12 +55,39 @@ public struct Card<Content: View>: View {
     // Appearance/config — mutated only through the modifiers below (R2).
     private var elevation: CardElevation = .soft
     /// Raw padding (deprecated escape hatch); `paddingKey` wins when set.
-    private var padding: CGFloat = 16
+    /// `nil` by default so the theme tokens / spacing role decide.
+    private var padding: CGFloat?
     /// Token padding (`contentPadding(_ key:)`) — resolved against the
     /// environment theme so it re-skins with a spacing-scale change.
     private var paddingKey: Theme.SpacingKey?
+    /// Per-slot token padding (`headerPadding(_:)` / `footerPadding(_:)`).
+    private var headerPaddingKey: Theme.SpacingKey?
+    private var footerPaddingKey: Theme.SpacingKey?
 
-    private var resolvedPadding: CGFloat { paddingKey.map { theme.spacing($0) } ?? padding }
+    /// General (umbrella) padding — see the padding contract in the type doc.
+    private var resolvedPadding: CGFloat {
+        paddingKey.map { theme.spacing($0) }
+            ?? padding
+            ?? theme.spacing(token: cardPaddingToken)
+            ?? theme.spacing(.box)
+    }
+    private var resolvedHeaderPadding: CGFloat {
+        headerPaddingKey.map { theme.spacing($0) }
+            ?? theme.spacing(token: cardHeaderPaddingToken)
+            ?? resolvedPadding
+    }
+    private var resolvedBodyPadding: CGFloat {
+        paddingKey.map { theme.spacing($0) }
+            ?? padding
+            ?? theme.spacing(token: cardBodyPaddingToken)
+            ?? theme.spacing(token: cardPaddingToken)
+            ?? theme.spacing(.box)
+    }
+    private var resolvedFooterPadding: CGFloat {
+        footerPaddingKey.map { theme.spacing($0) }
+            ?? theme.spacing(token: cardFooterPaddingToken)
+            ?? resolvedPadding
+    }
     private var subtitle: String?
     private var extraTitle: String?
     private var onExtra: (() -> Void)?
@@ -76,8 +126,8 @@ public struct Card<Content: View>: View {
                 titleHeader
             }
         }
-        .padding(.horizontal, resolvedPadding)
-        .padding(.top, resolvedPadding)
+        .padding(.horizontal, resolvedHeaderPadding)
+        .padding(.top, resolvedHeaderPadding)
         .padding(.bottom, Theme.SpacingKey.sm.value)
     }
 
@@ -113,9 +163,9 @@ public struct Card<Content: View>: View {
         if let footerContent {
             footerContent
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, resolvedPadding)
+                .padding(.horizontal, resolvedFooterPadding)
                 .padding(.top, Theme.SpacingKey.sm.value)
-                .padding(.bottom, resolvedPadding)
+                .padding(.bottom, resolvedFooterPadding)
         }
     }
 
@@ -156,10 +206,10 @@ public struct Card<Content: View>: View {
                 }
                 if isLoading {
                     loadingPlaceholder
-                        .padding(resolvedPadding).frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(resolvedBodyPadding).frame(maxWidth: .infinity, alignment: .leading)
                 } else if hasBody {
                     content()
-                        .padding(resolvedPadding).frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(resolvedBodyPadding).frame(maxWidth: .infinity, alignment: .leading)
                 }
                 if footerContent != nil {
                     if coverContent == nil { DividerView().size(.small) }
@@ -201,6 +251,9 @@ public extension Card {
     /// Inner content padding by spacing token (named so it doesn't shadow the
     /// native `.padding`; the `SurfaceView`/`TicketStub` twin) — resolved
     /// against the environment theme, so it re-skins with a spacing change.
+    /// This is the *general* override; `headerPadding(_:)` / `footerPadding(_:)`
+    /// tune single slots. Unset, the theme decides (`--card-padding` /
+    /// `Theme.SpacingRole.box`, default 16).
     func contentPadding(_ key: Theme.SpacingKey) -> Self {
         copy { $0.paddingKey = key }
     }
@@ -209,6 +262,20 @@ public extension Card {
     @available(*, deprecated, message: "Use contentPadding(_: Theme.SpacingKey) — the token-bound overload.")
     func contentPadding(_ padding: CGFloat) -> Self {
         copy { $0.padding = padding; $0.paddingKey = nil }
+    }
+
+    /// Header-slot padding by spacing token — overrides the general
+    /// `contentPadding(_:)` / theme padding for the header area only
+    /// (theme twin: `--card-header-padding`).
+    func headerPadding(_ key: Theme.SpacingKey) -> Self {
+        copy { $0.headerPaddingKey = key }
+    }
+
+    /// Footer-slot padding by spacing token — overrides the general
+    /// `contentPadding(_:)` / theme padding for the footer area only
+    /// (theme twin: `--card-footer-padding`).
+    func footerPadding(_ key: Theme.SpacingKey) -> Self {
+        copy { $0.footerPaddingKey = key }
     }
 
     /// Trailing header action (Ant `extra`) — renders when both title and action are set.
@@ -352,6 +419,41 @@ public extension View {
                     .foregroundStyle(theme.text(.textSecondary))
             }
             .surface(.bgSecondaryLight)
+        }
+        // Theme-driven padding: a CSS theme minting `--card-padding` /
+        // `--card-header-padding`, scoped to this subtree via `.theme(_:)`.
+        PreviewCase("CSS-padded theme") {
+            let cssTheme: Theme = {
+                let t = Theme()
+                t.setTheme(css: """
+                    :root {
+                      --accent: #056bfd;
+                      --card-padding: 24px;
+                      --card-header-padding: 8px;
+                    }
+                    """)
+                return t
+            }()
+            Card("CSS-padded") {
+                Text("24pt body from `--card-padding`; 8pt header from `--card-header-padding`.")
+                    .textStyle(.bodyBase400)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+            .theme(cssTheme)
+        }
+        // Per-slot instance overrides: header/footer tokens beat the general padding.
+        PreviewCase("Slot padding overrides") {
+            Card("Slot overrides") {
+                Text("Header at `.base` (24), footer at `.sm` (8), body default.")
+                    .textStyle(.bodyBase400)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
+            .headerPadding(.base)
+            .footerPadding(.sm)
+            .footer {
+                Text("Tight footer").textStyle(.labelSm600)
+                    .foregroundStyle(theme.text(.textSecondary))
+            }
         }
         // Token content padding (G5): the SpacingKey overload.
         PreviewCase("Compact padding") {

--- a/Sources/ThemeKitCore/Theme/CSSTheme.swift
+++ b/Sources/ThemeKitCore/Theme/CSSTheme.swift
@@ -39,7 +39,7 @@ public enum CSSTheme {
         /// Internal: `Theme.ThemeData` is an internal type — apply via `Theme.setTheme(css:)`.
         func themeData(dark: Bool, font: String = "System") -> Theme.ThemeData {
             CSSTheme.build(vars: dark ? self.dark : self.light,
-                           radiusFallback: self.light,   // radius is usually declared once, in :root
+                           rootFallback: self.light,   // structural tokens (radius, padding) are usually declared once, in :root
                            dark: dark, hue: hue, font: font)
         }
     }
@@ -99,9 +99,21 @@ public enum CSSTheme {
         (50, "background"), (100, "surface"), (200, "border"), (500, "muted"), (900, "foreground")]
     private static let steps = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900]
 
+    /// CSS var(s) -> the demand-minted spacing token each mints, DECLARED-ONLY:
+    /// a var maps 1:1 onto exactly ONE token — no cascade flattening here
+    /// (`--card-padding` does not write header/body/footer entries). Precedence
+    /// between the tokens lives in the component (Card) at render time.
+    /// First name in the alias list wins within a scheme block.
+    private static let spacingVarMap: [(token: String, cssNames: [String])] = [
+        ("card-padding", ["card-padding", "card-p", "padding-card"]),
+        ("card-header-padding", ["card-header-padding"]),
+        ("card-body-padding", ["card-body-padding"]),
+        ("card-footer-padding", ["card-footer-padding"]),
+    ]
+
     // MARK: - Build
 
-    private static func build(vars: [String: String], radiusFallback: [String: String],
+    private static func build(vars: [String: String], rootFallback: [String: String],
                               dark: Bool, hue: Double, font: String) -> Theme.ThemeData {
         let accent = parseColor(vars["accent"] ?? "")?.hex ?? "056bfd"
 
@@ -124,12 +136,22 @@ public enum CSSTheme {
         // 4) radius roles (--radius -> box/selector, --field-radius -> field);
         //    inherit from the light block when the scheme omits them.
         var radii: [String: CGFloat] = [:]
-        if let box = remToPx(vars["radius"] ?? radiusFallback["radius"] ?? "") {
+        if let box = remToPx(vars["radius"] ?? rootFallback["radius"] ?? "") {
             radii["radius-box"] = box
             radii["radius-selector"] = box
         }
-        if let field = remToPx(vars["field-radius"] ?? radiusFallback["field-radius"] ?? "") {
+        if let field = remToPx(vars["field-radius"] ?? rootFallback["field-radius"] ?? "") {
             radii["radius-field"] = field
+        }
+
+        // 5) per-component spacing tokens (--card-padding & friends) — declared-only
+        //    (a key is written ONLY when the var is present), inheriting from the
+        //    light block when the scheme omits them, exactly like radius.
+        var spacings: [String: CGFloat] = [:]
+        for entry in spacingVarMap {
+            let declared = entry.cssNames.lazy.compactMap { vars[$0] }.first
+                ?? entry.cssNames.lazy.compactMap { rootFallback[$0] }.first
+            if let declared, let px = remToPx(declared) { spacings[entry.token] = px }
         }
 
         return ThemeGenerator.generate(
@@ -137,7 +159,8 @@ public enum CSSTheme {
             font: font, fontScale: 1, radiusScale: 1, spacingScale: 1, shadowScale: 1,
             baseHex: nil, secondaryHex: nil, accentHex: nil,
             paletteSeeds: seeds, neutralRamp: ramp,
-            semanticOverrides: overrides, radiusOverrides: radii
+            semanticOverrides: overrides, radiusOverrides: radii,
+            spacingOverrides: spacings
         )
     }
 

--- a/Sources/ThemeKitCore/Theme/Theme.swift
+++ b/Sources/ThemeKitCore/Theme/Theme.swift
@@ -316,6 +316,21 @@ public final class Theme: @unchecked Sendable {
     }
     public func spacing(_ key: SpacingKey) -> CGFloat { spacingList[key.rawValue] ?? 0 }
 
+    /// Resolved spacing for a semantic *role* (box). Reads the theme's role token
+    /// if present, otherwise the role's fallback size key — so themes without
+    /// role tokens (bundled JSON) keep their existing insets.
+    public func spacing(_ role: SpacingRole) -> CGFloat {
+        spacingList[role.rawValue] ?? spacing(role.fallback)
+    }
+
+    /// A demand-minted component spacing token (`card-padding`,
+    /// `card-header-padding`, …), or `nil` when the active theme doesn't declare
+    /// it — deliberately unlike the `?? 0` key accessor, so a component can walk
+    /// its precedence chain (slot token → umbrella token → spacing role).
+    /// `package`: stringly token names stay inside the library — consumers go
+    /// through component modifiers or theme/CSS files.
+    package func spacing(token name: String) -> CGFloat? { spacingList[name] }
+
     // MARK: - Typography accessor
 
     /// The active theme's resolved style for a `TextStyle` (font + line spacing).

--- a/Sources/ThemeKitCore/Theme/ThemeGenerator.swift
+++ b/Sources/ThemeKitCore/Theme/ThemeGenerator.swift
@@ -233,6 +233,8 @@ enum ThemeGenerator {
     ]
     private static let spacingBase: [(String, CGFloat)] = [
         ("spacing-none", 0), ("sp-xs", 4), ("sp-sm", 8), ("sp-md", 16), ("sp-base", 24), ("sp-lg", 32), ("sp-xl", 40), ("sp-4xl", 64),
+        // Semantic spacing role — inner padding of box-class surfaces (Card, …).
+        ("spacing-box", 16),
     ]
     // name, size, weight, lineHeight
     private static let typographyBase: [(String, CGFloat, String, CGFloat)] = [
@@ -277,7 +279,8 @@ enum ThemeGenerator {
         paletteSeeds: [String: String] = [:],       // family -> seed hex (e.g. success/warning/error)
         neutralRamp: [String]? = nil,               // 10 hexes, step 50..900, overrides the gray ramp
         semanticOverrides: [String: String] = [:],  // "category.token" -> exact hex, applied last
-        radiusOverrides: [String: CGFloat] = [:]    // "radius-box"/"radius-field"/... -> px
+        radiusOverrides: [String: CGFloat] = [:],   // "radius-box"/"radius-field"/... -> px
+        spacingOverrides: [String: CGFloat] = [:]   // "spacing-box"/"card-padding"/... -> px
     ) -> Theme.ThemeData {
         let primary = primaryHex.hasPrefix("#") ? String(primaryHex.dropFirst()) : primaryHex
         let palette = buildPalette(primaryBase: primary, dark: dark, tint: tint,
@@ -340,7 +343,19 @@ enum ThemeGenerator {
         let radius = radiusBase.map {
             Theme.AppRadius(name: $0.0, radius: radiusOverrides[$0.0] ?? ($0.1 * radiusScale).rounded(.toNearestOrEven))
         }
-        let spacing = spacingBase.map { Theme.AppSpacing(name: $0.0, spacing: ($0.1 * spacingScale).rounded(.toNearestOrEven)) }
+        // Overrides are explicit theme values — applied verbatim, bypassing
+        // `spacingScale` (exactly like `radiusOverrides` bypasses `radiusScale`).
+        var spacing = spacingBase.map {
+            Theme.AppSpacing(name: $0.0, spacing: spacingOverrides[$0.0] ?? ($0.1 * spacingScale).rounded(.toNearestOrEven))
+        }
+        // Demand-minted component tokens (`card-padding`, …) aren't in the base
+        // table — append any override key the table doesn't know, so a theme/CSS
+        // can mint them without the generator pre-declaring every component.
+        let knownSpacing = Set(spacingBase.map(\.0))
+        spacing += spacingOverrides
+            .filter { !knownSpacing.contains($0.key) }
+            .sorted { $0.key < $1.key }
+            .map { Theme.AppSpacing(name: $0.key, spacing: $0.value) }
         let typography = typographyBase.map {
             Theme.AppTypography(name: $0.0, font: font, size: ($0.1 * fontScale).rounded(.toNearestOrEven),
                                 weight: $0.2, lineHeight: ($0.3 * fontScale).rounded(.toNearestOrEven))

--- a/Sources/ThemeKitCore/Theme/ThemeModel.swift
+++ b/Sources/ThemeKitCore/Theme/ThemeModel.swift
@@ -119,6 +119,25 @@ extension Theme {
         /// Resolved spacing from the active theme.
         public var value: CGFloat { Theme.shared.spacing(self) }
     }
+
+    /// Semantic spacing *roles* — the spacing twin of ``RadiusRole``. Name an
+    /// inset by the component's *role* instead of a fixed size, so a theme can
+    /// re-pad a whole category at once. A theme that omits the role token falls
+    /// back to the matching size key (so existing/bundled themes are unaffected).
+    public enum SpacingRole: String, CaseIterable {
+        /// Inner padding of box-class surfaces (cards, dialogs, sheets).
+        /// Demand-minted per-component override tokens follow the grammar
+        /// `<component>-<slot>-padding` (umbrella `<component>-padding`) and
+        /// resolve down to this role, then `.md`. Mint a component token ONLY
+        /// when a shipped component reads it — never pre-generate.
+        case box = "spacing-box"
+
+        /// Size key used when a theme doesn't define this role token.
+        public var fallback: SpacingKey { .md }   // 16
+
+        /// Resolved spacing from the active theme (role token, else the fallback size).
+        public var value: CGFloat { Theme.shared.spacing(self) }
+    }
 }
 
 // MARK: - Radius capping (HeroUI `min()` cap + concentric nesting)

--- a/Tests/ThemeKitTests/CSSThemeTests.swift
+++ b/Tests/ThemeKitTests/CSSThemeTests.swift
@@ -61,6 +61,9 @@ final class CSSThemeTests: XCTestCase {
     private func radius(_ d: Theme.ThemeData, _ name: String) -> CGFloat? {
         d.radius?.first(where: { $0.name == name })?.radius
     }
+    private func spacing(_ d: Theme.ThemeData, _ name: String) -> CGFloat? {
+        d.spacing?.first(where: { $0.name == name })?.spacing
+    }
 
     func testLightSchemeMatchesImporterOutput() {
         let d = CSSTheme.parse(css).themeData(dark: false, font: "Inter")
@@ -97,6 +100,39 @@ final class CSSThemeTests: XCTestCase {
         // Radius declared once in :root is inherited by the dark scheme.
         XCTAssertEqual(radius(d, "radius-box"), 8)
         XCTAssertEqual(radius(d, "radius-field"), 12)
+    }
+
+    /// Card padding vars are minted DECLARED-ONLY (no cascade flattening: an
+    /// umbrella `--card-padding` writes only `card-padding`), and — declared once
+    /// in `:root` — they reach the dark scheme exactly like the radius roles.
+    func testCardPaddingTokensMintedDeclaredOnlyAndInheritedByDark() {
+        let padded = css.replacingOccurrences(of: "--radius: 0.5rem;", with: """
+        --radius: 0.5rem;
+          --card-padding: 1.5rem;
+          --card-header-padding: 8px;
+        """)
+        for dark in [false, true] {
+            let d = CSSTheme.parse(padded).themeData(dark: dark, font: "Inter")
+            XCTAssertEqual(spacing(d, "card-padding"), 24, "dark=\(dark)")       // 1.5rem = 24
+            XCTAssertEqual(spacing(d, "card-header-padding"), 8, "dark=\(dark)")
+            // Declared-only: undeclared slot vars mint nothing (Card walks its
+            // own precedence chain down to card-padding / spacing-box).
+            XCTAssertNil(spacing(d, "card-body-padding"), "dark=\(dark)")
+            XCTAssertNil(spacing(d, "card-footer-padding"), "dark=\(dark)")
+            // The spacing role is generated for every theme.
+            XCTAssertEqual(spacing(d, "spacing-box"), 16, "dark=\(dark)")
+        }
+        // A CSS theme without the vars mints no card tokens at all.
+        let plain = CSSTheme.parse(css).themeData(dark: false, font: "Inter")
+        XCTAssertNil(spacing(plain, "card-padding"))
+    }
+
+    /// `--card-p` / `--padding-card` alias onto the same `card-padding` token.
+    func testCardPaddingAliasesResolve() {
+        let aliased = css.replacingOccurrences(of: "--radius: 0.5rem;",
+                                               with: "--card-p: 20px;\n  --radius: 0.5rem;")
+        let d = CSSTheme.parse(aliased).themeData(dark: false, font: "Inter")
+        XCTAssertEqual(spacing(d, "card-padding"), 20)
     }
 
     func testParseDetectsDarkBlock() {

--- a/Tests/ThemeKitTests/ThemeGeneratorTests.swift
+++ b/Tests/ThemeKitTests/ThemeGeneratorTests.swift
@@ -86,6 +86,40 @@ final class ThemeGeneratorTests: XCTestCase {
         Theme.shared.loadTheme(named: Theme.defaultThemeName)
     }
 
+    private func spacing(_ data: Theme.ThemeData, _ name: String) -> CGFloat? {
+        data.spacing?.first(where: { $0.name == name })?.spacing
+    }
+
+    func testSpacingOverridesApplyVerbatimAndUnknownKeysAppend() {
+        let d = ThemeGenerator.generate(primaryHex: "056bfd", tint: 0, dark: false,
+                                        font: "System", fontScale: 1, radiusScale: 1, spacingScale: 2, shadowScale: 1,
+                                        spacingOverrides: ["spacing-box": 20, "card-padding": 24])
+        // Known key: the override wins VERBATIM (no spacingScale multiplication) —
+        // mirroring how radiusOverrides bypass radiusScale…
+        XCTAssertEqual(spacing(d, "spacing-box"), 20)
+        // …while unoverridden base keys still scale.
+        XCTAssertEqual(spacing(d, "sp-md"), 32)
+        // Unknown (demand-minted component) keys are APPENDED, not silently dropped.
+        XCTAssertEqual(spacing(d, "card-padding"), 24)
+    }
+
+    func testSpacingBoxRoleGeneratedAndRoleFallback() {
+        // Generated themes mint the role token at 16 (× spacingScale).
+        let d = ThemeGenerator.generate(primaryHex: "056bfd", tint: 0, dark: false,
+                                        font: "System", fontScale: 1, radiusScale: 1, spacingScale: 1, shadowScale: 1)
+        XCTAssertEqual(spacing(d, "spacing-box"), 16)
+
+        // Bundled JSON themes predate `spacing-box` — the role accessor must fall
+        // back to `.md` (16), never 0 (a 0 would zero every Card's padding).
+        let t = Theme()
+        t.loadTheme(named: Theme.defaultThemeName)
+        XCTAssertNil(t.spacing(token: "spacing-box"))
+        XCTAssertEqual(t.spacing(.box), t.spacing(Theme.SpacingKey.md))
+        XCTAssertEqual(t.spacing(.box), 16)
+        // Demand-minted tokens are nil (not 0) when the theme doesn't declare them.
+        XCTAssertNil(t.spacing(token: "card-padding"))
+    }
+
     func testDefaultMatchesBakedSeed() {
         let d = ThemeGenerator.generate(primaryHex: "056bfd", tint: 0.06, dark: false,
                                         font: "Montserrat", fontScale: 1, radiusScale: 1, spacingScale: 1, shadowScale: 1)

--- a/tools/import_css_theme.py
+++ b/tools/import_css_theme.py
@@ -13,7 +13,10 @@ So this importer:
   4. builds a pure-neutral gray ramp interpolated from the CSS's own L anchors
      (background / border / muted / foreground), so surfaces stay HeroUI-neutral,
   5. overrides the exact semantic tokens the CSS specifies with their exact hexes,
-  6. maps `--radius` / `--field-radius` onto the `radius-box`/`-field` roles.
+  6. maps `--radius` / `--field-radius` onto the `radius-box`/`-field` roles,
+  7. mints per-component spacing tokens from `--card-padding` (aliases
+     `--card-p` / `--padding-card`) and `--card-header/-body/-footer-padding`
+     — declared-only, 1:1 (no cascade flattening; Card resolves precedence).
 
 Everything the CSS does NOT specify (turquoise/orange/purple/pink families,
 badges, shadows) falls back to ThemeKit's defaults.
@@ -155,6 +158,18 @@ NEUTRAL_ANCHORS_DARK = {50: "background", 100: "surface", 200: "border",
                         500: "muted", 900: "foreground"}
 STEPS = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900]
 
+# CSS var(s) -> the demand-minted spacing token each mints, DECLARED-ONLY:
+# a var maps 1:1 onto exactly ONE token — no cascade flattening here
+# (`--card-padding` does not write header/body/footer entries). Precedence
+# between the tokens lives in the component (Card) at render time.
+# First name in the alias list wins within a scheme block.
+SPACING_VAR_MAP = [
+    ("card-padding", ["card-padding", "card-p", "padding-card"]),
+    ("card-header-padding", ["card-header-padding"]),
+    ("card-body-padding", ["card-body-padding"]),
+    ("card-footer-padding", ["card-footer-padding"]),
+]
+
 
 def _lum_L(color, fallback):
     """L (0..100) of a parsed color; approximates from luminance when the source
@@ -262,6 +277,14 @@ def build_theme(ns, vars_, dark, hue, font):
         roles.append({"name": "radius-field", "radius": field})
     have = {r["name"] for r in data["radius"]}
     data["radius"] += [r for r in roles if r["name"] not in have]
+
+    # 6) per-component spacing tokens from --card-padding & friends (declared-only)
+    have_spacing = {s["name"] for s in data["spacing"]}
+    for token, names in SPACING_VAR_MAP:
+        raw = next((vars_[n] for n in names if n in vars_), None)
+        px = _rem_px(raw) if raw is not None else None
+        if px is not None and token not in have_spacing:
+            data["spacing"].append({"name": token, "spacing": px})
     return data
 
 
@@ -285,6 +308,14 @@ def main():
         for k in ("radius", "field-radius"):
             if k in light:
                 dark.setdefault(k, light[k])
+        # Spacing tokens inherit per-TOKEN (not per-alias): a dark block that
+        # declares ANY alias of a token keeps its own alias order — light's
+        # higher-priority alias must not shadow it (mirrors CSSTheme.swift).
+        for _, names in SPACING_VAR_MAP:
+            if not any(n in dark for n in names):
+                for n in names:
+                    if n in light:
+                        dark[n] = light[n]
 
     hue_c = parse_color(light["accent"])
     hue = hue_c.H if hue_c and hue_c.H is not None else 253.83


### PR DESCRIPTION
Makes Card's padding a **themeable, CSS-settable, consumer-overridable** token (default 16px both axes) — a bounded-hybrid token model reviewed + approved by the **ios-architect** (reconciling a shared spacing role with Ant Design's per-component/per-slot tokens, without the token explosion).

## Model — 3 tiers, resolved slot → umbrella → role → fallback
```
instance modifier (.headerPadding / .footerPadding / .contentPadding)
  → deprecated raw CGFloat escape hatch
  → component SLOT token   "card-header-padding"        (theme/CSS)
  → component UMBRELLA      "card-padding"              (theme/CSS)
  → spacing ROLE           "spacing-box" (16)           (theme/CSS)
  → SpacingKey.md fallback (16)                          (bundled JSON themes)
```
Modifiers stay **token-fed** (`Theme.SpacingKey`); arbitrary numeric values enter only through the theme/CSS layer — exactly how `radius-box` already works. Precedence lives in ONE place (Card's resolved-padding computed props); token names are file-private constants.

## What ships
- **`Theme.SpacingRole { case box = "spacing-box" }`** (16, fallback `.md`) + `theme.spacing(_ role:)` (role→fallback, never `?? 0`) + `package theme.spacing(token:)`.
- **`ThemeGenerator`**: `("spacing-box", 16)` + `spacingOverrides:` param (parity w/ `radiusOverrides`, applied **verbatim**, no `spacingScale`); unknown override keys **append** as extra tokens → enables demand-minted component tokens without editing the base scale.
- **CSSTheme + `import_css_theme.py`**: `--card-padding` (aliases `--card-p`, `--padding-card`), `--card-header-padding`, `--card-body-padding`, `--card-footer-padding` → tokens (declared-only, 1:1, no cascade flattening; dark inherits `:root` like radius).
- **Card**: hardcoded `16` → token default; new **`.headerPadding(_:)` / `.footerPadding(_:)`** modifiers; `.contentPadding(_:)` = general. Divider `sm`(8) inter-slot gaps deliberately stay out of the padding contract.
- 4 new tests + 2 previews (CSS-padded theme · slot overrides).

## Bounding rules (no token explosion)
Component tokens are **never pre-generated** — a name exists only when a shipped component reads it AND a theme declares it (undeclared = dictionary miss = zero cost). Grammar `<component>-<slot>-padding` + umbrella `<component>-padding`. Spacing-only (no per-component color/size tokens); no `-sm` size axis yet. Card-only adoption; Dialog/Sheet adopt `spacing(.box)` in follow-up PRs.

## Verify
`swift build` + `--build-tests` + `swift test` (337, 0 fail) green; `scripts/check-api.sh` additive/clean; `make l10n` no drift; Python↔Swift CSS parity checked.

## Follow-ups (out of scope — flagged, not blocking)
- **`gen_tokens.py` / bundled JSON**: the 34 bundled theme JSONs don't carry `spacing-box`; they resolve via the role→`.md` fallback (value-identical 16, just not byte-identical on that one key). Adding it forces regenerating all 34 — separate PR if wanted.
- **llms/skill regen**: `make skill` pulls in *pre-existing* unrelated drift already on main (index 236 vs source 245); reverted here to avoid smuggling a 346-line unrelated diff. Needs a standalone regen pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)